### PR TITLE
Don't show author field when editing topics

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/hbtemplates/edit_metadata_editor.handlebars
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/hbtemplates/edit_metadata_editor.handlebars
@@ -52,12 +52,12 @@
 		<br/>
 		<br/>
 	{{/if}}
-	<hr/>
 	{{#if isoriginal}}
+		{{#if is_file}}
+		<hr/>
 		{{#unless node}}<div class="input-tab-control tab_item" data-next="#author_field"></div>{{/unless}}
 		<h4>{{formatMessage (intlGet 'messages.author')}}</h4>
 		<input type="text" id="author_field" class="upload_input input_listener tab_item" value="{{author}}" placeholder="{{formatMessage (intlGet 'messages.author_placeholder')}}"/>
-		{{#if is_file}}
 		<div class="row">
 			<div class="content_nodes_only col-sm-6">
 				<h4>{{formatMessage (intlGet 'messages.license')}} <label class="required">*</label></h4>
@@ -77,8 +77,10 @@
 				</div>
 			</div>
 		</div>
+		<hr/>
 		{{/if}}
 	{{else}}
+		<hr/>
 		{{#if node}}
 		<p class="uploader-copied-warning">{{formatMessage (intlGet 'messages.readonly_text')}}</p>
 		{{/if}}
@@ -100,8 +102,8 @@
 				<p class="upload_input">{{copyright_owner}}</p>
 			</div>
 		</div>
+		<hr/>
 	{{/if}}
-	<hr/>
 	<br/>
 	{{#if node}}
 		<h4>{{formatMessage (intlGet 'messages.description')}} {{#if node}}<i id="description_counter" class="pull-right">{{formatMessage (intlGet 'messages.chars_left') data=word_limit}}</i>{{/if}}</h4>


### PR DESCRIPTION
Create a new topic in a test channel.

Before this change, see an author field:

![image](https://user-images.githubusercontent.com/159687/37689875-d878da90-2c64-11e8-8457-036f5b3decc8.png)

After this change, ensure there's no author field:

![image](https://user-images.githubusercontent.com/159687/37689897-f0ac8da0-2c64-11e8-9bd0-23bb8e7b2098.png)

... but ensure that the author field is still there when editing content nodes, i.e. when you click "Upload Files" or "Create Exercise":

![image](https://user-images.githubusercontent.com/159687/37689962-5970eafc-2c65-11e8-84e9-e3083bb56796.png)