### PR TITLE
Support cmd+click a channel to open it in a new tab

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
@@ -329,7 +329,12 @@ var ChannelListItem = BaseViews.BaseListEditableItemView.extend({
 	},
 	open_channel:function(event){
 		if(this.$('.channel-container-wrapper').hasClass('highlight')){
-			window.location.href = '/channels/' + this.model.get("id") + ((this.can_edit)? '/edit' : '/view');
+			var open_url = '/channels/' + this.model.get("id") + ((this.can_edit)? '/edit' : '/view');
+			if (event.metaKey) {
+				window.open(open_url, '_blank');
+			} else {
+				window.location.href = open_url;
+			}
 		}
 	},
 	copy_id:function(event){

--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
@@ -330,7 +330,7 @@ var ChannelListItem = BaseViews.BaseListEditableItemView.extend({
 	open_channel:function(event){
 		if(this.$('.channel-container-wrapper').hasClass('highlight')){
 			var open_url = '/channels/' + this.model.get("id") + ((this.can_edit)? '/edit' : '/view');
-			if (event.metaKey) {
+			if (event.metaKey || event.ctrlKey) {
 				window.open(open_url, '_blank');
 			} else {
 				window.location.href = open_url;

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework-bulk==0.2.1
 django-email-extras==0.3.3
 kolibri==0.7.0
 validators
-le-utils>=0.1.3
+le-utils>=0.1.9
 gunicorn==19.6.0
 django-mailgun==0.9.1
 pressurecooker==0.0.15


### PR DESCRIPTION
Tested on Mac + Chrome! Go to your channel list, click a channel, ensure it goes to the editor view in the same tab. But, when you hold down the command key and click a channel, ensure it opens in a new tab in the background!

According to the first comment on this [StackOverflow answer](https://stackoverflow.com/a/26823929/392426), this should work on Windows as well, as `metaKey` will map onto `ctrl`.