### PR TITLE
Add Google Analytics tracking to every page

### DIFF
--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -11,10 +11,13 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 SITE_ID = 2
 logging.basicConfig(level='DEBUG')
 
-# Allow the debug() context processor to add variables to template context. See
+# Allow the debug() context processor to add variables to template context.
+# Include here the IPs from which a local dev server might be accessed. See
 # https://docs.djangoproject.com/en/2.0/ref/settings/#internal-ips
 INTERNAL_IPS = (
     '127.0.0.1',
+    'studio.local',
+    '192.168.31.9',
 )
 
 try:

--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -11,6 +11,12 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 SITE_ID = 2
 logging.basicConfig(level='DEBUG')
 
+# Allow the debug() context processor to add variables to template context. See
+# https://docs.djangoproject.com/en/2.0/ref/settings/#internal-ips
+INTERNAL_IPS = (
+    '127.0.0.1',
+)
+
 try:
     import debug_panel
 except ImportError:
@@ -39,4 +45,3 @@ DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.logging.LoggingPanel',
     'debug_toolbar.panels.redirects.RedirectsPanel',
 ]
-

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -33,6 +33,19 @@
 			<script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 			{% endblock head %}
 
+      {% block analytics %}
+        {% if not debug %}
+          <!-- Global site tag (gtag.js) - Google Analytics -->
+          <script async src="https://www.googletagmanager.com/gtag/js?id=UA-36937407-7"></script>
+          <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-36937407-7');
+          </script>
+        {% endif %}
+      {% endblock %}
 	</head>
   <body>
       {% block nav %}


### PR DESCRIPTION
Test plan:

- Remove `{% if not debug %}` tag
- Refresh or open 127.0.0.1:8000 in your browser
- Go to the Studio property on Google Analytics
- See 1 active user from your IP
- Put back in the `{% if debug %}` tag
- Refresh localhost
- View source
- Ensure Google Analytics tracking code isn't in `<head>`

(I wish I knew an easier way to test production mode ... I tried a bunch of things but decided to let it go after spending 5 minutes on this.)