### PR TITLE
Quick fix for inline JS at Django template level.

### DIFF
--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -1,4 +1,5 @@
 var fastclick = require('fastclick');
+window.$ = $;
 
 // side effect: binds handlebars helpers to our handlebars instance
 require('../handlebars/helpers.js');


### PR DESCRIPTION
Ideal case would be to include this in a bundle.