### PR TITLE
Fixed "Make a Copy" function on main_tree nodes

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/views.js
@@ -568,6 +568,10 @@ var BaseListView = BaseView.extend({
 		_.bindAll(this, 'load_content', 'close', 'handle_if_empty', 'check_all', 'get_selected',
 			'set_root_model', 'update_views', 'cancel_actions');
 	},
+	is_segment: function() {
+		// Used for clipboard channel segmenting
+		return false;
+	},
 	set_root_model:function(model){
 		this.model.set(model.toJSON());
 	},
@@ -1228,6 +1232,7 @@ var BaseWorkspaceListNodeItemView = BaseListNodeItemView.extend({
 		});
 	},
 	make_copy: function(message){
+		// Makes inline copy
 		message=(message!=null)? message: this.get_translation("making_copy");
 		var copyCollection = new Models.ContentNodeCollection();
 		copyCollection.add(this.model);


### PR DESCRIPTION
## Description

Was getting an error with is_segment not being a function when using the "Make a Copy" option on the main_tree nodes, so I added it to the base list view


## Steps to Test

- [ ] Click the options on a tree item and select "Make a Copy"

## Checklist

- [x] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [x] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?