### PR TITLE
allow word breaking for long titles in channel content preview

### DIFF
--- a/contentcuration/contentcuration/static/less/details.less
+++ b/contentcuration/contentcuration/static/less/details.less
@@ -434,6 +434,7 @@
 							}
 							h5 {
 								font-weight: bold;
+								word-wrap: break-word;
 	    						color: @gray-500;
 							}
 							&:hover {

--- a/contentcuration/contentcuration/static/less/details.less
+++ b/contentcuration/contentcuration/static/less/details.less
@@ -434,7 +434,7 @@
 							}
 							h5 {
 								font-weight: bold;
-								word-wrap: break-word;
+								word-wrap: overflow-wrap;
 	    						color: @gray-500;
 							}
 							&:hover {


### PR DESCRIPTION
## Description
It lets long words get broken up in the channel content preview, so that they are still legible.

#### Issue Addressed (if applicable)
This is a fix for #765 

#### Before/After Screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/389782/42659917-53433caa-85ef-11e8-9b3b-5d2539b21660.png)

After:
![image](https://user-images.githubusercontent.com/389782/42659973-71fe40fe-85ef-11e8-9964-6dc135234c0d.png)

## Steps to Test

- [ ] Edit one of the titles of a root level content node in a channel to be something long and unwieldy such as "asldjgsadg_askjdgas_sakjdgaksdg_aksjdhgaksjdgkjsadgksa_sakdjgs_asdgsadg_blablabla"
- [ ] Save the content node
- [ ] Click on the channel in 'My Channels' and scroll down to the 'Preview' area.

#### At a high level, how did you implement this?

I added a `word-wrap: break-word` property to the CSS.

#### Does this introduce any tech-debt items?

We may want to add hyphens at some point.


## Checklist

- [x] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
