### PR TITLE
Bugfixing from the QA session

### DIFF
--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -62,6 +62,11 @@ def file_create(request):
     presets = FormatPreset.objects.filter(allowed_formats__extension__contains=ext[1:].lower())
     kind = presets.first().kind
     preferences = json.loads(request.META.get('HTTP_PREFERENCES'))
+
+    # sometimes we get a string no matter what. Try to parse it again
+    if isinstance(preferences, basestring):
+        preferences = json.loads(preferences)
+
     license = License.objects.filter(license_name=preferences.get('license')).first()  # Use filter/first in case preference hasn't been set
     license_id = license.pk if license else None
     new_node = ContentNode(

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -364,8 +364,8 @@ def duplicate_nodes(request):
         nodes_being_copied = []
         for node_data in nodes:
             nodes_being_copied.append(ContentNode.objects.get(pk=node_data['id']))
-        record_node_duplication_stats(nodes_being_copied, ContentNode.objects.get(pk=target_parent.pk),
-                                      Channel.objects.get(pk=channel_id))
+        # record_node_duplication_stats(nodes_being_copied, ContentNode.objects.get(pk=target_parent.pk),
+        #                               Channel.objects.get(pk=channel_id))
 
         with transaction.atomic():
             with ContentNode.objects.disable_mptt_updates():
@@ -398,8 +398,8 @@ def duplicate_node_inline(request):
         channel = target_parent.get_channel()
         request.user.can_edit(channel and channel.pk)
 
-        record_node_duplication_stats([node], ContentNode.objects.get(pk=target_parent.pk),
-                                      Channel.objects.get(pk=channel_id))
+        # record_node_duplication_stats([node], ContentNode.objects.get(pk=target_parent.pk),
+        #                               Channel.objects.get(pk=channel_id))
 
         new_node = None
         with transaction.atomic():


### PR DESCRIPTION
Remove use of node_duplication_stats. Not working for all cases anyway.

Force JSON parsing of preferences. It's still only a string despite first parsing.