### PR TITLE
Serve files on the /content/storage endpoint (debug only)

### DIFF
--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -3,6 +3,13 @@ import os
 
 from .test_settings import *
 
+# These endpoints will throw an error on the django debug panel
+EXCLUDED_DEBUG_URLS = [
+    "/content/storage",
+]
+
+def custom_show_toolbar(request):
+    return not any(request.path.startswith(url) for url in EXCLUDED_DEBUG_URLS)
 
 try:
     import debug_panel
@@ -14,7 +21,7 @@ else:
     INSTALLED_APPS += ('debug_panel', 'debug_toolbar', 'pympler')
     MIDDLEWARE_CLASSES += ('debug_panel.middleware.DebugPanelMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {
-        'SHOW_TOOLBAR_CALLBACK': lambda x: True,
+        'SHOW_TOOLBAR_CALLBACK': custom_show_toolbar,
     }
 
 DEBUG_TOOLBAR_PANELS = [

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -317,7 +317,7 @@ urlpatterns += [
 if settings.DEBUG:
     # static files (images, css, javascript, etc.)
     urlpatterns += [
-        url(r'^' + settings.STORAGE_URL[1:] + '(?P<path>.*)$', django_views.static.serve, {'document_root': settings.STORAGE_ROOT}),
+        url(r'^' + settings.STORAGE_URL[1:] + '(?P<path>.*)$', file_views.debug_serve_file, name='debug_serve_file'),
         url(r'^' + settings.CONTENT_DATABASE_URL[1:] + '(?P<path>.*)$', django_views.static.serve, {'document_root': settings.DB_ROOT}),
         url(r'^' + settings.CSV_URL[1:] + '(?P<path>.*)$', django_views.static.serve, {'document_root': settings.CSV_ROOT})
     ]

--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -4,16 +4,18 @@ import os
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.conf import settings
 from django.core.files import File as DjFile
+from django.core.files.storage import default_storage
 from rest_framework.renderers import JSONRenderer
 from contentcuration.api import write_file_to_storage, get_hash
 from contentcuration.utils.files import generate_thumbnail_from_node
-from contentcuration.models import File, FormatPreset, ContentNode, License, generate_storage_url
+from contentcuration.models import File, FormatPreset, ContentNode, License, generate_storage_url, generate_object_storage_name
 from contentcuration.serializers import FileSerializer, ContentNodeEditSerializer
 from le_utils.constants import format_presets, content_kinds, exercises, licenses
 from pressurecooker.videos import guess_video_preset_by_resolution
 from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.decorators import authentication_classes, permission_classes
+from wsgiref.util import FileWrapper
 
 
 @authentication_classes((TokenAuthentication, SessionAuthentication))
@@ -212,3 +214,16 @@ def exercise_image_upload(request):
         "file_id": file_object.pk,
         "path": generate_storage_url(str(file_object)),
     }))
+
+@authentication_classes((TokenAuthentication, SessionAuthentication))
+@permission_classes((IsAuthenticated,))
+def debug_serve_file(request, path):
+    # There's a problem with loading exercise images, so use this endpoint
+    # to serve the image files to the /content/storage url
+    filename = os.path.basename(path)
+    checksum, _ext = os.path.splitext(filename)
+    filepath = generate_object_storage_name(checksum, filename)
+
+    with default_storage.open(filepath, 'rb') as fobj:
+        response = HttpResponse(FileWrapper(fobj))
+        return response


### PR DESCRIPTION
## Description

Exercises with images need to use the /content/storage url to get images and can't use absolute urls. This will serve up files using the storage system at this endpoint (debug mode only)
