### PR TITLE
Use a shared database cache. Fixes #803.

### DIFF
--- a/contentcuration/contentcuration/management/commands/setup.py
+++ b/contentcuration/contentcuration/management/commands/setup.py
@@ -38,6 +38,9 @@ class Command(BaseCommand):
             print "{} is not a valid email".format(email)
             sys.exit()
 
+        # create the cache table
+        call_command("createcachetable")
+
         # Run migrations
         call_command('migrate')
 

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -77,6 +77,13 @@ INSTALLED_APPS = (
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'studio_db_cache',
+    }
+}
+
 MIDDLEWARE_CLASSES = (
     # 'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
The default was a local memory cache, which was fast, but led to discrepancies
in each app's cache. Also added the `createcachetable` command as part of setup.

