### PR TITLE
Merge user clipboard sort_order fix and _check_tree_space sanity check

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -58,6 +58,21 @@ DEFAULT_CONTENT_DEFAULTS = {
 DEFAULT_USER_PREFERENCES = json.dumps(DEFAULT_CONTENT_DEFAULTS, ensure_ascii=False)
 
 
+# Added 7-31-2018. We can remove this once we are certain we have eliminated all cases
+# where root nodes are getting prepended rather than appended to the tree list.
+def _create_tree_space(self, target_tree_id, num_trees=1):
+    """
+    Creates space for a new tree by incrementing all tree ids
+    greater than ``target_tree_id``.
+    """
+
+    if target_tree_id == -1:
+        raise Exception("ERROR: Calling _create_tree_space with -1! Something is attempting to sort all MPTT trees root nodes!")
+
+    self._orig_create_tree_space(target_tree_id, num_trees)
+
+TreeManager._orig_create_tree_space = TreeManager._create_tree_space
+TreeManager._create_tree_space = _create_tree_space
 
 
 class UserManager(BaseUserManager):

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -216,7 +216,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         if not self.clipboard_tree:
             self.clipboard_tree = ContentNode.objects.create(title=self.email + " clipboard", kind_id="topic",
-                                                             sort_order=0)
+                                                             sort_order=get_next_sort_order())
             self.clipboard_tree.save()
             changed = True
 


### PR DESCRIPTION
## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
