### PR TITLE
Send error reports to sentry.io

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -56,6 +56,7 @@ google-cloud-core = ">=0.28.1"
 gspread = "==3.0.1"
 google-api-python-client = "==1.6.4"
 django-db-readonly = "==0.5.0"
+raven = "*"
 
 [dev-packages]
 python-language-server = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d88b6d20788c6ec4cae6f82d3997ec45d927b9863163ee86cf40d917a5dc1db9"
+            "sha256": "d900ce5220bc4c03169088bedd50810e47280eee0b8b8f4aedfb15e48045a2b5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -52,17 +52,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:24f2de3eb977f31f9acca2abf661f8ae5b0ce82f6847d458bb13332ada7d17c6",
-                "sha256:c8492a53e0bfeca83fa03273dff7ab7d5ac5cf78a0ce1b7e9fc7f241ca6f4dd4"
+                "sha256:3ec81575237a56a3cc31e963bb7ef8847752b41dd8343a8a758d466830215772",
+                "sha256:8f0f16ad7a6672b7748f2fa753f44007ada17ffb8767bb59dbd73f26ec6d265a"
             ],
-            "version": "==1.7.65"
+            "version": "==1.7.66"
         },
         "botocore": {
             "hashes": [
-                "sha256:35f626029a6b17bfd503ce3379b121606e3f965edcab2612bc75ce8603fdf08c",
-                "sha256:db223c2d8004ebc9325e8b15d7c5ac87b66636fd76ce3f0caabc8f8ab2df8ef7"
+                "sha256:cc09308c7923331a330d02df055a966bd28657cb7b68b00ea1f3264599df133b",
+                "sha256:e8e120af179aef5df247178c94627836239c1ffb22694087d48e3fc57af3062e"
             ],
-            "version": "==1.10.65"
+            "version": "==1.10.66"
         },
         "cachetools": {
             "hashes": [
@@ -100,13 +100,13 @@
             ],
             "version": "==6.7"
         },
-        "colorama": {
+        "contextlib2": {
             "hashes": [
-                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
-                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+                "sha256:509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48",
+                "sha256:f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00"
             ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.3.9"
+            "markers": "python_version < '3.2'",
+            "version": "==0.5.5"
         },
         "cycler": {
             "hashes": [
@@ -277,7 +277,7 @@
                 "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
                 "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
             ],
-            "markers": "python_version < '3.2'",
+            "markers": "python_version == '2.6' or python_version == '2.7'",
             "version": "==3.2.0"
         },
         "google-api-core": {
@@ -359,7 +359,6 @@
             "hashes": [
                 "sha256:c075eddaa2628ab519e01b7d75b76e66c40eaa50fc52758d8225f84708950ef2"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==1.5.3"
         },
         "grpcio": {
@@ -490,7 +489,6 @@
                 "sha256:583179dc8d49b040a9da79bd33de59e160d2a8802b939e304eb359a4419f6498",
                 "sha256:dd4469a8f5a6833576e9f5433f1439c306de15dbbfeceabd32479b1123380fa5"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.5.2"
         },
         "markdown": {
@@ -657,7 +655,6 @@
                 "sha256:ddd16ab250b4fc97db1c47407e78c25216a75c29d29d10ad37e51b7a2ec7b2c3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==5.0.0"
         },
         "port-for": {
@@ -706,7 +703,6 @@
                 "sha256:d7ac50bc06d31deb07ace6de85556c1d7330e5c0958f3b2af85037d6d1182abf",
                 "sha256:dfe6899304b898538f4dc94fa0b281b56b70e40f58afa4c6f807805261cbe2e8"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==3.6.0"
         },
         "psutil": {
@@ -856,6 +852,14 @@
             ],
             "version": "==3.13"
         },
+        "raven": {
+            "hashes": [
+                "sha256:3fd787d19ebb49919268f06f19310e8112d619ef364f7989246fc8753d469888",
+                "sha256:95f44f3ea2c1b176d5450df4becdb96c15bf2632888f9ab193e9dd22300ce46a"
+            ],
+            "index": "pypi",
+            "version": "==6.9.0"
+        },
         "redis": {
             "hashes": [
                 "sha256:5dfbae6acfc54edf0a7a415b99e0b21c0a3c27a7f787b292eea727b1facc5533",
@@ -972,7 +976,6 @@
                 "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
                 "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "sqlalchemy": {
@@ -987,7 +990,6 @@
                 "sha256:24b66882f5f7aaedcd46b4669322e88d639d46c6ce4679ae7f397bbe4fe9a529",
                 "sha256:eb2b989cf03ffc7166339eb34f1aa26c5ace255243337b1e22dab7caa1166687"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
             "version": "==3.5.2"
         },
         "tornado": {
@@ -1025,7 +1027,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
             "version": "==1.23"
         },
         "validators": {
@@ -1089,7 +1090,6 @@
                 "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
                 "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
             ],
-            "markers": "python_version >= '2.6'",
             "version": "==1.6.5"
         },
         "atomicwrites": {
@@ -1133,7 +1133,6 @@
                 "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
                 "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
             ],
-            "markers": "sys_platform == 'win32'",
             "version": "==0.3.9"
         },
         "configparser": {
@@ -1202,7 +1201,7 @@
                 "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
                 "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
             ],
-            "markers": "python_version < '3.3'",
+            "markers": "python_version < '3.0'",
             "version": "==1.0.2"
         },
         "future": {
@@ -1216,7 +1215,7 @@
                 "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
                 "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
             ],
-            "markers": "python_version < '3.2'",
+            "markers": "python_version == '2.6' or python_version == '2.7'",
             "version": "==3.2.0"
         },
         "importmagic": {
@@ -1318,11 +1317,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "parso": {
             "hashes": [
@@ -1330,6 +1329,14 @@
                 "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
             ],
             "version": "==0.3.1"
+        },
+        "pathlib2": {
+            "hashes": [
+                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
+                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
+            ],
+            "markers": "python_version < '3.6'",
+            "version": "==2.3.2"
         },
         "pathtools": {
             "hashes": [
@@ -1346,12 +1353,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
-                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
+                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
             "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
-            "version": "==0.6.0"
+            "version": "==0.7.1"
         },
         "py": {
             "hashes": [
@@ -1400,11 +1406,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:341ec10361b64a24accaec3c7ba5f7d5ee1ca4cebea30f76fad3dd12db9f0541",
-                "sha256:952c0389db115437f966c4c2079ae9d54714b9455190e56acebe14e8c38a7efa"
+                "sha256:8214ab8446104a1d0c17fbd218ec6aac743236c6ffbe23abc038e40213c60b88",
+                "sha256:e2b2c6e1560b8f9dc8dd600b0923183fbd68ba3d9bdecde04467be6dd296a384"
             ],
             "index": "pypi",
-            "version": "==3.6.4"
+            "version": "==3.7.0"
         },
         "pytest-django": {
             "hashes": [
@@ -1472,6 +1478,23 @@
             ],
             "index": "pypi",
             "version": "==0.10.7"
+        },
+        "scandir": {
+            "hashes": [
+                "sha256:24f32112c483ac6c4a40b62f1282e61ecca7977153b66a0d26a9583a716dcb64",
+                "sha256:6c80092f8fe3e62c3da3110067589c6661c722b0889906d2974e5150f1314523",
+                "sha256:7729b8444c5f5187649ff58501e7c2ad22b84d7dc28f738f64c5b615913fec22",
+                "sha256:8e3ca5925cc13787aeafbf08f055a8066c091fc20bfa8783235b916cf047afbe",
+                "sha256:96dfc553f50946deb6d1cd762bac5cf122832c4aa253c885ca357ef53dd8d072",
+                "sha256:b2d55be869c4f716084a19b1e16932f0769711316ba62de941320bf2be84763d",
+                "sha256:b55a091b91f9e6c9c7129889b2f58df329530172a99172de9e784545342a45e6",
+                "sha256:b6cb611a18a828146a178362a36a2c6557c51c596ded4314cb516dd8c947b4ce",
+                "sha256:d985e36eb3effebb20434e6cd7495440b4ba676a22f3ec61e9fff9f3e2995238",
+                "sha256:f39dd5affde2860fb28176d2233f318ccca97c55019407ee8172b3fba0b211db",
+                "sha256:f91418e82edb5a43b020fa15e30a41d730b71c5957536749366bf63cc05427b1"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==1.7"
         },
         "service-factory": {
             "hashes": [

--- a/cloudbuild-production.yaml
+++ b/cloudbuild-production.yaml
@@ -67,7 +67,7 @@ steps:
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
   - 'CLOUDSDK_CONTAINER_CLUSTER=contentworkshop-central'
-  secretEnv: ['POSTMARK_API_KEY', 'POSTGRES_USERNAME', 'POSTGRES_DATABASE', 'POSTGRES_PASSWORD']
+  secretEnv: ['POSTMARK_API_KEY', 'POSTGRES_USERNAME', 'POSTGRES_DATABASE', 'POSTGRES_PASSWORD', 'SENTRY_DSN_KEY']
   entrypoint: 'bash'
   args:
     - -c
@@ -86,6 +86,7 @@ steps:
       $PROJECT_ID
       is_production
       ../gdrive-service-account.json
+      $$SENTRY_DSN_KEY
 
 substitutions:
   _DATABASE_INSTANCE_NAME: develop  # by default, connect to the develop DB
@@ -112,6 +113,9 @@ secrets:
 - kmsKeyName: projects/contentworkshop-159920/locations/global/keyRings/prod-secrets/cryptoKeys/crowdinApiKey
   secretEnv:
     CROWDIN_API_KEY: CiQA5yVB2KLpFiuaF4kAmNS2+I04GTIBpEl3hy4Px21xpuApka0SSQC1m2SkfC/mzvR1KhoNaKzDHQRG7SyPI69iG/NTjNwV/u56To3swMhMqsD1ErNTITgnZEloUXAPpGSJAL+LLJB0fbzhMsE4cpY=
+- kmsKeyName: projects/contentworkshop-159920/locations/global/keyRings/prod-secrets/cryptoKeys/sentryKey
+  secretEnv:
+    SENTRY_DSN_KEY: CiQAymGxx8tU8G23aFWKz52KLPvwY+EnKDPDMI4WZtVGtw7CJi8SagAaZGpaLvlDDdn2Nr4zJLLOxy3tpnzdteSDe8NJsQiIv8iSiULHOeA9wtZKSyzNWOv+gZrIAqgjipz7Sznm1sXC//qusnMFntzLOlRE3nJy9jp5h0XtCIY5grq/xUIW5MCeEDVf66sWO5U=
 
 images:
   - gcr.io/$PROJECT_ID/learningequality-studio-nginx:latest

--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -1,4 +1,5 @@
 import os
+import raven
 from .settings import *
 
 MEDIA_ROOT = STORAGE_ROOT
@@ -17,3 +18,15 @@ LANGUAGE_CODE = os.getenv("LANGUAGE_CODE") or "en"
 # Google drive settings
 GOOGLE_STORAGE_REQUEST_SHEET = "1uC1nsJPx_5g6pQT6ay0qciUVya0zUFJ8wIwbsTEh60Y"
 GOOGLE_AUTH_JSON = os.getenv("GOOGLE_DRIVE_AUTH_JSON") or GOOGLE_AUTH_JSON
+
+key = (os.getenv("SENTRY_DSN_KEY")
+       .strip())                # strip any possible trailing newline
+release_commit =  os.getenv("RELEASE_COMMIT_SHA")
+if key and release_commit:
+    RAVEN_CONFIG = {
+        'dsn': 'https://{secret}@sentry.io/1252819'.format(secret=key),
+        # If you are using git, you can also automatically configure the
+        # release based on the git info.
+        'release': release_commit,
+        'environment': os.getenv("BRANCH_ENVIRONMENT"),
+    }

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'rest_framework',
+    'raven.contrib.django.raven_compat',
     'django_js_reverse',
     'kolibri_content',
     'readonly',

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -21,11 +21,13 @@ else
 fi
 
 GDRIVE_SERVICE_ACCOUNT_JSON=${12}
+SENTRY_DSN_KEY=${13}
 
 helm upgrade --install $BRANCH . \
      -f values-prod-config.yaml \
      --set studioApp.imageName=gcr.io/$PROJECT_ID/learningequality-studio-app:$COMMIT \
      --set studioNginx.imageName=gcr.io/$PROJECT_ID/learningequality-studio-nginx:$COMMIT \
+     --set studioApp.releaseCommit=$COMMIT} \
      --set bucketName=$BUCKET \
      --set studioApp.postmarkApiKey=$POSTMARK_KEY \
      --set postgresql.postgresUser=$POSTGRES_USER \
@@ -34,4 +36,5 @@ helm upgrade --install $BRANCH . \
      --set postgresql.externalCloudSQL.proxyHostName=$GCLOUD_PROXY_HOSTNAME \
      --set minio.externalGoogleCloudStorage.gcsKeyJson=$(base64 $GCS_SERVICE_ACCOUNT_JSON --wrap=0) \
      --set productionIngress=$IS_PRODUCTION \
-     --set studioApp.gDrive.keyJson=$(base64 $GDRIVE_SERVICE_ACCOUNT_JSON  --wrap=0)
+     --set studioApp.gDrive.keyJson=$(base64 $GDRIVE_SERVICE_ACCOUNT_JSON  --wrap=0) \
+     --set sentry.dsnKey=$(echo "$SENTRY_DSN_KEY" | base64 --wrap=0)

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -71,6 +71,16 @@ spec:
               key: secretkey
               name: {{ template "minio.fullname" . }}
         {{ end }}
+        - name: RELEASE_COMMIT_SHA
+          value: {{ .Values.studioApp.releaseCommit | default "" }}
+        - name: BRANCH_ENVIRONMENT
+          value: {{ .Release.Name }}
+        - name: SENTRY_DSN_KEY
+          valueFrom:
+            secretKeyRef:
+              key: sentry-dsn-key
+              name: {{ template "studio.fullname" . }}
+              optional: true
         - name: AWS_BUCKET_NAME
           value: {{ .Values.bucketName }}
         {{ if .Values.minio.externalGoogleCloudStorage.gcsKeyJson }}
@@ -223,6 +233,16 @@ spec:
               key: secretkey
               name: {{ template "minio.fullname" . }}
         {{ end }}
+        - name: RELEASE_COMMIT_SHA
+          value: {{ .Values.studioApp.releaseCommit | default "" }}
+        - name: BRANCH_ENVIRONMENT
+          value: {{ .Release.Name }}
+        - name: SENTRY_DSN_KEY
+          valueFrom:
+            secretKeyRef:
+              key: sentry-dsn-key
+              name: {{ template "studio.fullname" . }}
+              optional: true
         - name: AWS_BUCKET_NAME
           value: {{ .Values.bucketName }}
         {{ if .Values.minio.externalGoogleCloudStorage.gcsKeyJson }}

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -13,3 +13,6 @@ data:
   postgres-user: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
   postgres-password: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
   postgres-database: {{ .Values.postgresql.postgresDatabase | default "" | b64enc }}
+  {{ if .Values.sentry.dsnKey }}
+  sentry-dsn-key: {{ .Values.sentry.dsnKey }}
+  {{ end }}

--- a/k8s/values-prod-config.yaml
+++ b/k8s/values-prod-config.yaml
@@ -16,11 +16,15 @@ productionIngress: false
 studioApp:
   imageName: "REPLACEME"        
   postmarkApiKey: "REPLACEME"
+  releaseCommit:
   replicas: 3
   gcs:
     enabled: true
   gDrive:
     keyJson:
+
+sentry:
+  dsnKey: ""
 
 studioNginx:
   imageName: "REPLACEME"

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ django-webpack-loader==0.6.0
 gspread==3.0.1
 google-api-python-client==1.6.4
 django-db-readonly==0.5.0
+raven==6.9.0


### PR DESCRIPTION
We now have a [Sentry dashboard](https://sentry.io/learningequality/studio/) for all error reports, with much more context and helpful information than the old Google Cloud error reports.

Integration here involved adding sentry to our python code, and adding the secrets to our build and deployment pipeline.

For now, there's no user dialog box created, but we do get any backend errors at least.