### PR TITLE
Fix token assignment when it already exists for some reason.

### DIFF
--- a/contentcuration/contentcuration/management/commands/exportchannel.py
+++ b/contentcuration/contentcuration/management/commands/exportchannel.py
@@ -593,7 +593,7 @@ def add_tokens_to_channel(channel):
                 raise ValueError("Cannot generate new token")
 
         tk_human = ccmodels.SecretToken.objects.create(token=token, is_primary=True)
-        tk = ccmodels.SecretToken.objects.create(token=channel.id)
+        tk = ccmodels.SecretToken.objects.get_or_create(token=channel.id)
         channel.secret_tokens.add(tk_human, tk)
 
 def fill_published_fields(channel):

--- a/contentcuration/contentcuration/management/commands/exportchannel.py
+++ b/contentcuration/contentcuration/management/commands/exportchannel.py
@@ -593,7 +593,7 @@ def add_tokens_to_channel(channel):
                 raise ValueError("Cannot generate new token")
 
         tk_human = ccmodels.SecretToken.objects.create(token=token, is_primary=True)
-        tk = ccmodels.SecretToken.objects.get_or_create(token=channel.id)
+        tk, _new = ccmodels.SecretToken.objects.get_or_create(token=channel.id)
         channel.secret_tokens.add(tk_human, tk)
 
 def fill_published_fields(channel):


### PR DESCRIPTION
Fixes #858. Don't error out when a token for a channel already exists.

Instead just get it and reassign to the channel.