### PR TITLE
Increase NGINX tolerance to long-running requests

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -41,6 +41,7 @@ http {
             proxy_pass         http://studio;
             proxy_redirect     off;
             proxy_set_header   Host $host;
+            proxy_read_timeout 500s;
         }
 
         location /content/ {


### PR DESCRIPTION
## or "Don't let the Russians tell us what we can or cannot POST!" ;)

Change the PROD configs for studio to not timeout after 30secs ([default value](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout)), but 500secs

Value chosen to match Studio gunicorn timout in
see https://github.com/learningequality/studio/blob/develop/deploy/gunicorn.py#L70

 - Aron @aronasorman (back end, devops)
