### PR TITLE
Store deleted chefs in a separate tree and always disable MPTT updates…

### DIFF
--- a/contentcuration/contentcuration/api.py
+++ b/contentcuration/contentcuration/api.py
@@ -217,10 +217,12 @@ def activate_channel(channel, user):
     user.check_channel_space(channel)
 
     if channel.previous_tree and channel.previous_tree != channel.main_tree:
-        garbage_node = models.ContentNode.objects.get(pk=settings.ORPHANAGE_ROOT_ID)
-        channel.previous_tree.parent = garbage_node
-        channel.previous_tree.title = "Previous tree for channel {}".format(channel.pk)
-        channel.previous_tree.save()
+        # IMPORTANT: Do not remove this block, MPTT updating the deleted chefs block could hang the server
+        with models.ContentNode.objects.disable_mptt_updates():
+            garbage_node, _new = models.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+            channel.previous_tree.parent = garbage_node
+            channel.previous_tree.title = "Previous tree for channel {}".format(channel.pk)
+            channel.previous_tree.save()
 
     channel.previous_tree = channel.main_tree
     channel.main_tree = channel.staging_tree

--- a/contentcuration/contentcuration/api.py
+++ b/contentcuration/contentcuration/api.py
@@ -17,6 +17,7 @@ from django.http import HttpResponse
 from django.utils.translation import ugettext as _
 from le_utils.constants import format_presets, content_kinds, file_formats
 import contentcuration.models as models
+from contentcuration.utils.garbage_collect import get_deleted_chefs_root
 from contentcuration.tasks import deletetree_task
 
 def check_health_check_browser(user_agent_string):
@@ -219,7 +220,7 @@ def activate_channel(channel, user):
     if channel.previous_tree and channel.previous_tree != channel.main_tree:
         # IMPORTANT: Do not remove this block, MPTT updating the deleted chefs block could hang the server
         with models.ContentNode.objects.disable_mptt_updates():
-            garbage_node, _new = models.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+            garbage_node = get_deleted_chefs_root()
             channel.previous_tree.parent = garbage_node
             channel.previous_tree.title = "Previous tree for channel {}".format(channel.pk)
             channel.previous_tree.save()

--- a/contentcuration/contentcuration/management/commands/garbage_collect.py
+++ b/contentcuration/contentcuration/management/commands/garbage_collect.py
@@ -6,7 +6,7 @@ database and in object storage.
 """
 from django.core.management.base import BaseCommand
 
-from contentcuration.utils.garbage_collect import clean_up_contentnodes
+from contentcuration.utils.garbage_collect import clean_up_contentnodes, clean_up_deleted_chefs
 
 
 class Command(BaseCommand):
@@ -19,3 +19,4 @@ class Command(BaseCommand):
         # clean up contentnodes, files and file objects on storage that are associated
         # with the orphan tree
         clean_up_contentnodes()
+        clean_up_deleted_chefs()

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -336,4 +336,4 @@ ORPHANAGE_ROOT_ID = "00000000000000000000000000000000"
 # of the tree. This tree is special in that it should always be accessed inside a disable_mptt_updates code block,
 # so we must be very careful to limit code that touches this tree and to carefully check code that does. If we
 # do choose to implement restore of old chefs, we will need to ensure moving nodes does not cause a tree sort.
-DELETED_CHEFS_ROOT_ID = "00000000000000000000000000000000"
+DELETED_CHEFS_ROOT_ID = "11111111111111111111111111111111"

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -331,3 +331,9 @@ GOOGLE_STORAGE_REQUEST_SHEET = "16X6zcFK8FS5t5tFaGpnxbWnWTXP88h4ccpSpPbyLeA8"
 
 # Used as the default parent to collect orphan nodes
 ORPHANAGE_ROOT_ID = "00000000000000000000000000000000"
+
+# IMPORTANT: Deleted chefs should not be in the orhpanage becuase this can lead to very large and painful resorts
+# of the tree. This tree is special in that it should always be accessed inside a disable_mptt_updates code block,
+# so we must be very careful to limit code that touches this tree and to carefully check code that does. If we
+# do choose to implement restore of old chefs, we will need to ensure moving nodes does not cause a tree sort.
+DELETED_CHEFS_ROOT_ID = "00000000000000000000000000000000"

--- a/contentcuration/contentcuration/tests/test_garbage_collect.py
+++ b/contentcuration/contentcuration/tests/test_garbage_collect.py
@@ -34,7 +34,6 @@ def _create_expired_contentnode(creation_date=THREE_MONTHS_AGO):
 
 
 class CleanUpContentNodesTestCase(StudioTestCase):
-
     def test_delete_all_contentnodes_in_orphanage_tree(self):
         """
         Make sure that by default, all nodes created with a timestamp of 3 months

--- a/contentcuration/contentcuration/tests/test_garbage_collection.py
+++ b/contentcuration/contentcuration/tests/test_garbage_collection.py
@@ -7,7 +7,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse_lazy
 from contentcuration import models as cc
 from contentcuration.api import activate_channel
-from contentcuration.utils.garbage_collect import clean_up_deleted_chefs
+from contentcuration.utils.garbage_collect import clean_up_deleted_chefs, get_deleted_chefs_root
 
 from base import BaseAPITestCase
 from testdata import tree
@@ -71,7 +71,7 @@ class NodeSettingTestCase(BaseAPITestCase):
         tree(parent=self.channel.chef_tree)
         chef_tree = self.channel.chef_tree
         self.assertTrue(chef_tree.get_descendant_count() > 0)
-        garbage_node, _new = cc.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+        garbage_node = get_deleted_chefs_root()
 
         self.assertNotEqual(chef_tree, self.channel.staging_tree)
         # Chef tree shouldn't be in garbage tree until create_channel is called
@@ -99,7 +99,7 @@ class NodeSettingTestCase(BaseAPITestCase):
 
     def test_old_staging_tree(self):
         staging_tree = self.channel.staging_tree
-        garbage_node, _new = cc.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+        garbage_node = get_deleted_chefs_root()
 
         tree(parent=staging_tree)
         self.assertTrue(staging_tree.get_descendant_count() > 0)
@@ -131,7 +131,7 @@ class NodeSettingTestCase(BaseAPITestCase):
     def test_activate_channel(self):
         previous_tree = self.channel.previous_tree
         tree(parent=previous_tree)
-        garbage_node, _new = cc.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+        garbage_node = get_deleted_chefs_root()
 
         # Previous tree shouldn't be in garbage tree until activate_channel is called
         self.assertFalse(garbage_node.get_descendants().filter(pk=previous_tree.pk).exists())

--- a/contentcuration/contentcuration/tests/test_garbage_collection.py
+++ b/contentcuration/contentcuration/tests/test_garbage_collection.py
@@ -7,8 +7,10 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse_lazy
 from contentcuration import models as cc
 from contentcuration.api import activate_channel
+from contentcuration.utils.garbage_collect import clean_up_deleted_chefs
 
 from base import BaseAPITestCase
+from testdata import tree
 
 from contentcuration.views.files import file_create
 from contentcuration.views.internal import create_channel, api_commit_channel
@@ -65,9 +67,13 @@ class NodeSettingTestCase(BaseAPITestCase):
 
 
     def test_old_chef_tree(self):
+        # make an actual tree for deletion tests
+        tree(parent=self.channel.chef_tree)
         chef_tree = self.channel.chef_tree
-        garbage_node = cc.ContentNode.objects.get(pk=settings.ORPHANAGE_ROOT_ID)
+        self.assertTrue(chef_tree.get_descendant_count() > 0)
+        garbage_node, _new = cc.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
 
+        self.assertNotEqual(chef_tree, self.channel.staging_tree)
         # Chef tree shouldn't be in garbage tree until create_channel is called
         self.assertFalse(garbage_node.get_descendants().filter(pk=chef_tree.pk).exists())
         create_channel(self.channel.__dict__, self.user)
@@ -75,17 +81,28 @@ class NodeSettingTestCase(BaseAPITestCase):
         chef_tree.refresh_from_db()
         self.channel.refresh_from_db()
 
-        # Old chef tree should be in garbage tree now
-        self.assertTrue(garbage_node.get_descendants().filter(pk=chef_tree.pk).exists())
-        self.assertEqual(garbage_node.tree_id, chef_tree.tree_id)
+        # We can't use MPTT methods to test the deleted chefs tree because we are not running the sort code
+        # for performance reasons, so just do a parent test instead.
+        self.assertEquals(chef_tree.parent.pk, garbage_node.pk)
 
-        # New chef tree should not be in garbage tree
-        self.assertFalse(garbage_node.get_descendants().filter(pk=self.channel.chef_tree.pk).exists())
+        # New staging tree should not be in garbage tree
+        self.assertFalse(self.channel.chef_tree.parent)
         self.assertNotEqual(garbage_node.tree_id, self.channel.chef_tree.tree_id)
+
+        child_pk = chef_tree.children.first().pk
+
+        clean_up_deleted_chefs()
+
+        self.assertFalse(cc.ContentNode.objects.filter(parent=garbage_node).exists())
+        self.assertFalse(cc.ContentNode.objects.filter(pk=child_pk).exists())
+
 
     def test_old_staging_tree(self):
         staging_tree = self.channel.staging_tree
-        garbage_node = cc.ContentNode.objects.get(pk=settings.ORPHANAGE_ROOT_ID)
+        garbage_node, _new = cc.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+
+        tree(parent=staging_tree)
+        self.assertTrue(staging_tree.get_descendant_count() > 0)
 
         # Staging tree shouldn't be in garbage tree until api_commit_channel is called
         self.assertFalse(garbage_node.get_descendants().filter(pk=staging_tree.pk).exists())
@@ -96,17 +113,25 @@ class NodeSettingTestCase(BaseAPITestCase):
         staging_tree.refresh_from_db()
         self.channel.refresh_from_db()
 
-        # Old staging tree should be in garbage tree now
-        self.assertTrue(garbage_node.get_descendants().filter(pk=staging_tree.pk).exists())
-        self.assertEqual(garbage_node.tree_id, staging_tree.tree_id)
+        # We can't use MPTT methods on the deleted chefs tree because we are not running the sort code
+        # for performance reasons, so just do a parent test instead.
+        self.assertEqual(staging_tree.parent, garbage_node)
 
         # New staging tree should not be in garbage tree
-        self.assertFalse(garbage_node.get_descendants().filter(pk=self.channel.main_tree.pk).exists())
+        self.assertFalse(self.channel.main_tree.parent)
         self.assertNotEqual(garbage_node.tree_id, self.channel.main_tree.tree_id)
+
+        child_pk = staging_tree.children.first().pk
+
+        clean_up_deleted_chefs()
+
+        self.assertFalse(cc.ContentNode.objects.filter(parent=garbage_node).exists())
+        self.assertFalse(cc.ContentNode.objects.filter(pk=child_pk).exists())
 
     def test_activate_channel(self):
         previous_tree = self.channel.previous_tree
-        garbage_node = cc.ContentNode.objects.get(pk=settings.ORPHANAGE_ROOT_ID)
+        tree(parent=previous_tree)
+        garbage_node, _new = cc.ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
 
         # Previous tree shouldn't be in garbage tree until activate_channel is called
         self.assertFalse(garbage_node.get_descendants().filter(pk=previous_tree.pk).exists())
@@ -115,10 +140,17 @@ class NodeSettingTestCase(BaseAPITestCase):
         previous_tree.refresh_from_db()
         self.channel.refresh_from_db()
 
-        # Old previous tree should be in garbage tree now
-        self.assertTrue(garbage_node.get_descendants().filter(pk=previous_tree.pk).exists())
-        self.assertEqual(garbage_node.tree_id, previous_tree.tree_id)
+        # We can't use MPTT methods on the deleted chefs tree because we are not running the sort code
+        # for performance reasons, so just do a parent test instead.
+        self.assertTrue(previous_tree.parent == garbage_node)
 
         # New previous tree should not be in garbage tree
-        self.assertFalse(garbage_node.get_descendants().filter(pk=self.channel.previous_tree.pk).exists())
+        self.assertFalse(self.channel.previous_tree.parent)
         self.assertNotEqual(garbage_node.tree_id, self.channel.previous_tree.tree_id)
+
+        child_pk = previous_tree.children.first().pk
+
+        clean_up_deleted_chefs()
+
+        self.assertFalse(cc.ContentNode.objects.filter(parent=garbage_node).exists())
+        self.assertFalse(cc.ContentNode.objects.filter(pk=child_pk).exists())

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -133,16 +133,21 @@ def node(data, parent=None):
 
     return new_node
 
-def channel():
-    channel = cc.Channel.objects.create(name="testchannel")
-    channel.save()
 
+def tree(parent=None):
     # Read from json fixture
     filepath = os.path.sep.join([os.path.dirname(__file__), "fixtures", "tree.json"])
     with open(filepath, "rb") as jsonfile:
         data = json.load(jsonfile)
 
-    channel.main_tree = node(data)
+    return node(data, parent)
+
+
+def channel():
+    channel = cc.Channel.objects.create(name="testchannel")
+    channel.save()
+
+    channel.main_tree = tree()
     channel.save()
 
     return channel

--- a/contentcuration/contentcuration/utils/garbage_collect.py
+++ b/contentcuration/contentcuration/utils/garbage_collect.py
@@ -8,6 +8,24 @@ from django.core.files.storage import default_storage as storage
 from contentcuration.models import ContentNode, File
 
 
+def clean_up_deleted_chefs():
+    """
+    Clean up all deleted chefs attached to the deleted chefs tree, including all
+    child nodes in that tree.
+
+    """
+    deleted_chefs_node, _new = ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+    # we cannot use MPTT methods like get_descendants() or use tree_id because for performance reasons
+    # we are avoiding MPTT entirely.
+    nodes_to_clean_up = ContentNode.objects.filter(parent=deleted_chefs_node)
+
+    # don't delete files until we can ensure files are not referenced anywhere.
+    for node in nodes_to_clean_up:
+        node.delete()
+
+    assert not ContentNode.objects.filter(parent=deleted_chefs_node).exists()
+
+
 def clean_up_contentnodes(delete_older_than=settings.ORPHAN_DATE_CLEAN_UP_THRESHOLD):
     """
     Clean up all contentnodes associated with the orphan tree with a `created`
@@ -28,7 +46,7 @@ def clean_up_contentnodes(delete_older_than=settings.ORPHAN_DATE_CLEAN_UP_THRESH
     clean_up_files(nodes_to_clean_up)
 
     # Use _raw_delete for fast bulk deletions
-    nodes_to_clean_up._raw_delete(nodes_to_clean_up.db)
+    nodes_to_clean_up.delete()
     # tell MPTT to rebuild our tree values, so descendant counts
     # will be right again.
     ContentNode._tree_manager.partial_rebuild(tree_id)

--- a/contentcuration/contentcuration/utils/garbage_collect.py
+++ b/contentcuration/contentcuration/utils/garbage_collect.py
@@ -6,6 +6,12 @@ from django.conf import settings
 from django.core.files.storage import default_storage as storage
 
 from contentcuration.models import ContentNode, File
+from le_utils.constants import content_kinds
+
+
+def get_deleted_chefs_root():
+    deleted_chefs_node, _new = ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID, kind_id=content_kinds.TOPIC)
+    return deleted_chefs_node
 
 
 def clean_up_deleted_chefs():
@@ -14,7 +20,7 @@ def clean_up_deleted_chefs():
     child nodes in that tree.
 
     """
-    deleted_chefs_node, _new = ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+    deleted_chefs_node = get_deleted_chefs_root()
     # we cannot use MPTT methods like get_descendants() or use tree_id because for performance reasons
     # we are avoiding MPTT entirely.
     nodes_to_clean_up = ContentNode.objects.filter(parent=deleted_chefs_node)

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -22,6 +22,7 @@ from contentcuration.api import get_staged_diff, write_file_to_storage, activate
 from contentcuration.models import AssessmentItem, Channel, ContentNode, ContentTag, File, FormatPreset, Language, License, StagedFile, generate_object_storage_name, get_next_sort_order
 from contentcuration.utils.tracing import trace
 from contentcuration.utils.files import get_file_diff
+from contentcuration.utils.garbage_collect import get_deleted_chefs_root
 
 VersionStatus = namedtuple('VersionStatus', ['version', 'status', 'message'])
 VERSION_OK = VersionStatus(version=rc.VERSION_OK, status=0, message=rc.VERSION_OK_MESSAGE)
@@ -193,7 +194,7 @@ def api_commit_channel(request):
         if old_staging and old_staging != obj.main_tree:
             # IMPORTANT: Do not remove this block, MPTT updating the deleted chefs block could hang the server
             with ContentNode.objects.disable_mptt_updates():
-                garbage_node = ContentNode.objects.get(pk=settings.DELETED_CHEFS_ROOT_ID)
+                garbage_node = get_deleted_chefs_root()
                 old_staging.parent = garbage_node
                 old_staging.title = "Old staging tree for channel {}".format(obj.pk)
                 old_staging.save()
@@ -471,7 +472,7 @@ def create_channel(channel_data, user):
     if old_chef_tree and old_chef_tree != channel.staging_tree:
         # IMPORTANT: Do not remove this block, MPTT updating the deleted chefs block could hang the server
         with ContentNode.objects.disable_mptt_updates():
-            garbage_node, _new = ContentNode.objects.get_or_create(pk=settings.DELETED_CHEFS_ROOT_ID)
+            garbage_node = get_deleted_chefs_root()
             old_chef_tree.parent = garbage_node
             old_chef_tree.title = "Old chef tree for channel {}".format(channel.pk)
             old_chef_tree.save()


### PR DESCRIPTION
…before accessing it.

## Description

Adding deleted chef trees to the orphanage would cause it to balloon in size, and adding, moving, or removing would cause very expensive sort operations. This change keeps deleted chef data in a separate tree, one in which we always disable MPTT sorting when accessing.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [x] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
