### PR TITLE
[django1.11] use FormatPresetSerializer as a PrimaryKeyRelatedField serializer

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -50,7 +50,7 @@ class FileFormatSerializer(serializers.ModelSerializer):
         fields = ("__all__")
 
 
-class FormatPresetSerializer(serializers.ModelSerializer):
+class FormatPresetSerializer(serializers.PrimaryKeyRelatedField):
     # files = FileSerializer(many=True, read_only=True)
     associated_mimetypes = serializers.SerializerMethodField('retrieve_mimetypes')
     # Handles multi-language content (Backbone won't allow duplicate ids in collection, so name retains id)
@@ -76,6 +76,7 @@ class FileListSerializer(serializers.ListSerializer):
         user = self.context['request'].user
         with transaction.atomic():
             for item in validated_data:
+                # import ipdb; ipdb.set_trace()
                 item.update({
                     'preset_id': item['preset']['id'],
                     'language_id': item.get('language')['id'] if item.get('language') else None
@@ -148,7 +149,8 @@ class FileSerializer(BulkSerializerMixin, serializers.ModelSerializer):
     language = LanguageSerializer(many=False, required=False, allow_null=True)
     display_name = serializers.SerializerMethodField('retrieve_display_name')
     id = serializers.CharField(required=False)
-    preset = FormatPresetSerializer(many=False)
+    preset = FormatPresetSerializer(many=False, read_only=True)
+    # preset = serializers.PrimaryKeyRelatedField(many=False, queryset=FormatPreset.objects.all())
 
     def get(*args, **kwargs):
         return super.get(*args, **kwargs)

--- a/contentcuration/contentcuration/utils/files.py
+++ b/contentcuration/contentcuration/utils/files.py
@@ -23,7 +23,7 @@ from pressurecooker.videos import compress_video, extract_thumbnail_from_video
 def create_file_from_contents(contents, ext=None, node=None, preset_id=None, uploaded_by=None):
     checksum, _, path = write_raw_content_to_storage(contents, ext=ext)
     with default_storage.open(path, 'rb') as new_file:
-        import ipdb; ipdb.set_trace()
+        # import ipdb; ipdb.set_trace()
         result = File.objects.create(
             file_on_disk=DjFile(new_file),
             file_format_id=ext,

--- a/contentcuration/contentcuration/utils/files.py
+++ b/contentcuration/contentcuration/utils/files.py
@@ -23,7 +23,8 @@ from pressurecooker.videos import compress_video, extract_thumbnail_from_video
 def create_file_from_contents(contents, ext=None, node=None, preset_id=None, uploaded_by=None):
     checksum, _, path = write_raw_content_to_storage(contents, ext=ext)
     with default_storage.open(path, 'rb') as new_file:
-        return File.objects.create(
+        import ipdb; ipdb.set_trace()
+        result = File.objects.create(
             file_on_disk=DjFile(new_file),
             file_format_id=ext,
             file_size=default_storage.size(path),
@@ -32,6 +33,7 @@ def create_file_from_contents(contents, ext=None, node=None, preset_id=None, upl
             contentnode=node,
             uploaded_by=uploaded_by
         )
+        return result
 
 
 def get_file_diff(files):

--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -55,6 +55,7 @@ def file_create(request):
     if request.method != 'POST':
         return HttpResponseBadRequest("Only POST requests are allowed on this endpoint.")
 
+    import ipdb; ipdb.set_trace()
     original_filename, ext = os.path.splitext(request.FILES.values()[0]._name)
     size = request.FILES.values()[0]._size
     contentfile = DjFile(request.FILES.values()[0])

--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -55,7 +55,7 @@ def file_create(request):
     if request.method != 'POST':
         return HttpResponseBadRequest("Only POST requests are allowed on this endpoint.")
 
-    import ipdb; ipdb.set_trace()
+    # import ipdb; ipdb.set_trace()
     original_filename, ext = os.path.splitext(request.FILES.values()[0]._name)
     size = request.FILES.values()[0]._size
     contentfile = DjFile(request.FILES.values()[0])


### PR DESCRIPTION
(**do not merge**) :stuck_out_tongue_winking_eye:
## Description

This is an attempt to make file uploading and metadata editing work with Django 1.11 and DRF 3.8.  
#### Issue Addressed (if applicable)

see #874 

#### Before/After Screenshots (if applicable)
Now we get this new issue:
![image](https://user-images.githubusercontent.com/389782/44238208-b25b9680-a181-11e8-998b-b046aa0b5f3c.png)

## Steps to Test

- [ ] Upload some content to a channel (e.g. a video)
- [ ] Check the console!  Notice that the file size is 0 bytes!
- [ ] Try to edit and save the metadata.  You will receive an error.