### PR TITLE
Fix short URL redirect handling and fix can_access_channel to handle …

### DIFF
--- a/contentcuration/contentcuration/decorators.py
+++ b/contentcuration/contentcuration/decorators.py
@@ -27,10 +27,10 @@ def browser_is_supported(function):
 
 def is_admin(function):
     def wrap(request, *args, **kwargs):
-        if not request.user.is_admin:
-            return render_to_response('unauthorized.html', context_instance=RequestContext(request))
+        if request.user.is_admin:
+            return function(request, *args, **kwargs)
 
-        return function(request, *args, **kwargs)
+        return render_to_response('unauthorized.html', context_instance=RequestContext(request), status=403)
 
     wrap.__doc__ = function.__doc__
     wrap.__name__ = function.__name__
@@ -47,7 +47,7 @@ def can_access_channel(function):
                 request.user.is_admin:
                 return function(request, *args, **kwargs)
 
-            return render_to_response('unauthorized.html', context_instance=RequestContext(request))
+            return render_to_response('unauthorized.html', context_instance=RequestContext(request), status=403)
         except ObjectDoesNotExist:
             return render_to_response('channel_not_found.html', context_instance=RequestContext(request))
 
@@ -61,7 +61,7 @@ def can_edit_channel(function):
             channel = Channel.objects.get(pk=kwargs['channel_id'], deleted=False)
 
             if not channel.editors.filter(id=request.user.id).exists() and not request.user.is_admin:
-                return render_to_response('unauthorized.html', context_instance=RequestContext(request))
+                return render_to_response('unauthorized.html', context_instance=RequestContext(request), status=403)
 
             return function(request, *args, **kwargs)
         except ObjectDoesNotExist:

--- a/contentcuration/contentcuration/decorators.py
+++ b/contentcuration/contentcuration/decorators.py
@@ -40,16 +40,16 @@ def can_access_channel(function):
     def wrap(request, *args, **kwargs):
         try:
             channel = Channel.objects.get(pk=kwargs['channel_id'])
-
-            if channel.public or \
-                channel.editors.filter(id=request.user.id).exists() or \
-                channel.viewers.filter(id=request.user.id).exists() or \
-                request.user.is_admin:
-                return function(request, *args, **kwargs)
-
-            return render_to_response('unauthorized.html', context_instance=RequestContext(request), status=403)
         except ObjectDoesNotExist:
             return render_to_response('channel_not_found.html', context_instance=RequestContext(request))
+
+        if channel.public or \
+            channel.editors.filter(id=request.user.id).exists() or \
+            channel.viewers.filter(id=request.user.id).exists() or \
+            request.user.is_admin:
+            return function(request, *args, **kwargs)
+
+        return render_to_response('unauthorized.html', context_instance=RequestContext(request), status=403)
 
     wrap.__doc__ = function.__doc__
     wrap.__name__ = function.__name__

--- a/contentcuration/contentcuration/decorators.py
+++ b/contentcuration/contentcuration/decorators.py
@@ -41,13 +41,13 @@ def can_access_channel(function):
         try:
             channel = Channel.objects.get(pk=kwargs['channel_id'])
 
-            if not channel.public and \
-                not channel.editors.filter(id=request.user.id).exists() and \
-                not channel.viewers.filter(id=request.user.id).exists() and \
-                not request.user.is_admin:
-                return render_to_response('unauthorized.html', context_instance=RequestContext(request))
+            if channel.public or \
+                channel.editors.filter(id=request.user.id).exists() or \
+                channel.viewers.filter(id=request.user.id).exists() or \
+                request.user.is_admin:
+                return function(request, *args, **kwargs)
 
-            return function(request, *args, **kwargs)
+            return render_to_response('unauthorized.html', context_instance=RequestContext(request))
         except ObjectDoesNotExist:
             return render_to_response('channel_not_found.html', context_instance=RequestContext(request))
 

--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
@@ -356,18 +356,21 @@ var EditorView = BaseViews.BaseView.extend({
     render_editor: function() {
         var self = this;
         this.toggle_loading(true);
-        this.parse_content(this.model.get(this.edit_key)).then(function(result){
-            var html = self.view_template({content: result}, {
-                data: self.get_intl_data()
+        var value = this.model.get(this.edit_key);
+        if (value && value.trim() !== "") {
+            this.parse_content(value).then(function(result){
+                var html = self.view_template({content: result}, {
+                    data: self.get_intl_data()
+                });
+                self.editor ? self.editor.setHTML(html) : self.$el.html(html);
+                self.toggle_loading(false);
+                self.render_toolbar();
+                if(self.editor){
+                    self.editor.push();
+                    self.editor.focus();
+                }
             });
-            self.editor ? self.editor.setHTML(html) : self.$el.html(html);
-            self.toggle_loading(false);
-            self.render_toolbar();
-            if(self.editor){
-                self.editor.push();
-                self.editor.focus();
-            }
-        });
+        }
     },
     render_toolbar:function(){
         if(this.numbersOnly){

--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -1,8 +1,11 @@
+import datetime
+
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
 from contentcuration.utils import minio_utils
+from contentcuration.utils.policies import get_latest_policies
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient, APIRequestFactory, APITestCase, force_authenticate
 
@@ -70,6 +73,15 @@ class BaseTestCase(StudioTestCase):
         self.channel = testdata.channel()
         self.user = testdata.user()
         self.channel.main_tree.refresh_from_db()
+
+    def sign_in(self, user=None):
+        if not user:
+            user = self.user
+        # We agree to #allthethings, so let us in!
+        for policy in get_latest_policies():
+            user.policies = {policy: datetime.datetime.now().strftime("%d/%m/%y %H:%M")}
+        user.save()
+        self.client.force_login(user)
 
     def get(self, url, data=None, follow=False, secure=False):
         return self.client.get(url, data=data, follow=follow, secure=secure, HTTP_USER_AGENT=settings.SUPPORTED_BROWSERS[0])

--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -69,6 +70,9 @@ class BaseTestCase(StudioTestCase):
         self.channel = testdata.channel()
         self.user = testdata.user()
         self.channel.main_tree.refresh_from_db()
+
+    def get(self, url, data=None, follow=False, secure=False):
+        return self.client.get(url, data=data, follow=follow, secure=secure, HTTP_USER_AGENT=settings.SUPPORTED_BROWSERS[0])
 
 
 class BaseAPITestCase(StudioAPITestCase):

--- a/contentcuration/contentcuration/tests/test_authentication.py
+++ b/contentcuration/contentcuration/tests/test_authentication.py
@@ -1,0 +1,85 @@
+import datetime
+from contentcuration.utils.policies import check_policies, get_latest_policies, POLICIES
+
+from base import BaseTestCase
+
+
+class AuthenticationTestCase(BaseTestCase):
+    def test_authenticate_policy_update(self):
+        """
+        Test that authenticated new users are shown the policies page regardless of what page was requested
+        if they have policies they have not yet agreed to.
+        """
+        channel_id = self.channel.pk
+        base_url = '/channels/{}'.format(channel_id)
+
+        self.channel.viewers.add(self.user)
+        self.client.force_login(self.user)
+
+        assert len(check_policies(self.user)) > 0
+        # ensure that a new user is redirected to policy update after authenticating the first time.
+        response = self.client.get(base_url, follow=True)
+        assert "/policies/update" == response.redirect_chain[-1][0]
+
+    def test_channel_access(self):
+        """
+        Ensures that short URLs without /view or /edit redirect based on the user's permissions,
+        that unauthenticated users are sent to the login page with the page they requested set as next,
+        and that direct visits to /edit or /view present unauthorized messages when the user doesn't have permissions.
+        """
+        channel_id = self.channel.pk
+        base_url = '/channels/{}'.format(channel_id)
+        view_url = '{}/view'.format(base_url)
+        edit_url = '{}/edit'.format(base_url)
+        response = self.client.get(base_url)
+        # test that it redirects
+        assert response.status_code == 302
+
+        # now test that when we are redirected we get taken to the login page since we're not signed in,
+        # and that after sign in we'll get sent to the right place.
+        response = self.get(base_url, follow=True)
+        assert "/accounts/login/?next={}".format(view_url) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+
+        # We agree to #allthethings, so let us in!
+        for policy in get_latest_policies():
+            self.user.policies = {policy: datetime.datetime.now().strftime("%d/%m/%y %H:%M")}
+        self.user.save()
+        self.client.force_login(self.user)
+
+        # TODO: See if it's possible to pull in unauthorized.html and check that its contents are in the response.
+        unauthorized_str = "You do not have access to this page."
+
+        response = self.get(base_url, follow=True)
+        assert "/channels/{}/view".format(channel_id) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+        assert unauthorized_str in response.content
+
+        self.channel.viewers.add(self.user)
+
+        response = self.get(base_url, follow=True)
+        assert "/channels/{}/view".format(channel_id) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+        assert not unauthorized_str in response.content
+
+        response = self.get(view_url, follow=True)
+        assert response.status_code == 200
+        assert not unauthorized_str in response.content
+
+        # make sure that a view-only user gets redirected if requesting edit page
+        response = self.get(edit_url, follow=True)
+        assert "/channels/{}/view".format(channel_id) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+        assert not unauthorized_str in response.content
+
+        self.channel.editors.add(self.user)
+
+        # we can edit!
+        response = self.get(base_url, follow=True)
+        assert "/channels/{}/edit".format(channel_id) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+        assert not unauthorized_str in response.content
+
+        response = self.get(edit_url, follow=True)
+        assert response.status_code == 200
+        assert not unauthorized_str in response.content

--- a/contentcuration/contentcuration/tests/test_authentication.py
+++ b/contentcuration/contentcuration/tests/test_authentication.py
@@ -1,17 +1,22 @@
 import datetime
-from contentcuration.utils.policies import check_policies, get_latest_policies, POLICIES
+from contentcuration.utils.policies import check_policies
 
 from base import BaseTestCase
 
 
 class AuthenticationTestCase(BaseTestCase):
+    def setUp(self):
+        super(AuthenticationTestCase, self).setUp()
+        self.base_url = '/channels/{}'.format(self.channel.pk)
+        self.view_url = '{}/view'.format(self.base_url)
+        self.edit_url = '{}/edit'.format(self.base_url)
+
     def test_authenticate_policy_update(self):
         """
         Test that authenticated new users are shown the policies page regardless of what page was requested
         if they have policies they have not yet agreed to.
         """
-        channel_id = self.channel.pk
-        base_url = '/channels/{}'.format(channel_id)
+        base_url = '/channels/{}'.format(self.channel.pk)
 
         self.channel.viewers.add(self.user)
         self.client.force_login(self.user)
@@ -21,65 +26,108 @@ class AuthenticationTestCase(BaseTestCase):
         response = self.client.get(base_url, follow=True)
         assert "/policies/update" == response.redirect_chain[-1][0]
 
-    def test_channel_access(self):
+    def test_staging_channel_access(self):
+        staging_url = '{}/staging'.format(self.base_url)
+
+        # test that when we are redirected we get taken to the login page since we're not signed in,
+        # and that after sign in we'll get sent to the right place.
+        response = self.get(staging_url, follow=True)
+        assert "/accounts/login/?next={}".format(staging_url) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+
+        self.sign_in()
+
+        response = self.get(staging_url)
+        assert response.status_code == 403
+
+        self.channel.viewers.add(self.user)
+
+        response = self.get(staging_url)
+        assert response.status_code == 403
+
+        self.channel.editors.add(self.user)
+
+        # finally!
+        response = self.get(staging_url)
+        assert response.status_code == 200
+
+    def test_channel_admin_access(self):
+        admin_url = '/channels/administration/'
+
+        response = self.get(admin_url, follow=True)
+        assert "/accounts/login/?next={}".format(admin_url) == response.redirect_chain[-1][0]
+        assert response.status_code == 200
+
+        self.sign_in()
+
+        response = self.get(admin_url)
+        assert response.status_code == 403
+
+        self.user.is_admin = True
+        self.user.save()
+
+        response = self.get(admin_url)
+        assert response.status_code == 200
+
+    def test_unathenticated_channel_access(self):
         """
         Ensures that short URLs without /view or /edit redirect based on the user's permissions,
         that unauthenticated users are sent to the login page with the page they requested set as next,
         and that direct visits to /edit or /view present unauthorized messages when the user doesn't have permissions.
         """
-        channel_id = self.channel.pk
-        base_url = '/channels/{}'.format(channel_id)
-        view_url = '{}/view'.format(base_url)
-        edit_url = '{}/edit'.format(base_url)
-        response = self.client.get(base_url)
+
+        response = self.client.get(self.base_url)
         # test that it redirects
         assert response.status_code == 302
 
         # now test that when we are redirected we get taken to the login page since we're not signed in,
         # and that after sign in we'll get sent to the right place.
-        response = self.get(base_url, follow=True)
-        assert "/accounts/login/?next={}".format(view_url) == response.redirect_chain[-1][0]
+        response = self.get(self.base_url, follow=True)
+        assert "/accounts/login/?next={}".format(self.view_url) == response.redirect_chain[-1][0]
         assert response.status_code == 200
 
-        # We agree to #allthethings, so let us in!
-        for policy in get_latest_policies():
-            self.user.policies = {policy: datetime.datetime.now().strftime("%d/%m/%y %H:%M")}
-        self.user.save()
-        self.client.force_login(self.user)
+    def test_no_rights_channel_access(self):
+        self.sign_in()
 
-        # TODO: See if it's possible to pull in unauthorized.html and check that its contents are in the response.
-        unauthorized_str = "You do not have access to this page."
+        response = self.get(self.base_url, follow=True)
+        assert self.view_url == response.redirect_chain[-1][0]
+        assert response.status_code == 403
 
-        response = self.get(base_url, follow=True)
-        assert "/channels/{}/view".format(channel_id) == response.redirect_chain[-1][0]
-        assert response.status_code == 200
-        assert unauthorized_str in response.content
+        response = self.get(self.view_url)
+        assert response.status_code == 403
+
+        # /edit URL first switches to /view in case the user has view access, so make sure we track the redirect
+        response = self.get(self.edit_url, follow=True)
+        assert response.status_code == 403
+
+    def test_view_only_channel_access(self):
+        self.sign_in()
 
         self.channel.viewers.add(self.user)
 
-        response = self.get(base_url, follow=True)
-        assert "/channels/{}/view".format(channel_id) == response.redirect_chain[-1][0]
+        response = self.get(self.base_url, follow=True)
+        assert self.view_url == response.redirect_chain[-1][0]
         assert response.status_code == 200
-        assert not unauthorized_str in response.content
 
-        response = self.get(view_url, follow=True)
+        response = self.get(self.view_url)
         assert response.status_code == 200
-        assert not unauthorized_str in response.content
 
         # make sure that a view-only user gets redirected if requesting edit page
-        response = self.get(edit_url, follow=True)
-        assert "/channels/{}/view".format(channel_id) == response.redirect_chain[-1][0]
+        response = self.get(self.edit_url, follow=True)
+        assert self.view_url == response.redirect_chain[-1][0]
         assert response.status_code == 200
-        assert not unauthorized_str in response.content
 
+    def test_edit_channel_access(self):
+        self.sign_in()
         self.channel.editors.add(self.user)
 
         # we can edit!
-        response = self.get(base_url, follow=True)
-        assert "/channels/{}/edit".format(channel_id) == response.redirect_chain[-1][0]
+        response = self.get(self.base_url, follow=True)
+        assert self.edit_url == response.redirect_chain[-1][0]
         assert response.status_code == 200
-        assert not unauthorized_str in response.content
 
-        response = self.get(edit_url, follow=True)
+        response = self.get(self.view_url)
         assert response.status_code == 200
-        assert not unauthorized_str in response.content
+
+        response = self.get(self.edit_url)
+        assert response.status_code == 200

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -53,14 +53,15 @@ def get_or_set_cached_constants(constant, serializer):
     cache.set(constant.__name__, constant_data, None)
     return constant_data
 
-@can_access_channel
 @has_accepted_policies
 def redirect_to_channel(request, channel_id):
     channel = Channel.objects.get(pk=channel_id)
     if channel.editors.filter(pk=request.user.pk).exists():
         return redirect(reverse_lazy('channel', kwargs={'channel_id': channel_id}))
-    elif channel.viewers.filter(pk=request.user.pk).exists() or channel.public:
-        return redirect(reverse_lazy('channel_view_only', kwargs={'channel_id': channel_id}))
+
+    # it will check the view authorization after the redirect
+    return redirect(reverse_lazy('channel_view_only', kwargs={'channel_id': channel_id}))
+
 
 def redirect_to_channel_edit(request, channel_id):
     return redirect(reverse_lazy('channel', kwargs={'channel_id': channel_id}))


### PR DESCRIPTION
…non-authenticated users properly. Also add tests for the various redirect and access scenarios.

#### Issue Addressed (if applicable)

#887 #894

## Steps to Test

- [ ] Delete the /edit or /view from a channel URL in Studio

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
