### PR TITLE
Ensure exercise editor responds gracefully to invalid AssessmentItem answer data

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
@@ -356,18 +356,21 @@ var EditorView = BaseViews.BaseView.extend({
     render_editor: function() {
         var self = this;
         this.toggle_loading(true);
-        this.parse_content(this.model.get(this.edit_key)).then(function(result){
-            var html = self.view_template({content: result}, {
-                data: self.get_intl_data()
+        var value = this.model.get(this.edit_key);
+        if (value && value.trim() !== "") {
+            this.parse_content(value).then(function(result){
+                var html = self.view_template({content: result}, {
+                    data: self.get_intl_data()
+                });
+                self.editor ? self.editor.setHTML(html) : self.$el.html(html);
+                self.toggle_loading(false);
+                self.render_toolbar();
+                if(self.editor){
+                    self.editor.push();
+                    self.editor.focus();
+                }
             });
-            self.editor ? self.editor.setHTML(html) : self.$el.html(html);
-            self.toggle_loading(false);
-            self.render_toolbar();
-            if(self.editor){
-                self.editor.push();
-                self.editor.focus();
-            }
-        });
+        }
     },
     render_toolbar:function(){
         if(this.numbersOnly){

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -424,8 +424,11 @@ var ContentNodeCollection = BaseCollection.extend({
                     item.set('contentnode', node.id);
                     if(item.get('type') === 'input_question'){
                         item.get('answers').each( function(a){
-                            var value = numParser.parse(a.get('answer'))
-                            a.set('answer', value !== null && value.toString());
+                            var answer = a.get('answer');
+                            if (answer) {
+                                var value = numParser.parse(a.get('answer'))
+                                a.set('answer', value !== null && value.toString());
+                            }
                         });
                     }
                 })

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -426,7 +426,7 @@ var ContentNodeCollection = BaseCollection.extend({
                         item.get('answers').each( function(a){
                             var answer = a.get('answer');
                             if (answer) {
-                                var value = numParser.parse(a.get('answer'))
+                                var value = numParser.parse(answer);
                                 a.set('answer', value !== null && value.toString());
                             }
                         });


### PR DESCRIPTION
## Description

Currently, if an AssessmentItem has invalid data, the exercise editor UI will fail to load and throw errors in the JS console. This makes it impossible for the exercise creator to delete or fix the problematic exercise item.

This change checks the existence of valid AssessmentItem answer data before trying to parse it. If invalid data exists, it will just not try to parse the invalid data and load it into the editor, which allows the editor and the valid data to appear. When the user saves, the invalid data will be replaced with whatever valid data the user provided while editing (or the invalid data will have been deleted).

#### Issue Addressed (if applicable)

#879 #892 

## Steps to Test

Since it is not clear how the data got into this state, the only currently known way to reproduce the problem is to manually add an AssessmentItem into the db with the bad data found in the original problem. Here is a command to add that item, where exercise points to the ContentNode you are adding it to:

AssessmentItem.objects.create(contentnode=exercise, type='input_question', question='List two things that come together to make the “Self”.', answers='[{"order":1,"answer":false,"correct":true}]')

Once this is added, simply try to open the Questions tab in the edit view for the exercise ContentNode. 

#### Does this introduce any tech-debt items?

We will need to address the issue of validating answer data to ensure that invalid data doesn't get saved to the database. This only fixes the case where there is a field but it returns nothing, not cases where the field data is of a wrong type, etc.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
