### PR TITLE
Catch errors in channel load. 

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
@@ -72,28 +72,56 @@ var ChannelListPage  = BaseViews.BaseView.extend({
 				el: self.$("#channel_list"),
 				collection: channels
 			});
-		});
+		}).catch(function(e) {
+			  if (Raven && Raven.catchException) {
+			    Raven.catchException(e);
+			  } else {
+			    console.log("Error retrieving current channel list:");
+			    console.log(e.statusText);
+			  }
+			});
 		window.current_user.get_bookmarked_channels().then(function(channels){
 			self.starred_channel_list = new StarredChannelList({
 				container: self,
 				el: self.$("#starred_list"),
 				collection: channels
 			});
-		});
+		}).catch(function(e) {
+			  if (Raven && Raven.catchException) {
+			    Raven.catchException(e);
+			  } else {
+			    console.log("Error retrieving bookmarked channel list:");
+			    console.log(e.statusText);
+			  }
+			});
 		window.current_user.get_public_channels().then(function(channels){
 			self.public_channel_list = new PublicChannelList({
 				container: self,
 				el: self.$("#public_list"),
 				collection: channels
 			});
-		});
+		}).catch(function(e) {
+			  if (Raven && Raven.catchException) {
+			    Raven.catchException(e);
+			  } else {
+			    console.log("Error retrieving public channel list:");
+			    console.log(e.statusText);
+			  }
+			});
 		window.current_user.get_view_only_channels().then(function(channels){
 			self.viewonly_channel_list = new ViewOnlyChannelList({
 				container: self,
 				el: self.$("#viewonly_list"),
 				collection: channels
 			});
-		});
+		}).catch(function(e) {
+			  if (Raven && Raven.catchException) {
+			    Raven.catchException(e);
+			  } else {
+			    console.log("Error retrieving view-only channel list:");
+			    console.log(e.statusText);
+			  }
+			});
 	},
 	events: {
 		'click .new_channel_button' : 'new_channel',


### PR DESCRIPTION
## Description

This code is basically just debugging code to help us track down the Sentry errors we're seeing with some channel_list objects being null at unexpected times.

#### Issue Addressed (if applicable)

#900 

## Steps to Test

As we don't know the cause of the error, the only way to test this change is to locally inject an error into one of the get_user_channels_* calls. That is how I tested that this function works in the non-Sentry case.  

#### Does this introduce any tech-debt items?

We should probably come up with a consistent approach to handling API call errors in the front end so that we have at least some default reporting / handling for failed API calls.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
