### PR TITLE
Choose the SQL instance name based on project ID

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
   entrypoint: 'bash'
   args: [
   '-c',
-  './create-cloudsql-database.sh $BRANCH_NAME develop'
+  './create-cloudsql-database.sh $BRANCH_NAME $PROJECT_ID'
   ]
 
 - name: 'gcr.io/$PROJECT_ID/helm'

--- a/k8s/create-cloudsql-database.sh
+++ b/k8s/create-cloudsql-database.sh
@@ -1,7 +1,16 @@
 set -e
 
 BRANCH=$1
-INSTANCE=$2
+PROJECT=$2
+
+# Use instance `develop` when in project `studio`. Use instance `studio-qa`
+# when in project `ops-central`
+if [[ ${PROJECT} = "contentworkshop-159920" ]];
+then
+	INSTANCE="develop"
+else
+	INSTANCE="studio-qa"
+fi
 
 DATABASES=`gcloud sql databases list --instance=${INSTANCE} | awk '{print $1}' | tail -n +2`
 


### PR DESCRIPTION
## Description

This PR is to resolve the issue that `develop` SQL instance does not exist in the `ops-central` google cloud project, so that when we run builds there, the builds will always fail. 


## Steps to Test

Check that the builds run successfully in both `studio` and `ops-central` projects.



## Checklist

- [X] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?


## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
