### PR TITLE
Add ContentConfig to installed apps so we get our bucket

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -56,7 +56,7 @@ ALLOWED_HOSTS = ["*"]  # In production, we serve through a file socket, so this 
 # Application definition
 
 INSTALLED_APPS = (
-    'contentcuration',
+    'contentcuration.apps.ContentConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
@@ -356,18 +356,21 @@ var EditorView = BaseViews.BaseView.extend({
     render_editor: function() {
         var self = this;
         this.toggle_loading(true);
-        this.parse_content(this.model.get(this.edit_key)).then(function(result){
-            var html = self.view_template({content: result}, {
-                data: self.get_intl_data()
+        var value = this.model.get(this.edit_key);
+        if (value && value.trim() !== "") {
+            this.parse_content(value).then(function(result){
+                var html = self.view_template({content: result}, {
+                    data: self.get_intl_data()
+                });
+                self.editor ? self.editor.setHTML(html) : self.$el.html(html);
+                self.toggle_loading(false);
+                self.render_toolbar();
+                if(self.editor){
+                    self.editor.push();
+                    self.editor.focus();
+                }
             });
-            self.editor ? self.editor.setHTML(html) : self.$el.html(html);
-            self.toggle_loading(false);
-            self.render_toolbar();
-            if(self.editor){
-                self.editor.push();
-                self.editor.focus();
-            }
-        });
+        }
     },
     render_toolbar:function(){
         if(this.numbersOnly){


### PR DESCRIPTION
## Description

'Nuff said!

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
