### PR TITLE
Check for errors before trying to set color from thumbnail

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/queue/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/queue/views.js
@@ -441,12 +441,14 @@ var ClipboardItem = BaseViews.BaseWorkspaceListNodeItemView.extend({
 			setTimeout(function() {
 				var v = new Vibrant(self.model.get('thumbnail'));
 				v.getPalette(function(err, palette) {
-					var colorHex = palette.Muted.getHex();
-					var color = palette.Muted.getRgb();
-					self.$('label.segment').css({
-						'border-left': `10px solid ${colorHex}`,
-						'background-color': `rgba(${color[0]}, ${color[1]}, ${color[2]}, 0.2)`,
-					});
+					if (!err && palette.Muted) {
+						var colorHex = palette.Muted.getHex();
+						var color = palette.Muted.getRgb();
+						self.$('label.segment').css({
+							'border-left': `10px solid ${colorHex}`,
+							'background-color': `rgba(${color[0]}, ${color[1]}, ${color[2]}, 0.2)`,
+						});
+					}
 				});
 			}, 0);
 		}


### PR DESCRIPTION
## Description

We don't check for errors before attempting to set the clipboard item color based on thumbnail.

#### Issue Addressed (if applicable)

#914 

## Steps to Test

As we do not have information on what error is triggering, the best we can do is test that adding an item with thumbnail to the clipboard works.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
