### PR TITLE
enable source maps for our JS code

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = {
       new UglifyJsPlugin({
         cache: true,
         parallel: true,
-        sourceMap: false
+        sourceMap: true
       }),
       new OptimizeCSSAssetsPlugin({})
     ]
@@ -170,6 +170,9 @@ module.exports = {
       chunkFilename: "[name]-[hash]-[id].css"
     }),
     new WebpackRTLPlugin(),
+    new webpack.SourceMapDevToolPlugin({
+      filename: '[name]-[hash].js.map'
+    })
   ],
   // new in webpack 4. Specifies the default bundle type
   mode: 'development',


### PR DESCRIPTION
This helps us have better errors on our Sentry frontend reports. This creates an
external source map (*.js.map)  for each of our final JS bundles.