### PR TITLE
Fix a typo in sentry release naming

### DIFF
--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -27,7 +27,7 @@ helm upgrade --install $BRANCH . \
      -f values-prod-config.yaml \
      --set studioApp.imageName=gcr.io/$PROJECT_ID/learningequality-studio-app:$COMMIT \
      --set studioNginx.imageName=gcr.io/$PROJECT_ID/learningequality-studio-nginx:$COMMIT \
-     --set studioApp.releaseCommit=$COMMIT} \
+     --set studioApp.releaseCommit=$COMMIT \
      --set bucketName=$BUCKET \
      --set studioApp.postmarkApiKey=$POSTMARK_KEY \
      --set postgresql.postgresUser=$POSTGRES_USER \


### PR DESCRIPTION
So we can start attaching releases to github commits

You can see the bug in here:
https://sentry.io/learningequality/studio/releases/71eb4f7cd95ba95ee7b1426c93a3026655194542%7D/
( the extra '}' in the end )