### PR TITLE
Attempt to auto-create buckets only on dev mode

### DIFF
--- a/contentcuration/contentcuration/apps.py
+++ b/contentcuration/contentcuration/apps.py
@@ -9,4 +9,5 @@ class ContentConfig(AppConfig):
     name = 'contentcuration'
 
     def ready(self):
-        ensure_storage_bucket_public()
+        if settings.AWS_AUTO_CREATE_BUCKET:
+            ensure_storage_bucket_public()

--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -43,3 +43,4 @@ DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.redirects.RedirectsPanel',
 ]
 
+AWS_AUTO_CREATE_BUCKET = True

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -322,7 +322,7 @@ AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID') or 'development'
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY') or 'development'
 AWS_S3_BUCKET_NAME = os.getenv('AWS_BUCKET_NAME') or 'content'
 AWS_S3_ENDPOINT_URL = os.getenv('AWS_S3_ENDPOINT_URL') or 'http://localhost:9000'
-AWS_AUTO_CREATE_BUCKET = True
+AWS_AUTO_CREATE_BUCKET = False
 AWS_S3_FILE_OVERWRITE = True
 AWS_S3_BUCKET_AUTH = False
 


### PR DESCRIPTION
Otherwise we don't need it on production (GCS already has our buckets). We also
don't need it on tests (we bring down and create buckets as tests need it).

We do this through the `AWS_AUTO_CREATE_BUCKET` setting. We set it to `False`
globally, then set it to `True` on `dev_settings.py`.