### PR TITLE
Add info endpoint so Kolibri knows Studio can serve content

### DIFF
--- a/contentcuration/contentcuration/tests/test_public_api.py
+++ b/contentcuration/contentcuration/tests/test_public_api.py
@@ -1,0 +1,18 @@
+from base import BaseAPITestCase
+from django.core.urlresolvers import reverse
+
+
+class PublicAPITestCase(BaseAPITestCase):
+    """
+    IMPORTANT: These tests are to never be changed. They are enforcing a
+    public API contract. If the tests fail, then the implementation needs
+    to be changed, and not the tests themselves.
+    """
+
+    def setUp(self):
+        super(PublicAPITestCase, self).setUp()
+
+    def test_info_endpoint(self):
+        response = self.client.get(reverse('info'))
+        self.assertEqual(response.data['application'], 'studio')
+        self.assertEqual(response.data['device_name'], 'Kolibri Studio')

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -202,6 +202,7 @@ urlpatterns += [
     url(r'^api/public/channel/(?P<channel_id>[^/]+)', public_views.get_channel_name_by_id, name='get_channel_name_by_id'),
     url(r'^api/public/(?P<version>[^/]+)/channels$', public_views.get_public_channel_list, name='get_public_channel_list'),
     url(r'^api/public/(?P<version>[^/]+)/channels/lookup/(?P<identifier>[^/]+)', public_views.get_public_channel_lookup, name='get_public_channel_lookup'),
+    url(r'^api/public/info', public_views.InfoViewSet.as_view({'get': 'list'}), name='info'),
 ]
 
 # Add node api enpoints

--- a/contentcuration/contentcuration/views/public.py
+++ b/contentcuration/contentcuration/views/public.py
@@ -4,8 +4,10 @@ from contentcuration.serializers import PublicChannelSerializer
 from django.db.models import Q, Value, TextField
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.translation import ugettext_lazy as _
+from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
 
 def _get_channel_list(version, params, identifier=None):
     if version == "v1":
@@ -71,3 +73,23 @@ def get_channel_name_by_id(request, channel_id):
         return HttpResponseNotFound('Channel with id {} not found'.format(channel_id))
     return HttpResponse(json.dumps({"name": channel.name, "description": channel.description, "version": channel.version}))
 
+
+class InfoViewSet(viewsets.ViewSet):
+    """
+    An equivalent endpoint in kolibri which allows kolibri devices to know
+    if this device can serve content.
+    Spec doc: https://docs.google.com/document/d/1XKXQe25sf9Tht6uIXvqb3T40KeY3BLkkexcV08wvR9M/edit#
+    """
+
+    permission_classes = (AllowAny, )
+
+    def list(self, request):
+        """Returns metadata information about the type of device"""
+
+        info = {'application': 'studio',
+                'kolibri_version': None,
+                'instance_id': None,
+                'device_name': "Kolibri Studio",
+                'operating_system': None,
+                }
+        return Response(info)


### PR DESCRIPTION
## Description

Adds an info endpoint which will help determine the type of device we are syncing content from. 
Basically is a copy of this https://github.com/jamalex/kolibri/pull/2

## Steps to Test

- [ ] go to /api/public/info/

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
