### PR TITLE
Check for invalid content in parse_content rather than before calling…

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
@@ -357,20 +357,18 @@ var EditorView = BaseViews.BaseView.extend({
         var self = this;
         this.toggle_loading(true);
         var value = this.model.get(this.edit_key);
-        if (value && value.trim() !== "") {
-            this.parse_content(value).then(function(result){
-                var html = self.view_template({content: result}, {
-                    data: self.get_intl_data()
-                });
-                self.editor ? self.editor.setHTML(html) : self.$el.html(html);
-                self.toggle_loading(false);
-                self.render_toolbar();
-                if(self.editor){
-                    self.editor.push();
-                    self.editor.focus();
-                }
+        this.parse_content(value).then(function(result){
+            var html = self.view_template({content: result}, {
+                data: self.get_intl_data()
             });
-        }
+            self.editor ? self.editor.setHTML(html) : self.$el.html(html);
+            self.toggle_loading(false);
+            self.render_toolbar();
+            if(self.editor){
+                self.editor.push();
+                self.editor.focus();
+            }
+        });
     },
     render_toolbar:function(){
         if(this.numbersOnly){
@@ -571,6 +569,10 @@ var EditorView = BaseViews.BaseView.extend({
         var self = this;
         content = this.parse_functions(content);
         return new Promise(function(resolve, reject){
+            if (!content || content.trim() == "") {
+              resolve(content);
+              return;
+            }
             content = self.replace_image_paths(content);
             content = stringHelper.escape_str(content.replace(/\\(?![^\\\s])/g, '\\\\'));
             // If the editor is open, convert to svgs. Otherwise use katex to make loading faster


### PR DESCRIPTION
… it, as empty values then fail to create an editor.

## Description

We previously had an issue where invalid input data for an editor would cause the quiz loading to fail, and leave users with a blank page. We resolved this by checking the input before render, but this created a new problem when creating new items, as a parse_content callback is where the editor gets rendered. This resolves the problem by moving the data validity check into parse_content.

## Steps to Test

- [ ] Create or open an exercise 
- [ ] Add a new question to it.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
