### PR TITLE
Add browser caching on static files

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -30,6 +30,7 @@ http {
         location /static/  {
             autoindex on;
             alias /app/contentworkshop_static/;
+            expires 4h;
         }
         # Serve a static file (ex. favico)
         # outside /static directory


### PR DESCRIPTION
This speeds up browser loading for mobile devices and those with slow internet connections.