### PR TITLE
Add caching to the get_user_public_channels endpoint

### DIFF
--- a/contentcuration/contentcuration/management/commands/exportchannel.py
+++ b/contentcuration/contentcuration/management/commands/exportchannel.py
@@ -582,19 +582,7 @@ def save_export_database(channel_id):
 def add_tokens_to_channel(channel):
     if not channel.secret_tokens.filter(is_primary=True).exists():
         logging.info("Generating tokens for the channel.")
-        token = proquint.generate()
-
-        # Try to generate the channel token, avoiding any infinite loops if possible
-        max_retries = 1000000
-        index = 0
-        while ccmodels.SecretToken.objects.filter(token=token).exists():
-            token = proquint.generate()
-            if index > max_retries:
-                raise ValueError("Cannot generate new token")
-
-        tk_human = ccmodels.SecretToken.objects.create(token=token, is_primary=True)
-        tk, _new = ccmodels.SecretToken.objects.get_or_create(token=channel.id)
-        channel.secret_tokens.add(tk_human, tk)
+        channel.make_token()
 
 def fill_published_fields(channel):
     published_nodes = channel.main_tree.get_descendants().filter(published=True).prefetch_related('files')

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -552,6 +552,9 @@ class Channel(models.Model):
 
         return '/static/img/kolibri_placeholder.png'
 
+    def get_date_modified(self):
+        return self.main_tree.get_descendants(include_self=True).aggregate(last_modified=Max('modified'))['last_modified']
+
     def get_resource_count(self):
         return self.main_tree.get_descendants().exclude(kind_id=content_kinds.TOPIC).count()
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -551,6 +551,25 @@ class Channel(models.Model):
 
         return '/static/img/kolibri_placeholder.png'
 
+    @classmethod
+    def get_public_channels(cls, defer_nonmain_trees=False):
+        """
+        Get all public channels.
+
+        If defer_nonmain_trees is True, defer the loading of all
+        trees except for the main_tree."""
+        if defer_nonmain_trees:
+            c = (Channel.objects
+                .filter(public=True)
+                .exclude(deleted=True)
+                .select_related('main_tree')
+                .prefetch_related('editors')
+                .defer('trash_tree', 'clipboard_tree', 'staging_tree', 'chef_tree', 'previous_tree', 'viewers'))
+        else:
+            c = Channel.objects.filter(public=True).exclude(deleted=True)
+
+        return c
+
     class Meta:
         verbose_name = _("Channel")
         verbose_name_plural = _("Channels")

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -552,6 +552,9 @@ class Channel(models.Model):
 
         return '/static/img/kolibri_placeholder.png'
 
+    def get_resource_count(self):
+        return self.main_tree.get_descendants().exclude(kind_id=content_kinds.TOPIC).count()
+
     def get_human_token(self):
         return self.secret_tokens.get(is_primary=True)
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -551,6 +551,24 @@ class Channel(models.Model):
 
         return '/static/img/kolibri_placeholder.png'
 
+    def make_public(self, bypass_signals=False):
+        """
+        Sets the current channel object to be public and viewable by anyone.
+
+        If bypass_signals is True, update the model in such a way that we
+        prevent any model signals from running due to the update.
+
+        Returns the same channel object.
+        """
+        if bypass_signals:
+            self.public = True     # set this attribute still, so the object will be updated
+            Channel.objects.filter(id=self.id).update(public=True)
+        else:
+            self.public = True
+            self.save()
+
+        return self
+
     @classmethod
     def get_public_channels(cls, defer_nonmain_trees=False):
         """

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -397,6 +397,14 @@ class SecretToken(models.Model):
     token = models.CharField(max_length=100, unique=True)
     is_primary = models.BooleanField(default=False)
 
+    @classmethod
+    def exists(cls, token):
+        """
+        Return true when the token string given by string already exists.
+        Returns false otherwise.
+        """
+        return cls.objects.filter(token=token).exists()
+
     def __str__(self):
         return self.token
 
@@ -563,6 +571,7 @@ class Channel(models.Model):
 
     def get_channel_id_token(self):
         return self.secret_tokens.get(token=self.id)
+
 
     def make_token(self):
         """

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -671,11 +671,6 @@ class ChannelFieldMixin(object):
     def check_publishing(self, channel):
         return channel.main_tree.publishing
 
-    def generate_thumbnail_url(self, channel):
-        if channel.thumbnail and 'static' not in channel.thumbnail:
-            return generate_storage_url(channel.thumbnail)
-        return '/static/img/kolibri_placeholder.png'
-
 
 class ChannelSerializer(ChannelFieldMixin, serializers.ModelSerializer):
     has_changed = serializers.SerializerMethodField('check_for_changes')

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -659,7 +659,7 @@ class ChannelFieldMixin(object):
         return channel.main_tree and channel.main_tree.get_descendants().filter(changed=True).count() > 0
 
     def get_resource_count(self, channel):
-        return channel.main_tree.get_descendants().exclude(kind_id=content_kinds.TOPIC).count()
+        return channel.get_resource_count()
 
     def get_date_created(self, channel):
         return channel.main_tree.created

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -657,7 +657,7 @@ class ChannelFieldMixin(object):
         return channel.main_tree and channel.main_tree.get_descendants().filter(changed=True).count() > 0
 
     def get_resource_count(self, channel):
-        return channel.get_resource_count()
+        return ChannelCacher.for_channel(channel).get_resource_count()
 
     def get_date_created(self, channel):
         return channel.main_tree.created

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -729,11 +729,6 @@ class ChannelListSerializer(ChannelFieldMixin, serializers.ModelSerializer):
     primary_token = serializers.SerializerMethodField('get_channel_primary_token')
     content_defaults = serializers.JSONField()
 
-    def generate_thumbnail_url(self, channel):
-        if channel.thumbnail and 'static' not in channel.thumbnail:
-            return generate_storage_url(channel.thumbnail)
-        return '/static/img/kolibri_placeholder.png'
-
     class Meta:
         model = Channel
         fields = ('id', 'created', 'name', 'published', 'pending_editors', 'editors', 'viewers', 'modified', 'language', 'primary_token', 'priority',

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -651,9 +651,7 @@ class ChannelFieldMixin(object):
         return "-".join([token[:5], token[5:]])
 
     def generate_thumbnail_url(self, channel):
-        if channel.thumbnail and 'static' not in channel.thumbnail:
-            return generate_storage_url(channel.thumbnail)
-        return '/static/img/kolibri_placeholder.png'
+        return channel.get_thumbnail()
 
     def check_for_changes(self, channel):
         return channel.main_tree and channel.main_tree.get_descendants().filter(changed=True).count() > 0

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -663,7 +663,7 @@ class ChannelFieldMixin(object):
         return channel.main_tree.created
 
     def get_date_modified(self, channel):
-        return channel.get_date_modified()
+        return ChannelCacher.for_channel(channel).get_date_modified()
 
     def check_published(self, channel):
         return channel.main_tree.published

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -663,7 +663,7 @@ class ChannelFieldMixin(object):
         return channel.main_tree.created
 
     def get_date_modified(self, channel):
-        return channel.main_tree.get_descendants(include_self=True).aggregate(last_modified=Max('modified'))['last_modified']
+        return channel.get_date_modified()
 
     def check_published(self, channel):
         return channel.main_tree.published

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from contentcuration.models import Channel
 from .base import StudioTestCase
-from .testdata import channel
+from .testdata import channel, node
 
 
 class PublicChannelsTestCase(StudioTestCase):
@@ -50,3 +50,47 @@ class ChannelTokenTestCase(StudioTestCase):
         self.channel.make_token()
 
         assert self.channel.get_channel_id_token().token == self.channel.id
+
+class ChannelResourceCountTestCase(StudioTestCase):
+
+    def setUp(self):
+        super(ChannelResourceCountTestCase, self).setUp()
+        self.channel = channel()
+
+    def test_returns_an_integer(self):
+        assert isinstance(self.channel.get_resource_count(), int)
+
+    def test_increments_when_we_add_a_new_content_node(self):
+        count = self.channel.get_resource_count()
+        tree = self.channel.main_tree
+
+        # add a new video node
+        node(
+            parent=tree,
+            data={
+                "title": "New cat video",
+                "kind_id": "video",
+                "node_id": "nice"
+            }
+        )
+
+        assert self.channel.get_resource_count() == count + 1
+
+    def test_does_not_increment_when_we_add_a_topic(self):
+        count = self.channel.get_resource_count()
+        tree = self.channel.main_tree
+
+        # add a new topic node
+        node(
+            parent=tree,
+            data={
+                "kind_id": "topic",
+                "title": "topic node",
+                "node_id": "nice",
+                "children": [],
+            }
+        )
+
+        # should be no difference in count
+        assert self.channel.get_resource_count() == count
+

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from django.test import TestCase
+
+from contentcuration.models import Channel
+
+
+class PublicChannelsTestCase(TestCase):
+
+    def test_channel_get_public_channels_only_returns_public_channels(self):
+        """
+        Check that Channel.get_public_channels() only returns public channels.
+        """
+        for c in Channel.get_public_channels():
+            assert c.public

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -3,6 +3,7 @@
 from django.test import TestCase
 
 from contentcuration.models import Channel
+from .testdata import channel
 
 
 class PublicChannelsTestCase(TestCase):
@@ -13,3 +14,9 @@ class PublicChannelsTestCase(TestCase):
         """
         for c in Channel.get_public_channels():
             assert c.public
+
+    def test_channel_make_public_makes_the_current_channel_public(self):
+        c = channel()
+        c.make_public()
+        assert c.public
+    # TODO(aron): test the bypass_signals arg to make_public

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -19,6 +19,7 @@ class PublicChannelsTestCase(StudioTestCase):
 
     def test_channel_make_public_makes_the_current_channel_public(self):
         c = channel()
+        assert not c.public
         c.make_public()
         assert c.public
     # TODO(aron): test the bypass_signals arg to make_public

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -3,10 +3,11 @@
 from django.test import TestCase
 
 from contentcuration.models import Channel
+from .base import StudioTestCase
 from .testdata import channel
 
 
-class PublicChannelsTestCase(TestCase):
+class PublicChannelsTestCase(StudioTestCase):
 
     def test_channel_get_public_channels_only_returns_public_channels(self):
         """

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -21,3 +21,32 @@ class PublicChannelsTestCase(StudioTestCase):
         c.make_public()
         assert c.public
     # TODO(aron): test the bypass_signals arg to make_public
+    #
+
+class ChannelTokenTestCase(StudioTestCase):
+
+    def setUp(self):
+        super(ChannelTokenTestCase, self).setUp()
+
+        self.channel = channel()
+
+    def test_make_token_creates_human_token(self):
+        """
+        Test that we create a new primary token for a channel.
+        """
+        token = self.channel.make_token()
+
+        # test that the new token is a string
+        assert isinstance(token.token, str)
+        # this string should not be empty
+        assert token.token
+        # this string should be equivalent to the human token
+        assert self.channel.get_human_token().token == token.token
+
+    def test_make_token_creates_channel_id_token(self):
+        """
+        Check that we create a new token with the channel's id as the token string.
+        """
+        self.channel.make_token()
+
+        assert self.channel.get_channel_id_token().token == self.channel.id

--- a/contentcuration/contentcuration/tests/test_channelcache.py
+++ b/contentcuration/contentcuration/tests/test_channelcache.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# These are tests for the ChannelCache class.
+#
+
+from django.test import TestCase
+
+from contentcuration.utils.channelcache import ChannelCacher
+from contentcuration.models import Channel
+
+from .base import StudioTestCase
+from .testdata import channel
+
+
+class ChannelCacherTestCase(StudioTestCase):
+
+    NUM_INITIAL_PUBLIC_CHANNELS = 2
+
+    def setUp(self):
+        super(ChannelCacherTestCase, self).setUp()
+
+        self.channels = []
+        for _ in range(self.NUM_INITIAL_PUBLIC_CHANNELS):
+            c = channel().make_public(bypass_signals=True)
+            self.channels.append(c)
+
+
+    def test_returns_public_channels(self):
+        """
+        Returns the list of public channels.
+        """
+
+        channels = ChannelCacher.get_public_channels()
+
+        assert (self.channels   # the channels we know are public...
+                == channels)    # ...should be present in get_public_channels
+
+    def test_new_public_channel_not_in_cache(self):
+        """
+        Check that our cache is indeed a cache by not returning any new public
+        channels created after regenerating our cache.
+        """
+
+        # force fill our public channel cache
+        ChannelCacher.regenerate_public_channel_cache()
+        # create our new channel and bypass signals when creating it
+        new_public_channel = channel()
+        new_public_channel.make_public(bypass_signals=True)
+        # fetch our cached channel list
+        cached_channels = ChannelCacher.get_public_channels()
+        # make sure our new public channel isn't in the cache
+        assert new_public_channel not in cached_channels

--- a/contentcuration/contentcuration/tests/test_channelcache.py
+++ b/contentcuration/contentcuration/tests/test_channelcache.py
@@ -50,3 +50,41 @@ class ChannelCacherTestCase(StudioTestCase):
         cached_channels = ChannelCacher.get_public_channels()
         # make sure our new public channel isn't in the cache
         assert new_public_channel not in cached_channels
+
+
+class ChannelTokenCacheTestCase(StudioTestCase):
+    """
+    Tests for caching tokens using the ChannelSpecificCacher proxy object.
+    """
+
+    def setUp(self):
+        super(ChannelTokenCacheTestCase, self).setUp()
+        self.channel = channel()
+
+    def test_channel_get_human_token_returns_token_if_present(self):
+        """
+        Check that cache.get_human_token() returns the same thing as
+        the real channel.get_human_token().
+        """
+        c = self.channel
+        c.make_token()
+
+        ccache = ChannelCacher.for_channel(c)
+
+        assert ccache.get_human_token() == c.get_human_token()
+
+    def test_channel_get_channel_id_token_returns_channel_id_token(self):
+        """
+        Check that cache.get_channel_id_token() returns the same thing as
+        the real channel.get_channel_id_token().
+        """
+        c = self.channel
+        c.make_token()
+
+        ccache = ChannelCacher.for_channel(c)
+
+        assert ccache.get_channel_id_token() == c.get_channel_id_token()
+
+
+class ChannelResourceCountCacheTestCase(StudioTestCase):
+    pass

--- a/contentcuration/contentcuration/tests/test_channelcache.py
+++ b/contentcuration/contentcuration/tests/test_channelcache.py
@@ -30,10 +30,11 @@ class ChannelCacherTestCase(StudioTestCase):
         Returns the list of public channels.
         """
 
-        channels = ChannelCacher.get_public_channels()
+        real_channel_ids = sorted([c.id for c in self.channels])
+        cached_channel_ids = sorted([c.id for c in ChannelCacher.get_public_channels()])
 
-        assert (self.channels   # the channels we know are public...
-                == channels)    # ...should be present in get_public_channels
+        assert (real_channel_ids          # the channels we know are public...
+                == cached_channel_ids)    # ...should be present in get_public_channels
 
     def test_new_public_channel_not_in_cache(self):
         """

--- a/contentcuration/contentcuration/tests/test_channelcache.py
+++ b/contentcuration/contentcuration/tests/test_channelcache.py
@@ -123,3 +123,48 @@ class ChannelResourceCountCacheTestCase(StudioTestCase):
 
         # check that our cache's count is now less than the real count
         assert ccache.get_resource_count() < self.channel.get_resource_count()
+
+
+class ChannelGetDateModifiedCacheTestCase(StudioTestCase):
+    """
+    Tests for ChannelCacher.get_date_modified()
+    """
+
+    def setUp(self):
+        super(ChannelGetDateModifiedCacheTestCase, self).setUp()
+        self.channel = channel()
+
+    def test_returns_the_same_as_real_get_date_modified(self):
+        """
+        When called with the cache unfilled, ChannelCacher.get_date_modified()
+        should return the same thing as channel.get_date_modified().
+        """
+
+        ccache = ChannelCacher.for_channel(self.channel)
+
+        assert ccache.get_date_modified() == self.channel.get_date_modified()
+
+    def test_get_date_modified_really_is_a_cache(self):
+        """
+        Check that the cache is really a cache by seeing if the cache value is not
+        the same as channel.get_date_modified() when we add a new node. If it
+        gets updated, then the cache is either too short lived, or it's not
+        really a cachd at all!
+        """
+        ccache = ChannelCacher.for_channel(self.channel)
+        # fill the cache by calling get_date_modified once
+        ccache.get_date_modified()
+
+        # add a new node to the channel
+        node(
+            parent=self.channel.main_tree,
+            data={
+                "node_id": "videoz",
+                "title": "new vid",
+                "kind_id": "video",
+            }
+        )
+
+        # check that the cached modified date is not equal to the channel's new
+        # modified date
+        assert ccache.get_date_modified() <= self.channel.get_date_modified()

--- a/contentcuration/contentcuration/tests/test_secrettoken_model.py
+++ b/contentcuration/contentcuration/tests/test_secrettoken_model.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+from django.test import TestCase
+from le_utils import proquint
+
+from contentcuration.models import SecretToken
+
+
+class SecretTokenTestCase(TestCase):
+    """
+    Tests for the SecretToken class.
+    """
+
+    def test_exists_returns_true_if_token_exists(self):
+        """
+        Check that SecretToken.exists() returns true if
+        the token already exists in the database.
+        """
+
+        token = proquint.generate()
+        # check that the proquint we just generated doesn't
+        # exist yet.
+        assert not SecretToken.exists(token)
+
+        # save the new token and check if it exists
+        SecretToken.objects.create(token=token, is_primary=True)
+        assert SecretToken.exists(token)

--- a/contentcuration/contentcuration/utils/channelcache.py
+++ b/contentcuration/contentcuration/utils/channelcache.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# Utilities related to caching expensive endpoints.
+#
+
+from django.core.cache import cache
+
+from contentcuration.models import Channel
+
+class ChannelCacher(object):
+    """
+    A proxy to the Channel object that caches return values for
+    expensive queries.
+    """
+
+    PUBLIC_CHANNEL_CACHE_KEY = "public_channel_cache"
+    PUBLIC_CHANNEL_CACHE_TIMEOUT = 60 # seconds
+
+    @classmethod
+    def get_public_channels(cls):
+        return cache.get_or_set(
+            cls.PUBLIC_CHANNEL_CACHE_KEY,
+            cls.regenerate_public_channel_cache,
+            cls.PUBLIC_CHANNEL_CACHE_TIMEOUT
+        )
+
+    @classmethod
+    def regenerate_public_channel_cache(cls):
+        """
+        Invalidate and recalculate the list of public channels and their attributes.
+        Returns the new list of public channels.
+
+        """
+        channels = list(Channel.get_public_channels())
+        cache.set(cls.PUBLIC_CHANNEL_CACHE_KEY, channels)
+
+        return channels

--- a/contentcuration/contentcuration/utils/channelcache.py
+++ b/contentcuration/contentcuration/utils/channelcache.py
@@ -35,3 +35,44 @@ class ChannelCacher(object):
         cache.set(cls.PUBLIC_CHANNEL_CACHE_KEY, channels)
 
         return channels
+
+    @classmethod
+    def for_channel(cls, channel):
+        """
+        Return a proxy for the cache specific to a channel.
+        """
+
+        return ChannelSpecificCacher(channel)
+
+
+class ChannelSpecificCacher(object):
+
+    CHANNEL_TOKEN_CACHE_KEY_PREFIX = "channel_token"
+    CHANNEL_TOKEN_CACHE_TIMEOUT = 60 # seconds
+
+    def __init__(self, channel):
+        self.channel = channel
+        # cache key prefix is the first 5 characters of the channel id
+        self.key = channel.id[:5]
+
+    def get_human_token(self):
+        key = "{prefix}_human_token_{key}".format(
+            prefix=self.CHANNEL_TOKEN_CACHE_KEY_PREFIX,
+            key=self.key
+        )
+        return cache.get_or_set(
+            key,
+            self.channel.get_human_token,
+            self.CHANNEL_TOKEN_CACHE_TIMEOUT,
+        )
+
+    def get_channel_id_token(self):
+        key = "{prefix}_channel_id_token_{key}".format(
+            prefix=self.CHANNEL_TOKEN_CACHE_KEY_PREFIX,
+            key=self.key
+        )
+        return cache.get_or_set(
+            key,
+            self.channel.get_channel_id_token,
+            self.CHANNEL_TOKEN_CACHE_TIMEOUT,
+        )

--- a/contentcuration/contentcuration/utils/channelcache.py
+++ b/contentcuration/contentcuration/utils/channelcache.py
@@ -17,10 +17,10 @@ class ChannelCacher(object):
     PUBLIC_CHANNEL_CACHE_TIMEOUT = 60 # seconds
 
     @classmethod
-    def get_public_channels(cls):
+    def get_public_channels(cls, *args, **kwargs):
         return cache.get_or_set(
             cls.PUBLIC_CHANNEL_CACHE_KEY,
-            cls.regenerate_public_channel_cache,
+            lambda: Channel.get_public_channels(*args, **kwargs),
             cls.PUBLIC_CHANNEL_CACHE_TIMEOUT
         )
 

--- a/contentcuration/contentcuration/utils/channelcache.py
+++ b/contentcuration/contentcuration/utils/channelcache.py
@@ -53,6 +53,9 @@ class ChannelSpecificCacher(object):
     CHANNEL_RESOURCE_COUNT_KEY_PREFIX = "channel_resource_count"
     CHANNEL_RESOURCE_COUNT_CACHE_TIMEOUT = 30 # seconds
 
+    CHANNEL_DATE_MODIFIED_KEY_PREFIX = "channel_date_modified"
+    CHANNEL_DATE_MODIFIED_CACHE_TIMEOUT = 30 # seconds
+
     def __init__(self, channel):
         self.channel = channel
         # cache key prefix is the first 5 characters of the channel id
@@ -90,4 +93,16 @@ class ChannelSpecificCacher(object):
             key,
             self.channel.get_resource_count,
             self.CHANNEL_RESOURCE_COUNT_CACHE_TIMEOUT,
+        )
+
+    def get_date_modified(self):
+        key = "{prefix}_{key}".format(
+            prefix=self.CHANNEL_DATE_MODIFIED_KEY_PREFIX,
+            key=self.key
+        )
+
+        return cache.get_or_set(
+            key,
+            self.channel.get_date_modified,
+            self.CHANNEL_DATE_MODIFIED_CACHE_TIMEOUT,
         )

--- a/contentcuration/contentcuration/utils/channelcache.py
+++ b/contentcuration/contentcuration/utils/channelcache.py
@@ -50,6 +50,9 @@ class ChannelSpecificCacher(object):
     CHANNEL_TOKEN_CACHE_KEY_PREFIX = "channel_token"
     CHANNEL_TOKEN_CACHE_TIMEOUT = 60 # seconds
 
+    CHANNEL_RESOURCE_COUNT_KEY_PREFIX = "channel_resource_count"
+    CHANNEL_RESOURCE_COUNT_CACHE_TIMEOUT = 30 # seconds
+
     def __init__(self, channel):
         self.channel = channel
         # cache key prefix is the first 5 characters of the channel id
@@ -75,4 +78,16 @@ class ChannelSpecificCacher(object):
             key,
             self.channel.get_channel_id_token,
             self.CHANNEL_TOKEN_CACHE_TIMEOUT,
+        )
+
+    def get_resource_count(self):
+        key = "{prefix}_{key}".format(
+            prefix=self.CHANNEL_RESOURCE_COUNT_KEY_PREFIX,
+            key=self.key,
+        )
+
+        return cache.get_or_set(
+            key,
+            self.channel.get_resource_count,
+            self.CHANNEL_RESOURCE_COUNT_CACHE_TIMEOUT,
         )

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -175,10 +175,7 @@ def get_user_edit_channels(request):
 @authentication_classes((SessionAuthentication, BasicAuthentication, TokenAuthentication))
 @permission_classes((IsAuthenticated,))
 def get_user_public_channels(request):
-    channels = Channel.objects.filter(public=True)\
-                    .exclude(deleted=True)\
-                    .select_related('main_tree').prefetch_related('editors')\
-                    .defer('trash_tree', 'clipboard_tree', 'staging_tree', 'chef_tree', 'previous_tree', 'viewers')
+    channels = Channel.get_public_channels(defer_nonmain_trees=True)
     channel_serializer = AltChannelListSerializer(channels, many=True)
     return Response(channel_serializer.data)
 


### PR DESCRIPTION
... and add testing to a bunch of stuff along the way.

This PR does 4 things:
1. Move certain logic found in views into Channel model functions:
    - getting the public channel list
    - creating a human readable token
    - reading the human readable token
    - getting the resource count for a channel
    - getting the last modified date for a channel's content
1. Add tests for the functions mentioned above ^
1. Add a class called `ChannelCacher`. This class wraps any channel and caches
   certain functions:
    - getting the public channel list
    - creating a human readable token
    - reading the human readable token
    - getting the resource count for a channel
    - getting the last modified date for a channel's content
1. Cache the entire get_user_public_channels function.

I'm not able to fully compare the speed up compared to the uncached version
unfortunately -- but hopefully the rest of the refactorings here make this PR
worth it.