### PR TITLE
Remove the hardcoded server IP in tests…

### DIFF
--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -45,7 +45,6 @@ class StudioTestCase(TestCase, BucketTestMixin):
     def setUpClass(cls):
         super(StudioTestCase, cls).setUpClass()
         call_command('loadconstants')
-        cls.url = "http://127.0.0.1:8000"
         cls.admin_user = User.objects.create_superuser('big_shot', 'bigshot@reallybigcompany.com', 'password')
 
     def setUp(self):
@@ -69,7 +68,7 @@ class StudioTestCase(TestCase, BucketTestMixin):
         name = fileobj_temp['name']
 
         f = SimpleUploadedFile(name, data)
-        file_upload_url = self.url + str(reverse_lazy('api_file_upload'))
+        file_upload_url = str(reverse_lazy('api_file_upload'))
         return fileobj_temp, self.admin_client().post(file_upload_url, {"file": f})
 
 

--- a/contentcuration/contentcuration/tests/test_createchannel.py
+++ b/contentcuration/contentcuration/tests/test_createchannel.py
@@ -75,7 +75,7 @@ class CreateChannelTestCase(BaseTestCase):
         self.fileobj_exercise = create_temp_file("jkl", 'exercise', 'perseus', 'application/perseus')
 
     def create_channel(self):
-        create_channel_url = self.url + str(reverse_lazy('api_create_channel'))
+        create_channel_url = str(reverse_lazy('api_create_channel'))
         payload = {
             'channel_data': self.channel_metadata,
         }
@@ -294,7 +294,7 @@ class CreateChannelTestCase(BaseTestCase):
         root_id = json.loads(self.create_channel().content)['root']
 
         def upload_nodes(root_id, nodes):
-            add_nodes_url = self.url + str(reverse_lazy('api_add_nodes_to_tree'))
+            add_nodes_url = str(reverse_lazy('api_add_nodes_to_tree'))
             payload = {
                 'root_id': root_id,
                 'content_data': nodes,


### PR DESCRIPTION
… so that configuration changes don't break them.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
