### PR TITLE
Rmove assertion error on file type

### DIFF
--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -28,8 +28,6 @@ class GoogleCloudStorage(Storage):
         Raises an AssertionError if filename is not a string.
         """
 
-        assert isinstance(filename, str), "Expected filename to be string, passed in {}".format(filename)
-
         typ, _ =  mimetypes.guess_type(filename)
 
         if not typ:


### PR DESCRIPTION
Fixes #967. The assertion was too specific too strings, and errored out on unicode.