### PR TITLE
Reduce the # of storage calls on add_nodes APIs

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -988,6 +988,18 @@ class FormatPreset(models.Model):
     def __str__(self):
         return self.id
 
+    @classmethod
+    def get_preset(cls, preset_name):
+        """
+        Get the FormatPreset object with that exact name.
+
+        Returns None if that format preset is not found.
+        """
+        try:
+            return FormatPreset.objects.get(id=preset_name)
+        except FormatPreset.DoesNotExist:
+            return None
+
 
 class Language(models.Model):
     id = models.CharField(max_length=14, primary_key=True)

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -989,6 +989,21 @@ class FormatPreset(models.Model):
         return self.id
 
     @classmethod
+    def guess_format_preset(cls, filename):
+        """
+        Guess the format preset of a filename based on its extension.
+
+        Return None if format is unknown.
+        """
+
+        _, ext = os.path.splitext(filename)
+        f = FormatPreset.objects.filter(
+            allowed_formats__extension=ext,
+            display=True
+            )
+        return f.first()
+
+    @classmethod
     def get_preset(cls, preset_name):
         """
         Get the FormatPreset object with that exact name.

--- a/contentcuration/contentcuration/tests/test_format_preset_model.py
+++ b/contentcuration/contentcuration/tests/test_format_preset_model.py
@@ -1,0 +1,28 @@
+from contentcuration.models import FormatPreset
+from base import StudioTestCase
+
+class GetPresetTestCase(StudioTestCase):
+
+    def test_accepts_string(self):
+        """
+        Check that if we pass in a string, we won't error out.
+        """
+        FormatPreset.get_preset("a")
+
+    def test_returns_model_if_correct_preset_name(self):
+        """
+        Check that we get a Django model if we pass a correct preset name, like PDF.
+        """
+        preset = "document"
+        model = FormatPreset.get_preset(preset)
+        assert isinstance(model, FormatPreset)
+
+    def test_returns_none_if_called_with_nonexistent_preset(self):
+        """
+        Make sure we return None when we pass in a formatpreset that doesn't exist.
+        """
+
+        preset = "hats"
+        model = FormatPreset.get_preset(preset)
+        assert isinstance(model, types.NoneType)
+

--- a/contentcuration/contentcuration/tests/test_format_preset_model.py
+++ b/contentcuration/contentcuration/tests/test_format_preset_model.py
@@ -1,3 +1,5 @@
+import types
+
 from contentcuration.models import FormatPreset
 from base import StudioTestCase
 
@@ -24,5 +26,30 @@ class GetPresetTestCase(StudioTestCase):
 
         preset = "hats"
         model = FormatPreset.get_preset(preset)
+        assert isinstance(model, types.NoneType)
+
+
+class GuessFormatPresetTestCase(StudioTestCase):
+
+    def test_accepts_string(self):
+        """
+        Make sure we don't raise an error if we pass a string.
+        """
+        FormatPreset.guess_format_preset("a")
+
+    def test_returns_model_if_correct_preset_name(self):
+        """
+        Check that we return a FormatPreset model instance.
+        """
+        filename = "blah.pdf"
+        model = FormatPreset.guess_format_preset(filename)
+        assert isinstance(model, FormatPreset)
+
+    def test_returns_none_if_unknown_extension(self):
+        """
+        Check that we return a None for an unknown format.
+        """
+        filename = "blah.hat"
+        model = FormatPreset.guess_format_preset(filename)
         assert isinstance(model, types.NoneType)
 

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -71,7 +71,6 @@ def license_wtfpl():
     """
     return cc.License.objects.first() or mixer.blend(cc.License, license_name="WTF License")
 
-
 def fileobj_video(contents=None):
     """
     Create an "mp4" video file on storage, and then create a File model pointing to it.
@@ -93,9 +92,15 @@ def fileobj_video(contents=None):
     default_storage.save(storage_file_path, fileobj)
 
     # then create a File object with that
-    db_file_obj = mixer.blend(cc.File, file_format=fileformat_mp4(), preset=preset_video(), file_on_disk=storage_file_path)
+    db_file_obj = mixer.blend(
+        cc.File,
+        file_format=fileformat_mp4(),
+        checksum=digest,
+        preset=preset_video(),
+        file_on_disk=storage_file_path,
+    )
 
-    yield db_file_obj
+    return db_file_obj
 
 
 def node_json(data):
@@ -129,7 +134,7 @@ def node(data, parent=None):
     elif data['kind_id'] == "video":
         new_node = cc.ContentNode(kind=video(), parent=parent, title=data['title'], node_id=data['node_id'], license=license_wtfpl())
         new_node.save()
-        video_file = fileobj_video(contents="Video File").next()
+        video_file = fileobj_video(contents="Video File")
         video_file.contentnode = new_node
         video_file.preset_id = format_presets.VIDEO_HIGH_RES
         video_file.save()

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -1,0 +1,111 @@
+"""
+Tests for contentcuration.views.internal functions.
+"""
+import json
+from mixer.main import mixer
+
+from contentcuration.models import ContentNode
+
+from ..base import StudioTestCase
+from ..testdata import tree, fileobj_video
+
+class ApiAddNodesToTreeTestCase(StudioTestCase):
+    """
+    Tests for contentcuration.views.internal.api_add_nodes_to_tree function.
+    """
+
+    class SampleNodeDataSchema:
+        """
+        A class schema that we use to autogenerate parts of the
+        JSON data we send to api_add_nodes_to_tree. Pair this with
+        mixer.blend to autogenerate the schema with random values.
+        """
+        title = str
+        description = str
+        node_id = str
+        content_id = str
+        source_domain = str
+        source_id = str
+        author = str
+        copyright_holder = str
+
+    def setUp(self):
+        super(ApiAddNodesToTreeTestCase, self).setUp()
+        # get our random data from mixer
+        random_data = mixer.blend(self.SampleNodeDataSchema)
+        self.root_node = tree()
+        self.fileobj = fileobj_video()
+        self.title = random_data.title
+        sample_data = {
+            "root_id": self.root_node.id,
+            "content_data": [
+                {
+                    "title": self.title,
+                    "language": "en",
+                    "description": random_data.description,
+                    "node_id": random_data.node_id,
+                    "content_id": random_data.content_id,
+                    "source_domain": random_data.source_domain,
+                    "source_id": random_data.source_id,
+                    "author": random_data.author,
+                    "files": [
+                        {
+                            "size": self.fileobj.file_size,
+                            "preset": "video",
+                            "filename": self.fileobj.filename(),
+                            "original_filename": self.fileobj.original_filename,
+                            "language": self.fileobj.language,
+                            "source_url": self.fileobj.source_url
+                        }
+                    ],
+                    "kind": "document",
+                    "license": "CC BY",
+                    "license_description": None,
+                    "copyright_holder": random_data.copyright_holder,
+                    "questions": [],
+                    "extra_fields": "{}",
+                    "role": "learner"
+                }
+            ]
+        }
+
+        serialized_data = json.dumps(sample_data)
+
+        self.resp = self.admin_client().post(
+            "/api/internal/add_nodes",
+            data=serialized_data,
+            # remember to set content_type to json, so django will
+            # decode it
+            content_type="application/json"
+        )
+
+    def test_returns_200_status_code(self):
+        """
+        Check that we return 200 if passed in a valid JSON.
+        """
+        # check that we returned 200 with that POST request
+        assert self.resp.status_code == 200, "Got a request error: {}".format(self.resp.content)
+
+    def test_creates_nodes(self):
+        """
+        Test that it creates a node with the given title and parent.
+        """
+
+        # make sure a node with our given self.title exists, with the given parent.
+        assert ContentNode.get_nodes_with_title(title=self.title, limit_to_children_of=self.root_node.id).exists()
+
+    def test_associates_file_with_created_node(self):
+        """
+        Check that the file we created beforehand is now associated
+        with the node we just created through add_nodes.
+        """
+
+        c = ContentNode.objects.get(title=self.title)
+
+        # check that the file we associated has the same checksum
+        f = c.files.get(checksum=self.fileobj.checksum)
+        assert f
+
+        # check that we can read the file and it's equivalent to
+        # our original file object
+        assert f.file_on_disk.read() == self.fileobj.file_on_disk.read()

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -1,0 +1,65 @@
+import os
+
+from django.conf import settings
+from django.core.files import File as DjFile
+from django.core.files.storage import default_storage
+from django_s3_storage.storage import S3Error
+
+from contentcuration.models import Language, User, ContentNode, FormatPreset, generate_object_storage_name, File
+
+def map_files_to_node(user, node, data):
+    """
+    Generate files that reference the content node.
+    """
+    if settings.DEBUG:
+        # assert that our parameters match expected values
+        assert isinstance(user, User)
+        assert isinstance(node, ContentNode)
+        assert isinstance(data, list)
+
+    # filter for file data that's not empty;
+    valid_data = filter_out_nones(data)
+
+    for file_data in valid_data:
+        filename = file_data["filename"]
+        checksum, ext = filename.split(".")
+
+        # Determine a preset if none is given
+        kind_preset = FormatPreset.get_preset(file_data["preset"]) or FormatPreset.guess_format_preset(filename)
+
+        file_path = generate_object_storage_name(checksum, filename)
+        storage = default_storage
+
+        if not storage.exists(file_path):
+            raise IOError('{} not found'.format(file_path))
+
+        try:
+            if file_data.get('language'):
+                # TODO: Remove DB call per file?
+                file_data['language'] = Language.objects.get(pk=file_data['language'])
+        except ObjectDoesNotExist as e:
+            invalid_lang = file_data.get('language')
+            logging.warning("file_data with language {} does not exist.".format(invalid_lang))
+            return ValidationError("file_data given was invalid; expected string, got {}".format(invalid_lang))
+
+        resource_obj = File(
+            checksum=checksum,
+            contentnode=node,
+            file_format_id=ext,
+            original_filename=file_data.get('original_filename') or 'file',
+            source_url=file_data.get('source_url'),
+            file_size=file_data['size'],
+            preset=kind_preset,
+            language_id=file_data.get('language'),
+            uploaded_by=user,
+        )
+        resource_obj.file_on_disk.name = file_path
+        resource_obj.save()
+
+
+def filter_out_nones(data):
+    """
+    Filter out any falsey values from data.
+    """
+    return (l for l in data if l)
+


### PR DESCRIPTION
Fixes #941. We first add some API call tests for /api/internal/add_nodes. That will
allow us to refactor it while keeping the same behaviour. I then removed the
call to `storage.open`, and then simply set the `file_on_disk.name` to the right
path. That prevents us from writing to the same file all the time, and avoiding
any GCS errors.

Some other changes:
- I did some halfway refactorings, like move `map_files_to_node` to a separate
  utility function. I was planning to write more granular tests and do heavier
  refactorings. I decided to postpone that since the current tests should be
  good enough.