### PR TITLE
Create simplified implementation for gcs_storage.generate_filename

### DIFF
--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -145,4 +145,5 @@ class GoogleCloudStorage(Storage):
         return name
 
     def generate_filename(self, filename):
-        raise NotImplementedError
+        # TODO(aron): can we move the generate_object_storage_name logic to here?
+        return filename


### PR DESCRIPTION
Just return the filename passed in, since the logic is implemented through generate_object_storage_name.

