### PR TITLE
Remove the GCS storage cache

### DIFF
--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -4,7 +4,9 @@ from cStringIO import StringIO
 
 import pytest
 from django.test import TestCase
+from django.core.files import File
 from mock import create_autospec
+from mixer.main import mixer
 from google.cloud.storage import Client
 from google.cloud.storage.blob import Blob
 
@@ -80,3 +82,47 @@ class GoogleCloudStorageSaveTestCase(TestCase):
 
         # Check that we pass self.content file_object to upload_from_file
         self.blob_obj.upload_from_file.assert_called_once_with(self.content, content_type="image/jpeg")
+
+
+class GoogleCloudStorageOpenTestCase(TestCase):
+    """
+    Tests for GoogleCloudStorage.open().
+    """
+
+    class RandomFileSchema:
+        """
+        A schema for a file we're about to upload.
+        """
+        contents = str
+        filename = str
+
+    def setUp(self):
+        self.blob_class = create_autospec(Blob)
+        self.blob_obj = self.blob_class("blob", "blob")
+        self.mock_client = create_autospec(Client)
+        self.storage = gcs(client=self.mock_client())
+        self.local_file = mixer.blend(self.RandomFileSchema)
+
+    def test_raises_error_if_mode_is_not_rb(self):
+        """
+        open() should raise an assertion error if passed in a mode flag that's not "rb".
+        """
+        with pytest.raises(AssertionError):
+            self.storage.open("randfile", mode="wb")
+
+    def test_calls_blob_download_to_file(self):
+        """
+        Check that open() eventually calls blob.download_to_file().
+        """
+        self.storage.open(self.local_file.filename, blob_object=self.blob_obj)
+
+        # assert that we called download_from_file
+        self.blob_obj.download_to_file.assert_called()
+
+    def test_returns_django_file(self):
+        """
+        Test that we return a Django File instance.
+        """
+        f = self.storage.open(self.local_file.filename, blob_object=self.blob_obj)
+
+        assert isinstance(f, File)

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -1,3 +1,4 @@
+import tempfile
 import logging
 import mimetypes
 import os.path
@@ -37,43 +38,37 @@ class GoogleCloudStorage(Storage):
         else:
             return typ
 
-    def open(self, name, mode="rb"):
+    def open(self, name, mode="rb", blob_object=None):
+        """
+        open returns a Django File object containing the bytes of name suitable for reading.
+
+        You can pass in an optional 'mode' argument, but is only there for Django Storage class
+        compatibility. It would error out if given any other argument than "rb".
+
+        You can also pass in an object in the blob_object argument. This must have a method called
+        `download_to_file` that accepts as writeable file object as an argument, and writes the
+        bytes to it. (this is mainly used for mocking in tests.)
+        """
         # We don't have any logic for returning the file object in write
         # so just raise an error if we get any mode other than rb
         assert mode == "rb",\
             ("Sorry, we can't handle any open mode other than rb."
              " Please use Storage.save() instead.")
 
-        blob = self.bucket.get_blob(name)
-
-        # take advantage of the fact that we only
-        # write a file once, and that GCS returns the MD5
-        # hash as part of the metadata.
-
-        # See if a file with a matching MD5 hash is already
-        # present. If so, just return that.
-        tmp_filename = os.path.join("/tmp", blob.md5_hash)
-
-        # the md5 hash from gcloud storage encoded in base64, which may not be
-        # compatible as a filesystem name. Change it to hex.
-        tmp_filename = tmp_filename.decode("base64").encode("hex")
-
-        is_new = True
-        if os.path.exists(tmp_filename):
-            f = open(tmp_filename)
-            is_new = False
-
-        # If there's no such file, then download that file
-        # from GCS.
+        if not blob_object:
+            blob = self.bucket.get_blob(name)
         else:
-            with open(tmp_filename, "wb") as fobj:
-                blob.download_to_file(fobj)
+            blob = blob_object
 
-            # reopen the file we just wrote, this time in read mode
-            f = open(tmp_filename)
+        # create a spooled tempfile, where small amounts of data
+        # are stored in memory, but written to disk if it gets large.
+        fobj = tempfile.SpooledTemporaryFile()
+        blob.download_to_file(fobj)
+        # flush it to disk
+        fobj.flush()
 
-        django_file = File(f)
-        django_file.just_downloaded = is_new
+        django_file = File(fobj)
+        django_file.just_downloaded = True
         return django_file
 
     def exists(self, name):


### PR DESCRIPTION
It may be causing issues with zip files. The compute instances are also close enough to GCS and have big enough bandwidth to make the caching negligible.