### PR TITLE
Add caching to the admins page

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -473,6 +473,10 @@ class Channel(models.Model):
         blank=True,
     )
 
+    @classmethod
+    def get_all_channels(cls):
+        return cls.objects.select_related('main_tree').prefetch_related('editors', 'viewers').distinct()
+
     def resource_size_key(self):
         return "{}_resource_size".format(self.pk)
 

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 from django.test import TestCase
+from mixer.backend.django import mixer
 
 from contentcuration.models import Channel
 from .base import StudioTestCase
@@ -145,3 +146,23 @@ class ChannelGetDateModifiedTestCase(StudioTestCase):
         )
         # check that the returned date is newer
         assert self.channel.get_date_modified() > old_date
+
+
+class GetAllChannelsTestCase(StudioTestCase):
+    """
+    Tests for Channel.get_all_channels().
+    """
+
+    def setUp(self):
+        super(GetAllChannelsTestCase, self).setUp()
+
+        # create 10 channels for comparison
+        self.channels = mixer.cycle(10).blend(Channel)
+
+    def test_returns_all_channels_in_the_db(self):
+        """
+        Check that all channels in self.channels are also created.
+        """
+        returned_channel_ids = [c.id for c in Channel.get_all_channels()]
+        for c in self.channels:
+            assert c.id in returned_channel_ids

--- a/contentcuration/contentcuration/utils/channelcache.py
+++ b/contentcuration/contentcuration/utils/channelcache.py
@@ -16,6 +16,17 @@ class ChannelCacher(object):
     PUBLIC_CHANNEL_CACHE_KEY = "public_channel_cache"
     PUBLIC_CHANNEL_CACHE_TIMEOUT = 60 # seconds
 
+    ALL_CHANNELS_CACHE_KEY = "all_channels_cache"
+    ALL_CHANNELS_TIMEOUT = 60 * 10 # 10 minutes
+
+    @classmethod
+    def get_all_channels(cls):
+        return cache.get_or_set(
+            cls.ALL_CHANNELS_CACHE_KEY,
+            lambda: Channel.get_all_channels(),
+            cls.ALL_CHANNELS_TIMEOUT,
+        )
+
     @classmethod
     def get_public_channels(cls, *args, **kwargs):
         return cache.get_or_set(

--- a/contentcuration/contentcuration/views/admin.py
+++ b/contentcuration/contentcuration/views/admin.py
@@ -93,7 +93,7 @@ def get_all_channels(request):
     if not request.user.is_admin:
         raise SuspiciousOperation("You are not authorized to access this endpoint")
 
-    channel_list = Channel.objects.select_related('main_tree').prefetch_related('editors', 'viewers').distinct()
+    channel_list = Channel.get_all_channels()
     channel_serializer = AdminChannelListSerializer(channel_list, many=True)
 
     return Response(channel_serializer.data)

--- a/contentcuration/contentcuration/views/admin.py
+++ b/contentcuration/contentcuration/views/admin.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.http import HttpResponse, HttpResponseNotFound, FileResponse, HttpResponseBadRequest, StreamingHttpResponse
 from django.views.decorators.http import condition
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.cache import cache_page
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
@@ -31,6 +32,7 @@ from rest_framework.renderers import JSONRenderer
 from contentcuration.decorators import browser_is_supported, is_admin
 from contentcuration.models import Channel, User, Invitation, ContentNode, generate_file_on_disk_name, File, Language
 from contentcuration.utils.messages import get_messages
+from contentcuration.utils.channelcache import ChannelCacher
 from contentcuration.serializers import AdminChannelListSerializer, AdminUserListSerializer, CurrentUserSerializer, UserChannelListSerializer
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
@@ -85,6 +87,7 @@ def administration(request):
                                                  "messages": get_messages(),
                                                 })
 
+@cache_page(60 * 10) # 10 minutes
 @login_required
 @api_view(['GET'])
 @authentication_classes((SessionAuthentication, BasicAuthentication, TokenAuthentication))
@@ -93,7 +96,7 @@ def get_all_channels(request):
     if not request.user.is_admin:
         raise SuspiciousOperation("You are not authorized to access this endpoint")
 
-    channel_list = Channel.get_all_channels()
+    channel_list = ChannelCacher.get_all_channels()
     channel_serializer = AdminChannelListSerializer(channel_list, many=True)
 
     return Response(channel_serializer.data)

--- a/deploy/chaos/loadtest/locustfile.py
+++ b/deploy/chaos/loadtest/locustfile.py
@@ -55,8 +55,17 @@ class ChannelListPage(BaseTaskSet):
         resp = self.client.get("/channels/")
         self.channel_list_api_calls()
 
+class AdminChannelListPage(BaseTaskSet):
+
+    def on_start(self):
+        self._login()
+
+    @task
+    def channel_list_api_call(self):
+        self.client.get("/api/get_all_channels")
+
 class LoginPage(BaseTaskSet):
-    tasks = [ChannelListPage]
+    tasks = [ChannelListPage, AdminChannelListPage]
 
     @task
     def loginpage(self):
@@ -65,7 +74,6 @@ class LoginPage(BaseTaskSet):
         """
         self.client.get("/accounts/login/")
         self.i18n_requests()
-
 
 class StudioDesktopBrowserUser(HttpLocust):
     task_set = LoginPage

--- a/deploy/chaos/loadtest/prep.py
+++ b/deploy/chaos/loadtest/prep.py
@@ -1,0 +1,73 @@
+"""
+THIS WILL CLEAR YOUR DATABASE AND FILL IT WITH TEST DATA!
+
+Prepare the local database for load testing.
+
+It does the following:
+- Creates an admin user.
+- Creates 1000 channels. Each one has 500 topic nodes. Each node has 30 videos each.
+"""
+import json
+import logging
+import os
+import subprocess
+import sys
+import warnings
+
+# output any info logs
+logging.basicConfig(level="INFO")
+
+# set sys.path to include the contentcuration dir
+root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+cc_dir = os.path.join(root_dir, "contentcuration")
+sys.path.append(cc_dir)
+
+# set the settings module
+os.putenv("DJANGO_SETTINGS_MODULE", "contentcuration.test_settings")
+
+from django.core.management import call_command
+# from mixer.backend.django import mixer
+
+from contentcuration.tests.testdata import channel
+from contentcuration.models import Channel, ContentNode, User
+
+# CONSTANTS
+NUM_CHANNELS = 1000
+NUM_NODES_PER_CHANNEL = 500
+
+from mixer.backend.django import mixer
+
+mixer.register(
+    User,
+    information="{}",
+    content_defaults="{}",
+    policies="{}"
+)
+
+
+if __name__ == "__main__":
+    warnings.warn("THIS WILL CLEAR YOUR DATABASE AND FILL IT WITH TEST DATA!")
+    logging.info("Clearing the DB")
+    call_command("flush", "--noinput")
+
+    # set up our DB from scratch and create our user
+    logging.info("Setting up the database")
+    call_command("setup")
+
+    # create NUM_CHANNELS channels using mixer
+
+    logging.info("Creating {} channels".format(NUM_CHANNELS))
+
+    for _ in range(NUM_CHANNELS):
+        editor = mixer.blend(User)
+        c = mixer.blend(Channel)
+        c.editors.add(editor)
+        viewers = mixer.cycle(2).blend(User)
+        for v in viewers:
+            v.view_only_channels.add(c)
+            v.save()
+        c.save()
+
+    # start the server in prod mode
+    subprocess.call(["yarn", "run", "devserver"])
+

--- a/deploy/chaos/loadtest/prep.py
+++ b/deploy/chaos/loadtest/prep.py
@@ -5,7 +5,7 @@ Prepare the local database for load testing.
 
 It does the following:
 - Creates an admin user.
-- Creates 1000 channels. Each one has 500 topic nodes. Each node has 30 videos each.
+- Creates 1000 channels. Create 3 users for each channel, and assign 1 as the editor and the other two as viewers.
 """
 import json
 import logging


### PR DESCRIPTION
Add basic caching to the `get_all_channels` endpoint. This caches both the entire endpoint's return value, and the listing of all channels from the DB. I moved that line of code to its own method in the `Channel` model as well.

Along the way, I needed to benchmark that endpoint to see if my changes are effective. I created a new `prep.py` file to create 1000 channels with editors and viewers attached. I also extended our load testing script to query the get all channels endpoint as well.