### PR TITLE
Removing languages we don't have frontend translations for.

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -242,11 +242,11 @@ LOCALE_PATHS = (
 ugettext = lambda s: s
 LANGUAGES = (
     ('en', ugettext('English')),
-    ('es', ugettext('Spanish')),
+    # ('es', ugettext('Spanish')),
     # ('ar', ugettext('Arabic')), # Uncomment when we have translations
-    ('es-es', ugettext('Spanish - Spain')),
+    # ('es-es', ugettext('Spanish - Spain')),
     ('es-mx', ugettext('Spanish - Mexico')),
-    ('en-PT', ugettext('English - Pirate')),
+    # ('en-PT', ugettext('English - Pirate')),
 )
 
 


### PR DESCRIPTION
## Description

Allows Django to handle fallbacks for each message (built-in feature).

#### Issue Addressed (if applicable)

Resolves #405 

## Steps to Test

- [ ] Change browser language to a spanish other than Mexican
- [ ] Open studio
- [ ] Ensure that the page is in spanish
- [ ] Change browser language to Mexican spanish
- [ ] Ensure that the page is _still_ in spanish

## Implementation Notes (optional)

Killed off a few languages, including pirate english :disappointed: sorry y'all.

Django has language fallback features that automatically update the code returned in `get_language` - if a regional version of the language isn't found, it'll fall back to the next closest thing (non-regional, then some other region).

#### Does this introduce any tech-debt items?

Not that I know of, but this is why I included @jayoshih 

## Additional Comments
Please verify asap so that I can get the points for the bug bash :smile: 