### PR TITLE
SpooledTemporaryFile sometimes wouldn't generate an on-disk file, so …

### DIFF
--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -118,3 +118,4 @@ class GoogleCloudStorageOpenTestCase(TestCase):
         f = self.storage.open(self.local_file.filename, blob_object=self.blob_obj)
 
         assert isinstance(f, File)
+        assert f.name

--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -118,4 +118,5 @@ class GoogleCloudStorageOpenTestCase(TestCase):
         f = self.storage.open(self.local_file.filename, blob_object=self.blob_obj)
 
         assert isinstance(f, File)
+        # This checks that an actual temp file was written on disk for the file.git
         assert f.name

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -58,8 +58,6 @@ class GoogleCloudStorage(Storage):
         else:
             blob = blob_object
 
-        # create a spooled tempfile, where small amounts of data
-        # are stored in memory, but written to disk if it gets large.
         fobj = tempfile.NamedTemporaryFile()
         blob.download_to_file(fobj)
         # flush it to disk

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -60,7 +60,7 @@ class GoogleCloudStorage(Storage):
 
         # create a spooled tempfile, where small amounts of data
         # are stored in memory, but written to disk if it gets large.
-        fobj = tempfile.SpooledTemporaryFile()
+        fobj = tempfile.NamedTemporaryFile()
         blob.download_to_file(fobj)
         # flush it to disk
         fobj.flush()


### PR DESCRIPTION
…switch to NamedTemporaryFile instead. Also test that it does the right thing.

## Description

SpooledTemporaryFile was not creating an on-disk file, and the pseudo-File object appears to get garbage collected, leaving an empty file reference.

#### Issue Addressed (if applicable)

#1005 

## Steps to Test

- [ ] Upload a file

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
