### PR TITLE
SpooledTemporaryFile sometimes wouldn't generate an on-disk file, so …

### DIFF
--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -118,3 +118,5 @@ class GoogleCloudStorageOpenTestCase(TestCase):
         f = self.storage.open(self.local_file.filename, blob_object=self.blob_obj)
 
         assert isinstance(f, File)
+        # This checks that an actual temp file was written on disk for the file.git
+        assert f.name

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -58,9 +58,7 @@ class GoogleCloudStorage(Storage):
         else:
             blob = blob_object
 
-        # create a spooled tempfile, where small amounts of data
-        # are stored in memory, but written to disk if it gets large.
-        fobj = tempfile.SpooledTemporaryFile()
+        fobj = tempfile.NamedTemporaryFile()
         blob.download_to_file(fobj)
         # flush it to disk
         fobj.flush()


### PR DESCRIPTION
…… (#1007)

* SpooledTemporaryFile sometimes wouldn't generate an on-disk file, so switch to NamedTemporaryFile instead. Also test that it does the right thing.

* Update the docs as well.

**Please remove any unused sections**

## Description

*What does this PR do? Briefly describe in 1-2 sentences*

#### Issue Addressed (if applicable)

Addresses #*PR# HERE*

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan @jayoshih (full stack)
- Aron @aronasorman (back end, devops)
- Ivan @ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard @rtibbles ([Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
