### PR TITLE
Image fix b

### DIFF
--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -60,6 +60,7 @@ class GoogleCloudStorage(Storage):
         blob.download_to_file(fobj)
         # flush it to disk
         fobj.flush()
+        fobj.seek(0)
 
         django_file = File(fobj)
         django_file.just_downloaded = True

--- a/contentcuration/contentcuration/views/admin.py
+++ b/contentcuration/contentcuration/views/admin.py
@@ -43,6 +43,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.http import condition
 from le_utils.constants import content_kinds
 from PIL import Image
+from raven.contrib.django.raven_compat.models import client
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.authentication import TokenAuthentication
@@ -430,6 +431,8 @@ def generate_thumbnail(channel):
                 image.save(buffer, image.format)
                 return "data:image/{};base64,{}".format(ext[1:], base64.b64encode(buffer.getvalue()))
         except IOError:
+            client.captureMessage("Failed to generate thumbnail for channel id={}, filepath={}".format(
+                channel.id, filepath))
             pass
 
 


### PR DESCRIPTION
## Description

This is to fix the chef's failing to thumbnail upload issue on develop:
```
WARNING: The following nodes have one or more descendants that could not be created:
 1 descendant (Internal Server Error)
```

This was a very weird issue because it didn't occur on local dev (mac), and in local docker-env deployed with docker-compose (linux). Issue is only occuring on develop.studio.leq.org

#### Issue Addressed (if applicable)

https://sentry.io/learningequality/studio/issues/720026215/


Two possible root causes:
  1. Temp file returned by `default_storage.open` is is not read from the beginning (since last thing it saw was a flush so it could be at the end of the file "end" and needs to be.
  2. OS-level disk buffering: the call to `tempf.close()` does a flush, but OS might have not sync-ed the data to disk yet, so when PIL.Image tries to open it doesn't see valid image data.

Thanks to Kevin helping out with debugged this!


Note: This race condition might also occur here:
https://github.com/learningequality/studio/blob/develop/contentcuration/contentcuration/views/admin.py#L423-L426