### PR TITLE
Stop getting le-utils constants from github

### DIFF
--- a/contentcuration/contentcuration/management/commands/loadconstants.py
+++ b/contentcuration/contentcuration/management/commands/loadconstants.py
@@ -18,7 +18,6 @@ from contentcuration import models
 logging = logmodule.getLogger(__name__)
 
 
-BASE_URL = "https://raw.githubusercontent.com/learningequality/le-utils/master/le_utils/resources/{}"
 
 
 class ConstantGenerator():
@@ -74,24 +73,6 @@ class LanguageGenerator(ConstantGenerator):
     filename = "languagelookup.json"
     default_list = languages.LANGUAGELIST
     model = models.Language
-
-    def generate_list(self):
-        # Try to get json from github to avoid releasing le-utils for every new lang
-        try:
-            response = urllib.urlopen(BASE_URL.format(self.filename))
-            data = json.loads(response.read())
-            language_list = languages.generate_list(data)
-        except Exception:
-            logging.warning("Failed to retrieve latest {filename} from GitHub.".format(filename=self.filename))
-            language_list = self.default_list
-
-        return [
-            {
-                "model": self.model,
-                "pk": self.id_field,
-                "fields": self.get_dict(constant),
-            } for constant in language_list
-        ]
 
     def get_dict(self, constant):
         return {

--- a/contentcuration/contentcuration/tests/test_utils.py
+++ b/contentcuration/contentcuration/tests/test_utils.py
@@ -1,17 +1,30 @@
 import datetime
 from cStringIO import StringIO
-from unittest import TestCase
+from django.test import TestCase
+
 
 from base import StudioTestCase
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
+from django.core.management import call_command
 
+from contentcuration.models import ContentKind
 from contentcuration.models import File
+from contentcuration.models import FileFormat
+from contentcuration.models import FormatPreset
+from contentcuration.models import Language
+from contentcuration.models import License
 from contentcuration.models import generate_object_storage_name
 from contentcuration.models import User
 from contentcuration.utils.files import get_file_diff
 from contentcuration.utils.policies import check_policies
 from contentcuration.utils.policies import POLICIES
+
+from le_utils.constants import content_kinds
+from le_utils.constants import file_formats
+from le_utils.constants import format_presets
+from le_utils.constants import languages
+from le_utils.constants import licenses
 
 
 class CheckPoliciesTestCase(TestCase):
@@ -114,3 +127,49 @@ class FileFormatsTestCase(StudioTestCase):
                 file_with_ext.file_on_disk.save("aaa.{}".format(ext), ContentFile("aaa"))
             except Exception as e:
                 raise type(e)(e.message + " ... (hint: make sure that the version of le-utils you're using has its file formats synced).")
+
+
+
+class LEUtilsListsTestCase(TestCase):
+    """
+    Ensure that le-utils has the necessay lists to populate the Studio models.
+    """
+
+    def test_le_utils_has_all_consstants_lists(self):
+        assert licenses.LICENSELIST, 'licenses.LICENSELIST missing from LE-UTILS!'
+        assert content_kinds.KINDLIST, 'content_kinds.KINDLIST missing from LE-UTILS!'
+        assert languages.LANGUAGELIST, 'languages.LANGUAGELIST missing from LE-UTILS!'
+        assert file_formats.FORMATLIST, 'file_formats.FORMATLIST missing from LE-UTILS!'
+        assert format_presets.PRESETLIST, 'format_presets.PRESETLIST missing from LE-UTILS!'
+
+    def test_le_utils_has_all_choices(self):
+        """Used for django model choices fields to provide validation."""
+        assert content_kinds.choices, 'content_kinds.choices missing from LE-UTILS!'
+        assert format_presets.choices, 'format_presets.choices missing from LE-UTILS!'
+        assert file_formats.choices, 'file_formats.choices missing from LE-UTILS!'
+
+
+
+class LoadConstantsManagementCommandTestCase(TestCase):
+    """
+    Check `loadconstants` works.
+    """
+    models = [
+        ContentKind,
+        FileFormat,
+        FormatPreset,
+        Language,
+        License
+    ]
+
+    def test_starting_from_empty_db(self):
+        for model in self.models:
+            qset = model.objects.all()
+            assert len(list(qset)) == 0, 'Constants of type {} already exist.'.format(str(model))
+
+    def test_models_exist_after_loadconstants(self):
+        call_command("loadconstants")
+        for model in self.models:
+            qset = model.objects.all()
+            assert len(list(qset)) > 3, 'Only {} constants of type {} created.'.format(len(list(qset)), str(model))
+


### PR DESCRIPTION
## Description

No need to get from github json; prefer constants from le_utils package.


Added tests to make sure loadconstants doesn't break







## Checklist

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?


