### PR TITLE
A snapshot of a snapshot

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/__tests__/ExerciseView.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/__tests__/ExerciseView.spec.js
@@ -1,0 +1,103 @@
+const ExerciseView = require('../views').ExerciseView;
+const Backbone = require('backbone');
+// Register handlebars helpers to ensure templates are rendered properly.
+require('handlebars/helpers');
+
+const exampleAnswer = {
+  type: 'multiplechoice',
+  question: 'Ceci n\'est pas un question?',
+  hints: '["Maybe it is, maybe not?"]',
+  answers: '[{ "correct": true, "answer": "First" }, { "correct": false, "answer": "Second" }, { "correct": false, "answer": "Fish" } ]',
+  order: 1,
+  assessment_id: 'test',
+  raw_data: '',
+  source_url: '',
+  randomize: true,
+  deleted: false,
+};
+
+describe('ExerciseView', () => {
+  let model;
+  beforeEach(() => {
+    model = new Backbone.Model({
+      title: 'test',
+      changed: false,
+      id: 'test',
+      description: 'test',
+      sort_order: 1.5,
+      author: 'test',
+      copyright_holder: 'test',
+      license: 'test',
+      language: 'test',
+      license_description: 'test',
+      assessment_items: [],
+      files: [],
+      parent_title: 'test',
+      ancestors: [],
+      modified: 'test',
+      original_channel: 'test',
+      kind: 'test',
+      parent: 'test',
+      children: 'test',
+      published: 'test',
+      associated_presets: [],
+      valid: 'test',
+      metadata: 'test',
+      original_source_node_id: 'test',
+      tags: 'test',
+      extra_fields: {
+        randomize: false,
+      },
+      prerequisite: [],
+      is_prerequisite_of: 'test',
+      node_id: 'test',
+      tree_id: 'test',
+      publishing: false,
+      freeze_authoring_data: false,
+      role_visibility: 'test',
+      provider: 'test',
+      aggregator: 'test',
+      thumbnail_src: 'test',
+    });
+  });
+  describe('render method', () => {
+    it('should render with a valid content node with no assessment_items', () => {
+      const view = new ExerciseView({
+        model,
+      });
+      view.render();
+      const html = view.$el[0].outerHTML
+      expect(html).toMatchSnapshot();
+    });
+    it('should render with a valid content node with 1 assessment_items', () => {
+      model.set('assessment_items', [
+        exampleAnswer,
+      ]);
+      const view = new ExerciseView({
+        model,
+      });
+      view.render();
+      const html = view.$el[0].outerHTML
+      expect(html).toMatchSnapshot();
+    });
+    it('should render with a valid content node with 3 different assessment_items', () => {
+      const exampleAnswer1 = exampleAnswer;
+      const exampleAnswer2 = Object.assign({}, exampleAnswer);
+      exampleAnswer2.type = 'single_selection';
+      const exampleAnswer3 = Object.assign({}, exampleAnswer);
+      exampleAnswer3.type = 'single_selection';
+      exampleAnswer3.answers = "[]";
+      model.set('assessment_items', [
+        exampleAnswer1,
+        exampleAnswer2,
+        exampleAnswer3,
+      ]);
+      const view = new ExerciseView({
+        model,
+      });
+      view.render();
+      const html = view.$el[0].outerHTML
+      expect(html).toMatchSnapshot();
+    });
+  });
+});

--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/__tests__/__snapshots__/ExerciseView.spec.js.snap
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/__tests__/__snapshots__/ExerciseView.spec.js.snap
@@ -1,0 +1,501 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExerciseView render method should render with a valid content node with 1 assessment_items 1`] = `
+<div>
+  <div class="container-fluid" id="exercisecreation">
+    <div class="container-fluid exercise_header_bar">
+      <div class="toggle_question_order pull-right">
+        <input id="randomize_question_order" class="randomize_exercise" type="checkbox" disabled="">
+        <label for="randomize_question_order" class="randomize_exercise"> Randomize question order for learners</label>
+      </div>
+      <div class="show_question_toggle">
+        <input type="checkbox" id="exercise_show_answers">
+        <label for="exercise_show_answers"> View questions only</label>
+      </div>
+    </div>
+    <br>
+    <ol class="panel-group" id="exercise_list" role="tablist" aria-multiselectable="true">
+      <div class="default-item container-fluid text-center" style="display: none;">No questions associated with this exercise</div>
+      <li class="assessment_li">
+        <div class="input-tab-control tab_item" data-next="#mastery_modal_close_button"></div>
+        <div class="assessment_order_area text-center pull-left">
+          <div class="order"></div>
+        </div>
+        <div class="assessment_item container-fluid ">
+          <div class="main_edit_area">
+            <div class="question_area toggle_exercise">
+              <div class="row question_controls">
+                <div class="col-sm-5">
+                  <div class="question_type">Unknown Question Type</div>
+                  <select class="question_type_select show_on_focus" value="multiplechoice">
+                    <option class="single_selection" value="single_selection">Single Selection</option>
+                    <option class="multiple_selection" value="multiple_selection">Multiple Selection</option>
+                    <option class="true_false" value="true_false">True/False</option>
+                    <option class="input_question" value="input_question">Input Question</option>
+                  </select>
+                </div>
+                <div class="col-sm-3 hint_link_cell">
+                  <div class="open_hints hint_link pull-right uppercase">
+                    <span class="hint_count">1 Hint</span>&nbsp;
+                    <i class="material-icons">launch</i>
+                  </div>
+                </div>
+                <div class="col-sm-4 random_answers_order">
+                  <div class="random_answer_section">
+                    <input type="checkbox" id="random_answer_order_view38" checked="" disabled="" class="random_order_check">
+                  </div>
+                  <div class="random_answer_section">
+                    <label for="random_answer_order_view38" disabled="">Randomize Answer Order</label>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <ul class="error-list list-unstyled text-center"></ul>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="question editable" data-ph="Question">
+                    <div id="editor_view_view39"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div id="" class="list_area">
+              <div class="answers">
+                <div>
+                  <div class="show_on_focus answer_header">
+                    <div class="col-sm-1 correct_header">
+                      <i class="material-icons align-bottom" title="Correct?">check_circle</i>
+                    </div>
+                    <div class="col-sm-11 uppercase">Answers</div>
+                  </div>
+
+                  <ul class="list-unstyled answer_list">
+                    <div class="default-item" style="display: none;">No answers provided.</div>
+                    <li class="answer_li">
+                      <div class="answer_item  is_correct">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="checkbox" aria-label="Correct" name="answer_c8" disabled="" checked="" title="Correct">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view44"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="answer_li">
+                      <div class="answer_item  ">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="checkbox" aria-label="Correct" name="answer_c8" disabled="" title="Incorrect">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view48"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="answer_li">
+                      <div class="answer_item  ">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="checkbox" aria-label="Correct" name="answer_c8" disabled="" title="Incorrect">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view52"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <div class="show_on_focus addanswer" title="Add">
+                    <i class="material-icons align-bottom">add</i>&nbsp; <span class="addanswertext uppercase">Answer</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="remove_area">
+            <div class="toolbar"></div>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+</div>
+`;
+
+exports[`ExerciseView render method should render with a valid content node with 3 different assessment_items 1`] = `
+<div>
+  <div class="container-fluid" id="exercisecreation">
+    <div class="container-fluid exercise_header_bar">
+      <div class="toggle_question_order pull-right">
+        <input id="randomize_question_order" class="randomize_exercise" type="checkbox" disabled="">
+        <label for="randomize_question_order" class="randomize_exercise"> Randomize question order for learners</label>
+      </div>
+      <div class="show_question_toggle">
+        <input type="checkbox" id="exercise_show_answers">
+        <label for="exercise_show_answers"> View questions only</label>
+      </div>
+    </div>
+    <br>
+    <ol class="panel-group" id="exercise_list" role="tablist" aria-multiselectable="true">
+      <div class="default-item container-fluid text-center" style="display: none;">No questions associated with this exercise</div>
+      <li class="assessment_li">
+        <div class="input-tab-control tab_item" data-next="#mastery_modal_close_button"></div>
+        <div class="assessment_order_area text-center pull-left">
+          <div class="order"></div>
+        </div>
+        <div class="assessment_item container-fluid ">
+          <div class="main_edit_area">
+            <div class="question_area toggle_exercise">
+              <div class="row question_controls">
+                <div class="col-sm-5">
+                  <div class="question_type">Unknown Question Type</div>
+                  <select class="question_type_select show_on_focus" value="multiplechoice">
+                    <option class="single_selection" value="single_selection">Single Selection</option>
+                    <option class="multiple_selection" value="multiple_selection">Multiple Selection</option>
+                    <option class="true_false" value="true_false">True/False</option>
+                    <option class="input_question" value="input_question">Input Question</option>
+                  </select>
+                </div>
+                <div class="col-sm-3 hint_link_cell">
+                  <div class="open_hints hint_link pull-right uppercase">
+                    <span class="hint_count">1 Hint</span>&nbsp;
+                    <i class="material-icons">launch</i>
+                  </div>
+                </div>
+                <div class="col-sm-4 random_answers_order">
+                  <div class="random_answer_section">
+                    <input type="checkbox" id="random_answer_order_view126" checked="" disabled="" class="random_order_check">
+                  </div>
+                  <div class="random_answer_section">
+                    <label for="random_answer_order_view126" disabled="">Randomize Answer Order</label>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <ul class="error-list list-unstyled text-center"></ul>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="question editable" data-ph="Question">
+                    <div id="editor_view_view127"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div id="" class="list_area">
+              <div class="answers">
+                <div>
+                  <div class="show_on_focus answer_header">
+                    <div class="col-sm-1 correct_header">
+                      <i class="material-icons align-bottom" title="Correct?">check_circle</i>
+                    </div>
+                    <div class="col-sm-11 uppercase">Answers</div>
+                  </div>
+
+                  <ul class="list-unstyled answer_list">
+                    <div class="default-item" style="display: none;">No answers provided.</div>
+                    <li class="answer_li">
+                      <div class="answer_item  is_correct">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="checkbox" aria-label="Correct" name="answer_c58" disabled="" checked="" title="Correct">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view132"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="answer_li">
+                      <div class="answer_item  ">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="checkbox" aria-label="Correct" name="answer_c58" disabled="" title="Incorrect">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view136"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="answer_li">
+                      <div class="answer_item  ">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="checkbox" aria-label="Correct" name="answer_c58" disabled="" title="Incorrect">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view140"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <div class="show_on_focus addanswer" title="Add">
+                    <i class="material-icons align-bottom">add</i>&nbsp; <span class="addanswertext uppercase">Answer</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="remove_area">
+            <div class="toolbar"></div>
+          </div>
+        </div>
+      </li>
+      <li class="assessment_li">
+        <div class="input-tab-control tab_item" data-next="#mastery_modal_close_button"></div>
+        <div class="assessment_order_area text-center pull-left">
+          <div class="order"></div>
+        </div>
+        <div class="assessment_item container-fluid ">
+          <div class="main_edit_area">
+            <div class="question_area toggle_exercise">
+              <div class="row question_controls">
+                <div class="col-sm-5">
+                  <div class="question_type">Single Selection</div>
+                  <select class="question_type_select show_on_focus" value="single_selection">
+                    <option class="single_selection" value="single_selection">Single Selection</option>
+                    <option class="multiple_selection" value="multiple_selection">Multiple Selection</option>
+                    <option class="true_false" value="true_false">True/False</option>
+                    <option class="input_question" value="input_question">Input Question</option>
+                  </select>
+                </div>
+                <div class="col-sm-3 hint_link_cell">
+                  <div class="open_hints hint_link pull-right uppercase">
+                    <span class="hint_count">1 Hint</span>&nbsp;
+                    <i class="material-icons">launch</i>
+                  </div>
+                </div>
+                <div class="col-sm-4 random_answers_order">
+                  <div class="random_answer_section">
+                    <input type="checkbox" id="random_answer_order_view144" checked="" disabled="" class="random_order_check">
+                  </div>
+                  <div class="random_answer_section">
+                    <label for="random_answer_order_view144" disabled="">Randomize Answer Order</label>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <ul class="error-list list-unstyled text-center"></ul>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="question editable" data-ph="Question">
+                    <div id="editor_view_view145"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div id="" class="list_area">
+              <div class="answers">
+                <div>
+                  <div class="show_on_focus answer_header">
+                    <div class="col-sm-1 correct_header">
+                      <i class="material-icons align-bottom" title="Correct?">check_circle</i>
+                    </div>
+                    <div class="col-sm-11 uppercase">Answers</div>
+                  </div>
+
+                  <ul class="list-unstyled answer_list">
+                    <div class="default-item" style="display: none;">No answers provided.</div>
+                    <li class="answer_li">
+                      <div class="answer_item  is_correct">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="radio" aria-label="Correct" name="answer_c63" disabled="" checked="" title="Correct">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view150"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="answer_li">
+                      <div class="answer_item  ">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="radio" aria-label="Correct" name="answer_c63" disabled="" title="Incorrect">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view154"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="answer_li">
+                      <div class="answer_item  ">
+                        <div class="row">
+                          <div class="col-xs-1 text-center">
+                            <input class="correct" type="radio" aria-label="Correct" name="answer_c63" disabled="" title="Incorrect">
+                          </div>
+                          <div class="col-xs-8 editor-col">
+                            <div class="answer editable" data-ph="Answer">
+                              <div id="editor_view_view158"></div>
+                            </div>
+                          </div>
+                          <div class="col-xs-3 answer_options">
+
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <div class="show_on_focus addanswer" title="Add">
+                    <i class="material-icons align-bottom">add</i>&nbsp; <span class="addanswertext uppercase">Answer</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="remove_area">
+            <div class="toolbar"></div>
+          </div>
+        </div>
+      </li>
+      <li class="assessment_li">
+        <div class="input-tab-control tab_item" data-next="#mastery_modal_close_button"></div>
+        <div class="assessment_order_area text-center pull-left">
+          <div class="order"></div>
+        </div>
+        <div class="assessment_item container-fluid ">
+          <div class="main_edit_area">
+            <div class="question_area toggle_exercise">
+              <div class="row question_controls">
+                <div class="col-sm-5">
+                  <div class="question_type">Single Selection</div>
+                  <select class="question_type_select show_on_focus" value="single_selection">
+                    <option class="single_selection" value="single_selection">Single Selection</option>
+                    <option class="multiple_selection" value="multiple_selection">Multiple Selection</option>
+                    <option class="true_false" value="true_false">True/False</option>
+                    <option class="input_question" value="input_question">Input Question</option>
+                  </select>
+                </div>
+                <div class="col-sm-3 hint_link_cell">
+                  <div class="open_hints hint_link pull-right uppercase">
+                    <span class="hint_count">1 Hint</span>&nbsp;
+                    <i class="material-icons">launch</i>
+                  </div>
+                </div>
+                <div class="col-sm-4 random_answers_order">
+                  <div class="random_answer_section">
+                    <input type="checkbox" id="random_answer_order_view162" checked="" disabled="" class="random_order_check">
+                  </div>
+                  <div class="random_answer_section">
+                    <label for="random_answer_order_view162" disabled="">Randomize Answer Order</label>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <ul class="error-list list-unstyled text-center"></ul>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="question editable" data-ph="Question">
+                    <div id="editor_view_view163"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div id="" class="list_area">
+              <div class="answers">
+                <div>
+                  <div class="show_on_focus answer_header">
+                    <div class="col-sm-1 correct_header">
+                      <i class="material-icons align-bottom" title="Correct?">check_circle</i>
+                    </div>
+                    <div class="col-sm-11 uppercase">Answers</div>
+                  </div>
+
+                  <ul class="list-unstyled answer_list">
+                    <div class="default-item" style="display: block;">No answers provided.</div>
+                  </ul>
+                  <div class="show_on_focus addanswer" title="Add">
+                    <i class="material-icons align-bottom">add</i>&nbsp; <span class="addanswertext uppercase">Answer</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="remove_area">
+            <div class="toolbar"></div>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+</div>
+`;
+
+exports[`ExerciseView render method should render with a valid content node with no assessment_items 1`] = `
+<div>
+  <div class="container-fluid" id="exercisecreation">
+    <div class="container-fluid exercise_header_bar">
+      <div class="toggle_question_order pull-right">
+        <input id="randomize_question_order" class="randomize_exercise" type="checkbox" disabled="">
+        <label for="randomize_question_order" class="randomize_exercise"> Randomize question order for learners</label>
+      </div>
+      <div class="show_question_toggle">
+        <input type="checkbox" id="exercise_show_answers">
+        <label for="exercise_show_answers"> View questions only</label>
+      </div>
+    </div>
+    <br>
+    <ol class="panel-group" id="exercise_list" role="tablist" aria-multiselectable="true">
+      <div class="default-item container-fluid text-center" style="display: block;">No questions associated with this exercise</div>
+    </ol>
+  </div>
+</div>
+`;

--- a/contentcuration/contentcuration/static/js/edit_channel/information/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/information/views.js
@@ -2,6 +2,7 @@ var Backbone = require("backbone");
 var _ = require("underscore");
 var BaseViews = require("edit_channel/views");
 var Models = require("edit_channel/models");
+const State = require("edit_channel/state");
 require("information.less");
 
 var NAMESPACE = "information";
@@ -76,7 +77,7 @@ var LicenseModalView = BaseInfoModalView.extend({
   get_render_data: function(){ return {
     license: this.data.select_license,
     is_cc: this.data.select_license.license_url.includes('creativecommons.org'),
-    locale: window.languageCode && window.languageCode.split('-')[0] || 'en'
+    locale: State.currentLanguage.id,
   }; }
 });
 

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -1,7 +1,6 @@
 var Backbone = require("backbone");
 var _ = require("underscore");
 var mail_helper = require("edit_channel/utils/mail");
-const State = require("./state");
 const Constants = require("./constants/index");
 
 const DEFAULT_ADMIN_PAGE_SIZE = 25
@@ -447,6 +446,7 @@ var ContentNodeModel = BaseModel.extend({
         return attributes;
     },
     setExtraFields: function () {
+        const State = require("./state");
         if (typeof this.get('extra_fields') === 'string') {
             this.set('extra_fields', JSON.parse(this.get('extra_fields')));
         }
@@ -474,6 +474,7 @@ var ContentNodeModel = BaseModel.extend({
         return promise;
     },
     make_copy: function (target_parent) {
+        const State = require("./state");
         var self = this;
         return new Promise(function (resolve, reject) {
             var data = {
@@ -664,6 +665,7 @@ var ContentNodeCollection = BaseCollection.extend({
         this.highest_sort_order = (this.length > 0) ? this.at(this.length - 1).get("sort_order") : 1;
     },
     duplicate: function (target_parent) {
+        const State = require("./state");
         var self = this;
         return new Promise(function (resolve, reject) {
             var sort_order = (target_parent) ? target_parent.get("metadata").max_sort_order + 1 : 1;
@@ -687,6 +689,7 @@ var ContentNodeCollection = BaseCollection.extend({
         });
     },
     move: function (target_parent, max_order, min_order) {
+        const State = require("./state");
         var self = this;
         return new Promise(function (resolve, reject) {
             var data = {
@@ -708,6 +711,7 @@ var ContentNodeCollection = BaseCollection.extend({
         });
     },
     delete: function () {
+        const State = require("./state");
         var self = this;
         return new Promise(function (resolve, reject) {
             var data = {
@@ -724,6 +728,7 @@ var ContentNodeCollection = BaseCollection.extend({
         });
     },
     sync_nodes: function (models) {
+        const State = require("./state");
         var self = this;
         return new Promise(function (resolve, reject) {
             var data = { "nodes": _.pluck(models, 'id'), "channel_id": State.current_channel.id };

--- a/contentcuration/contentcuration/static/js/edit_channel/state.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/state.js
@@ -21,7 +21,7 @@ const State = {
   current_channel: window.channel && new Models.ChannelModel(window.channel),
   current_user: new Models.UserModel(window.user),
   nodeCollection: new Models.ContentNodeCollection(),
-  currentLanguage: Constants.Languages.find(l => l.id && l.id.toLowerCase() === window.languageCode ),
+  currentLanguage: Constants.Languages.find(l => l.id && l.id.toLowerCase() === (window.languageCode || 'en') ),
   openChannel(data) {
     this.staging = data.is_staging || false;
     Store.commit('SET_CONTENT_TAGS', this.current_channel.get('tags'))

--- a/contentcuration/contentcuration/static/js/edit_channel/utils/dialog.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/utils/dialog.js
@@ -1,4 +1,5 @@
 var Models = require("edit_channel/models");
+const State = require("edit_channel/state");
 var template = require("edit_channel/utils/hbtemplates/dialog.handlebars");
 var _ = require('underscore');
 var stringHelper = require("edit_channel/utils/string_helper");
@@ -16,7 +17,7 @@ function dialog(title, submessage, actions, onclose){
     autoOpen: false,
     resizable: false,
     height: "auto",
-    width: (window.languageCode.startsWith("es"))? 500 : 400, // Spanish translations tend to be longer
+    width: State.currentLanguage.lang_code === "es" ? 500 : 400, // Spanish translations tend to be longer
     modal: false,
     buttons: actions,
     zIndex: 10000,

--- a/contentcuration/contentcuration/static/js/edit_channel/utils/number_parser.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/utils/number_parser.js
@@ -19,9 +19,11 @@ EXPONENT: [DECIMAL | INTEGER]e+{0,1}[INTEGER]
 TODO: Add log and pi?
 
 ****************/
+const State = require("edit_channel/state");
+
 var SEP = /,/g;
 var POINT = /\./;
-if (window.languageCode.startsWith("es")) {
+if (State.currentLanguage.lang_code === "es") {
   SEP = /\./g;
   POINT = /,/;
 }

--- a/contentcuration/contentcuration/static/js/utils/get_cookie.js
+++ b/contentcuration/contentcuration/static/js/utils/get_cookie.js
@@ -1,12 +1,9 @@
-var jQuery = require("rawJquery");
-
-// using jQuery
 module.exports = function get_cookie(name) {
     var cookieValue = null;
     if (document.cookie && document.cookie !== '') {
         var cookies = document.cookie.split(';');
         for (var i = 0; i < cookies.length; i++) {
-            var cookie = jQuery.trim(cookies[i]);
+            var cookie = cookies[i].trim();
             // Does this cookie string begin with the name we want?
             if (cookie.substring(0, name.length + 1) == (name + '=')) {
                 cookieValue = decodeURIComponent(cookie.substring(name.length + 1));

--- a/contentcuration/contentcuration/static/js/utils/offline_helper.js
+++ b/contentcuration/contentcuration/static/js/utils/offline_helper.js
@@ -4,6 +4,7 @@
 */
 
 var $ = require('jquery');
+const State = require("edit_channel/state");
 require("offline-js");
 require("../../css/offline-theme-slide.css");
 require("utils/snake");
@@ -32,10 +33,6 @@ var languageMapping = {
     "ar": "arabic"
 }
 
-function getOfflineLanguageName(code) {
-	return languageMapping[code.split("-")[0]] || languageMapping['en'];
-}
-
 var disabledOverlay = document.createElement("DIV");
 disabledOverlay.className = "fade";
 disabledOverlay.setAttribute('id', 'offline_overlay');
@@ -45,7 +42,7 @@ $(function() {
 	disabledOverlay.style.display = "none";
 });
 
-var language = getOfflineLanguageName(window.languageCode || "en");
+var language = languageMapping[State.currentLanguage.lang_code];
 
 Offline.options = {
 	checks: {xhr: {url: window.Urls.stealth()}},

--- a/contentcuration/contentcuration/static/js/utils/studioJquery.js
+++ b/contentcuration/contentcuration/static/js/utils/studioJquery.js
@@ -2,6 +2,7 @@ var $ = require('rawJquery');
 var get_cookie = require('./get_cookie');
 var csrftoken = get_cookie('csrftoken') || '';
 
+global.jQuery = global.$ = $;
 
 // side effect: bind jquery-ui functionality to jquery object
 require('./jquery-ui.js');

--- a/jest_config/jest.conf.js
+++ b/jest_config/jest.conf.js
@@ -1,16 +1,34 @@
 const path = require('path');
 
+const staticFilesDir = '<rootDir>/contentcuration/contentcuration/static';
+const staticJsDir = path.join(staticFilesDir, 'js');
+const staticLessDir = path.join(staticFilesDir, 'less');
+const studioJqueryDir = path.join(staticJsDir, 'utils', 'studioJquery');
+
 module.exports = {
-  globals: {},
+  globals: {
+    "handlebars-jest": {
+      helperDirs: [
+        path.join(staticJsDir, 'handlebars')
+      ],
+    }
+  },
   rootDir: path.resolve(__dirname, '../'),
   moduleFileExtensions: ['js', 'json', 'vue'],
-  modulePaths: ['<rootDir>/contentcuration/contentcuration/static/js'],
+  modulePaths: [staticJsDir, staticLessDir],
+  moduleNameMapper: {
+    // copied from webpack config aliases
+    jquery: studioJqueryDir,
+    '^rawJquery$': '<rootDir>/node_modules/jquery',
+    '\\.(css|less)$': path.resolve(__dirname, './styleMock.js'),
+  },
   testURL: 'http://studio.time',
   transform: {
     '^.+\\.js$': '<rootDir>/node_modules/babel-jest',
     '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest',
+    '.*\\.handlebars$': '<rootDir>/node_modules/handlebars-jest',
   },
-  transformIgnorePatterns: ["/node_modules/"],
+  transformIgnorePatterns: ['/node_modules/'],
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
   setupFiles: [path.resolve(__dirname, './setup')],
   coverageDirectory: '<rootDir>/coverage',

--- a/jest_config/styleMock.js
+++ b/jest_config/styleMock.js
@@ -1,0 +1,3 @@
+// A dummy style mock for jest tests
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-vue": "^3.5.0",
     "esprima": "^4.0.0",
     "glob": "^7.1.2",
+    "handlebars-jest": "^0.3.0",
     "handlebars-template-loader": "^1.0.0",
     "imports-loader": "^0.8.0",
     "jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3781,6 +3781,12 @@ handlebars-intl@^1.1.2:
     intl-messageformat "1.1.0"
     intl-relativeformat "1.1.0"
 
+handlebars-jest@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/handlebars-jest/-/handlebars-jest-0.3.0.tgz#696761ccf2338332e8c504204447b7d37eef5307"
+  dependencies:
+    node-cache "^4.2.0"
+
 handlebars-template-loader@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/handlebars-template-loader/-/handlebars-template-loader-1.0.0.tgz#264a8fdc356aa04d09ee08788c2980d710b01809"
@@ -5885,7 +5891,7 @@ nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
-node-cache@^4.1.1:
+node-cache@^4.1.1, node-cache@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.0.tgz#48ac796a874e762582692004a376d26dfa875811"
   dependencies:


### PR DESCRIPTION
## Description

Adds the basic tooling for doing snapshot tests in Jest with handlebars templates.
Implements three basic snapshot tests for the exercise editor tool.
Fixes up a few other things that cropped up while trying to get the tests to run!

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?