### PR TITLE
Moving exercises

### DIFF
--- a/__mocks__/backbone.js
+++ b/__mocks__/backbone.js
@@ -1,0 +1,23 @@
+const Backbone = require('backbone');
+
+let requestSuccess = true;
+let requestData = [];
+let requestError = 'Error';
+
+function setResponse({ success, data, error }) {
+  requestSuccess = success;
+  requestData = data;
+  requestError = error;
+}
+
+Backbone.sync = jest.fn((method, object, options) => {
+  if (requestSuccess) {
+    options.success(requestData);
+  } else {
+    options.error(requestError);
+  }
+});
+
+Backbone.__setResponse = setResponse;
+
+module.exports = Backbone;

--- a/contentcuration/contentcuration/static/js/edit_channel/__tests__/ContentNodeCollection.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/__tests__/ContentNodeCollection.spec.js
@@ -1,0 +1,107 @@
+const Backbone = require('backbone');
+
+const ContentNodeCollection = require('../models').ContentNodeCollection;
+
+function exampleContentNode() {
+  const id = String(Math.floor(Math.random()*Math.pow(10, 32)));
+  return {
+    title: id,
+    changed: false,
+    id: id,
+    description: id,
+    sort_order: 1.5,
+    author: id,
+    copyright_holder: id,
+    license: id,
+    language: id,
+    license_description: id,
+    assessment_items: [],
+    files: [],
+    parent_title: id,
+    ancestors: [],
+    modified: id,
+    original_channel: id,
+    kind: id,
+    parent: id,
+    children: id,
+    published: id,
+    associated_presets: [],
+    valid: id,
+    metadata: id,
+    original_source_node_id: id,
+    tags: id,
+    extra_fields: {
+      randomize: false,
+    },
+    prerequisite: [],
+    is_prerequisite_of: id,
+    node_id: id,
+    tree_id: id,
+    publishing: false,
+    freeze_authoring_data: false,
+    role_visibility: id,
+    provider: id,
+    aggregator: id,
+    thumbnail_src: id,
+  }
+}
+
+function exampleFile() {
+  const id = String(Math.floor(Math.random()*Math.pow(10, 32)));
+  return {
+    id: id,
+    preset: {
+      name: id,
+      id: id,
+    },
+  };
+}
+
+function exampleAssessment() {
+  const id = String(Math.floor(Math.random()*Math.pow(10, 32)));
+  return {
+    type: 'multiplechoice',
+    question: 'Ceci n\'est pas un question?',
+    hints: '["Maybe it is, maybe not?"]',
+    answers: '[{ "correct": true, "answer": "First" }, { "correct": false, "answer": "Second" }, { "correct": false, "answer": "Fish" } ]',
+    order: 1,
+    assessment_id: 'test',
+    raw_data: '',
+    source_url: '',
+    randomize: true,
+    deleted: false,
+    id,
+  };
+}
+
+describe('ContentNodeCollection', () => {
+  let collection;
+  beforeEach(() => {
+    collection = new ContentNodeCollection([])
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('save method', () => {
+    it('should call Backbone.sync three times', () => {
+      const node = exampleContentNode();
+      node.files = [exampleFile()];
+      node.assessment_items = [exampleAssessment()];
+      collection.add(node);
+      return collection.save().then(() => {
+        expect(Backbone.sync).toHaveBeenCalledTimes(3);
+      });
+    });
+    it('should save each assessment item to its own content node', () => {
+      const node1 = exampleContentNode();
+      node1.assessment_items = [exampleAssessment()];
+      const node2 = exampleContentNode();
+      node2.assessment_items = [exampleAssessment()];
+      collection.add([node1, node2]);
+      return collection.save().then(() => {
+        expect(Backbone.sync.mock.calls[1][1].where({ contentnode: node1.id }).length).toBe(1);
+        expect(Backbone.sync.mock.calls[1][1].where({ contentnode: node2.id }).length).toBe(1);
+      });
+    });
+  });
+});

--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/__tests__/ExerciseView.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/__tests__/ExerciseView.spec.js
@@ -3,7 +3,7 @@ const Backbone = require('backbone');
 // Register handlebars helpers to ensure templates are rendered properly.
 require('handlebars/helpers');
 
-const exampleAnswer = {
+const exampleAssessment = {
   type: 'multiplechoice',
   question: 'Ceci n\'est pas un question?',
   hints: '["Maybe it is, maybe not?"]',
@@ -71,7 +71,7 @@ describe('ExerciseView', () => {
     });
     it('should render with a valid content node with 1 assessment_items', () => {
       model.set('assessment_items', [
-        exampleAnswer,
+        exampleAssessment,
       ]);
       const view = new ExerciseView({
         model,
@@ -81,16 +81,16 @@ describe('ExerciseView', () => {
       expect(html).toMatchSnapshot();
     });
     it('should render with a valid content node with 3 different assessment_items', () => {
-      const exampleAnswer1 = exampleAnswer;
-      const exampleAnswer2 = Object.assign({}, exampleAnswer);
-      exampleAnswer2.type = 'single_selection';
-      const exampleAnswer3 = Object.assign({}, exampleAnswer);
-      exampleAnswer3.type = 'single_selection';
-      exampleAnswer3.answers = "[]";
+      const exampleAssessment1 = exampleAssessment;
+      const exampleAssessment2 = Object.assign({}, exampleAssessment);
+      exampleAssessment2.type = 'single_selection';
+      const exampleAssessment3 = Object.assign({}, exampleAssessment);
+      exampleAssessment3.type = 'single_selection';
+      exampleAssessment3.answers = "[]";
       model.set('assessment_items', [
-        exampleAnswer1,
-        exampleAnswer2,
-        exampleAnswer3,
+        exampleAssessment1,
+        exampleAssessment2,
+        exampleAssessment3,
       ]);
       const view = new ExerciseView({
         model,

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -513,8 +513,8 @@ var ContentNodeCollection = BaseCollection.extend({
                     preset_data.id = file.preset.name || file.preset.id;
                     fileCollection.add(to_add);
                 });
-                assessmentCollection.add(node.get('assessment_items'));
-                assessmentCollection.forEach(function (item) {
+                node.get('assessment_items').forEach(function (item) {
+                    item = new AssessmentItemModel(item);
                     item.set('contentnode', node.id);
                     if (item.get('type') === 'input_question') {
                         item.get('answers').each(function (a) {
@@ -525,6 +525,7 @@ var ContentNodeCollection = BaseCollection.extend({
                             }
                         });
                     }
+                    assessmentCollection.add(item);
                 })
             });
             Promise.all([fileCollection.save(), assessmentCollection.save()]).then(function () {

--- a/jest_config/setup.js
+++ b/jest_config/setup.js
@@ -3,7 +3,7 @@ csrf.name = 'csrfmiddlewaretoken';
 csrf.value = 'csrfmiddlewaretoken';
 global.document.body.append(csrf);
 global.window.Urls = new Proxy({}, {
-  get() {
-    return () => undefined;
+  get(obj, prop) {
+    return () => prop;
   }
 });


### PR DESCRIPTION
## Description

This PR adds a regression test for, and then fixes the issue of assessment items moving to the last item in a list of nodes.

#### Issue Addressed (if applicable)

Fixes #1047

## Steps to Test

* Create multiple exercise content nodes
* Add an assessment item to each one
* Select all of them to modify the metadata all at once.
* Observe the assessment items not all migrate to the last content node.
(Also try this on develop to see it happening!)

## Implementation Notes (optional)

This seems to be a result of an asymmetrical implementation between assessment items and files. It also might be a result of always calling save on a collection, even when only one model is being edited, but not sure.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
