### PR TITLE
put back the celery import

### DIFF
--- a/contentcuration/contentcuration/__init__.py
+++ b/contentcuration/contentcuration/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
+from .celery import app as celery_app  # noqa


### PR DESCRIPTION
## Description

  - We ran into some trouble PUBLISHing channels on develop today.
  - Instead of being an "async" call, studio backend would hang and timeout.
  - I was able to reproduce locally, then found the missing piece of code


#### Issue Addressed

https://github.com/learningequality/studio/issues/1060


#### Before/After Screenshots (if applicable)

Before: no can haz publish

After: publish works again
