### PR TITLE
Oct 26th patch release to production

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -417,8 +417,8 @@ var ContentNodeCollection = BaseCollection.extend({
                     preset_data.id = file.preset.name || file.preset.id;
                     fileCollection.add(to_add);
                 });
-                assessmentCollection.add(node.get('assessment_items'));
-                assessmentCollection.forEach(function(item){
+                node.get('assessment_items').forEach(function (item) {
+                    item = new AssessmentItemModel(item);
                     item.set('contentnode', node.id);
                     if(item.get('type') === 'input_question'){
                         item.get('answers').each( function(a){
@@ -429,6 +429,7 @@ var ContentNodeCollection = BaseCollection.extend({
                             }
                         });
                     }
+                    assessmentCollection.add(item);
                 })
             });
             Promise.all([fileCollection.save(), assessmentCollection.save()]).then(function() {

--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -73,6 +73,12 @@ class GoogleCloudStorageSaveTestCase(TestCase):
         # Check that we pass self.content file_object to upload_from_file
         self.blob_obj.upload_from_file.assert_called_once_with(self.content, content_type="image/jpeg")
 
+    def test_save_an_existing_exercise(self):
+        """
+        Test if an existing exercise would be saved again
+        """
+        self.storage.save("testuploadexercises.perseus", self.content, blob_object=self.blob_obj)
+        self.blob_obj.upload_from_file.assert_not_called()
 
 class GoogleCloudStorageOpenTestCase(TestCase):
     """

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -60,6 +60,7 @@ class GoogleCloudStorage(Storage):
         blob.download_to_file(fobj)
         # flush it to disk
         fobj.flush()
+        fobj.seek(0)
 
         django_file = File(fobj)
         django_file.just_downloaded = True

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -74,6 +74,9 @@ class GoogleCloudStorage(Storage):
         return blob.size
 
     def save(self, name, fobj, max_length=None, blob_object=None):
+        if name.endswith(".perseus") and self.exists(name):
+            logging.info("{} exists in Google Cloud Storage, so it's not saved again.".format(name))
+            return name
 
         if not blob_object:
             blob = Blob(name, self.bucket)

--- a/contentcuration/contentcuration/views/admin.py
+++ b/contentcuration/contentcuration/views/admin.py
@@ -33,6 +33,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.http import condition
 from le_utils.constants import content_kinds
 from PIL import Image
+from raven.contrib.django.raven_compat.models import client
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.authentication import TokenAuthentication
@@ -253,6 +254,8 @@ def generate_thumbnail(channel):
                 image.save(buffer, image.format)
                 return "data:image/{};base64,{}".format(ext[1:], base64.b64encode(buffer.getvalue()))
         except IOError:
+            client.captureMessage("Failed to generate thumbnail for channel id={}, filepath={}".format(
+                channel.id, filepath))
             pass
 
 


### PR DESCRIPTION
## Description

This PR contains three bugfixes from develop. 

### PRs

  - https://github.com/learningequality/studio/pull/1056  (subset of)
  - https://github.com/learningequality/studio/pull/1034
  - https://github.com/learningequality/studio/pull/1042


#### Issue Addressed (if applicable)

  - https://sentry.io/learningequality/studio/issues/720026215/
  - https://github.com/learningequality/studio/issues/1047
  - https://github.com/learningequality/studio/issues/1030


## Steps to Test (one in prod)

 - [ ] Try running a chef script (should not error out)
 - [ ] Try editing metadata for multiple exercises in parallel (questions should not move)
 - [ ] Try steps from [here](https://github.com/learningequality/studio/pull/1034)



## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments


## Reviewers
- Kevin kollivier (back end)
