### PR TITLE
Celery hotfix master

### DIFF
--- a/contentcuration/contentcuration/__init__.py
+++ b/contentcuration/contentcuration/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
+from .celery import app as celery_app  # noqa


### PR DESCRIPTION
Celery broke during deploy from 30 mins ago.
This is what happens on PUBLISH:

<img width="552" alt="screen shot 2018-10-26 at 2 48 23 pm" src="https://user-images.githubusercontent.com/163966/47586849-3e7efc80-d92f-11e8-9e26-204cd7e9bf72.png">

^ caued because publish `.delay` task hangs.

For some reason this wasn't a problem before the current deploy. Why??

Yesterday during local testing this fixed the issue. So I'm hoping this will fix prod now.
