### PR TITLE
Get detailed Sentry error reports for AJAX call errors.

### DIFF
--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -16,6 +16,30 @@ if(!global.Promise) {
 
 
 $(function() {
+  $(document).ajaxError(function(event, jqXHR, ajaxSettings, thrownError) {
+    let message = thrownError || jqXHR.statusText;
+    // Put the URL in the main message for timeouts so we can see which timeouts are most frequent.
+    if (jqXHR.status === 504) {
+      message = "Request Timed Out: " + ajaxSettings.url;
+    }
+    const extraData = {
+              type: ajaxSettings.type,
+              url: ajaxSettings.url,
+              data: ajaxSettings.data,
+              status: jqXHR.status,
+              error: thrownError || jqXHR.statusText,
+              response: jqXHR.responseText.substring(0, 100)
+    };
+
+    console.log("AJAX Request Error: " + message);
+    console.log("Error data: " + JSON.stringify(extraData));
+    if (Raven && Raven.captureMessage) {
+      Raven.captureMessage(message, {
+          extra: extraData
+      });
+    }
+  });
+
   // TODO revaluate need. From their repo:
   // Note: As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing bugs into your application. Consider carefully whether you really need to use it.
   fastclick.attach(document.body);


### PR DESCRIPTION
## Description

In Sentry, we get a lot of errors that appear to be printouts of some form of the jquery XHR object. Some sample reports can be found here:

https://sentry.io/learningequality/studio/issues/658785918/

This PR basically implements the solution described here for catching jQuery AJAX errors:

https://docs.sentry.io/clients/javascript/tips/#jquery-ajax-error-reporting

With any luck, this will allow us to get AJAX error reports we can actually make sense of.

## Steps to Test

- [ ] Load up Studio, open the Chrome console, and call $.ajax("/badURL")
(Or, just try to copy a few thousand KA nodes on develop :) 

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
