### PR TITLE
Sanity check that lists are populated before calling methods on them.…

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
@@ -74,56 +74,28 @@ var ChannelListPage  = BaseViews.BaseView.extend({
 				el: self.$("#channel_list"),
 				collection: channels
 			});
-		}).catch(function(e) {
-			  if (Raven && Raven.catchException) {
-			    Raven.catchException(e);
-			  } else {
-			    console.log("Error retrieving current channel list:");
-			    console.log(e.statusText);
-			  }
-			});
+		});
 		State.current_user.get_bookmarked_channels().then(function(channels){
 			self.starred_channel_list = new StarredChannelList({
 				container: self,
 				el: self.$("#starred_list"),
 				collection: channels
 			});
-		}).catch(function(e) {
-			  if (Raven && Raven.catchException) {
-			    Raven.catchException(e);
-			  } else {
-			    console.log("Error retrieving bookmarked channel list:");
-			    console.log(e.statusText);
-			  }
-			});
+		});
 		State.current_user.get_public_channels().then(function(channels){
 			self.public_channel_list = new PublicChannelList({
 				container: self,
 				el: self.$("#public_list"),
 				collection: channels
 			});
-		}).catch(function(e) {
-			  if (Raven && Raven.catchException) {
-			    Raven.catchException(e);
-			  } else {
-			    console.log("Error retrieving public channel list:");
-			    console.log(e.statusText);
-			  }
-			});
+		});
 		State.current_user.get_view_only_channels().then(function(channels){
 			self.viewonly_channel_list = new ViewOnlyChannelList({
 				container: self,
 				el: self.$("#viewonly_list"),
 				collection: channels
 			});
-		}).catch(function(e) {
-			  if (Raven && Raven.catchException) {
-			    Raven.catchException(e);
-			  } else {
-			    console.log("Error retrieving view-only channel list:");
-			    console.log(e.statusText);
-			  }
-			});
+		});
 	},
 	events: {
 		'click .new_channel_button' : 'new_channel',
@@ -163,10 +135,22 @@ var ChannelListPage  = BaseViews.BaseView.extend({
 	},
 	set_active_channel(channel) {
 		this.$el.removeClass("active_channel");
-		this.starred_channel_list.set_active_channel(channel);
-		this.current_channel_list.set_active_channel(channel);
-		this.public_channel_list.set_active_channel(channel);
-		this.viewonly_channel_list.set_active_channel(channel);
+		// This function gets called by open_channel, but since the API calls to populate the channels list can be slow,
+		// these lists may be undefined when this gets called. For now, just check that the list is undefined to prevent
+		// this from throwing errors.
+		// TODO: The real fix is to make the channel list code more performant so that this doesn't happen.
+		if (this.starred_channel_list) {
+		  this.starred_channel_list.set_active_channel(channel);
+		}
+		if (this.current_channel_list) {
+		  this.current_channel_list.set_active_channel(channel);
+		}
+		if (this.public_channel_list) {
+		  this.public_channel_list.set_active_channel(channel);
+		}
+		if (this.viewonly_channel_list) {
+		  this.viewonly_channel_list.set_active_channel(channel);
+		}
 	},
 	set_all_models: function(channel){
 		this.starred_channel_list.set_model(channel);


### PR DESCRIPTION
… Also remove error handlers, as the API calls aren't erroring out, just slow, and we now have a global error handler for AJAX calls.

## Description

Prevents slow API calls on the channels page from throwing JavaScript errors. All the set_active_channel error reports in Sentry are a result of not checking our channel list models are loaded before calling methods on them.

## Steps to Test

- [ ] Load the channels page

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
