### PR TITLE
Correctly display channel item counts

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
@@ -341,7 +341,7 @@ var ChannelListItem = BaseViews.BaseListEditableItemView.extend({
 			can_edit: this.can_edit,
 			channel: this.model.toJSON(),
 			total_file_size: this.model.get("size"),
-			resource_count: this.model.get("resource_count"),
+			resource_count: this.model.get("count"),
 			channel_link : this.model.get("id"),
 			picture : (this.model.get("thumbnail_encoding") && this.model.get("thumbnail_encoding").base64) || this.model.get("thumbnail_url"),
 			modified: this.model.get("modified") || new Date(),


### PR DESCRIPTION
## Description

Ensures that channels correctly display their item count.

#### At a high level, how did you implement this?

First, I broke it by accidentally changing the variable name in the template.  Then I fixed it by changing it back!

Before:
![image](https://user-images.githubusercontent.com/389782/47685659-34feca00-dba5-11e8-8e20-f0c8e318b7be.png)

After:
![image](https://user-images.githubusercontent.com/389782/47685668-40ea8c00-dba5-11e8-8797-957a996e7b8e.png)


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?