### PR TITLE
License ids need int conversion. Also fix some find calls…

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/channel_settings/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_settings/views.js
@@ -126,11 +126,11 @@ var SettingsView = BaseViews.BaseListEditableItemView.extend({
     },
     get_license_name: function(){
         var el = $("#license_select");
-        return el.val()!=0 && Constants.Licenses.find(license => license.id === el.val()).license_name;
+        return el.val()!=0 && Constants.Licenses.find(license => license.id === parseInt(el.val(), 10)).license_name;
     },
     check_custom_license: function(){
         var el = $("#license_select");
-        return el.val()!=0 && Constants.Licenses.find(license => license.id === el.val()).is_custom;
+        return el.val()!=0 && Constants.Licenses.find(license => license.id === parseInt(el.val(), 10)).is_custom;
     },
     submit_changes:function(){
         var content_defaults = this.model.get("content_defaults");

--- a/contentcuration/contentcuration/static/js/edit_channel/details/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/details/views.js
@@ -247,7 +247,7 @@ var ChannelEditorView = BaseViews.BaseListEditableItemView.extend({
             channel: this.model.toJSON(),
             languages: Constants.Languages,
             picture : (this.model.get("thumbnail_encoding") && this.model.get("thumbnail_encoding").base64) || this.model.get("thumbnail_url"),
-            language: Constants.Languages.find(id => id === this.model.get("language")),
+            language: Constants.Languages.find(language => language.id === this.model.get("language")),
             can_edit: this.allow_edit,
             is_new: !!this.onnew,
             edit: this.edit

--- a/contentcuration/contentcuration/static/js/edit_channel/image/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/image/views.js
@@ -384,7 +384,7 @@ var ImageUploadView = BaseViews.BaseModalView.extend({
             this.dropzone = new Dropzone(this.$("#dropzone").get(0), {
                 maxFiles: 1,
                 clickable: ["#dropzone", "#dropzone_placeholder"],
-                acceptedFiles: Constants.FormatPresets.find(id => id === this.preset_id).associated_mimetypes.join(','),
+                acceptedFiles: Constants.FormatPresets.find(preset => preset.id === this.preset_id).associated_mimetypes.join(','),
                 url: window.Urls.exercise_image_upload(),
                 thumbnailWidth:null,
                 thumbnailHeight:null,

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -1144,7 +1144,7 @@ var ContentKindModel = BaseModel.extend({
         kind: "topic"
     },
     get_presets: function () {
-        Constants.FormatPresets.filter(preset => preset.kind === this.get("kind"))
+        Constants.FormatPresets.filter(preset => preset.kind_id === this.get("kind"))
     }
 });
 

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -1026,7 +1026,7 @@ var FileModel = BaseModel.extend({
     root_list: "file-list",
     model_name: "FileModel",
     get_preset: function () {
-        return Constants.FormatPresets.find(id => id === this.get("id"));
+        return Constants.FormatPresets.find(preset => preset.id === this.get("id"));
     },
     initialize: function () {
         this.set_preset(this.get("preset"), this.get("language"));
@@ -1144,7 +1144,7 @@ var ContentKindModel = BaseModel.extend({
         kind: "topic"
     },
     get_presets: function () {
-        Constants.FormatPresets.filter(kind => kind === this.get("kind"))
+        Constants.FormatPresets.filter(preset => preset.kind === this.get("kind"))
     }
 });
 

--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/views.js
@@ -346,7 +346,7 @@ var ChannelListItem = BaseViews.BaseListEditableItemView.extend({
 			picture : (this.model.get("thumbnail_encoding") && this.model.get("thumbnail_encoding").base64) || this.model.get("thumbnail_url"),
 			modified: this.model.get("modified") || new Date(),
 			languages: Constants.Languages,
-			language: Constants.Languages.find(id => id === this.model.get("language")),
+			language: Constants.Languages.find(language => language.id === this.model.get("language")),
 			new: this.isNew
 		}, {
 			data: this.get_intl_data()

--- a/contentcuration/contentcuration/static/js/edit_channel/preview/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/preview/views.js
@@ -117,7 +117,7 @@ var PreviewView = BaseViews.BaseView.extend({
         this.model.get("files").forEach(function(file){
             var file_json = (file.attributes)? file.attributes : file;
             var preset_id = (file_json.preset && file_json.preset.name)? file_json.preset.name : file_json.preset;
-            var current_preset = Constants.FormatPresets.find(id => id === preset_id);
+            var current_preset = Constants.FormatPresets.find(preset => preset.id === preset_id);
             if(current_preset && current_preset.subtitle){
                 subtitles.push(file_json);
             }

--- a/contentcuration/contentcuration/static/js/edit_channel/sync/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/sync/views.js
@@ -309,8 +309,8 @@ var SyncPreviewView = BaseViews.BaseView.extend({
             case "license":
                 return {
                     "field" : this.get_translation("license"),
-                    "current": stringHelper.translate(Constants.Licenses.find(license => license.id === this.model.get(field)).license_name),
-                    "source": stringHelper.translate(Constants.Licenses.find(license => license.id === this.changed.get(field)).license_name),
+                    "current": stringHelper.translate(Constants.Licenses.find(license => license.id === parseInt(this.model.get(field), 10)).license_name),
+                    "source": stringHelper.translate(Constants.Licenses.find(license => license.id === parseInt(this.changed.get(field), 10)).license_name),
                 }
             case "language":
                 var current_lang = (this.model.get(field))? Constants.Languages.find(lang => lang.id === this.model.get(field)).native_name : this.get_translation("same_as_topic");

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
@@ -646,7 +646,7 @@ var EditMetadataEditor = BaseViews.BaseView.extend({
     var alloriginal = this.all_original();
     var original_source_license = "---";
     if(this.shared_data && this.shared_data.shared_license){
-      original_source_license = Constants.Licenses.find(license => license.id === this.shared_data.shared_license).license_name;
+      original_source_license = Constants.Licenses.find(license => license.id === parseInt(this.shared_data.shared_license, 10)).license_name;
     }
     var copyright_owner = (this.shared_data && this.shared_data.shared_copyright_owner)? this.shared_data.shared_copyright_owner: (alloriginal)? null: "---";
     var author = (this.shared_data && this.shared_data.shared_author)? this.shared_data.shared_author: (alloriginal)? null: "---";
@@ -783,10 +783,11 @@ var EditMetadataEditor = BaseViews.BaseView.extend({
   get_license: function(license_id){
     if(isNaN(license_id)){ return license_id; }
     else if(!license_id || license_id <= 0){ return null; }
-    return Constants.Licenses.find(license => license.id === license_id).license_name;
+    // isNaN actually coerces a numeric string to a number before checking, so to be safe we need to convert to int
+    return Constants.Licenses.find(license => license.id === parseInt(license_id, 10)).license_name;
   },
   display_license_description: function(license_id){
-    var license = license_id > 0 && Constants.Licenses.find(license => license.id === license_id);
+    var license = license_id > 0 && Constants.Licenses.find(license => license.id === parseInt(license_id, 10));
     if(license && license.is_custom){
       this.$("#custom_license_description").css('display', 'block');
       if(this.shared_data){
@@ -852,7 +853,7 @@ var EditMetadataEditor = BaseViews.BaseView.extend({
   load_license:function(){
     if (this.selected_items.length){
       var license_modal = new Info.LicenseModalView({
-        select_license : Constants.Licenses.find(license => license.id === this.selected_items[0].model.get("license"))
+        select_license : Constants.Licenses.find(license => license.id === parseInt(this.selected_items[0].model.get("license"), 10))
       });
     }
 
@@ -941,11 +942,6 @@ var EditMetadataEditor = BaseViews.BaseView.extend({
     this.$("#license_about").css("display", "inline");
     this.set_selected();
     this.display_license_description($("#license_select").val());
-  },
-  toggle_license_description: function() {
-    const license_id = (iscopied || !this.allow_edit)? this.selected_items[0].model.get("license") : $("#license_select").val();
-    var license = Constants.Licenses.find(license => license.id === license_id);
-    // TODO: This function appears to be a noop
   },
   set_selected:function(){
     var self = this;
@@ -1219,7 +1215,7 @@ var UploadedItem = BaseViews.BaseListEditableItemView.extend({
       (this.uploads_in_progress===0)? this.container.enable_submit() : this.container.disable_submit();
   },
   validate: function() {
-    var license = Constants.Licenses.find(license => license.id === this.model.get("license"));
+    var license = Constants.Licenses.find(license => license.id === parseInt(this.model.get("license"), 10));
     this.error = "";
     $(".input_listener, select").removeClass("invalid_field");
     if(!this.model.get("title")) {


### PR DESCRIPTION
…where the object was identified as its id field instead. Lastly, remove a dead code block.

## Description

When switching to Array-based constants, we needed to explicitly convert types in a few situations where Backbone previously handled it for us. There were also a few spots during the conversion where the object got referenced as an id instead of as the object, causing some find calls to fail.

#### Issue Addressed (if applicable)

Fixes #1059

## Steps to Test

- [ ] Upload a file and try to specify license information. (On current develop it will fail to validate on save.)
- [ ] Create an exercise and try to upload an image for it. 

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
