### PR TITLE
Add extra labels to app and worker pods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@
     hooks:
     -   id: trailing-whitespace
     -   id: flake8
-    -   id: check-yaml
     -   id: check-added-large-files
     -   id: debug-statements
     -   id: end-of-file-fixer

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -11,6 +11,7 @@ spec:
         checksum: {{ include (print $.Template.BasePath "/studio-secrets.yaml") . | sha256sum }}
       labels:
         app: {{ template "studio.fullname" . }}
+        tier: app
     spec:
       containers:
       - name: app
@@ -18,7 +19,7 @@ spec:
         env:
         {{ include "studio.sharedEnvs" . }}
         - name: STATICFILES_DIR
-          value: /app/contentworkshop_static/        
+          value: /app/contentworkshop_static/
         - name: SEND_USER_ACTIVATION_NOTIFICATION_EMAIL
           value: "true"
         livenessProbe:
@@ -84,6 +85,7 @@ spec:
     metadata:
       labels:
         app: {{template "studio.fullname" . }}-workers
+        tier: workers
     spec:
       volumes:
       - name: gcs-creds

--- a/k8s/templates/studio-service.yaml
+++ b/k8s/templates/studio-service.yaml
@@ -9,4 +9,5 @@ spec:
     targetPort: {{ .Values.studioNginx.port }}
   selector:
     app: {{ template "studio.fullname" . }}
+    tier: app
   type: NodePort


### PR DESCRIPTION
## Description

This adds extra labels on our app and worker containers, and makes our service
route only to the app containers. This will avoid accidentally routing requests
to the worker container. The latter will just not respond, leading to 502 errors.

Oh, and remove the check-yaml portion of our pre-commit hooks. It barfs on our perfectly valid templated yaml files.