### PR TITLE
Silence offline errors

### DIFF
--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -22,7 +22,14 @@
             -->
             <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js" crossorigin="anonymous"></script>
             <script>
-                Raven.config('{% sentry_public_dsn %}').install()
+                // Ignore errors when CloudFlare-AlwaysOnline is in the user agent as these are errors serving
+                // the offline version and I don't think we can fix or reproduce these easily.
+                // Fix taken from here: https://github.com/getsentry/sentry-javascript/issues/617#issuecomment-227562203
+                Raven.config('{% sentry_public_dsn %}', {
+                      shouldSendCallback(data) {
+                        return !/^(.*CloudFlare-AlwaysOnline.*)$/.test(window.navigator.userAgent);
+                      }
+                    }).install()
             </script>
 	<link rel="shortcut icon" href="{% static 'img/logo.ico' %}">
 


### PR DESCRIPTION
## Description

Silence the last of the Sentry noise trifecta - the CloudFlare AlwaysOnline errors. (At least 151 of these in the error reports.) These appear to be caused by issues where CloudFlare tries to serve an offline version of the site. I'm not even sure if we should allow this, but in the meantime, we should at least silence errors generated by CloudFlare's offline cache versions as it doesn't seem possible to reproduce with the actual site.

Once this has been pushed to production, the reports should hopefully be mostly signal rather than noise!

Test is just to make sure we get Sentry errors.

#### Issue Addressed (if applicable)

#1069 

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
