### PR TITLE
Check existence of files before saving to storage to fix GCS 410 error

### DIFF
--- a/contentcuration/contentcuration/api.py
+++ b/contentcuration/contentcuration/api.py
@@ -56,7 +56,10 @@ def write_file_to_storage(fobj, check_valid=False, name=None):
 
     # Write file
     storage = default_storage
-    storage.save(file_path, fobj)
+    if storage.exists(file_path):
+        logging.info("{} exists in Google Cloud Storage, so it's not saved again.".format(file_path))
+    else:
+        storage.save(file_path, fobj)
     return full_filename
 
 
@@ -72,7 +75,10 @@ def write_raw_content_to_storage(contents, ext=None):
 
     # Write file
     storage = default_storage
-    storage.save(file_path, StringIO(contents))
+    if storage.exists(file_path):
+        logging.info("{} exists in Google Cloud Storage, so it's not saved again.".format(file_path))
+    else:
+        storage.save(file_path, StringIO(contents))
 
     return hashed_filename, full_filename, file_path
 

--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -73,12 +73,6 @@ class GoogleCloudStorageSaveTestCase(TestCase):
         # Check that we pass self.content file_object to upload_from_file
         self.blob_obj.upload_from_file.assert_called_once_with(self.content, content_type="image/jpeg")
 
-    def test_save_an_existing_exercise(self):
-        """
-        Test if an existing exercise would be saved again
-        """
-        self.storage.save("testuploadexercises.perseus", self.content, blob_object=self.blob_obj)
-        self.blob_obj.upload_from_file.assert_not_called()
 
 class GoogleCloudStorageOpenTestCase(TestCase):
     """

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -75,10 +75,6 @@ class GoogleCloudStorage(Storage):
         return blob.size
 
     def save(self, name, fobj, max_length=None, blob_object=None):
-        if name.endswith(".perseus") and self.exists(name):
-            logging.info("{} exists in Google Cloud Storage, so it's not saved again.".format(name))
-            return name
-
         if not blob_object:
             blob = Blob(name, self.bucket)
         else:


### PR DESCRIPTION

## Description

This PR is to fix the GCS 410 error that keeps showing up after the previous fix #1034 

#### Issue Addressed (if applicable)

Addresses #1030 

## Steps to Test

- Please check if the tests pass or not

#### *Briefly describe how this works*

Based on the discussion with @aronasorman , we decide to check the existence of files before saving them to storage. If the file exists in GCS, then we are not going to save it again.

#### *List anything that will need to be addressed later*
Will cherry-pick this commit to master once this PR gets approved.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

