### PR TITLE
Add STUDIO_BETA_MODE var on deployments

### DIFF
--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -77,6 +77,8 @@ Generate the shared environment variables between studio app and workers
           value: /var/log/django.log
         - name: MPLBACKEND
           value: PS
+        - name: STUDIO_BETA_MODE
+          value: "yes"
         - name: RUN_MODE
           value: k8s
         - name: DATA_DB_HOST


### PR DESCRIPTION
## Description

We define a new environment variable, STUDIO_BETA_MODE, that sets that env var
on production clusters.