### PR TITLE
[Don't merge] Pin pipenv to fix Travis CI builds

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN npm install -g yarn
 
 EXPOSE 8080
 
-RUN pip install pipenv
+RUN pip install pipenv==2018.10.13
 # pip 18.1 gives an error with pipenv, so pin the version to 18.0 until there is a fix.
 # More info here: https://github.com/pypa/pipenv/issues/2924
 RUN pip install pip==18.0

--- a/k8s/images/app/Dockerfile
+++ b/k8s/images/app/Dockerfile
@@ -28,7 +28,7 @@ COPY Pipfile.lock .
 # pip 18.1 gives an error with pipenv, so pin the version to 18.0 until there is a fix.
 # More info here: https://github.com/pypa/pipenv/issues/2924
 RUN pip install pip==18.0
-RUN pip install -U pipenv
+RUN pip install pipenv==2018.10.13
 RUN pipenv install --system  # install packages from Pipfile.lock into system
 
 COPY  . /contentcuration/


### PR DESCRIPTION
## Description

Attempt to fix Travis CI builds by pinning pipenv to the previous version.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
