### PR TITLE
[Don't merge] No terminal emojis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       CELERY_BROKER_ENDPOINT: studio-redis
       CELERY_RESULT_BACKEND_ENDPOINT: studio-redis
       CELERY_REDIS_PASSWORD: ""
+      PIPENV_HIDE_EMOJIS: "true"
     volumes:
       - .:/src
       - studio_app_virtualenv:/root/.local/share/virtualenvs/
@@ -54,6 +55,7 @@ services:
       CELERY_BROKER_ENDPOINT: studio-redis
       CELERY_RESULT_BACKEND_ENDPOINT: studio-redis
       CELERY_REDIS_PASSWORD: ""
+      PIPENV_HIDE_EMOJIS: "true"
   minio:
     image: minio/minio
     # logging:


### PR DESCRIPTION
## Description

Alternate attempt to fix pipenv by turning off the emoji output. This would allow us to not pin pipenv.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
