### PR TITLE
GCS 410 error fix for writing thumbnails repeatedly

### DIFF
--- a/contentcuration/contentcuration/tests/test_files.py
+++ b/contentcuration/contentcuration/tests/test_files.py
@@ -100,6 +100,13 @@ class FileThumbnailTestCase(BaseAPITestCase):
         self.assertEqual(file_data['encoding'], generated_base64encoding())
         storage_save_mock.assert_not_called()
 
+    @patch('contentcuration.api.default_storage.save')
+    @patch('contentcuration.api.default_storage.exists', return_value=True)
+    def test_existing_thumbnail_is_not_created(self, storage_exists_mock, storage_save_mock):
+        thumbnail_fobj = create_thumbnail_from_base64(base64encoding())
+        storage_exists_mock.assert_called()
+        storage_save_mock.assert_not_called()
+
     def test_generate_thumbnail(self):
         # Create exercise node (generated images are more predictable)
         node = ContentNode(title="Test Node", kind_id=content_kinds.EXERCISE)

--- a/contentcuration/contentcuration/utils/files.py
+++ b/contentcuration/contentcuration/utils/files.py
@@ -34,17 +34,18 @@ THUMBNAIL_DIMENSION = 400
 
 def create_file_from_contents(contents, ext=None, node=None, preset_id=None, uploaded_by=None):
     checksum, _, path = write_raw_content_to_storage(contents, ext=ext)
-    with default_storage.open(path, 'rb') as new_file:
-        result = File.objects.create(
-            file_on_disk=DjFile(new_file),
-            file_format_id=ext,
-            file_size=default_storage.size(path),
-            checksum=checksum,
-            preset_id=preset_id,
-            contentnode=node,
-            uploaded_by=uploaded_by
-        )
-        return result
+
+    result = File(
+        file_format_id=ext,
+        file_size=default_storage.size(path),
+        checksum=checksum,
+        preset_id=preset_id,
+        contentnode=node,
+        uploaded_by=uploaded_by
+    )
+    result.file_on_disk.name = path
+    result.save()
+    return result
 
 
 def get_file_diff(files):


### PR DESCRIPTION
## Description

Avoid creating the file multiple times by just setting the path in the file object after writing the file.

#### Issue Addressed (if applicable)

Addresses #1030 

## Steps to Test

- [ ] Run a sushi chef that uses the same thumbnail in multiple files

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Does this introduce a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
