### PR TITLE
Remove wait-on time limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test-jest-cov": "jest --config jest_config/jest.conf.js --coverage",
     "minio:test": "rm -rf ~/.minio_test && minio server ~/.minio_test/ || true",
     "minio": "MINIO_ACCESS_KEY=development MINIO_SECRET_KEY=development minio server ~/.minio_data/ || true",
-    "runserver": "wait-on -t 5000 tcp:9000 && (cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8080)",
+    "runserver": "wait-on tcp:9000 && (cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8080)",
     "testserver": "wait-on -t 5000 tcp:9000 && (cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8081) || true",
     "devserver": "npm-run-all --parallel services build:dev runserver"
   },


### PR DESCRIPTION
I've been getting a lot of `SIGTERM` errors when the time limit runs out, so I just removed it completely