### PR TITLE
Image file error hotfix part 2

### DIFF
--- a/contentcuration/contentcuration/management/commands/exportchannel.py
+++ b/contentcuration/contentcuration/management/commands/exportchannel.py
@@ -263,6 +263,8 @@ def create_associated_thumbnail(ccnode, ccfilemodel):
         encoding = ccnode.thumbnail_encoding and load_json_string(ccnode.thumbnail_encoding).get('base64')
     except ValueError:
         logging.error("ERROR: node thumbnail is not in correct format ({}: {})".format(ccnode.id, ccnode.thumbnail_encoding))
+    except IOError:
+        logging.error("ERROR: cannot identify the thumbnail ({}: {})".format(ccnode.id, ccnode.thumbnail_encoding))
 
     # Save the encoding if it doesn't already have an encoding
     if not encoding:
@@ -274,7 +276,12 @@ def create_associated_thumbnail(ccnode, ccfilemodel):
         })
         ccnode.save()
 
-    return create_thumbnail_from_base64(encoding, uploaded_by=ccfilemodel.uploaded_by, file_format_id=ccfilemodel.file_format_id, preset_id=ccfilemodel.preset_id)
+    return create_thumbnail_from_base64(
+        encoding,
+        uploaded_by=ccfilemodel.uploaded_by,
+        file_format_id=ccfilemodel.file_format_id,
+        preset_id=ccfilemodel.preset_id
+    )
 
 
 def create_associated_file_objects(kolibrinode, ccnode):

--- a/contentcuration/contentcuration/management/commands/exportchannel.py
+++ b/contentcuration/contentcuration/management/commands/exportchannel.py
@@ -263,8 +263,10 @@ def create_associated_thumbnail(ccnode, ccfilemodel):
         encoding = ccnode.thumbnail_encoding and load_json_string(ccnode.thumbnail_encoding).get('base64')
     except ValueError:
         logging.error("ERROR: node thumbnail is not in correct format ({}: {})".format(ccnode.id, ccnode.thumbnail_encoding))
+        return
     except IOError:
         logging.error("ERROR: cannot identify the thumbnail ({}: {})".format(ccnode.id, ccnode.thumbnail_encoding))
+        return
 
     # Save the encoding if it doesn't already have an encoding
     if not encoding:


### PR DESCRIPTION
This time, catch a thumbnail that's not an image!

We get this traceback:

```python
  File "/usr/lib/python2.7/pdb.py", line 1314, in main
    pdb._runscript(mainpyfile)
  File "/usr/lib/python2.7/pdb.py", line 1233, in _runscript
    self.run(statement)
  File "/usr/lib/python2.7/bdb.py", line 400, in run
    exec cmd in globals, locals
  File "<string>", line 1, in <module>
  File "contentcuration/manage.py", line 2, in <module>
    import os
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "contentcuration/contentcuration/management/commands/exportchannel.py", line 81, in handle
    create_content_database(channel_id, force, user_id, force_exercises)
  File "contentcuration/contentcuration/management/commands/exportchannel.py", line 138, in create_content_database
    map_content_nodes(channel.main_tree, channel.language, channel.id, channel.name, user_id=user_id, force_exercises=force_exercises)
  File "contentcuration/contentcuration/management/commands/exportchannel.py", line 192, in map_content_nodes
    create_associated_file_objects(kolibrinode, node)
  File "contentcuration/contentcuration/management/commands/exportchannel.py", line 289, in create_associated_file_objects
    ccfilemodel = create_associated_thumbnail(ccnode, ccfilemodel) or ccfilemodel
  File "contentcuration/contentcuration/management/commands/exportchannel.py", line 269, in create_associated_thumbnail
    encoding = get_thumbnail_encoding(str(ccfilemodel))
  File "contentcuration/contentcuration/utils/files.py", line 243, in get_thumbnail_encoding
    with Image.open(inbuffer) as image:
  File "/usr/local/lib/python2.7/dist-packages/PIL/Image.py", line 2585, in open
    % (filename if filename else fp))
IOError: cannot identify image file <cStringIO.StringO object at 0x7f4e69e82f80>
```

If you request the file it's uploading:

```bash
curl https://storage.googleapis.com/studio-content/storage/f/6/f675110eb9e2454ca7ab8b9a56a69e61.png
```

It's actually an HTML file!