### PR TITLE
Fixed language not showing up

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/details/hbtemplates/channel_editor.handlebars
+++ b/contentcuration/contentcuration/static/js/edit_channel/details/hbtemplates/channel_editor.handlebars
@@ -15,7 +15,7 @@
                 {{#each languages}}<option value="{{id}}" title="{{readable_name}}">{{readable_name}}</option>{{/each}}
             </select>
         {{else}}
-            {{#if language}}<i class="material-icons">language</i> <b>{{language.attributes.native_name}}</b>{{/if}}
+            {{#if language}}<i class="material-icons">language</i> <b>{{language.native_name}}</b>{{/if}}
         {{/if}}
     </div>
     {{#if edit}}

--- a/contentcuration/contentcuration/static/js/edit_channel/new_channel/hbtemplates/channel_item.handlebars
+++ b/contentcuration/contentcuration/static/js/edit_channel/new_channel/hbtemplates/channel_item.handlebars
@@ -8,7 +8,7 @@
 		<span class="channel_metadata text-left">
 			{{#if language}}
 				<span class="pull-left">
-					<div class="channel_language truncate" title="{{language.attributes.readable_name}}">{{language.attributes.readable_name}}</div>
+					<div class="channel_language truncate" title="{{language.native_name}}">{{language.native_name}}</div>
 					&nbsp;|&nbsp;
 				</span>
 			{{/if}}


### PR DESCRIPTION
Languages weren't being properly referenced on the handlebars templates, which was leading to languages not showing up.

## Before
![image](https://user-images.githubusercontent.com/7447496/49482637-d6042480-f7e4-11e8-8162-33006748751d.png)

![image](https://user-images.githubusercontent.com/7447496/49482624-cab0f900-f7e4-11e8-8678-d3cc05c0ed91.png)

## After
![image](https://user-images.githubusercontent.com/7447496/49482653-e1575000-f7e4-11e8-9d44-ad3d2661574a.png)

![image](https://user-images.githubusercontent.com/7447496/49482662-e7e5c780-f7e4-11e8-9595-a1d3568fd3ee.png)

