### PR TITLE
Add a couple more variations of the IndexSizeError messages to the ignoreErrors list.

### DIFF
--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -32,8 +32,13 @@
                       // If there are errors that are known bugs in third-party libs or are clearly harmless,
                       // add them here to reduce sentry noise.
                       ignoreErrors: [
-                        // This looks like an error in Summernote: https://github.com/summernote/summernote/issues/1759
+                        // These appear to be errors in Summernote, but we have yet to reproduce. Although we get a lot
+                        // of Sentry reports with these errors, they lack a stack trace, and we also have not yet gotten
+                        // any user reports of this problem. For the moment, silence them so that they don't drown out
+                        // other errors. We may wish to remove these once we resolve the other errors.
                         'IndexSizeError: Failed to execute \'setStart\' on \'Range\'',
+                        'IndexSizeError: Failed to execute \'setEnd\' on \'Range\'',
+                        'IndexSizeError: Index or size is negative or greater than the allowed amount',
                       ]
                     }).install()
             </script>


### PR DESCRIPTION
## Description

We're getting a lot of IndexSizeError Sentry reports still, but we can't seem to reproduce or get valid stack traces, so these reports aren't very helpful. I have created #1148 to make sure we have a ticket for this issue for when we have more time to investigate.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
