### PR TITLE
Exercise Images Fix

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/image/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/image/views.js
@@ -349,6 +349,7 @@ var ImageUploadView = BaseViews.BaseModalView.extend({
         this.callback = options.callback;
         this.file = this.alt_text = null;
         this.preset_id = options.preset_id;
+        this.assessmentItemId = options.assessmentItemId;
         this.render();
     },
 
@@ -390,7 +391,10 @@ var ImageUploadView = BaseViews.BaseModalView.extend({
                 thumbnailHeight:null,
                 previewTemplate:this.dropzone_template(null, { data: this.get_intl_data() }),
                 previewsContainer: "#dropzone",
-                headers: {"X-CSRFToken": get_cookie("csrftoken")}
+                headers: {"X-CSRFToken": get_cookie("csrftoken")},
+                params: {
+                  assessment_item: this.assessmentItemId,
+                },
             });
             this.dropzone.on("success", this.file_uploaded);
             this.dropzone.on("addedfile", this.file_added);

--- a/contentcuration/contentcuration/tests/test_fileendpoints.py
+++ b/contentcuration/contentcuration/tests/test_fileendpoints.py
@@ -1,163 +1,25 @@
-import tempfile
+from io import BytesIO
 
-import pytest
-from django.conf import settings
-from mixer.backend.django import mixer
+from base import StudioTestCase
+from django.core.urlresolvers import reverse
 
-pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def video():
-    return mixer.blend('contentcuration.ContentKind', kind='video')
+from contentcuration.models import AssessmentItem
+from contentcuration.models import File
 
 
-@pytest.fixture
-def preset_video(video):
-    return mixer.blend('contentcuration.FormatPreset', id='mp4', kind=video)
+class ExerciseImageUploadTestCase(StudioTestCase):
 
+    def test_post_exercise_image(self):
+        File.objects.all().delete()
+        img = BytesIO(b'mybinarydata')
+        img.name = 'myimage.jpg'
+        self.client.post(reverse('exercise_image_upload'), {0: img})
+        self.assertEqual(File.objects.all().count(), 1)
 
-@pytest.fixture
-def fileformat_mp4():
-    return mixer.blend('contentcuration.FileFormat', extension='mp4', mimetype='application/video')
-
-
-@pytest.yield_fixture
-def fileobj_video(preset_video, fileformat_mp4):
-    randomfilebytes = "4"
-
-    with tempfile.NamedTemporaryFile(dir=settings.STORAGE_ROOT, mode='w+t', delete=False) as f:
-        filename = f.name
-        f.write(randomfilebytes)
-        f.flush()
-        db_file_obj = mixer.blend('contentcuration.File', file_format=fileformat_mp4, preset=preset_video, file_on_disk=filename)
-
-        yield db_file_obj
-
-
-@pytest.fixture
-def audio():
-    return mixer.blend('contentcuration.ContentKind', kind='audio')
-
-
-@pytest.fixture
-def preset_audio(audio):
-    return mixer.blend('contentcuration.FormatPreset', id='mp3', kind=audio)
-
-
-@pytest.fixture
-def fileformat_mp3():
-    return mixer.blend('contentcuration.FileFormat', extension='mp3', mimetype='application/audio')
-
-
-@pytest.yield_fixture
-def fileobj_audio(preset_audio, fileformat_mp3):
-    randomfilebytes = "4"
-
-    with tempfile.NamedTemporaryFile(dir=settings.STORAGE_ROOT, mode='w+t', delete=False) as f:
-        filename = f.name
-        f.write(randomfilebytes)
-        f.flush()
-        db_file_obj = mixer.blend('contentcuration.File', file_format=fileformat_mp3, preset=preset_audio, file_on_disk=filename)
-
-        yield db_file_obj
-
-
-@pytest.fixture
-def exercise():
-    return mixer.blend('contentcuration.ContentKind', kind='exercise')
-
-
-@pytest.fixture
-def preset_exercise(exercise):
-    return mixer.blend('contentcuration.FormatPreset', id='perseus', kind=exercise)
-
-
-@pytest.fixture
-def fileformat_perseus():
-    return mixer.blend('contentcuration.FileFormat', extension='perseus', mimetype='application/perseus')
-
-
-@pytest.yield_fixture
-def fileobj_exercise(preset_exercise, fileformat_perseus):
-    randomfilebytes = "4"
-
-    with tempfile.NamedTemporaryFile(dir=settings.STORAGE_ROOT, mode='w+t', delete=False) as f:
-        filename = f.name
-        f.write(randomfilebytes)
-        f.flush()
-        db_file_obj = mixer.blend('contentcuration.File', file_format=fileformat_perseus, preset=preset_exercise, file_on_disk=filename)
-
-        yield db_file_obj
-
-
-@pytest.fixture
-def document():
-    return mixer.blend('contentcuration.ContentKind', kind='document')
-
-
-@pytest.fixture
-def preset_document(document):
-    return mixer.blend('contentcuration.FormatPreset', id='pdf', kind=document)
-
-
-@pytest.fixture
-def fileformat_pdf():
-    return mixer.blend('contentcuration.FileFormat', extension='pdf', mimetype='application/pdf')
-
-
-@pytest.yield_fixture
-def fileobj_document(preset_document, fileformat_pdf):
-    randomfilebytes = "4"
-
-    with tempfile.NamedTemporaryFile(dir=settings.STORAGE_ROOT, mode='w+t', delete=False) as f:
-        filename = f.name
-        f.write(randomfilebytes)
-        f.flush()
-        db_file_obj = mixer.blend('contentcuration.File', file_format=fileformat_pdf, preset=preset_document, file_on_disk=filename)
-
-        yield db_file_obj
-
-
-@pytest.fixture
-def fileobj_id1():
-    return 'notarealid.pdf'
-
-
-@pytest.fixture
-def fileobj_id2():
-    return 'notarealid.mp3'
-
-
-@pytest.fixture
-def fileobj_id3():
-    return 'notarealid.mp4'
-
-
-@pytest.fixture
-def fileobj_id4():
-    return 'notarealid.perseus'
-
-
-@pytest.fixture
-def file_list(fileobj_video, fileobj_audio, fileobj_document, fileobj_exercise, fileobj_id1, fileobj_id2, fileobj_id3, fileobj_id4):
-    return [
-        fileobj_video.__str__(),
-        fileobj_audio.__str__(),
-        fileobj_document.__str__(),
-        fileobj_exercise.__str__(),
-        fileobj_id1,
-        fileobj_id2,
-        fileobj_id3,
-        fileobj_id4,
-    ]
-
-
-@pytest.fixture
-def file_diff(fileobj_id1, fileobj_id2, fileobj_id3, fileobj_id4):
-    return [
-        fileobj_id1,
-        fileobj_id2,
-        fileobj_id3,
-        fileobj_id4,
-    ]
+    def test_post_exercise_image_assessment_item_id(self):
+        File.objects.all().delete()
+        item = AssessmentItem.objects.create()
+        img = BytesIO(b'mybinarydata')
+        img.name = 'myimage.jpg'
+        self.client.post(reverse('exercise_image_upload'), {0: img, 'assessment_item_id': item.id})
+        self.assertEqual(File.objects.get().assessment_item, item)

--- a/contentcuration/contentcuration/tests/test_rest_framework.py
+++ b/contentcuration/contentcuration/tests/test_rest_framework.py
@@ -4,6 +4,12 @@ import pytest
 from base import BaseAPITestCase
 from django.core.urlresolvers import reverse_lazy
 
+from le_utils.constants import content_kinds
+from le_utils.constants import exercises
+
+from contentcuration.models import AssessmentItem
+from contentcuration.models import ContentNode
+from contentcuration.models import File
 from contentcuration.models import User
 
 pytestmark = pytest.mark.django_db
@@ -36,3 +42,84 @@ class ChannelTestCase(BaseAPITestCase):
         response = self.put(url, {'version': original_version + 1, 'content_defaults': {}, 'pending_editors': []})
         self.channel.refresh_from_db()
         self.assertEqual(original_version, self.channel.version)
+
+
+class AssessmentItemTestCase(BaseAPITestCase):
+
+    def test_bulk_update(self):
+        exercise = ContentNode.objects.filter(kind=content_kinds.EXERCISE).first()
+        item1 = AssessmentItem.objects.create(contentnode=exercise)
+        item2 = AssessmentItem.objects.create(contentnode=exercise)
+        item3 = AssessmentItem.objects.create(contentnode=exercise)
+        item1dict = {}
+        item2dict = {}
+        item3dict = {}
+        for field in AssessmentItem._meta.fields:
+            attname = field.attname
+            set_attname = attname
+            if attname == 'contentnode_id':
+                set_attname = 'contentnode'
+            item1dict[set_attname] = getattr(item1, attname)
+            item2dict[set_attname] = getattr(item2, attname)
+            item3dict[set_attname] = getattr(item3, attname)
+        item1dict["question"] = "test"
+        item2dict["type"] = "test"
+        self.client.put(reverse_lazy('assessmentitem-list'), json.dumps([item1dict, item2dict, item3dict]), content_type="application/json")
+        item1.refresh_from_db()
+        self.assertEqual(item1.question, 'test')
+        item2.refresh_from_db()
+        self.assertEqual(item2.type, 'test')
+        item3.refresh_from_db()
+        self.assertEqual(item3.question, item3dict['question'])
+
+    def test_bulk_update_non_existent_item(self):
+        exercise = ContentNode.objects.filter(kind=content_kinds.EXERCISE).first()
+        item1 = AssessmentItem.objects.create(contentnode=exercise)
+        item1dict = {}
+        item2dict = {}
+        item3dict = {}
+        for field in AssessmentItem._meta.fields:
+            attname = field.attname
+            set_attname = attname
+            if attname == 'contentnode_id':
+                set_attname = 'contentnode'
+            item1dict[set_attname] = getattr(item1, attname)
+            item2dict[set_attname] = getattr(item1, attname)
+            item3dict[set_attname] = getattr(item1, attname)
+        item2dict['id'] = 10000
+        item3dict['id'] = 10001
+        item1dict["question"] = "test"
+        response = self.client.put(reverse_lazy('assessmentitem-list'), json.dumps([item1dict, item2dict, item3dict]), content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_bulk_update_checksum_file_not_associated_create_new_file_object(self):
+        exercise = ContentNode.objects.filter(kind=content_kinds.EXERCISE).first()
+        item1 = AssessmentItem.objects.create(contentnode=exercise)
+        item1dict = {}
+        for field in AssessmentItem._meta.fields:
+            attname = field.attname
+            set_attname = attname
+            if attname == 'contentnode_id':
+                set_attname = 'contentnode'
+            item1dict[set_attname] = getattr(item1, attname)
+        checksum = "b6d83d66859b0cf095ef81120ef98e1f"
+        item1dict["question"] = "![I'm an image!]($" + exercises.IMG_PLACEHOLDER + "/{checksum}.gif)".format(checksum=checksum)
+        File.objects.create(checksum=checksum)
+        self.client.put(reverse_lazy('assessmentitem-list'), json.dumps([item1dict]), content_type="application/json")
+        self.assertEqual(File.objects.filter(checksum=checksum).count(), 2)
+
+    def test_bulk_update_checksum_file_associated_use_existing_file_object(self):
+        exercise = ContentNode.objects.filter(kind=content_kinds.EXERCISE).first()
+        item1 = AssessmentItem.objects.create(contentnode=exercise)
+        item1dict = {}
+        for field in AssessmentItem._meta.fields:
+            attname = field.attname
+            set_attname = attname
+            if attname == 'contentnode_id':
+                set_attname = 'contentnode'
+            item1dict[set_attname] = getattr(item1, attname)
+        checksum = "b6d83d66859b0cf095ef81120ef98e1f"
+        item1dict["question"] = "![I'm an image!]($" + exercises.IMG_PLACEHOLDER + "/{checksum}.gif)".format(checksum=checksum)
+        File.objects.create(checksum=checksum, assessment_item=item1)
+        self.client.put(reverse_lazy('assessmentitem-list'), json.dumps([item1dict]), content_type="application/json")
+        self.assertEqual(File.objects.filter(checksum=checksum).count(), 1)

--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -221,12 +221,14 @@ def exercise_image_upload(request):
         return HttpResponseBadRequest("Only POST requests are allowed on this endpoint.")
 
     fobj = request.FILES.values()[0]
+    assessment_item_id = request.POST.get('assessment_item_id', None)
     name, ext = os.path.splitext(fobj._name)
     get_hash(DjFile(fobj))
     file_object = File(
         preset_id=format_presets.EXERCISE_IMAGE,
         file_on_disk=DjFile(request.FILES.values()[0]),
         file_format_id=ext[1:].lower(),
+        assessment_item_id=assessment_item_id,
     )
     file_object.save()
     return HttpResponse(json.dumps({


### PR DESCRIPTION
## Description
Change how we handle exercise image file uploads in the frontend.
Associate files with assessment item at upload time.
Simplify bulk update endpoint to just update.
Use explicit POST and DELETE for creating and deleting assessment items.

#### Issue Addressed (if applicable)

Fixes #1135 and resolves #1139.

## Steps to Test

- Create an exercise
- Create a question
- Add image to the question
- Delete the image
- Add another image
- Save the exercise
- See no error

#### Does this introduce any tech-debt items?

No, but I think the approach of associating the file object with the ContentNode or AssessmentItem in question at the time of initial upload means that we can reduce complexity in the frontend trying to set foreign keys from there, and should be replicated in other file upload endpoints.

## Checklist

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?