### PR TITLE
Fix thumbnail_encoding issues for channels.

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -690,7 +690,7 @@ class ChannelSerializer(ChannelFieldMixin, serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
     primary_token = serializers.SerializerMethodField('get_channel_primary_token')
     content_defaults = serializers.JSONField()
-    thumbnail_encoding = serializers.JSONField()
+    thumbnail_encoding = serializers.JSONField(required=False)
 
     def get_date_created(self, channel):
         return channel.main_tree.created.strftime("%X %x")

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_settings/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_settings/views.js
@@ -158,6 +158,7 @@ var SettingsView = BaseViews.BaseListEditableItemView.extend({
             "name": $("#input_title").val().trim(),
             "description": $("#input_description").val(),
             "thumbnail": this.model.get("thumbnail"),
+            "thumbnail_encoding": this.model.get("thumbnail_encoding"),
             "content_defaults": content_defaults,
             "language": (language===0)? null : language
         }).then(function(data){
@@ -193,6 +194,7 @@ var SettingsView = BaseViews.BaseListEditableItemView.extend({
     },
     remove_thumbnail:function(){
         this.model.set("thumbnail", "/static/img/kolibri_placeholder.png");
+        this.model.set("thumbnail_encoding", {});
         this.register_changes();
     },
     set_thumbnail:function(thumbnail, encoding, formatted_name, path){

--- a/contentcuration/contentcuration/static/js/edit_channel/image/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/image/views.js
@@ -106,9 +106,7 @@ var ThumbnailUploadView = BaseViews.BaseView.extend({
     },
     get_thumbnail_url:function(ignore_encoding){
         var thumbnail = _.find(this.model.get('files'), function(f){ return f.preset.thumbnail; });
-        if(!ignore_encoding && this.thumbnail_encoding){
-            if(typeof this.thumbnail_encoding === "string")
-                this.thumbnail_encoding = JSON.parse(this.thumbnail_encoding);
+        if(!ignore_encoding && this.thumbnail_encoding.base64){
             return this.thumbnail_encoding.base64;
         }
         else if(this.image_url){ return this.image_url; }
@@ -125,7 +123,7 @@ var ThumbnailUploadView = BaseViews.BaseView.extend({
             [this.get_translation("remove")]: function(){
                 self.image = null;
                 self.image_url = self.default_url;
-                self.thumbnail_encoding = null;
+                self.thumbnail_encoding = {};
                 self.onremove();
                 self.render();
             },


### PR DESCRIPTION
## Description

The migration to a JSONField for thumbnail_encoding introduced a couple of bugs. This resolves them.

Makes the thumbnail_encoding field optional to allow creation of new channels without a thumbnail.

Updates the thumbnail_encoding frontend logic for the ThumbnailUploadView, and the Channel Settings Modal, to account for the fact that an unset `thumbnail_encoding` field is now an empty object, and not simply undefined.

Also fixes a hitherto unreported bug where thumbnails could not be removed from the channel settings modal.

## Steps to Test
A
- Create a new channel
- Don't set a thumbnail
- Finish creating the channel
- Great success!

B
- Create a new channel
- Don't set a thumbnail
- Open the channel
- Open channel settings thumbnail
- See thumbnail!

C
- Add a thumbnail to channel from channel settings modal
- Save
- Refresh
- Thumbnail still set
- Remove thumbnail
- Save
- Refresh
- Thumbnail still removed

## Implementation Notes (optional)

`thumbnail_encoding` behaviour is now scattered around quite a lot of the frontend, and could probably be consolidated.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?