### PR TITLE
Much more responsive channel edit page, part 2

### DIFF
--- a/contentcuration/contentcuration/static/less/content-container.less
+++ b/contentcuration/contentcuration/static/less/content-container.less
@@ -24,7 +24,7 @@
 		flex-grow: 1;
 		#queue {
 			width: 100%;
-			flex-grow: 1;
+			flex-shrink: 1;
 			.ui-droppable {
 				display: flex;
 				align-items: center;
@@ -35,6 +35,45 @@
 		}
 	}
 }
+
+// in order to make topic tree more responsive, a chain of nested flexbox settings
+
+body {
+	display: flex;
+	flex-direction: column;
+
+	#channel-edit-sortable-boundary {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+
+		#channel-edit-content-wrapper {
+			display: flex;
+			flex-direction: column;
+			flex-grow: 1;
+
+			#main-content-area {
+				display: flex;
+				flex-direction: column;
+				flex-grow: 1;
+				
+				#edit {
+					display: flex;
+					flex-direction: column;
+					flex-grow: 1;
+					
+					#container-wrapper {
+						flex-grow: 1;
+						
+					}
+				}
+	
+			}
+		}
+	}
+}
+
+// end of flexbox settings, for now.
 
 #secondary-nav {
 	@secondary-nav-btn-color:#F2F2F2;
@@ -219,7 +258,7 @@
 
 #channel-edit-content-wrapper {
 	@container-height: calc( 100vh - var(--approxChannelEditNavHeight) );
-	@container-min-height:400px;
+	@container-min-height:250px;
 	@container-border-color: #BCBCBC;
 	@container-title-color: #30302F;
 	@container-last-width: 525px;
@@ -239,9 +278,6 @@
 	@thumbnail-width: 80px;
 	@thumbnail-height: 45px;
 
-	overflow-x:hidden;
-	width:100vw;
-	height:100%;
 	padding: 0;
 	border-top: 1px solid @blue-500;
 
@@ -253,14 +289,8 @@
 	}
 
 	#container-wrapper{
-		overflow:hidden;
-		overflow-x:auto;
-		min-height: @container-min-height + 100;
-		position:absolute;
-		width:100vw;
-		padding-left:40px;
+		overflow:auto;
 		margin-top:20px;
-		margin-bottom: 5rem;
 	}
 	.close_clipboard{
 		margin-top:10px;
@@ -273,8 +303,10 @@
 	    width: -o-max-content;
 		width: -moz-max-content;
 		width: max-content;
-    	padding-right: 200px;
-    	list-style: none;
+		list-style: none;
+		display: grid;
+		grid-template-columns: repeat(1000, auto);
+		padding: 0 40px;
 
 		#container_area_title{
 			margin-top: 0px;
@@ -477,7 +509,6 @@
 						    height: @thumbnail-height;
 						    object-fit: cover;
 						    vertical-align: baseline;
-						    position: absolute;
 						    margin-top: 2px;
 						}
 						.content-item-icon{
@@ -718,8 +749,6 @@
 		}
 	}
 }
-
-#container_area
 
 .staging_channel_wrapper{
 	.copy_item_button{ display: none !important; }

--- a/contentcuration/contentcuration/static/less/content-container.less
+++ b/contentcuration/contentcuration/static/less/content-container.less
@@ -47,6 +47,10 @@ body {
 		flex-direction: column;
 		flex-grow: 1;
 
+		#secondary-nav {
+			flex-shrink: 0;
+		}
+
 		#channel-edit-content-wrapper {
 			display: flex;
 			flex-direction: column;
@@ -63,11 +67,35 @@ body {
 					flex-grow: 1;
 					
 					#container-wrapper {
+						display: flex;
+						flex-direction: column;	
 						flex-grow: 1;
-						
+
+						ul#container_area {
+							display: flex;
+							flex-direction: row;
+							flex-wrap: nowrap;
+							
+							> li {
+								.title-bar {
+									flex-shrink: 0;	
+								}
+								
+								display: flex;
+								flex-direction: column;
+
+								> ul {
+									display: flex;
+									flex-direction: column;
+
+									> li {
+										flex-shrink: 0;
+									}
+								}
+							}
+						}
 					}
 				}
-	
 			}
 		}
 	}
@@ -252,12 +280,7 @@ body {
 	}
 }
 
-:root {
-	--approxChannelEditNavHeight: 35rem;
-}
-
 #channel-edit-content-wrapper {
-	@container-height: calc( 100vh - var(--approxChannelEditNavHeight) );
 	@container-min-height:250px;
 	@container-border-color: #BCBCBC;
 	@container-title-color: #30302F;
@@ -290,7 +313,7 @@ body {
 
 	#container-wrapper{
 		overflow:auto;
-		margin-top:20px;
+		padding: 20px 0;
 	}
 	.close_clipboard{
 		margin-top:10px;
@@ -304,8 +327,6 @@ body {
 		width: -moz-max-content;
 		width: max-content;
 		list-style: none;
-		display: grid;
-		grid-template-columns: repeat(1000, auto);
 		padding: 0 40px;
 
 		#container_area_title{
@@ -325,6 +346,7 @@ body {
 			margin:0;
 			margin-right:5px;
 			width: @container-width;
+			min-height: @container-min-height;
 			display:inline-block;
 			cursor:default;
 			border: 2px solid transparent;
@@ -358,8 +380,8 @@ body {
 				overflow-y: auto;
 				overflow-x: hidden;
 				padding: 0 0 5px 0;
-				height:@container-height;
-				min-height: @container-min-height;
+				height: 100%;
+				flex-grow: 1;
 				background-color:white;
 				margin: 5px 0px;
 				margin-bottom:0px;
@@ -653,7 +675,6 @@ body {
 				background-color: @edit-container-color;
 			}
 			.content-list{
-				min-height: @container-min-height * 0.80;
 				li{
 					border-color: @edit-container-color;
 					&.current_topic{

--- a/contentcuration/contentcuration/static/less/content-container.less
+++ b/contentcuration/contentcuration/static/less/content-container.less
@@ -73,9 +73,9 @@ body {
 
 						ul#container_area {
 							display: flex;
-							flex-direction: row;
-							flex-wrap: nowrap;
-							
+							flex-direction: row;	
+							flex-grow: 1;							
+
 							> li {
 								.title-bar {
 									flex-shrink: 0;	
@@ -83,10 +83,14 @@ body {
 								
 								display: flex;
 								flex-direction: column;
+								max-height: 100%;
 
-								> ul {
+								> ul.content-list {
 									display: flex;
 									flex-direction: column;
+									height: 0;
+									flex-grow: 1;
+					
 
 									> li {
 										flex-shrink: 0;
@@ -380,8 +384,6 @@ body {
 				overflow-y: auto;
 				overflow-x: hidden;
 				padding: 0 0 5px 0;
-				height: 100%;
-				flex-grow: 1;
 				background-color:white;
 				margin: 5px 0px;
 				margin-bottom:0px;

--- a/contentcuration/contentcuration/static/less/styles.less
+++ b/contentcuration/contentcuration/static/less/styles.less
@@ -18,19 +18,6 @@ body {
 	overflow-x:hidden;
 }
 
-#channel-edit-content-wrapper{
-	overflow-x:hidden !important;
-	overflow-y:auto;
-	height:100vh;
-	position:fixed;
-}
-
-#channel-edit-sortable-boundary{
-	width:100vw;
-	height:100%;
-	position:fixed;
-}
-
 /* NAVIGATION BAR */
 /* nav variables/mixins */
 #top-navigation {

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -150,11 +150,6 @@
     <div id="beta-banner" class="text-center info main-banner">
       <i class="material-icons">build</i> {% url 'issues_settings' as issue_url %}{% blocktrans %}Kolibri Studio is undergoing active development, and during usage you may encounter unexpected behavior or problems. <a href="{{issue_url}}" target="_blank">Please read here</a> on best practices, known issues, and error reporting recommendations. We appreciate your patience and assistance as we work to improve the Kolibri Studio Beta!{% endblocktrans %}
     </div>
-    <script>
-      // this line ensures that the Channel Edit tree view height is calculated in consideration of the BETA_MODE notification bar height.
-      // If the BETA_MODE notification is changed to be more streamlined, please change or adjust this line.
-      document.querySelector('html').style.setProperty('--approxChannelEditNavHeight', '41.5rem')
-    </script>
     {% endif %}
     {% endblock nav %}
 

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -153,7 +153,7 @@
     <script>
       // this line ensures that the Channel Edit tree view height is calculated in consideration of the BETA_MODE notification bar height.
       // If the BETA_MODE notification is changed to be more streamlined, please change or adjust this line.
-      document.querySelector('html').style.setProperty('--approxChannelEditNavHeight', '41rem')
+      document.querySelector('html').style.setProperty('--approxChannelEditNavHeight', '41.5rem')
     </script>
     {% endif %}
     {% endblock nav %}

--- a/contentcuration/contentcuration/templates/channel_edit.html
+++ b/contentcuration/contentcuration/templates/channel_edit.html
@@ -25,7 +25,7 @@
 	<div id="channel-edit-sortable-boundary">
 
 	<nav class="navbar" id="secondary-nav">
-		<ul class="nav navbar-nav">
+		<ul class="nav">
 			<li><a href="/channels" id="back_to_home"><i class="material-icons">home</i></a></li>
 			{% if not allow_edit %}<li class="channel_edit_label">{% if is_public %}{%trans "Public Channel" %}{% else %}{%trans "Viewing" %}{% endif %}</li>{% endif %}
 			{% if allow_edit %}


### PR DESCRIPTION
## Description
An improvement on [PR#1142](https://github.com/learningequality/studio/pull/1142)

This PR makes the topic tree navigator much more responsive on devices with smaller screens.  I even tried it at 1024x768 :tada: !

#### Before/After Screenshots (if applicable)
![channel edit responsive before round 2](https://user-images.githubusercontent.com/389782/50666581-0cb39300-0f7b-11e9-9c2a-cfb5cc4798a9.gif)
![channel edit responsive after round 2](https://user-images.githubusercontent.com/389782/50666587-10dfb080-0f7b-11e9-8dc9-adb7d5491e05.gif)



## Steps to Test

- [ ] Open a channel
- [ ] Resize the window
- [ ] Make sure the scrollbars feel comfortable
- [ ] Make sure everything is visible

## Implementation Notes
In order to make the topic tree navigation area feel more responsive, I introduced a nested chain of flexbox settings.  This ensures that the horizontal scrollbar will appear at the very bottom of the window, rather than at some awkward, arbitrary offset from the bottom.

In the future, it'd be great if we can get rid of all those extra nested containers!

#### At a high level, how did you implement this?

1. Removed lots of `position: absolute` and `position: fixed` properties that were unnecessarily complicating the layout (as well as their accompanying `width` and `height` settings).
2. Added a nested chain of flexbox settings.

- [ ] Is the code clean and well-commented?
- [x] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
