### PR TITLE
Don't fall over for content node thumbnails

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/image/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/image/views.js
@@ -106,7 +106,7 @@ var ThumbnailUploadView = BaseViews.BaseView.extend({
     },
     get_thumbnail_url:function(ignore_encoding){
         var thumbnail = _.find(this.model.get('files'), function(f){ return f.preset.thumbnail; });
-        if(!ignore_encoding && this.thumbnail_encoding.base64){
+        if(!ignore_encoding && this.thumbnail_encoding !== null && this.thumbnail_encoding.base64){
             return this.thumbnail_encoding.base64;
         }
         else if(this.image_url){ return this.image_url; }


### PR DESCRIPTION
## Description

Don't check for base64 key of null in thumbnail_encoding.

#### Issue Addressed

Fixes #1153

#### After Screenshot

![image](https://user-images.githubusercontent.com/1680573/50701957-42508e80-1004-11e9-8b11-7103331873e8.png)


## Steps to Test

- Open an exercise
- See questions have loaded