### PR TITLE
Fixed clipboard styling (cleaner)

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/queue/hbtemplates/queue_list.handlebars
+++ b/contentcuration/contentcuration/static/js/edit_channel/queue/hbtemplates/queue_list.handlebars
@@ -24,7 +24,6 @@
 			<input type="checkbox" class="select_all select_all_component" id="select_all_check_{{id}}"/>
 			<label class="select_all_label" for="select_all_check_{{id}}">{{formatMessage (intlGet 'messages.select_all')}}</label>
 		</div>
-		<hr/>
 		<div id="clipboard_list" class="list_content">
 			<div class="queue-list-wrapper">
 				<ul class="list-unstyled content-list" id="list_for_{{id}}">

--- a/contentcuration/contentcuration/static/less/queue.less
+++ b/contentcuration/contentcuration/static/less/queue.less
@@ -12,7 +12,7 @@
 	@queue-background-color:@gray-300;
 	@queue-min-height: 575px;
 	@queue-list-item-height: 40px;
-	@queue-top-bar-padding: 16px;
+	@queue-top-bar-padding: 10px;
 	@highlight-color: #E6E6E6;
 	@placeholder-color:#666666;
 
@@ -104,6 +104,10 @@
 			background-color: white;
 			min-height:@queue-min-height;
 
+			.wrapper {
+				width: 100%;
+			}
+
 			.queue-overlay {
 				display: none;
 				position: absolute;
@@ -167,12 +171,13 @@
 			}
 			.select_all_fixed {
 				padding: @queue-top-bar-padding;
+				border-bottom: 1px solid @gray-200;
 			}
 			.select_all_label {
 				width: auto;
 			}
 			.pin_clipboard {
-				padding: 16px;
+				padding: @queue-top-bar-padding;
 				margin: 0;
 
 


### PR DESCRIPTION
## Description

Currently, the clipboard options are getting cut off. This is a quick fix for handling this problem


#### Before/After Screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/7447496/50864366-abaf0500-1356-11e9-8f6c-414a5d5961ba.png)

After:
![image](https://user-images.githubusercontent.com/7447496/50864423-db5e0d00-1356-11e9-8f79-b1f3cf00db6b.png)
