### PR TITLE
Turned off offline js in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Studio Changelog
 
-## 2019-01-08 Update
+## 2019-01-10 Update
 #### Changes
 * [[@jayoshih](https://github.com/jayoshih)] Turned off offline.js when in debug mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2019-01-08 Update
 #### Changes
+* [[@jayoshih](https://github.com/jayoshih)] Turned off offline.js when in debug mode
+
+
+## 2019-01-08 Update
+#### Changes
 * [[@jayoshih](https://github.com/jayoshih)] Added a changelog
 
 #### Issues

--- a/contentcuration/contentcuration/context_processors.py
+++ b/contentcuration/contentcuration/context_processors.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 def site_variables(request):
-    return {'INCIDENT': settings.INCIDENT, 'BETA_MODE': settings.BETA_MODE}
+    return {'INCIDENT': settings.INCIDENT, 'BETA_MODE': settings.BETA_MODE, 'DEBUG': settings.DEBUG}

--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -6,7 +6,9 @@ require('../handlebars/helpers.js');
 // side effect: adds shared styles to the DOM
 require('../../less/styles.less');
 
-require('../utils/offline_helper');
+if(!window.DEBUG) {
+  require('../utils/offline_helper');
+}
 
 // Promise polyfill
 if(!global.Promise) {

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -55,6 +55,7 @@
 
       {% render_offline_css LANGUAGE_CODE %}
       <script>
+        window.DEBUG = "{{DEBUG}}" === "True";
         window.languageCode = "{{LANGUAGE_CODE}}";
         window.isRTL = "{{ LANGUAGE_BIDI }}" === "True";
         try{


### PR DESCRIPTION
## Description

Sorry guys, can't take it anymore. Turning off offline js when Studio is in debug mode

## Steps to Test

- [ ] Run devserver and see if there are any calls to /stealthz

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [x] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?