### PR TITLE
Don't allow user to set prerequisite from garbage tree on new content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 2019-01-11 Update
 #### Changes
 * [[@jayoshih](https://github.com/jayoshih)] Fixed login screen layout
+* [[@jayoshih](https://github.com/jayoshih)] Disabled prerequisite selection from garbage tree
+
+#### Issues
+* [#1018](https://github.com/learningequality/studio/issues/1018)
+
 
 
 ## 2019-01-10 Update

--- a/contentcuration/contentcuration/static/js/edit_channel/related/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/related/views.js
@@ -147,6 +147,7 @@ var PrerequisiteModalView = BaseViews.BaseModalView.extend({
         this.onselect = options.onselect;
         this.parent_view = options.parent_view;
         this.collection = options.collection;
+        this.rootID = options.rootID;
         this.views_to_update = options.views_to_update;
         this.modal = true;
         this.render(this.close, {});
@@ -155,6 +156,7 @@ var PrerequisiteModalView = BaseViews.BaseModalView.extend({
             onselect: this.close_prerequisites,
             modal : this,
             model:this.model,
+            rootID: this.rootID,
             views_to_update: this.views_to_update,
             collection: this.collection,
             allow_edit: options.allow_edit
@@ -179,6 +181,7 @@ var PrerequisiteView = BaseViews.BaseListView.extend({
         this.collection = State.nodeCollection;
         this.onselect = options.onselect;
         this.allow_edit = options.allow_edit;
+        this.rootID = options.rootID;
         this.views_to_update = options.views_to_update;
         this.render();
     },
@@ -221,7 +224,8 @@ var PrerequisiteView = BaseViews.BaseListView.extend({
         this.$("#selected_view_wrapper").css('display', 'none');
         this.relatedView = new RelatedView({
             model: this.model,
-            container: this
+            container: this,
+            rootID: this.rootID
         });
         this.$("#related_view_wrapper").html(this.relatedView.el);
     },
@@ -244,6 +248,7 @@ var BasePrerequisiteView = BaseViews.BaseView.extend({
         this.allow_edit = options.allow_edit;
         this.collection = new Models.ContentNodeCollection();
         this.container = options.container;
+        this.rootID = options.rootID || this.model.get("parent");
         this.render();
     },
     events:{
@@ -285,7 +290,7 @@ var RelatedView = BasePrerequisiteView.extend({
         this.$el.html(this.template(null, {
             data: this.get_intl_data()
         }));
-        this.collection.get_all_fetch_simplified([this.model.get('parent')]).then(function(collection){
+        this.collection.get_all_fetch_simplified([this.rootID]).then(function(collection){
             self.navigate_to_node(collection.at(0) || State.current_channel.get_root("main_tree"));
         });
     },

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
@@ -232,6 +232,7 @@ var EditMetadataView = BaseViews.BaseEditableListView.extend({
       this.prerequisite_view = new Related.PrerequisiteView({
         modal: false,
         model: selected_items[0].model,
+        rootID: this.model.id,
         onselect: this.set_prerequisites,
         views_to_update: selected_items,
         el: this.$("#metadata_prerequisites"),


### PR DESCRIPTION
## Description

This will fix the bug where a user could select a prerequisite from the garbage tree on new content

#### Issue Addressed (if applicable)

#1018 


## Steps to Test

- [ ] Create a new exercise
- [ ] Without saving, open the prerequisites tab
- [ ] Click the +ADD button

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

In the future, I would like to move this to vue so we can use the state more effectively instead of passing variables between views


## Checklist

- [X] Is the code clean and well-commented?
- [X] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?