### PR TITLE
Fix channel details width

### DIFF
--- a/contentcuration/contentcuration/static/less/channel_create.less
+++ b/contentcuration/contentcuration/static/less/channel_create.less
@@ -403,6 +403,11 @@ body {
 		vertical-align: top;
 		height: 83vh;
 		width: @channel-preview-width - 40px;
+
+		#channel_details {
+			width: 100%;
+		}
+		
 		.default-item {
 			padding-top: 45%;
 		    font-size: 15pt;


### PR DESCRIPTION
Fixes this issue:
![image](https://user-images.githubusercontent.com/389782/51353980-cdf00380-1a77-11e9-909c-09f5c85f05ca.png)

Afterward:
![image](https://user-images.githubusercontent.com/389782/51354009-ec55ff00-1a77-11e9-9d44-1c6a535f45b0.png)

### To reproduce:
1. Click the "+ Channel" button on the Studio channel list page
2. Make sure the sidebar contents stretch to their full width