### PR TITLE
Add fonts-freefont-ttf to installation packages

### DIFF
--- a/k8s/images/app/Dockerfile
+++ b/k8s/images/app/Dockerfile
@@ -13,7 +13,7 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 # install node
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 
-RUN apt-get -y install nodejs python python-dev python-pip gcc libpq-dev ffmpeg imagemagick ghostscript python-tk make git gettext openjdk-9-jre-headless curl libjpeg-dev wkhtmltopdf google-cloud-sdk
+RUN apt-get -y install nodejs python python-dev python-pip gcc libpq-dev ffmpeg imagemagick ghostscript python-tk make git gettext openjdk-9-jre-headless curl libjpeg-dev wkhtmltopdf google-cloud-sdk fonts-freefont-ttf
 
 RUN npm install -g yarn
 


### PR DESCRIPTION
The pdf export functions are generating blank pdfs as the font is not installed. This adds this to the build to make sure the proper font is available