### PR TITLE
Remove div tags from markdown output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Studio Changelog
 
+## 2019-01-30 Update
+#### Changes
+* [[@kollivier](https://github.com/kollivier)] Remove div tags from markdown output.
+
+#### Issues
+* [#1199](https://github.com/learningequality/studio/issues/1199)
+
+
 ## 2019-01-24 Update
 #### Changes
 * [[@jayoshih](https://github.com/jayoshih)] Force pdf exports to use Arial font file to fix blank pdfs

--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
@@ -679,6 +679,14 @@ var EditorView = BaseViews.BaseView.extend({
                     replacement: function (content) { return '*' + content + '*'; }
                 },
                 {
+                    filter: ['div'], // div is a block element, so add a line break before it.
+                    replacement: function (content) {
+                        var div = document.createElement('div');
+                        div.innerHTML = content;
+                        return '\n' + div.textContent;
+                    }
+                },
+                {
                     filter: ['span'],
                     replacement: function (content) {
                         var div = document.createElement('div');


### PR DESCRIPTION
## Description

Currently, the HTML to markdown logic leaves div tags intact. The editor creates div tags whenever enter is hit.

#### Issue Addressed (if applicable)

#1199 

## Steps to Test

- [ ] Create or edit an exercise
- [ ] Add a hint
- [ ] Type text and hit enter serveral times to add multiple lines of text
- [ ] Close and re-open the hint editor (if fixed, you will not see any <div> tags)

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [x] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
