### PR TITLE
Fixed view-only icon in share modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Studio Changelog
 
+## 2019-02-04 Update
+#### Changes
+* [[@jayoshih](https://github.com/jayoshih)] Fixed editors/viewers icons displaying incorrectly
+
+#### Issues
+* [#1194](https://github.com/learningequality/studio/issues/1194)
+
+
+
 ## 2019-01-30 Update
 #### Changes
 * [[@kollivier](https://github.com/kollivier)] Remove div tags from markdown output.

--- a/contentcuration/contentcuration/static/js/edit_channel/share/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/share/views.js
@@ -355,6 +355,7 @@ var ShareCurrentList = BaseShareList.extend({
         var share_item = new ShareCurrentItem({
             model:model,
             containing_list_view:this,
+            channel: this.model
         });
         this.views.push(share_item);
         return share_item;
@@ -472,7 +473,7 @@ var ShareCurrentItem = ShareItem.extend({
         _.bindAll(this, 'remove_editor');
         this.bind_edit_functions();
         this.containing_list_view = options.containing_list_view;
-        if(this.model.get("viewers") && this.model.get("viewers").indexOf(this.model.get("id")) >= 0){
+        if(options.channel.get("viewers") && options.channel.get("viewers").indexOf(this.model.get("id")) >= 0){
             this.share_mode = "view";
         }
         this.render();


### PR DESCRIPTION
## Description

Look up viewers using correct channel model, not user model

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1194

#### Before/After Screenshots (if applicable)

*Insert images here*
![image](https://user-images.githubusercontent.com/7447496/52245030-e1330980-2894-11e9-97e6-1725d7c082b7.png)



## Steps to Test

- [ ] Run setup command
- [ ] Accept invitations as user@a.com and user@b.com
- [ ] Log in as administrator and check Published Channel invite modal

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?