### PR TITLE
Update content-container.less

### DIFF
--- a/contentcuration/contentcuration/static/less/content-container.less
+++ b/contentcuration/contentcuration/static/less/content-container.less
@@ -558,6 +558,7 @@ body {
 						    object-fit: cover;
 						    vertical-align: baseline;
 						    margin-top: 2px;
+						    position: absolute;
 						}
 						.content-item-icon{
 							position: relative;


### PR DESCRIPTION
## Description

Fixes thumbnails taking up more space in topic tree

#### Before/After Screenshots (if applicable)

Before
![image](https://user-images.githubusercontent.com/7447496/52295790-83083400-2931-11e9-94d2-c8b552199094.png)

After
![image](https://user-images.githubusercontent.com/7447496/52295801-8ac7d880-2931-11e9-8db9-d408f35affd2.png)

## Steps to Test

- [ ] Open a channel and check topic tree in default or comfortable mode