### PR TITLE
Ensure that Vue based modals close properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Studio Changelog
 
+## 2019-02-05 Update
+#### Changes
+* [[@micah](https://github.com/micahscopes)] Fixed a bug where Vue-based modals weren't closing properly
+
 ## 2019-02-04 Update
 #### Changes
 * [[@jayoshih](https://github.com/jayoshih)] Fixed editors/viewers icons displaying incorrectly

--- a/contentcuration/contentcuration/static/js/edit_channel/__tests__/PrimaryModalState.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/__tests__/PrimaryModalState.spec.js
@@ -17,20 +17,20 @@ describe('ContentNodeCollection', () => {
             })
         })
         it('should not run the view setup function if a primary modal is already open', done => {
-            State.Store.commit('OPEN_PRIMARY_MODAL')
+            State.Store.commit('OPEN_PRIMARY_MODAL', {name:'dummyModal'})
             State.Store.dispatch('usePrimaryModal', makeModalView).catch((error) => {
-                expect(error.message).toBe(ERROR_PRIMARY_MODAL_ALREADY_OPEN)
+                expect(error.message).toBe(ERROR_PRIMARY_MODAL_ALREADY_OPEN('dummyModal'))
                 done()
             })
         })
         it('should appropriately set `primaryModalInUse` as the modal view is created and removed', done => {
             // start out with the primary modal closed
             State.Store.commit('CLOSE_PRIMARY_MODAL')
-            expect(State.Store.getters.primaryModalInUse).toBe(false)
+            expect(State.Store.getters.primaryModalInUse).toBe(null)
 
             // create a primary modal
             State.Store.dispatch('usePrimaryModal', makeModalView).then(modalView => {
-                expect(State.Store.getters.primaryModalInUse).toBe(true)
+                expect(State.Store.getters.primaryModalInUse).toBe(modalView)
 
                 // make sure we aren't allowed to create another primary modal
                 State.Store.dispatch('usePrimaryModal', makeModalView).catch(error => {
@@ -38,7 +38,7 @@ describe('ContentNodeCollection', () => {
 
                     // remove the primary modal
                     modalView.remove()
-                    expect(State.Store.getters.primaryModalInUse).toBe(false)
+                    expect(State.Store.getters.primaryModalInUse).toBe(null)
 
                     // now we should be free to create another primary modal
                     State.Store.dispatch('usePrimaryModal', makeModalView).then(anotherModalView => {

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_set/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_set/views.js
@@ -26,6 +26,7 @@ var ChannelSetModalView = BaseViews.BaseView.extend({
     name: NAMESPACE,
     $trs: MESSAGES,
     initialize: function(options) {
+        _.bindAll(this, "close")
         this.options = options;
         this.statusWatcher = store.watch(
           checkForSave,
@@ -52,6 +53,7 @@ var ChannelSetModalView = BaseViews.BaseView.extend({
         this._resetPageState();
         this.ChannelSetModal = new ChannelSetModal({ store: store });
         this.ChannelSetModal.$on('modalclosed', this._destroy.bind(this));
+        this.ChannelSetModal.$on('modalclosed', this.close)
         this.ChannelSetModal.$on('modalclosing', this._checkChanges.bind(this));
         this.ChannelSetModal.$mount();
     },

--- a/contentcuration/contentcuration/static/js/edit_channel/import/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/import/views.js
@@ -20,10 +20,11 @@ var MESSAGES = {
     "importing_content": "Importing Content..."
 }
 
-var ImportModalView = BaseViews.BaseView.extend({
+var ImportModalView = BaseViews.BaseModalView.extend({
     name: NAMESPACE,
     $trs: MESSAGES,
     initialize: function(options) {
+        _.bindAll(this, "close")
         this.options = options;
         this.statusWatcher = store.watch(
           getImportStatus,
@@ -34,7 +35,7 @@ var ImportModalView = BaseViews.BaseView.extend({
     },
 
     render: function() {
-        Vue.nextTick().then(this._mountVueComponent.bind(this));
+      Vue.nextTick().then(this._mountVueComponent.bind(this));
     },
 
     _handleImportStatusChange: function(status) {
@@ -68,6 +69,7 @@ var ImportModalView = BaseViews.BaseView.extend({
         this._resetPageState();
         this.ImportModal = new ImportModal({ store: store });
         this.ImportModal.$on('modalclosed', this._destroy.bind(this))
+        this.ImportModal.$on('modalclosed', this.close)
         this.ImportModal.$mount();
     },
 

--- a/contentcuration/contentcuration/static/js/edit_channel/vuexModules/primaryModal.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/vuexModules/primaryModal.js
@@ -1,8 +1,8 @@
-const ERROR_PRIMARY_MODAL_ALREADY_OPEN = 'The primary modal is already open.'
+const ERROR_PRIMARY_MODAL_ALREADY_OPEN = (modalName) => `The primary modal is in use by: ${modalName} modal.`
 
 const primaryModalModule = {
     state: {
-      primaryModalInUse: false,
+      primaryModalInUse: null,
     },
     getters: {
       primaryModalInUse(state) {
@@ -10,19 +10,19 @@ const primaryModalModule = {
       },
     },
     mutations: {
-      OPEN_PRIMARY_MODAL: (state) => { state.primaryModalInUse = true },
-      CLOSE_PRIMARY_MODAL: (state) => { state.primaryModalInUse = false },
+      OPEN_PRIMARY_MODAL: (state, payload) => { state.primaryModalInUse = payload },
+      CLOSE_PRIMARY_MODAL: (state) => { state.primaryModalInUse = null },
     },
     actions: {
       usePrimaryModal({state, commit}, buildModalView){
         return new Promise((resolve, reject) => {
           if (!state.primaryModalInUse) {
             let modalView = buildModalView()
-            commit('OPEN_PRIMARY_MODAL')
+            commit('OPEN_PRIMARY_MODAL', modalView)
             modalView.listenTo(modalView, 'removed', () => commit('CLOSE_PRIMARY_MODAL'))
             resolve(modalView)
           } else {
-            throw new Error(ERROR_PRIMARY_MODAL_ALREADY_OPEN)
+            throw new Error(ERROR_PRIMARY_MODAL_ALREADY_OPEN(state.primaryModalInUse.name))
           }
         })
       },


### PR DESCRIPTION
## Description
Fixes a bug where Vue based modals weren't notifying their Backbone view when they closed.

#### Issue Addressed
Addresses a major issue where the Import modal couldn't be opened a second time.