### PR TITLE
Automatically load html previews, pause videos/audios on preview close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * [[@micah](https://github.com/micahscopes)] Fixed a bug where Vue-based modals weren't closing properly
 * [[@kollivier](https://github.com/kollivier)] Fixed a HTML5 app preview bug by updating le-utils.
 * [[@jayoshih](https://github.com/jayoshih)] Added saving indicator for move operations
+* [[@jayoshih](https://github.com/jayoshih)] Automatically start html when preview tab is opened
+* [[@jayoshih](https://github.com/jayoshih)] Pause videos and audios when preview tab is closed
+
+#### Issues
+* [#1050](https://github.com/learningequality/studio/issues/1050)
+* [#728](https://github.com/learningequality/studio/issues/728)
 
 
 ## 2019-02-04 Update

--- a/contentcuration/contentcuration/static/js/edit_channel/preview/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/preview/views.js
@@ -112,6 +112,23 @@ var PreviewView = BaseViews.BaseView.extend({
             );
         }
     },
+    pause: function() {
+        switch(this.model.get('kind')) {
+            case "video":
+                this.$("video").get(0).pause();
+                break;
+            case "audio":
+                this.$("audio").get(0).pause();
+                break;
+        }
+    },
+    play: function() {
+        switch(this.model.get('kind')) {
+            case "html5":
+                this.$("iframe").prop("src", this.$("iframe").data("src"));
+                break;
+        }
+    },
     get_subtitles:function(){
         var subtitles = [];
         this.model.get("files").forEach(function(file){

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
@@ -199,6 +199,19 @@ var EditMetadataView = BaseViews.BaseEditableListView.extend({
       if(self.collection.length > 1){
         self.load_editor(self.edit_list.selected_items);
       }
+      self.$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+        if(self.edit_list.selected_items.length === 1) {
+          var preview_view = self.edit_list.selected_items[0].preview_view;
+          if(e.target.id === "metadata_preview_btn" && preview_view) {
+            // Load previews
+            preview_view.play();
+          } else if(preview_view) {
+            // Close previewer
+            preview_view.pause();
+          }
+        }
+
+      });
     });
   },
   load_list:function(){


### PR DESCRIPTION
**Please remove any unused sections**

## Description

When user opens Preview tab, load html apps automatically. When user leaves Preview tab, pause videos and audios

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/728 and https://github.com/learningequality/studio/issues/1050

## Steps to Test

- [ ] Upload an html app and open Preview
- [ ] Play a video or audio and navigate away

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?