### PR TITLE
Add Save & Close option to channel collection modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [[@kollivier](https://github.com/kollivier)] Fixed a HTML5 app preview bug by updating le-utils.
 * [[@jayoshih](https://github.com/jayoshih)] Added saving indicator for move operations
 * [[@jayoshih](https://github.com/jayoshih)] Update gcs storage to handle opening legacy files from the server
+* [[@jayoshih](https://github.com/jayoshih)] Added Save & Close option to channel collections
 
 
 ## 2019-02-04 Update

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_set/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_set/views.js
@@ -39,12 +39,15 @@ var ChannelSetModalView = BaseViews.BaseView.extend({
         Vue.nextTick().then(this._mountVueComponent.bind(this));
     },
 
-    _handleSaving: function(saving, callback) {
+    _handleSaving: function(saving, close) {
         if(saving) {
             var self = this;
             store.dispatch('channel_set/saveChannelSet', function(model) {
                 self.options.onsave(model);
-                callback && callback();
+                if(close || store.state.channel_set.closing) {
+                  store.commit('channel_set/SET_CLOSING', false);
+                  self.ChannelSetModal.closeModal();
+                }
             });
         }
     },
@@ -69,7 +72,7 @@ var ChannelSetModalView = BaseViews.BaseView.extend({
               },
               [this.get_translation("keep_open")]:function(){},
               [this.get_translation("save_and_close")]:function(){
-                self._handleSaving(true, self.ChannelSetModal.closeModal);
+                self._handleSaving(true, true);
               },
           }, null);
         }

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_set/views/ChannelSetDialog.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_set/views/ChannelSetDialog.vue
@@ -14,6 +14,14 @@
       </a>
       <button
         class="action-button pull-right modal-main-action-button uppercase"
+        @click="handleSaveClose"
+        :disabled="!enableSave"
+        :title="saveButtonTitle"
+      >
+        {{ $tr('saveCloseButtonLabel') }}
+      </button>
+      <button
+        class="action-text pull-right modal-main-action-button uppercase"
         @click="handleSave"
         :disabled="!enableSave"
         :title="saveButtonTitle"
@@ -45,6 +53,7 @@ export default {
   $trs: {
     cancelButtonLabel: 'Close',
     saveButtonLabel: 'Save',
+    saveCloseButtonLabel: 'Save & Close',
     noChangesTitle: "No changes detected",
     invalidCollection: "Must enter all required fields",
     saving: "Saving...",
@@ -78,9 +87,14 @@ export default {
   methods: Object.assign(
     mapMutations('channel_set', {
       setSaving: 'SET_SAVING',
+      setClosing: 'SET_CLOSING'
     }),
     {
       handleSave() {
+        this.setSaving(true);
+      },
+      handleSaveClose() {
+        this.setClosing(true);
         this.setSaving(true);
       }
     }

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_set/vuex/getters.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_set/vuex/getters.js
@@ -40,3 +40,7 @@ export function isValid(state) {
 export function saving(state) {
   return state.saving;
 }
+
+export function closing(state) {
+  return state.closing;
+}

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_set/vuex/mutations.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_set/vuex/mutations.js
@@ -30,6 +30,7 @@ export function RESET_PAGE_STATE(state) {
     description: "",
     channels: [],
     saving: false,
+    closing: false,
     error: false,
     allChannels: {},
     changed: false,
@@ -89,6 +90,10 @@ export function SET_CHANGED(state, changed) {
 
 export function SET_SAVING(state, saving) {
   state.saving = saving;
+}
+
+export function SET_CLOSING(state, closing) {
+  state.closing = closing;
 }
 
 export function SET_ERROR(state, error) {

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_set/vuex/store.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_set/vuex/store.js
@@ -17,6 +17,7 @@ var store = new Vuex.Store({
 	    channels: [],
 	    allChannels: {},
 	    saving: false,
+	    closing: false,
 	    error: false,
 	    changed: false,
 	    channelSet:null,


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Added Save & Close option to channel collection modal

#### Before/After Screenshots (if applicable)

*Insert images here*
![image](https://user-images.githubusercontent.com/7447496/52317939-157ef680-2977-11e9-84cf-a28f4fba14fc.png)


## Steps to Test

- [ ] Create a collection
- [ ] Click Save & Close

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are all user-facing strings translated properly (if applicable)?
