### PR TITLE
Update admin page spinners to use global spinner styling

### DIFF
--- a/contentcuration/contentcuration/static/js/administration/hbtemplates/channel_list.handlebars
+++ b/contentcuration/contentcuration/static/js/administration/hbtemplates/channel_list.handlebars
@@ -1,5 +1,5 @@
-<div class="spinner">
-    <div class="glyphicon glyphicon-refresh spinner-animate"></div>
+<div class="loading-spinner">
+    <div class="spinner"></div>
 </div>
 
 <div class="header_row grid_row channel_list">

--- a/contentcuration/contentcuration/static/js/administration/hbtemplates/user_list.handlebars
+++ b/contentcuration/contentcuration/static/js/administration/hbtemplates/user_list.handlebars
@@ -1,6 +1,7 @@
-<div class="spinner">
-    <div class="glyphicon glyphicon-refresh spinner-animate"></div>
+<div class="loading-spinner">
+    <div class="spinner"></div>
 </div>
+
 
 <div class="header_row grid_row user_list">
     <div class="grid_item header">Name</div>

--- a/contentcuration/contentcuration/static/less/admin.less
+++ b/contentcuration/contentcuration/static/less/admin.less
@@ -17,7 +17,7 @@ body {
 
 #admin-page {
 	margin: 0 1em;
-	h2 { 
+	h2 {
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -28,11 +28,11 @@ body {
 		pointer-events: none;
 	}
 	nav {
-		text-align: center;		
+		text-align: center;
 		.pagination {
 			margin: 5px;
 			user-select: none;
-		}	
+		}
 		.disabled {
 			pointer-events: none;
 		}
@@ -248,7 +248,7 @@ body {
 			opacity: 1;
 			transition: opacity 0.25s ease-in-out;
 		}
-		.spinner {
+		.loading-spinner {
 			position: absolute;
 			pointer-events: none;
 			left: 0;
@@ -257,15 +257,9 @@ body {
 			height: 100%;
 			font-size: 5em;
 			color: @gray-300;
-		}
-
-		.spinner-animate {
-			animation: spin 1.5s infinite linear;
-		}
-				
-		@keyframes spin {
-			from { transform: scale(1) rotate(0deg);}
-			to { transform: scale(1) rotate(360deg);}
+    		.spinner {
+    			font-size: 75pt;
+    		}
 		}
 
 		&.loaded .spinner {

--- a/contentcuration/contentcuration/static/less/admin_grid.less
+++ b/contentcuration/contentcuration/static/less/admin_grid.less
@@ -24,7 +24,7 @@
 		.can_edit, .editors{
 			display: grid;
 			grid-template-columns: max-content 0em;
-			margin: 0 auto;		
+			margin: 0 auto;
 		}
 		.table_actions{
 			grid-row: 1 / span 1;
@@ -48,7 +48,7 @@
 	}
 
 	.admin_table_wrapper {
-		.spinner {
+		.loading-spinner {
 			display: grid;
 			grid-template-columns: auto max-content auto;
 			grid-template-rows: auto max-content auto;
@@ -59,13 +59,13 @@
 			}
 		}
 	}
-	
+
 	.table_actions{
 		.select_all {
 			grid-row: 2;
 			grid-column: 1;
 		}
-		#email_selected_users { 
+		#email_selected_users {
 			grid-row: 2;
 			grid-column: 5;
 		}


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Fixes whatever is happening here:
![spinner bug](https://user-images.githubusercontent.com/7447496/52376906-34819500-2a18-11e9-8512-e605715b4a3f.gif)


## Steps to Test

- [ ] Open admin page

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
