### PR TITLE
Fix pie chart styling

### DIFF
--- a/contentcuration/contentcuration/utils/export_writer.py
+++ b/contentcuration/contentcuration/utils/export_writer.py
@@ -345,7 +345,7 @@ class ChannelDetailsWriter(ExportWriter):
                 loc='center left',
                 labels=[l['text'].split('\n')[0] for l in labels],
                 prop={'size': 20},
-                bbox_to_anchor=(0.85, 0.5),
+                bbox_to_anchor=(0.7, 0.5),
                 bbox_transform=plt.gcf().transFigure
             )
 


### PR DESCRIPTION
One small fix- pie chart is rendering strangely on pdf/ppt export

### Before:

**PDF export**
![image](https://user-images.githubusercontent.com/7447496/52385046-df07b100-2a34-11e9-85ab-92535b32105d.png)

**PPT export**
![image](https://user-images.githubusercontent.com/7447496/52385107-0e1e2280-2a35-11e9-997b-538faf9d9cae.png)

___________
### After: 

**PDF export**
![image](https://user-images.githubusercontent.com/7447496/52385057-e75fec00-2a34-11e9-934b-48de72075b3a.png)

**PPT export**
![image](https://user-images.githubusercontent.com/7447496/52385114-170ef400-2a35-11e9-8057-58ec8df7a72f.png)
