### PR TITLE
Allow editors and viewers on the channel to access invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Studio Changelog
 
+## Unreleased
+#### Changes
+* [[@jayoshih](https://github.com/jayoshih)]Allow users to access invitations when they have access to the channel
+
+#### Issues Resolved
+* [#1094](https://github.com/learningequality/studio/issues/1094)
+
 
 ## 2019-02-06 Release
 #### Changes

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -169,7 +169,10 @@ class InvitationViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         if self.request.user.is_admin:
             return Invitation.objects.all()
-        return Invitation.objects.filter(Q(invited=self.request.user) | Q(sender=self.request.user)).distinct()
+        return Invitation.objects.filter(Q(invited=self.request.user) |
+                                         Q(sender=self.request.user) |
+                                         Q(channel__editors=self.request.user) |
+                                         Q(channel__viewers=self.request.user)).distinct()
 
 
 class AssessmentItemViewSet(BulkModelViewSet):


### PR DESCRIPTION
## Description

The invitation queryset was only allowing users to access invitations where they were either the sender or the invited. This means that if a third user were to open the invitations modal, they would receive a 404 error as the invitation would be filtered out. 

#### Issue Addressed (if applicable)

Fixes #1094 


## Steps to Test

- [ ] Invite a user to a channel
- [ ] Switch accounts and try to open the invitation modal on the same channel


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?
