### PR TITLE
Content defaults fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Studio Changelog
 
+## Upcoming release
+#### Changes
+* [[@kollivier](https://github.com/kollivier)] Fix issue with channel content defaults only supporting English characters.
+
+
+#### Issues Resolved
+* [#1044](https://github.com/learningequality/studio/issues/1044)
+
 
 ## 2019-02-06 Release
 #### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 
 #### Issues Resolved
-* [#1044](https://github.com/learningequality/studio/issues/1044)
+* [#1004](https://github.com/learningequality/studio/issues/1004)
 
 
 ## 2019-02-06 Release

--- a/contentcuration/contentcuration/static/js/edit_channel/file_upload/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/file_upload/views.js
@@ -267,7 +267,9 @@ var FileUploadList = BaseViews.BaseEditableListView.extend({
                 previewsContainer: this.list_selector, // Define the container to display the previews
                 headers: {
                     "X-CSRFToken": get_cookie("csrftoken"),
-                    "Preferences": JSON.stringify(State.current_channel.get('content_defaults'))
+                },
+                params: {
+                    "content_defaults": JSON.stringify(State.current_channel.get('content_defaults'))
                 },
                 dictInvalidFileType: this.get_translation("file_not_supported"),
                 dictFileTooBig: this.get_translation("max_size_exceeded"),

--- a/contentcuration/contentcuration/tests/test_files.py
+++ b/contentcuration/contentcuration/tests/test_files.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import json
 
 import pytest
@@ -14,12 +16,14 @@ from .testdata import node
 from contentcuration.management.commands.exportchannel import create_associated_thumbnail
 from contentcuration.models import AssessmentItem
 from contentcuration.models import ContentNode
+from contentcuration.models import DEFAULT_CONTENT_DEFAULTS
 from contentcuration.models import File
 from contentcuration.models import generate_object_storage_name
 from contentcuration.serializers import FileSerializer
 from contentcuration.utils.files import create_thumbnail_from_base64
 from contentcuration.utils.files import get_thumbnail_encoding
 from contentcuration.utils.nodes import map_files_to_node
+from contentcuration.views.files import file_create
 from contentcuration.views.files import generate_thumbnail
 from contentcuration.views.files import image_upload
 from contentcuration.views.files import thumbnail_upload
@@ -104,6 +108,35 @@ class FileSaveTestCase(BaseAPITestCase):
         self.assertTrue(self.video.files.filter(pk=self.newfile.pk).exists())
         self.assertFalse(self.video.files.filter(pk=self.video_file.pk).exists())
         self.assertFalse(File.objects.filter(pk=self.video_file.pk).exists())
+
+
+class FileCreateTestCase(BaseAPITestCase):
+    def test_file_create_no_content_defaults(self):
+        post_data = {'file': SimpleUploadedFile("file.pdf", b"contents")}
+        request = self.create_post_request(reverse_lazy('file_create'), post_data)
+        response = file_create(request)
+        self.assertTrue(response.status_code, 201)
+
+    def test_file_create_content_defaults(self):
+        content_defaults = DEFAULT_CONTENT_DEFAULTS
+        post_data = {
+            'file': SimpleUploadedFile("file.pdf", b"contents"),
+            'content_defaults': json.dumps(content_defaults)
+        }
+        request = self.create_post_request(reverse_lazy('file_create'), post_data)
+        response = file_create(request)
+        self.assertTrue(response.status_code, 201)
+
+    def test_file_create_non_ascii_defaults(self):
+        content_defaults = DEFAULT_CONTENT_DEFAULTS
+        content_defaults['author'] = 'José'
+        post_data = {
+            'file': SimpleUploadedFile("file.pdf", b"contents"),
+            'content_defaults': json.dumps(content_defaults)
+        }
+        request = self.create_post_request(reverse_lazy('file_create'), post_data)
+        response = file_create(request)
+        self.assertTrue(response.status_code, 201)
 
 
 class FileThumbnailTestCase(BaseAPITestCase):

--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -80,11 +80,8 @@ def file_create(request):
 
     presets = FormatPreset.objects.filter(allowed_formats__extension__contains=ext[1:].lower())
     kind = presets.first().kind
-    preferences = json.loads(request.META.get('HTTP_PREFERENCES') or "{}")
+    preferences = json.loads(request.POST.get('content_defaults', None) or "{}")
 
-    # sometimes we get a string no matter what. Try to parse it again
-    if isinstance(preferences, basestring):
-        preferences = json.loads(preferences)
 
     license = License.objects.filter(license_name=preferences.get('license')).first()  # Use filter/first in case preference hasn't been set
     license_id = license.pk if license else None


### PR DESCRIPTION
## Description

This fixes issues where people setting content defaults with non-English characters were unable to upload files.

#### Issue Addressed (if applicable)

#1004

## Steps to Test

- [ ] In the channel settings, use non-ASCII characters for content defaults.
- [ ] Try to upload a file.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
