### PR TITLE
Sort countries by localized name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Upcoming release
 #### Changes
 * [[@kollivier](https://github.com/kollivier)] Fix issue with channel content defaults only supporting English characters.
+* [[@kollivier](https://github.com/kollivier)] Sort countries by localized country name.
 
 
 #### Issues Resolved
 * [#1004](https://github.com/learningequality/studio/issues/1004)
-
+* [#976](https://github.com/learningequality/studio/issues/1004)
 
 ## 2019-02-06 Release
 #### Changes

--- a/contentcuration/contentcuration/forms.py
+++ b/contentcuration/contentcuration/forms.py
@@ -124,7 +124,8 @@ class RegistrationInformationForm(UserCreationForm, ExtraFormMixin):
             fallback=True,
         )
 
-        countries = [(c.name, translator.gettext(c.name)) for c in list(pycountry.countries)]
+        countries = sorted([(c.name, translator.gettext(c.name)) for c in list(pycountry.countries)],
+            key=lambda x: x[1])
         self.fields['location'] = forms.ChoiceField(required=True, widget=forms.SelectMultiple, label=_(
             'Where do you plan to use Kolibri? (select all that apply)'), choices=countries)
 

--- a/contentcuration/contentcuration/tests/test_forms.py
+++ b/contentcuration/contentcuration/tests/test_forms.py
@@ -1,0 +1,17 @@
+import copy
+
+from base import BaseTestCase
+from contentcuration import forms
+
+
+class LanguageSortTest(BaseTestCase):
+    def test_sorted_countries_en(self):
+        countries = forms.get_sorted_countries("en")
+        localized_names = [country[1] for country in countries]
+
+        # Since we're using English, Python's default sort should give the same language order as the one
+        # returned from get_sorted_countries. If we want to test sorts in different languages, we'll probably
+        # need a different approach.
+        sorted = copy.copy(localized_names)
+        sorted.sort()
+        assert localized_names == sorted


### PR DESCRIPTION
## Description

Sorts countries by localized names, rather than just presenting them in the order they are in the pycountry.countries list. 

#### Issue Addressed (if applicable)

Addresses #976 

## Steps to Test

- [x] Create a new user and check the country list in the registration info page
- [x] Go to the storage request form in Account settings and check the country list

## Checklist

- [x] Is the code clean and well-commented?
- [x] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [x] Are there tests for this change?
- [x] Are all user-facing strings translated properly (if applicable)?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
