### PR TITLE
Added banner to redirect users from contentworkshop to studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming release
 #### Changes
 * [[@kollivier](https://github.com/kollivier)] Fix issue with channel content defaults only supporting English characters.
+* [[@jayoshih](https://github.com/jayoshih)] Added banner to redirect users from contentworkshop.learningequality.org to studio.learningequality.org
 
 
 #### Issues Resolved

--- a/contentcuration/contentcuration/context_processors.py
+++ b/contentcuration/contentcuration/context_processors.py
@@ -2,4 +2,7 @@ from django.conf import settings
 
 
 def site_variables(request):
-    return {'INCIDENT': settings.INCIDENT, 'BETA_MODE': settings.BETA_MODE, 'DEBUG': settings.DEBUG}
+    return {'INCIDENT': settings.INCIDENT,
+            'BETA_MODE': settings.BETA_MODE,
+            'DEPRECATED': "contentworkshop" in request.get_host(),
+            'DEBUG': settings.DEBUG}

--- a/contentcuration/contentcuration/static/less/global-variables.less
+++ b/contentcuration/contentcuration/static/less/global-variables.less
@@ -55,7 +55,7 @@
 @topnav-active-tab-color:#564462;
 @red-error-color:#EF2121;
 @darkred-color: firebrick;
-@yellow-bg-color: #FFE300;
+@yellow-bg-color: #F5DC14;
 .action-button {
   background: @blue-500;
   border: 1px solid @blue-500 !important;

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -137,15 +137,19 @@
         </div>
 
     </nav>
+
     {% if INCIDENT %}
-    <div id="emergency-banner" class="text-center main-banner {% if INCIDENT.readonly %}error{% else %}warning{% endif %}">
-      <i class="material-icons">error</i> {{INCIDENT.message | safe}}
-    </div>
-    {% endif %}
-    {% if BETA_MODE %}
-    <div id="beta-banner" class="text-center info main-banner">
-      <i class="material-icons">build</i> {% url 'issues_settings' as issue_url %}{% blocktrans %}Kolibri Studio is undergoing active development, and during usage you may encounter unexpected behavior or problems. <a href="{{issue_url}}" target="_blank">Please read here</a> on best practices, known issues, and error reporting recommendations. We appreciate your patience and assistance as we work to improve the Kolibri Studio Beta!{% endblocktrans %}
-    </div>
+      <div id="emergency-banner" class="text-center main-banner {% if INCIDENT.readonly %}error{% else %}warning{% endif %}">
+        <i class="material-icons">error</i> {{INCIDENT.message | safe}}
+      </div>
+    {% elif DEPRECATED %}
+      <div class="text-center main-banner warning" id="redirect-banner">
+        <i class="material-icons">error</i> {% blocktrans %}Contentworkshop.learningequality.org has been deprecated. Please go to <a href="https://studio.learningequality.org">studio.learningequality.org</a> for the latest version of Studio{% endblocktrans %}
+      </div>
+    {% elif BETA_MODE %}
+      <div id="beta-banner" class="text-center info main-banner">
+        <i class="material-icons">build</i> {% url 'issues_settings' as issue_url %}{% blocktrans %}Kolibri Studio is undergoing active development, and during usage you may encounter unexpected behavior or problems. <a href="{{issue_url}}" target="_blank">Please read here</a> on best practices, known issues, and error reporting recommendations. We appreciate your patience and assistance as we work to improve the Kolibri Studio Beta!{% endblocktrans %}
+      </div>
     {% endif %}
     {% endblock nav %}
 


### PR DESCRIPTION
## Description

There are still a number of users who are still using contentworkshop, which does not include any caching. This banner redirects users to studio.learningequality.org

#### Before/After Screenshots (if applicable)

*Insert images here*
![image](https://user-images.githubusercontent.com/7447496/52510766-34b59800-2bb2-11e9-9b2e-518ec476a6c8.png)


## Checklist
- [x] Is the code clean and well-commented?
- [x] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [x] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?