### PR TITLE
Don't allow users to set prerequisites on topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Upcoming release
 #### Changes
+* [[@jayoshih](https://github.com/jayoshih)] Don't allow users to set prerequisites on topics
 
 #### Issues Resolved
-
+* [#1254](https://github.com/learningequality/studio/issues/1254)
 
 ## 2019-02-11 Release
 #### Changes

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
@@ -269,9 +269,10 @@ var EditMetadataView = BaseViews.BaseEditableListView.extend({
     var has_files = is_individual && selected_items[0].model.get("files").some(function(f){
                       return Constants.FormatPresets.find(preset => preset.id === f.preset.name || preset.id === f.preset.id || preset.id === f.preset).display;
                     });
+    var is_topic = is_individual && selected_items[0].model.get("kind") === "topic";
     this.$("#metadata_details_btn").css("display", (selected_items.length) ? "inline-block" : "none");
     this.$("#metadata_preview_btn").css("display", (is_individual && has_files) ? "inline-block" : "none");
-    this.$("#metadata_prerequisites_btn").css("display", (is_individual && (has_files || is_exercise)) ? "inline-block" : "none");
+    this.$("#metadata_prerequisites_btn").css("display", (is_individual && !is_topic) ? "inline-block" : "none");
     this.$("#metadata_questions_btn").css("display", (is_exercise) ? "inline-block" : "none");
     if(!is_individual){
       this.$("a[href='#metadata_edit_details']").tab('show');


### PR DESCRIPTION
**Please remove any unused sections**

## Description

User should not be able to add prerequisites to topics 

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1254

## Steps to Test

- [ ] Add a thumbnail to a topic
- [ ] See if prerequisites tab appears

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
