### PR TITLE
Fix return code of unauthorized access attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Studio Changelog
 
-## Unreleased
+
+## Upcoming Release
 #### Changes
-
-#### Issues Resolved
-
-
-## Upcoming release
-#### Changes
+* [[@kollivier](https://github.com/kollivier)] Ensure attempts to access objects without permissions returns 403.
 
 #### Issues Resolved
 

--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -31,15 +31,6 @@ class BucketTestMixin:
     def delete_bucket(self):
         minio_utils.ensure_bucket_deleted()
 
-    def setUp(self):
-        raise Exception("Called?")
-        if not self.persist_bucket:
-            self.create_bucket()
-
-    def tearDown(self):
-        if not self.persist_bucket:
-            self.delete_bucket()
-
 
 class StudioTestCase(TestCase, BucketTestMixin):
 

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -19,8 +19,11 @@ from django.conf.urls import include
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse_lazy
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from django.views.i18n import javascript_catalog
 from rest_framework import routers
 from rest_framework import viewsets
@@ -99,6 +102,17 @@ class FileViewSet(BulkModelViewSet):
     queryset = File.objects.all()
     serializer_class = serializers.FileSerializer
 
+    def get_object(self):
+        # when a specific node is requested, make sure we run the appropriate permissions check before
+        # returning, so that we return 403 instead of 404 when permissions aren't correct.
+        obj = get_object_or_404(File.objects.all(), pk=self.kwargs["pk"])
+        self.check_object_permissions(self.request, obj)
+        try:
+            self.get_queryset().get(pk=obj.pk)
+        except ObjectDoesNotExist:
+            raise PermissionDenied("You do not have access to this File.")
+        return obj
+
     def get_queryset(self):
         if self.request.user.is_admin:
             return File.objects.all()
@@ -124,6 +138,17 @@ class ContentKindViewSet(viewsets.ModelViewSet):
 class ContentNodeViewSet(BulkModelViewSet):
     queryset = ContentNode.objects.all()
     serializer_class = serializers.ContentNodeCompleteSerializer
+
+    def get_object(self):
+        # when a specific node is requested, make sure we run the appropriate permissions check before
+        # returning, so that we return 403 instead of 404 when permissions aren't correct.
+        obj = get_object_or_404(ContentNode.objects.all(), pk=self.kwargs["pk"])
+        self.check_object_permissions(self.request, obj)
+        try:
+            self.get_queryset().get(pk=obj.pk)
+        except ObjectDoesNotExist:
+            raise PermissionDenied("You do not have access to this content node.")
+        return obj
 
     def get_queryset(self):
         if self.request.user.is_admin:
@@ -166,6 +191,17 @@ class InvitationViewSet(viewsets.ModelViewSet):
 
     serializer_class = serializers.InvitationSerializer
 
+    def get_object(self):
+        # when a specific node is requested, make sure we run the appropriate permissions check before
+        # returning, so that we return 403 instead of 404 when permissions aren't correct.
+        obj = get_object_or_404(Invitation.objects.all(), pk=self.kwargs["pk"])
+        self.check_object_permissions(self.request, obj)
+        try:
+            self.get_queryset().get(pk=obj.pk)
+        except ObjectDoesNotExist:
+            raise PermissionDenied("You do not have access to this File.")
+        return obj
+
     def get_queryset(self):
         if self.request.user.is_admin:
             return Invitation.objects.all()
@@ -179,6 +215,17 @@ class AssessmentItemViewSet(BulkModelViewSet):
     queryset = AssessmentItem.objects.all()
 
     serializer_class = serializers.AssessmentItemSerializer
+
+    def get_object(self):
+        # when a specific node is requested, make sure we run the appropriate permissions check before
+        # returning, so that we return 403 instead of 404 when permissions aren't correct.
+        obj = get_object_or_404(AssessmentItem.objects.all(), pk=self.kwargs["pk"])
+        self.check_object_permissions(self.request, obj)
+        try:
+            self.get_queryset().get(pk=obj.pk)
+        except ObjectDoesNotExist:
+            raise PermissionDenied("You do not have access to this File.")
+        return obj
 
     def get_queryset(self):
         if self.request.user.is_admin:


### PR DESCRIPTION
## Description

Ensures we return 403s instead of 404s when a node, file, etc. exists but the user does not have proper permissions to access it. This avoids confusing error reports of 404s on existing content.

## Steps to Test

- [ ] Try to access a node, assessmentitem, file, or Invitation you don't have permissions to via API (or run the tests :)

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
