### PR TITLE
Fix for Mac MPL backend issue

### DIFF
--- a/contentcuration/contentcuration/utils/export_writer.py
+++ b/contentcuration/contentcuration/utils/export_writer.py
@@ -8,7 +8,7 @@ import tempfile
 from collections import OrderedDict
 
 # On OS X, the default backend will fail if you are not using a Framework build of Python,
-# e.g. in a virtualenv. To avoid having to set MPLBACKEND each time we use Pressure Cooker,
+# e.g. in a virtualenv. To avoid having to set MPLBACKEND each time we use Studio,
 # automatically set the backend.
 if sys.platform.startswith("darwin"):
     import matplotlib

--- a/contentcuration/contentcuration/utils/export_writer.py
+++ b/contentcuration/contentcuration/utils/export_writer.py
@@ -7,6 +7,14 @@ import sys
 import tempfile
 from collections import OrderedDict
 
+# On OS X, the default backend will fail if you are not using a Framework build of Python,
+# e.g. in a virtualenv. To avoid having to set MPLBACKEND each time we use Pressure Cooker,
+# automatically set the backend.
+if sys.platform.startswith("darwin"):
+    import matplotlib
+    if matplotlib.get_backend().lower() == "macosx":
+        matplotlib.use('PS')
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pdfkit


### PR DESCRIPTION
## Description

The default MPL backend doesn't work when running in a virtualenv, so pick one that does instead. This is basically re-applying the fix made to pressurecooker some time back to Studio. Given the nature of this change, I didn't think we should add a changelog entry for it. 

## Steps to Test

- [ ] Run Studio on Mac :)

## Checklist

- [ ] Is the code clean and well-commented?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
