### PR TITLE
Exclude deleted channels from channel list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 ## Upcoming release
 #### Changes
 * [[@jayoshih](https://github.com/jayoshih)] Don't allow users to set prerequisites on topics
+* [[@jayoshih](https://github.com/jayoshih)] Removed deleted channels from storage request list
 
 #### Issues Resolved
 * [#1254](https://github.com/learningequality/studio/issues/1254)
+* [#1269](https://github.com/learningequality/studio/issues/1269)
 
 ## 2019-02-11 Release
 #### Changes

--- a/contentcuration/contentcuration/views/settings.py
+++ b/contentcuration/contentcuration/views/settings.py
@@ -252,7 +252,7 @@ class StorageSettingsView(LoginRequiredMixin, FormView):
 
     def get_form_kwargs(self):
         kw = super(StorageSettingsView, self).get_form_kwargs()
-        kw['channel_choices'] = [(c['id'], c['name']) for c in self.request.user.editable_channels.values("id", "name")]
+        kw['channel_choices'] = [(c['id'], c['name']) for c in self.request.user.editable_channels.exclude(deleted=True).values("id", "name")]
         kw['request'] = self.request
         return kw
 


### PR DESCRIPTION
#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1269

## Steps to Test

- [ ] Delete a channel
- [ ] Check the list of channels under Settings > Storage 

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
