### PR TITLE
Fixes for prerequisites and deleted channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@
 #### Issues Resolved
 
 
-## Upcoming release
+## Upcoming Release
 #### Changes
 
 #### Issues Resolved
+
+
+## 2019-03-11 Release
+#### Changes
+* [[@jayoshih](https://github.com/jayoshih)] Don't allow users to set prerequisites on topics
+* [[@jayoshih](https://github.com/jayoshih)] Removed deleted channels from storage request list
+
+#### Issues Resolved
+* [#1254](https://github.com/learningequality/studio/issues/1254)
+* [#1269](https://github.com/learningequality/studio/issues/1269)
 
 
 ## 2019-02-11 Release

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views.js
@@ -269,9 +269,10 @@ var EditMetadataView = BaseViews.BaseEditableListView.extend({
     var has_files = is_individual && selected_items[0].model.get("files").some(function(f){
                       return Constants.FormatPresets.find(preset => preset.id === f.preset.name || preset.id === f.preset.id || preset.id === f.preset).display;
                     });
+    var is_topic = is_individual && selected_items[0].model.get("kind") === "topic";
     this.$("#metadata_details_btn").css("display", (selected_items.length) ? "inline-block" : "none");
     this.$("#metadata_preview_btn").css("display", (is_individual && has_files) ? "inline-block" : "none");
-    this.$("#metadata_prerequisites_btn").css("display", (is_individual && (has_files || is_exercise)) ? "inline-block" : "none");
+    this.$("#metadata_prerequisites_btn").css("display", (is_individual  && !is_topic) ? "inline-block" : "none");
     this.$("#metadata_questions_btn").css("display", (is_exercise) ? "inline-block" : "none");
     if(!is_individual){
       this.$("a[href='#metadata_edit_details']").tab('show');

--- a/contentcuration/contentcuration/views/settings.py
+++ b/contentcuration/contentcuration/views/settings.py
@@ -252,7 +252,7 @@ class StorageSettingsView(LoginRequiredMixin, FormView):
 
     def get_form_kwargs(self):
         kw = super(StorageSettingsView, self).get_form_kwargs()
-        kw['channel_choices'] = [(c['id'], c['name']) for c in self.request.user.editable_channels.values("id", "name")]
+        kw['channel_choices'] = [(c['id'], c['name']) for c in self.request.user.editable_channels.exclude(deleted=True).values("id", "name")]
         kw['request'] = self.request
         return kw
 


### PR DESCRIPTION
## Description

Disable prerequisites on topics, remove deleted channels from storag request form

#### Issue Addressed (if applicable)

https://github.com/learningequality/studio/issues/1269
https://github.com/learningequality/studio/issues/1254


## Steps to Test

**Storage request bug**
- [ ] Delete a channel
- [ ] Make sure channel doesn't appear under storage request form

**Topic prerequisites bug**
- [ ] Make sure the prerequisites tab is hidden when you try to edit a topic


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
