### PR TITLE
Added check for shared files and garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Upcoming release
 #### Changes
-* 
+*
 
 #### Issues Resolved
-* 
+* [#875 Make sure files referenced by both orphan and non-orphan nodes aren't deleted](https://github.com/learningequality/studio/issues/875)
+*
 
 ## 2019-02-11 Release
 #### Changes

--- a/contentcuration/contentcuration/tests/test_garbage_collect.py
+++ b/contentcuration/contentcuration/tests/test_garbage_collect.py
@@ -76,6 +76,10 @@ class CleanUpContentNodesTestCase(StudioTestCase):
         assert File.objects.count() == 0
 
     def test_doesnt_delete_shared_files(self):
+        """
+        Make sure that a file shared between two file objects doesn't
+        get deleted when one of the file objects gets deleted
+        """
         c = _create_expired_contentnode()
         file_on_disk = ContentFile("test")
         f = File.objects.create(


### PR DESCRIPTION
## Description

Adds a check that shared files aren't deleted when one of the file objects is deleted

#### Issue Addressed (if applicable)

https://github.com/learningequality/studio/issues/875

#### Does this introduce any tech-debt items?

Not any new tech-debt items, just reiterating that we need to delete files that are no longer referenced by any objects


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?
- [ ] Are there tests for this change?
