### PR TITLE
Silence Sentry 404 errors on the frontend.

### DIFF
--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -22,12 +22,11 @@ $(function() {
     let message = thrownError || jqXHR.statusText;
 
     // Don't send a Sentry report for permissions errors
-    if (jqXHR.status === 403) {
+    // Many 404s are in fact also unauthorized requests so
+    // we should silence those on the front end and try
+    // to catch legitimate request issues in the backend.
+    if (jqXHR.status === 403 || jqXHR.status === 404) {
       return;
-    }
-
-    if (jqXHR.status === 404) {
-      message = '404 Error: ' + ajaxSettings.url;
     }
 
     if (jqXHR.status === 0) {


### PR DESCRIPTION
## Description

As pointed out by @rtibbles, most 404s are actually unauthorized access attempts, but are given as 404s so as not to confirm the existence of the resource to someone without access.

Given that, we should treat 404s like 403s in terms of error reporting and silence them. We can differentiate in the backend, so that is where we should report a true 404.

#### Issue Addressed (if applicable)

No tickets, just a bunch of 404 Sentry errors. :) 

## Steps to Test

- [ ] Try to access a resource you don't have access to
- [ ] Check no Sentry report is generated

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
