### PR TITLE
Constants are baked into the JS now, so remove unused constant queries.

### DIFF
--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -41,13 +41,8 @@ from contentcuration.decorators import can_access_channel
 from contentcuration.decorators import can_edit_channel
 from contentcuration.decorators import has_accepted_policies
 from contentcuration.models import Channel
-from contentcuration.models import ContentKind
 from contentcuration.models import ContentNode
-from contentcuration.models import FileFormat
-from contentcuration.models import FormatPreset
 from contentcuration.models import Invitation
-from contentcuration.models import Language
-from contentcuration.models import License
 from contentcuration.models import SecretToken
 from contentcuration.models import User
 from contentcuration.models import VIEW_ACCESS
@@ -56,13 +51,8 @@ from contentcuration.serializers import ChannelListSerializer
 from contentcuration.serializers import ChannelSerializer
 from contentcuration.serializers import ChannelSetChannelListSerializer
 from contentcuration.serializers import ChannelSetSerializer
-from contentcuration.serializers import ContentKindSerializer
 from contentcuration.serializers import CurrentUserSerializer
-from contentcuration.serializers import FileFormatSerializer
-from contentcuration.serializers import FormatPresetSerializer
 from contentcuration.serializers import InvitationSerializer
-from contentcuration.serializers import LanguageSerializer
-from contentcuration.serializers import LicenseSerializer
 from contentcuration.serializers import RootNodeSerializer
 from contentcuration.serializers import UserChannelListSerializer
 from contentcuration.tasks import exportchannel_task
@@ -170,22 +160,9 @@ def channel_page(request, channel, allow_edit=False, staging=False):
 @authentication_classes((SessionAuthentication, BasicAuthentication, TokenAuthentication))
 @permission_classes((IsAuthenticated,))
 def channel_list(request):
-    languages = get_or_set_cached_constants(Language, LanguageSerializer)
-    fileformats = get_or_set_cached_constants(FileFormat, FileFormatSerializer)
-    licenses = get_or_set_cached_constants(License, LicenseSerializer)
-    formatpresets = get_or_set_cached_constants(FormatPreset, FormatPresetSerializer)
-    contentkinds = get_or_set_cached_constants(ContentKind, ContentKindSerializer)
-    languages = get_or_set_cached_constants(Language, LanguageSerializer)
-
     return render(request, 'channel_list.html', {"channel_name": False,
                                                  "current_user": JSONRenderer().render(UserChannelListSerializer(request.user).data),
                                                  "user_preferences": json.dumps(request.user.content_defaults),
-                                                 "langs_list": languages,
-                                                 "fileformat_list": fileformats,
-                                                 "license_list": licenses,
-                                                 "fpreset_list": formatpresets,
-                                                 "ckinds_list": contentkinds,
-                                                 "langs_list": languages,
                                                  "messages": get_messages(),
                                                  })
 


### PR DESCRIPTION
## Description

Now that the load constants are baked into the JS files, we no longer need to query and pass down all the constants via the Django template. This PR removes those queries, which probably constitute a majority of the page's response time.

I did a full text search for each of the variables, but I would appreciate a closer look by those familiar with this code.

## Steps to Test

- [ ] Load the channels page

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
