### PR TITLE
Allow channel titles to wrap

### DIFF
--- a/contentcuration/contentcuration/static/less/channel_list.less
+++ b/contentcuration/contentcuration/static/less/channel_list.less
@@ -193,11 +193,10 @@ body {
     }
 
     h4 {
-      .truncate;
-
       padding-bottom: 5px;
       font-size: 18pt;
       font-weight: bold;
+      line-height: 30px;
       color: @body-font-color;
     }
     .description {


### PR DESCRIPTION
## Description

Fixes an issue with channel item titles

#### Before/After Screenshots (if applicable)

**Before**
![image](https://user-images.githubusercontent.com/7447496/54965478-ebd15d00-4f2d-11e9-80cc-b90fc06b6054.png)

**After**
![image](https://user-images.githubusercontent.com/7447496/54965435-c2b0cc80-4f2d-11e9-8611-8a82df900b82.png)

## Steps to Test

- [ ] Make a channel with a really long title
- [ ] See if title wraps to a new line

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Have the changes been added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md)?