### PR TITLE
Re-import base settings into production settings

### DIFF
--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -1,4 +1,8 @@
+# production_settings.py -- production studio settings override
+#
+# noinspection PyUnresolvedReferences
 import settings as base_settings
+from settings import *  # noqa
 
 from contentcuration.utils.secretmanagement import get_secret
 


### PR DESCRIPTION
Our deployments are failing right now because I accidentally removed the star imports from our settings. This re-adds that.