### PR TITLE
PyCharm settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ var/
 
 # Ignore editor / IDE related data
 .vscode/
+.idea/*
+!.idea/studio.iml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ var/
 
 # Ignore editor / IDE related data
 .vscode/
+
+# IntelliJ IDE, except project config
 .idea/*
 !.idea/studio.iml
 

--- a/.idea/studio.iml
+++ b/.idea/studio.iml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/contentcuration" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PackageRequirementsSettings">
+    <option name="requirementsPath" value="" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Django" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/contentcuration/contentcuration/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="projectConfiguration" value="pytest" />
+    <option name="PROJECT_TEST_RUNNER" value="pytest" />
+  </component>
+</module>


### PR DESCRIPTION
## Description

This adds an ignore for the majority of the `.idea/` directory, a folder used by IntelliJ IDEs, like PyCharm. It also commits a file which defines the project structure for code completion assistance.

## Steps to Test

- [ ] Checkout this branch
- [ ] Ensure `.idea/studio.iml` exists
- [ ] Verify project configuration in PyCharm is correct: File > Settings > Project: studio > Project Structure
- [ ] Verify no other files in `.idea/` are staged for commit or could be committed

## Implementation Notes

The changes to `.gitignore` use `*` ignore paired with an exclude using `!`. This tells the parse to ignore all files and directories except the file following `!`. The `.idea/studio.iml` was generated by PyCharm. 

## Checklist

- [ ] Is the code clean and well-commented?
