### PR TITLE
Uncommented material-icon rule

### DIFF
--- a/contentcuration/contentcuration/static/less/global-variables.less
+++ b/contentcuration/contentcuration/static/less/global-variables.less
@@ -353,7 +353,8 @@ a {
 }
 
 .spinner {
-  // .material-icons;
+  .material-icons;
+
   animation: spin 1.5s infinite linear;
   &::before {
     content: 'rotate_right';


### PR DESCRIPTION
## Description

Uncomments material-icons rule that is used for spinners

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1322

#### Before/After Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/7447496/56700517-94024f00-66af-11e9-8f28-12e86d8bd4cb.png)


## Steps to Test

- [ ] Move an item around in the topic tree and verify spinner is displayed

## Checklist
- [ ] Is the code clean and well-commented?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
