### PR TITLE
Run all migrations in tearDownClass for Test*JSONMigration

### DIFF
--- a/contentcuration/contentcuration/tests/test_thumbnail_encoding_json_migration.py
+++ b/contentcuration/contentcuration/tests/test_thumbnail_encoding_json_migration.py
@@ -1,4 +1,5 @@
 from django.db import connection
+from django.core import management
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TransactionTestCase
 
@@ -33,6 +34,14 @@ class MigrationTestCase(TransactionTestCase):
         executor.migrate(migrate_to)
 
         self.apps = executor.loader.project_state(migrate_to).apps
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Ensures that the DB is reset and fully migrated due to this
+        test class's selective migrations
+        """
+        management.call_command("migrate")
 
 
 class TestForwardJSONMigration(MigrationTestCase):


### PR DESCRIPTION
## Description

I was working to write new tests in this PR https://github.com/learningequality/studio/pull/1308 but when I ran `pytest` several tests were failing. The failures were due to an attempted DB transaction for a FK that did not exist in the test DB.

After investigating with Aron, we found that the tests were only failing after the `contentcuration/tests/test_thumbnail_encoding_json_migration.py` tests ran.

So, at a high level, the issue is that the tests in that file are running a specific set of migrations, but never reset the DB to be fully migrated. Any tests run after this test that depend on newer migrations being run will fail with a DB error

#### Issue Addressed (if applicable)

After fiddling a bit with loading migrations, traversing the migration graph and running a specific set of migrations - I found that you can just call commands from code.

So it's simple - when the classes tearDown, they run the migrations. It is worth noting that the command doesn't run the migrations that are already migrated - so this tearDown basically "finishes migrating" from where the tests leave off.

## Steps to Test

- Fetch and checkout the latest at nucleogenesis:slideshow-content-kind
- Run pytest and see the failures
- Copy the new `contentcuration/tests/test_thumbnail_encoding_json_migration.py` file into your checked out slideshow branch.
- Run pytest and see no failures

#### Does this introduce any tech-debt items?

Running migrations can take some time as the codebase grows and more migrations are added. Currently, I don't notice it taking an exceptionally long time to run the tearDown in these tests but that could change over time.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
