### PR TITLE
Upgrade pip during Travis build

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -29,6 +29,7 @@ ENV PATH="/src/node_modules/.bin:$PATH"
 
 # Python packages ##############################################################
 COPY Pipfile Pipfile.lock   /src/
+RUN pip install --upgrade pip
 RUN pip install -U pipenv
 # install packages from Pipfile.lock into system
 RUN pipenv install --dev --system --ignore-pipfile

--- a/k8s/images/app/Dockerfile
+++ b/k8s/images/app/Dockerfile
@@ -27,6 +27,7 @@ ENV PATH="/node_modules/.bin:$PATH"
 COPY Pipfile .
 COPY Pipfile.lock .
 
+RUN pip install --upgrade pip
 RUN pip install -U pipenv
 # install the environment exactly as specified in the Pipfile.lock file
 RUN pipenv install --system --ignore-pipfile --keep-outdated

--- a/k8s/images/app/Dockerfile
+++ b/k8s/images/app/Dockerfile
@@ -27,9 +27,6 @@ ENV PATH="/node_modules/.bin:$PATH"
 COPY Pipfile .
 COPY Pipfile.lock .
 
-# pip 18.1 gives an error with pipenv, so pin the version to 18.0 until there is a fix.
-# More info here: https://github.com/pypa/pipenv/issues/2924
-RUN pip install pip==18.0
 RUN pip install -U pipenv
 # install the environment exactly as specified in the Pipfile.lock file
 RUN pipenv install --system --ignore-pipfile --keep-outdated


### PR DESCRIPTION
By default, the version of pip available in our base docker image is extremely old.  This was causing Travis builds to fail when there were apparently timeouts installing pipenv.

This also unpins pip in the production Dockerfile.  We may want to pin it again at some point.