### PR TITLE
Docker Invalidation FIxes

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,7 +20,7 @@ RUN curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases
 
 # Download then install node
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
-    apt install -y nodejs
+    apt-get install -y nodejs
 ################################################################################
 
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -7,15 +7,20 @@ WORKDIR /src
 
 
 # System packages ##############################################################
-RUN apt-get update --fix-missing
-RUN apt-get -y install curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get -y install nodejs python python-dev \
-    fish man \
-    python-pip gcc libpq-dev ffmpeg imagemagick unzip \
+
+RUN apt-get update --fix-missing && apt-get -y install \
+    curl fish man \
+    python python-dev python-pip \
+    gcc libpq-dev ffmpeg imagemagick unzip \
     ghostscript python-tk make git gettext openjdk-9-jre-headless libjpeg-dev \
     wkhtmltopdf fonts-freefont-ttf xfonts-75dpi poppler-utils
+
+# Download and install wkhtmltox
 RUN curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb && dpkg -i wkhtmltox.deb
+
+# Download then install node
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
+    apt install -y nodejs
 ################################################################################
 
 


### PR DESCRIPTION
## Description

Bakes `apt-get update` and `apt install` commands into the same layer so that we never run into issues when Ubuntu updates package sources.


## Steps to Test

- [ ] Wait for Ubuntu to update sources
- [ ] Fail to run `docker run` or `docker build` without manually invalidating cache
- [ ] Use this PR
- [ ] Wait for Ubuntu to updates sources again
- [ ] Successfully run `docker run` or `docker build` without the need for manual invalidation.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Consolidated most of the apt-related layers to a single one, making apt installation failures due to out-of-date sources unlikely.

Weeded out some unnecessary commands to simplify the docker build.

#### Does this introduce any tech-debt items?

No. Kind of resolves one, though.


## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?