### PR TITLE
[Fixes #1299] Restore thumbnail data to public channels API.

### DIFF
--- a/contentcuration/contentcuration/tests/test_public_api.py
+++ b/contentcuration/contentcuration/tests/test_public_api.py
@@ -1,5 +1,6 @@
 from base import BaseAPITestCase
 from django.core.urlresolvers import reverse
+from testdata import generated_base64encoding
 
 
 class PublicAPITestCase(BaseAPITestCase):
@@ -11,8 +12,42 @@ class PublicAPITestCase(BaseAPITestCase):
 
     def setUp(self):
         super(PublicAPITestCase, self).setUp()
+        self.channel_list_url = reverse('get_public_channel_list', kwargs={'version': 'v1'})
 
     def test_info_endpoint(self):
+        """
+        Test that the public info endpoint returns the correct identifying information
+        about Studio.
+        """
         response = self.client.get(reverse('info'))
         self.assertEqual(response.data['application'], 'studio')
         self.assertEqual(response.data['device_name'], 'Kolibri Studio')
+
+    def test_empty_public_channels(self):
+        """
+        Ensure that we get a valid, but empty, JSON response when there are no
+        public channels.
+        """
+        response = self.get(self.channel_list_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+    def test_public_channels_endpoint(self):
+        """
+        Test that the public channels endpoint returns information about
+        public channels and that this information is correct.
+        """
+        self.channel.public = True
+        self.channel.thumbnail_encoding = {'base64': generated_base64encoding()}
+        self.channel.main_tree.published = True
+        self.channel.main_tree.save()
+        self.channel.save()
+
+        response = self.client.get(self.channel_list_url)
+        self.assertEqual(response.status_code, 200)
+
+        assert len(response.data) == 1
+        first_channel = response.data[0]
+        self.assertEqual(first_channel['name'], self.channel.name)
+        self.assertEqual(first_channel['id'], self.channel.id)
+        self.assertEqual(first_channel['icon_encoding'], generated_base64encoding())

--- a/contentcuration/contentcuration/views/public.py
+++ b/contentcuration/contentcuration/views/public.py
@@ -3,7 +3,6 @@ import json
 from django.db.models import Q
 from django.db.models import TextField
 from django.db.models import Value
-from django.http import HttpResponse
 from django.http import HttpResponseNotFound
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import viewsets
@@ -59,7 +58,7 @@ def get_public_channel_list(request, version):
         channel_list = _get_channel_list(version, request.query_params)
     except LookupError:
         return HttpResponseNotFound(_("Api endpoint {} is not available").format(version))
-    return HttpResponse(json.dumps(PublicChannelSerializer(channel_list, many=True).data))
+    return Response(PublicChannelSerializer(channel_list, many=True).data)
 
 
 @api_view(['GET'])
@@ -72,7 +71,7 @@ def get_public_channel_lookup(request, version, identifier):
         return HttpResponseNotFound(_("Api endpoint {} is not available").format(version))
     if not channel_list.exists():
         return HttpResponseNotFound(_("No channel matching {} found").format(identifier))
-    return HttpResponse(json.dumps(PublicChannelSerializer(channel_list, many=True).data))
+    return Response(PublicChannelSerializer(channel_list, many=True).data)
 
 
 @api_view(['GET'])
@@ -82,7 +81,12 @@ def get_channel_name_by_id(request, channel_id):
     channel = Channel.objects.filter(pk=channel_id).first()
     if not channel:
         return HttpResponseNotFound('Channel with id {} not found'.format(channel_id))
-    return HttpResponse(json.dumps({"name": channel.name, "description": channel.description, "version": channel.version}))
+    channel_info = {
+        "name": channel.name,
+        "description": channel.description,
+        "version": channel.version
+    }
+    return Response(channel_info)
 
 
 class InfoViewSet(viewsets.ViewSet):


### PR DESCRIPTION
Also fix content type value for public JSON endpoints.

## Description

The public channel list API gets its thumbnail from the `icon_encoding` field in the Channel model. However, in Studio, we never set this field. We only ever set it on the Kolibri sqlite db. In Studio, the thumbnail comes from the `thumbnail_encoding` field instead. As a result, Kolibri import always shows blank thumbnails for Studio content sources available to import.

To fix this, this PR updates the channel public list API serializer to return the `thumbnail_encoding` thumbnail if the `icon_encoding` field is not set.

#### Issue Addressed (if applicable)

Addresses #1299 

## Steps to Test

- [x] Try to import a channel from Kolibri, and see if the thumbnail appears

## Checklist

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
