### PR TITLE
wait for jQuery to load on signup/policy pages

### DIFF
--- a/contentcuration/contentcuration/templates/policies/policy_accept.html
+++ b/contentcuration/contentcuration/templates/policies/policy_accept.html
@@ -22,9 +22,11 @@
 	</form>
 </div>
 <script>
-	$("#id_accepted").on("change", function(event){
-		(event.target.checked)? $("#submit").removeAttr("disabled").removeClass("disabled") :
-			$("#submit").attr("disabled", true).addClass("disabled");
+	window.addEventListener('load', function(){
+		$("#id_accepted").on("change", function(event){
+			(event.target.checked)? $("#submit").removeAttr("disabled").removeClass("disabled") :
+				$("#submit").attr("disabled", true).addClass("disabled");
+		});
 	});
 </script>
 {% endblock content %}

--- a/contentcuration/contentcuration/templates/registration/registration_information_form.html
+++ b/contentcuration/contentcuration/templates/registration/registration_information_form.html
@@ -115,45 +115,46 @@
 </div>
 
 <script>
-	// Toggle storage blank depending on whether "Storage" usage option is checked
-	function handleStorage() {
-		($(".check_storage").prop("checked"))? $("#storage").slideDown(100) : $("#storage").slideUp(100);
-	}
-	$(".check_storage").on("change", handleStorage);
-	handleStorage();
+	window.addEventListener('load', function(){
+		// Toggle storage blank depending on whether "Storage" usage option is checked
+		function handleStorage() {
+			($(".check_storage").prop("checked"))? $("#storage").slideDown(100) : $("#storage").slideUp(100);
+		}
+		$(".check_storage").on("change", handleStorage);
+		handleStorage();
 
-	// Set "Other" as selected for form.clean
-	function checkOther() {
-		$(".check_other").prop("checked", !!$("#id_other_use").val());
-	}
-	$("#id_other_use").on("keypress", checkOther);
-	$("#id_other_use").on("paste", checkOther);
+		// Set "Other" as selected for form.clean
+		function checkOther() {
+			$(".check_other").prop("checked", !!$("#id_other_use").val());
+		}
+		$("#id_other_use").on("keypress", checkOther);
+		$("#id_other_use").on("paste", checkOther);
 
-	// Display blanks for extra information on "Where did you hear about us" question
-	function displaySource() {
-		$("#source .optional_field").slideUp(100);
-		$("#source_" + $("#id_source").val()).slideDown(100);
-	}
-	$("#id_source").on("change", displaySource);
-	displaySource();
+		// Display blanks for extra information on "Where did you hear about us" question
+		function displaySource() {
+			$("#source .optional_field").slideUp(100);
+			$("#source_" + $("#id_source").val()).slideDown(100);
+		}
+		$("#id_source").on("change", displaySource);
+		displaySource();
 
-	// Allow deselection if item is clicked, don't deselect everything on click
-	$("#id_location").on("mousedown", function(ev) {
-		ev.preventDefault();
-		ev.target.selected = !ev.target.selected;
+		// Allow deselection if item is clicked, don't deselect everything on click
+		$("#id_location").on("mousedown", function(ev) {
+			ev.preventDefault();
+			ev.target.selected = !ev.target.selected;
 
-		// Prevent select box from jumping to the top every click
-		var st = this.scrollTop;
-		var self = this;
-		setTimeout(function() {
-			self.scrollTop = st, 0;
+			// Prevent select box from jumping to the top every click
+			var st = this.scrollTop;
+			var self = this;
+			setTimeout(function() {
+				self.scrollTop = st, 0;
+			});
+			this.focus();
 		});
-		this.focus();
+		$("#id_location").on("mousemove", function(ev) {
+			ev.preventDefault();
+		});
 	});
-	$("#id_location").on("mousemove", function(ev) {
-		ev.preventDefault();
-	});
-
 
 </script>
 {% endblock %}


### PR DESCRIPTION
## Description
Makes sure jQuery is available before trying to use it on the signup and policy acceptance pages.

(All this change does is to put the code that uses jQuery inside of a `window.onload` listener.)

#### Issue Addressed (if applicable)

Addresses #1359 