### PR TITLE
Fix docker download link to one that doesn't 404

### DIFF
--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -5,7 +5,7 @@ One of Kolibri Studio's deployment methods use Kubernetes and Docker. If you wou
 
 ## Running Docker
 
-You need to install the latest [Docker edition](https://www.docker.com/community-edition). Make sure it comes with the `docker-compose` executable.
+You need to install the latest [Docker edition](https://hub.docker.com/search/?type=edition&offering=community). Make sure it comes with the `docker-compose` executable.
 
 To set up your environment, run 
 


### PR DESCRIPTION
## Description

Fix docker download link to one that doesn't 404

## Steps to Test

- [ Go to https://www.docker.com/community-edition and see that it does 404] *Step 1*
- [Go to https://hub.docker.com/search/?type=edition&offering=community and see that it does not 404 ] *Step 2*

