### PR TITLE
Fixed tab not changing issue

### DIFF
--- a/contentcuration/contentcuration/static/js/bundle_modules/channel_list.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/channel_list.js
@@ -3,64 +3,14 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Vuex from 'vuex';
 import ChannelEditIndex from './ChannelEditIndex.vue';
-import ChannelListPage from 'edit_channel/channel_list/views/ChannelListPage.vue';
 import State from 'edit_channel/state';
 
 Vue.use(VueRouter);
 Vue.use(Vuex);
 
 const store = require('edit_channel/channel_list/vuex/store');
+const router = require('edit_channel/channel_list/router');
 require('./base');
-
-const router = new VueRouter({
-  routes: [
-    {
-      name: 'ChannelList',
-      path: '/',
-      component: ChannelListPage,
-      props: {
-        activeList: 'EDITABLE',
-      },
-    },
-    {
-      name: 'ChannelList/Starred',
-      path: '/starred',
-      component: ChannelListPage,
-      props: {
-        activeList: 'STARRED',
-      },
-    },
-    {
-      name: 'ChannelList/ViewOnly',
-      path: '/view_only',
-      component: ChannelListPage,
-      props: {
-        activeList: 'VIEW_ONLY',
-      },
-    },
-    {
-      name: 'ChannelList/Public',
-      path: '/public',
-      component: ChannelListPage,
-      props: {
-        activeList: 'PUBLIC',
-      },
-    },
-    {
-      name: 'ChannelList/Collections',
-      path: '/collections',
-      component: ChannelListPage,
-      props: {
-        activeList: 'CHANNEL_SETS',
-      },
-    },
-    // Catch-all for unrecognized URLs
-    {
-      path: '*',
-      redirect: '/',
-    },
-  ],
-});
 
 $(function() {
   // Bind extra stuff to window object that channel_list will need

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/constants.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/constants.js
@@ -13,7 +13,12 @@ export const ChannelListUrls = {
   [ListTypes.PUBLIC]: window.Urls.get_user_public_channels(),
 };
 
+export const InvitationShareModes = {
+  EDIT: 'edit',
+  VIEW_ONLY: 'view',
+};
+
 export const ChannelInvitationMapping = {
-  edit: ListTypes.EDITABLE,
-  view: ListTypes.VIEW_ONLY,
+  [InvitationShareModes.EDIT]: ListTypes.EDITABLE,
+  [InvitationShareModes.VIEW_ONLY]: ListTypes.VIEW_ONLY,
 };

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/constants.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/constants.js
@@ -22,3 +22,11 @@ export const ChannelInvitationMapping = {
   [InvitationShareModes.EDIT]: ListTypes.EDITABLE,
   [InvitationShareModes.VIEW_ONLY]: ListTypes.VIEW_ONLY,
 };
+
+export const RouterNames = {
+  [ListTypes.EDITABLE]: 'ChannelList',
+  [ListTypes.STARRED]: 'ChannelList/Starred',
+  [ListTypes.VIEW_ONLY]: 'ChannelList/ViewOnly',
+  [ListTypes.PUBLIC]: 'ChannelList/Public',
+  [ListTypes.CHANNEL_SETS]: 'ChannelList/Collections',
+};

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/router.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/router.js
@@ -1,0 +1,59 @@
+// include all logic in "base" entrypoint
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+import ChannelListPage from 'edit_channel/channel_list/views/ChannelListPage.vue';
+
+Vue.use(VueRouter);
+
+const router = new VueRouter({
+  routes: [
+    {
+      name: 'ChannelList',
+      path: '/',
+      component: ChannelListPage,
+      props: {
+        activeList: 'EDITABLE',
+      },
+    },
+    {
+      name: 'ChannelList/Starred',
+      path: '/starred',
+      component: ChannelListPage,
+      props: {
+        activeList: 'STARRED',
+      },
+    },
+    {
+      name: 'ChannelList/ViewOnly',
+      path: '/view_only',
+      component: ChannelListPage,
+      props: {
+        activeList: 'VIEW_ONLY',
+      },
+    },
+    {
+      name: 'ChannelList/Public',
+      path: '/public',
+      component: ChannelListPage,
+      props: {
+        activeList: 'PUBLIC',
+      },
+    },
+    {
+      name: 'ChannelList/Collections',
+      path: '/collections',
+      component: ChannelListPage,
+      props: {
+        activeList: 'CHANNEL_SETS',
+      },
+    },
+    // Catch-all for unrecognized URLs
+    {
+      path: '*',
+      redirect: '/',
+    },
+  ],
+});
+
+export default router;
+module.exports = router;

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/tests/channelListPage.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/tests/channelListPage.spec.js
@@ -1,12 +1,30 @@
-import { mount, RouterLinkStub } from '@vue/test-utils';
+import { mount, RouterLinkStub, createLocalVue } from '@vue/test-utils';
 import _ from 'underscore';
+import VueRouter from 'vue-router';
 import ChannelListPage from './../views/ChannelListPage.vue';
 import ChannelDetailsPanel from './../views/ChannelDetailsPanel.vue';
-import { ListTypes } from './../constants';
+import ChannelInvitationList from './../views/ChannelInvitationList.vue';
+import { ListTypes, RouterNames } from './../constants';
 import { localStore } from './data';
 
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+
 function makeWrapper() {
+  // TODO: update with actual routes once the central vue router is available
+  const router = new VueRouter({
+    routes: [
+      { path: '/', name: 'ChannelList', component: ChannelListPage },
+      { path: '/view_only', name: 'ChannelList/ViewOnly', component: ChannelListPage },
+      { path: '/starred', name: 'ChannelList/Starred', component: ChannelListPage },
+      { path: '/public', name: 'ChannelList/Public', component: ChannelListPage },
+      { path: '/collections', name: 'ChannelList/Collections', component: ChannelListPage },
+    ],
+  });
+
   return mount(ChannelListPage, {
+    localVue,
+    router,
     store: localStore,
     propsData: {
       activeList: 'EDITABLE',
@@ -15,9 +33,7 @@ function makeWrapper() {
       RouterLink: RouterLinkStub,
       ChannelDetailsPanel: '<div />',
       ChannelList: '<div />',
-    },
-    mocks: {
-      $route: {},
+      ChannelInvitationList: '<div />',
     },
   });
 }
@@ -49,5 +65,12 @@ describe('channelListPage', () => {
     expect(wrapper.find(ChannelDetailsPanel).exists()).toBe(false);
     wrapper.vm.$store.commit('channel_list/SET_ACTIVE_CHANNEL', '');
     expect(wrapper.find(ChannelDetailsPanel).exists()).toBe(true);
+  });
+  it('accepting an invitation should set the channel list', () => {
+    let inviteList = wrapper.find(ChannelInvitationList);
+    _.each(_.pairs(RouterNames), tab => {
+      inviteList.vm.$emit('setActiveList', tab[0]);
+      expect(wrapper.vm.$route.name).toEqual(tab[1]);
+    });
   });
 });

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/tests/channelListPage.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/tests/channelListPage.spec.js
@@ -1,29 +1,15 @@
-import { mount, RouterLinkStub, createLocalVue } from '@vue/test-utils';
+import { mount, RouterLinkStub } from '@vue/test-utils';
 import _ from 'underscore';
-import VueRouter from 'vue-router';
 import ChannelListPage from './../views/ChannelListPage.vue';
 import ChannelDetailsPanel from './../views/ChannelDetailsPanel.vue';
 import ChannelInvitationList from './../views/ChannelInvitationList.vue';
 import { ListTypes, RouterNames } from './../constants';
 import { localStore } from './data';
 
-const localVue = createLocalVue();
-localVue.use(VueRouter);
+let router = require('edit_channel/channel_list/router');
 
 function makeWrapper() {
-  // TODO: update with actual routes once the central vue router is available
-  const router = new VueRouter({
-    routes: [
-      { path: '/', name: 'ChannelList', component: ChannelListPage },
-      { path: '/view_only', name: 'ChannelList/ViewOnly', component: ChannelListPage },
-      { path: '/starred', name: 'ChannelList/Starred', component: ChannelListPage },
-      { path: '/public', name: 'ChannelList/Public', component: ChannelListPage },
-      { path: '/collections', name: 'ChannelList/Collections', component: ChannelListPage },
-    ],
-  });
-
   return mount(ChannelListPage, {
-    localVue,
     router,
     store: localStore,
     propsData: {

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/views/ChannelInvitationItem.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/views/ChannelInvitationItem.vue
@@ -40,7 +40,7 @@
 <script>
 
   import { mapActions, mapGetters, mapMutations } from 'vuex';
-  import { ListTypes } from '../constants';
+  import { InvitationShareModes } from '../constants';
   import dialog from 'edit_channel/utils/dialog';
 
   export default {
@@ -79,7 +79,7 @@
       },
       acceptedText() {
         switch (this.invitation.share_mode) {
-          case ListTypes.EDITABLE:
+          case InvitationShareModes.EDIT:
             return this.$tr('acceptedEditText', { channel: this.invitation.channel_name });
           default:
             return this.$tr('acceptedViewText', { channel: this.invitation.channel_name });
@@ -87,7 +87,7 @@
       },
       declinedText() {
         switch (this.invitation.share_mode) {
-          case ListTypes.EDITABLE:
+          case InvitationShareModes.EDIT:
             return this.$tr('declinedEditText', { channel: this.invitation.channel_name });
           default:
             return this.$tr('declinedViewText', { channel: this.invitation.channel_name });
@@ -101,7 +101,7 @@
         };
 
         switch (this.invitation.share_mode) {
-          case ListTypes.EDITABLE:
+          case InvitationShareModes.EDIT:
             return this.$tr('editText', messageArgs);
           default:
             return this.$tr('viewText', messageArgs);

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/views/ChannelListPage.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/views/ChannelListPage.vue
@@ -102,7 +102,7 @@
         return false;
       },
       setActiveList(listType) {
-        this.activeList = listType;
+        this.$router.push(this.getLink(listType));
       },
       handleChanneListReady(listType) {
         // Only open the channel tab if the channel list for this page is ready

--- a/contentcuration/contentcuration/static/js/edit_channel/channel_list/views/ChannelListPage.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/channel_list/views/ChannelListPage.vue
@@ -49,7 +49,7 @@
 
   import _ from 'underscore';
   import { mapState } from 'vuex';
-  import { ListTypes } from '../constants';
+  import { ListTypes, RouterNames } from '../constants';
   import { setChannelMixin } from '../mixins';
   import ChannelList from './ChannelList.vue';
   import ChannelSetList from './ChannelSetList.vue';
@@ -111,13 +111,7 @@
         }
       },
       getLink(listType) {
-        const name = {
-          EDITABLE: 'ChannelList',
-          STARRED: 'ChannelList/Starred',
-          VIEW_ONLY: 'ChannelList/ViewOnly',
-          PUBLIC: 'ChannelList/Public',
-          CHANNEL_SETS: 'ChannelList/Collections',
-        }[listType];
+        const name = RouterNames[listType];
         return { name };
       },
       setActiveChannelFromQuery() {


### PR DESCRIPTION
## Description

Turns out there were two problems here:
1. There was a mismatch between share modes and list names, so all invites were defaulting to view only
2. Accepting an invitation didn't change the tab

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1395

## Steps to Test

- [ ] Invite a user to a channel
- [ ] As the invited user, accept the invite

## Checklist

- [ ] Is the code clean and well-commented?