### PR TITLE
Publish internal API endpoint tests

### DIFF
--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -13,6 +13,7 @@ from ..testdata import fileobj_exercise_graphie
 from ..testdata import fileobj_exercise_image
 from ..testdata import fileobj_video
 from ..testdata import tree
+from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 
 
@@ -262,6 +263,12 @@ class PublishEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_200_publish_successful(self):
+        self.channel.editors.add(self.user)
         response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": self.channel.id})
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["success"])
+
+    def test_404_not_authorized(self):
+        new_channel = Channel.objects.create()
+        response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": new_channel.id})
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -2,8 +2,12 @@
 """
 Tests for contentcuration.views.internal functions.
 """
+import uuid
+
+from django.core.urlresolvers import reverse_lazy
 from mixer.main import mixer
 
+from ..base import BaseAPITestCase
 from ..base import StudioTestCase
 from ..testdata import fileobj_exercise_graphie
 from ..testdata import fileobj_exercise_image
@@ -157,7 +161,7 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
                             ],
                             "question": u"Which numbers are even?\n\nTest local image include: ![](${☣ CONTENTSTORAGE}/%s)" % self.exercise_image.filename(),
                             "hints": "[]",
-                            "answers": "[{\"answer\": \"1\", \"correct\": false, \"order\": 0}, {\"answer\": \"2\", \"correct\": True, \"order\": 1}, {\"answer\": \"3\", \"correct\": false, \"order\": 2}, {\"answer\": \"4\", \"correct\": true, \"order\": 3}, {\"answer\": \"5\", \"correct\": false, \"order\": 4}]",
+                            "answers": "[{\"answer\": \"1\", \"correct\": false, \"order\": 0}, {\"answer\": \"2\", \"correct\": True, \"order\": 1}, {\"answer\": \"3\", \"correct\": false, \"order\": 2}, {\"answer\": \"4\", \"correct\": true, \"order\": 3}, {\"answer\": \"5\", \"correct\": false, \"order\": 4}]",  # noqa
                             "raw_data": "",
                             "source_url": None,
                             "randomize": False
@@ -178,7 +182,7 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
                             "question": "",
                             "hints": "[]",
                             "answers": "[]",
-                            "raw_data": u"{\"question\": {\"content\": \"What was the main idea in the passage you just read?\\n\\n[[☃ radio 1]]\\n\\n Test web+graphie image ![graph](web+graphie:${☣ CONTENTSTORAGE}/%s)\", \"images\": {}, \"widgets\": {\"radio 1\": {\"type\": \"radio\", \"alignment\": \"default\", \"static\": false, \"graded\": true, \"options\": {\"choices\": [{\"content\": \"The right answer\", \"correct\": true}, {\"content\": \"Another option\", \"correct\": false}, {\"isNoneOfTheAbove\": false, \"content\": \"Nope, not this\", \"correct\": false}], \"randomize\": false, \"multipleSelect\": false, \"countChoices\": false, \"displayCount\": null, \"hasNoneOfTheAbove\": false, \"deselectEnabled\": false}, \"version\": {\"major\": 1, \"minor\": 0}}}}, \"answerArea\": {\"calculator\": false, \"chi2Table\": false, \"periodicTable\": false, \"tTable\": false, \"zTable\": false}, \"itemDataVersion\": {\"major\": 0, \"minor\": 1}, \"hints\": []}" % self.exercise_graphie.original_filename,
+                            "raw_data": u"{\"question\": {\"content\": \"What was the main idea in the passage you just read?\\n\\n[[☃ radio 1]]\\n\\n Test web+graphie image ![graph](web+graphie:${☣ CONTENTSTORAGE}/%s)\", \"images\": {}, \"widgets\": {\"radio 1\": {\"type\": \"radio\", \"alignment\": \"default\", \"static\": false, \"graded\": true, \"options\": {\"choices\": [{\"content\": \"The right answer\", \"correct\": true}, {\"content\": \"Another option\", \"correct\": false}, {\"isNoneOfTheAbove\": false, \"content\": \"Nope, not this\", \"correct\": false}], \"randomize\": false, \"multipleSelect\": false, \"countChoices\": false, \"displayCount\": null, \"hasNoneOfTheAbove\": false, \"deselectEnabled\": false}, \"version\": {\"major\": 1, \"minor\": 0}}}}, \"answerArea\": {\"calculator\": false, \"chi2Table\": false, \"periodicTable\": false, \"tTable\": false, \"zTable\": false}, \"itemDataVersion\": {\"major\": 0, \"minor\": 1}, \"hints\": []}" % self.exercise_graphie.original_filename,  # noqa
                             "source_url": None,
                             "randomize": False
                         }
@@ -249,3 +253,15 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
         assert file2.filename() == self.exercise_graphie.filename(), 'wrong file'
         assert file2.file_on_disk.read() == self.exercise_graphie.file_on_disk.read(), 'different contents'
         assert file2.original_filename == self.exercise_graphie.original_filename, 'wrong original_filename'
+
+
+class PublishEndpointTestCase(BaseAPITestCase):
+
+    def test_404_non_existent(self):
+        response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": uuid.uuid4().hex})
+        self.assertEqual(response.status_code, 404)
+
+    def test_200_publish_successful(self):
+        response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": self.channel.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -11,7 +11,9 @@ from django.db import transaction
 from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseForbidden
+from django.http import HttpResponseNotFound
 from django.http import HttpResponseServerError
+from django.http import JsonResponse
 from le_utils.constants import content_kinds
 from le_utils.constants import roles
 from raven.contrib.django.raven_compat.models import client
@@ -251,12 +253,12 @@ def api_publish_channel(request):
         channel_id = data["channel_id"]
         call_command("exportchannel", channel_id, user_id=request.user.pk)
 
-        return HttpResponse(json.dumps({
+        return JsonResponse({
             "success": True,
             "channel": channel_id
-        }))
-    except KeyError:
-        raise ObjectDoesNotExist("Missing attribute from data: {}".format(data))
+        })
+    except (KeyError, Channel.DoesNotExist):
+        return HttpResponseNotFound("No channel matching: {}".format(data))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -251,13 +251,15 @@ def api_publish_channel(request):
 
     try:
         channel_id = data["channel_id"]
+        # Ensure that the user has permission to edit this channel.
+        request.user.can_edit(channel_id)
         call_command("exportchannel", channel_id, user_id=request.user.pk)
 
         return JsonResponse({
             "success": True,
             "channel": channel_id
         })
-    except (KeyError, Channel.DoesNotExist):
+    except (KeyError, Channel.DoesNotExist, PermissionDenied):
         return HttpResponseNotFound("No channel matching: {}".format(data))
     except Exception as e:
         handle_server_error(request)


### PR DESCRIPTION
## Description
* Adds tests to guarantee 200 if publish is successful, 404 if channel is not found, or no data passed.
* Adds tests to guarantee a 404 if a user is not authenticated to publish the channel (is not an editor)

#### Issue Addressed (if applicable)

Fixes #1415