### PR TITLE
Reduce the warnings from 5000 to 21 …

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=contentcuration.test_settings
+filterwarnings =
+    ignore::UserWarning
+    ignore::django.utils.deprecation.RemovedInDjango20Warning


### PR DESCRIPTION
…by filtering out deprecation warnings and user warnings during tests.

## Description

I've noticed that our merge commits tend to be failing in Travis with stdout errors that may be getting trigged by the 5000+ plus warnings that spit out at the end of our pytest run. (This noise isn't very helpful for reading test output logs either.) Strangely, PR builds do not fail with the same problem.

While the commit still gets landed, this affects code coverage reporting because it checks each merge commit for the code coverage report, and if Travis fails, it keeps going back until it finds one that didn't fail.

So, let's see if silencing these warnings stops the stdout overflow and gets the Travis merge commit checks to pass. 

## Steps to Test

- [ ] Check the test logs and make sure there isn't a flood of deprecation and user warnings after pytest completes

