### PR TITLE
Cleanup and fixes around internal API tests cases

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -793,7 +793,7 @@ class ContentNode(MPTTModel, models.Model):
     """
     By default, all nodes have a title and can be used as a topic.
     """
-    # The id should be the same between the content curation server and Kolibri.
+    # Random id used internally on Studio (See `node_id` for id used in Kolibri)
     id = UUIDField(primary_key=True, default=uuid.uuid4)
 
     # the content_id is used for tracking a user's interaction with a piece of
@@ -833,8 +833,10 @@ class ContentNode(MPTTModel, models.Model):
                                    help_text=_("Ascending, lowest number shown first"))
     copyright_holder = models.CharField(max_length=200, null=True, blank=True, default="",
                                         help_text=_("Organization of person who holds the essential rights"))
-    cloned_source = TreeForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True, related_name='clones')
+    # legacy field...
     original_node = TreeForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True, related_name='duplicates')
+    cloned_source = TreeForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True, related_name='clones')
+
     thumbnail_encoding = models.TextField(blank=True, null=True)
 
     created = models.DateTimeField(auto_now_add=True, verbose_name=_("created"))

--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -123,33 +123,33 @@ class BaseAPITestCase(StudioAPITestCase):
         self.user = testdata.user()
         self.channel.editors.add(self.user)
         token, _new = Token.objects.get_or_create(user=self.user)
-        self.header = {"Authorization": "Token {0}".format(token)}
+        self.token, _new = Token.objects.get_or_create(user=self.user)
         self.client = APIClient()
-        self.client.force_authenticate(self.user)
+        self.client.force_authenticate(self.user)   # This will skip all authentication checks
         self.channel.main_tree.refresh_from_db()
 
     def delete(self, url):
-        return self.client.delete(url, headers=self.header)
+        return self.client.delete(url)
 
     def get(self, url):
-        return self.client.get(url, headers=self.header)
+        return self.client.get(url)
 
     def post(self, url, data, format='json'):
-        return self.client.post(url, data, headers=self.header, format=format)
+        return self.client.post(url, data, format=format)
 
     def put(self, url, data, format='json'):
-        return self.client.put(url, data, headers=self.header, format=format)
+        return self.client.put(url, data, format=format)
 
     def create_get_request(self, url, *args, **kwargs):
         factory = APIRequestFactory()
-        request = factory.get(url, headers=self.header, *args, **kwargs)
+        request = factory.get(url, *args, **kwargs)
         request.user = self.user
         force_authenticate(request, user=self.user)
         return request
 
     def create_post_request(self, url, *args, **kwargs):
         factory = APIRequestFactory()
-        request = factory.post(url, headers=self.header, *args, **kwargs)
+        request = factory.post(url, *args, **kwargs)
         request.user = self.user
         force_authenticate(request, user=self.user)
         return request

--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -20,6 +20,7 @@ from contentcuration.utils import minio_utils
 from contentcuration.utils.policies import get_latest_policies
 
 
+
 class BucketTestMixin:
     """
     Handles bucket setup and tear down for test classes. If you want your entire TestCase to share the same bucket,
@@ -69,7 +70,7 @@ class StudioTestCase(TestCase, BucketTestMixin):
         """
         Uploads a file to the server using an authorized client.
         """
-        fileobj_temp = testdata.create_temp_file(data, preset=preset, ext=ext)
+        fileobj_temp = testdata.create_studio_file(data, preset=preset, ext=ext)
         name = fileobj_temp['name']
 
         f = SimpleUploadedFile(name, data)

--- a/contentcuration/contentcuration/tests/base.py
+++ b/contentcuration/contentcuration/tests/base.py
@@ -123,7 +123,6 @@ class BaseAPITestCase(StudioAPITestCase):
         self.channel = testdata.channel()
         self.user = testdata.user()
         self.channel.editors.add(self.user)
-        token, _new = Token.objects.get_or_create(user=self.user)
         self.token, _new = Token.objects.get_or_create(user=self.user)
         self.client = APIClient()
         self.client.force_authenticate(self.user)   # This will skip all authentication checks

--- a/contentcuration/contentcuration/tests/test_chef_pipeline.py
+++ b/contentcuration/contentcuration/tests/test_chef_pipeline.py
@@ -2,9 +2,11 @@ import json
 
 from base import BaseAPITestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
 from testdata import create_temp_file
 from testdata import invalid_file_json
 from testdata import node_json
+from testdata import user
 
 from contentcuration import models as cc
 
@@ -17,15 +19,76 @@ channel_metadata = {
 }
 
 
+
+
+class EndpointNamesTestCase(BaseAPITestCase):
+    """
+    Make sure the API endpoints defined in Ricecooker are the the expected ones.
+    """
+    # checks
+    assert '/api/internal/authenticate_user_internal' == reverse('authenticate_user_internal')
+    assert '/api/internal/check_version' == reverse('check_version')
+    # File upload
+    assert '/api/internal/file_diff' == reverse('file_diff')
+    assert '/api/internal/file_upload' == reverse('api_file_upload')
+    # Metadata upload
+    assert '/api/internal/create_channel' == reverse('api_create_channel')
+    assert '/api/internal/add_nodes' == reverse('api_add_nodes_to_tree')
+    assert '/api/internal/finish_channel' == reverse('api_finish_channel')
+    # Publish (optional)
+    assert '/api/internal/publish_channel' == reverse('api_publish_channel')
+
+
+
+
 class ChefTestCase(BaseAPITestCase):
+    """
+    Exercises all the Ricecooker endpoints with fake data.
+    """
 
     def setUp(self):
         super(ChefTestCase, self).setUp()
-        self.check_version_url = '/api/internal/check_version'
-        self.create_channel_url = '/api/internal/create_channel'
-        self.add_nodes_url = '/api/internal/add_nodes'
-        self.file_upload_url = '/api/internal/file_upload'
-        self.finish_channel_url = '/api/internal/finish_channel'
+        # BaseAPITestCase.setUp calls client.force_authenticate(user), but we do
+        # not want that for this test case since Ricecooker uses Token-only auth.
+        self.client.force_authenticate(user=None)
+        # To set the header 'Authorization' in the HTTP request made by the API
+        # client, we must pass HTTP_AUTHORIZATION keyword to `client.credentials`
+        self.client.credentials(HTTP_AUTHORIZATION='Token {0}'.format(self.token))
+        # these token credentials will be presisted for all tests...
+        #
+        self.authenticate_user_internal_url = reverse('authenticate_user_internal')
+        self.check_version_url = reverse('check_version')
+        self.file_diff_url = reverse('file_diff')
+        self.file_upload_url = reverse('api_file_upload')
+        self.create_channel_url = reverse('api_create_channel')
+        self.add_nodes_url = reverse('api_add_nodes_to_tree')
+        self.finish_channel_url = reverse('api_finish_channel')
+
+    def test_authenticate_user_internal_bad_token(self):
+        # clear previously set credentials good credentials
+        self.client.credentials()
+        badtoken = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        self.client.credentials(HTTP_AUTHORIZATION='Token {0}'.format(badtoken))
+        response = self.post(self.authenticate_user_internal_url, None)
+        assert response.status_code == 401
+        # restore good credentials so rest of tests in this class will be OK
+        self.client.credentials(HTTP_AUTHORIZATION='Token {0}'.format(self.token))
+
+    def test_authenticate_user_internal_no_token(self):
+        # clear previously set credentials good credentials
+        self.client.credentials()
+        response = self.post(self.authenticate_user_internal_url, None)
+        assert response.status_code == 401
+        # restore good credentials so rest of tests in this class will be OK
+        self.client.credentials(HTTP_AUTHORIZATION='Token {0}'.format(self.token))
+
+    def test_authenticate_user_internal(self):
+        # No need to set headers since the Authorization Token was added in setUp
+        response = self.post(self.authenticate_user_internal_url, None)
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data['success'] == True
+        assert data['username'] == user().email
 
     def test_check_version_bad_request(self):
         response = self.post(self.check_version_url, {})
@@ -53,15 +116,17 @@ class ChefTestCase(BaseAPITestCase):
         assert response.status_code == 500
 
     def test_file_upload_bad_hash(self):
-        file_data = create_temp_file("Just some data.")
+        file_data = create_temp_file("Just some data.")  # replace this with barebones file
         f = SimpleUploadedFile("myfile.txt", file_data['data'])
         response = self.post(self.file_upload_url, {'file': f}, format='multipart')
+        # shoulf fail because api_file_upload calls write_file_to_storage with check_valid=True
         assert response.status_code == 500
 
     def test_file_upload(self):
         file_data = create_temp_file("Just some data.")
         f = SimpleUploadedFile(file_data['name'], file_data['data'])
         response = self.post(self.file_upload_url, {'file': f}, format='multipart')
+        # TODO: check file content saved to storage
         assert response.status_code == 200, "Call failed:\n output: {}".format(response.content)
 
     def test_create_channel_bad_request(self):

--- a/contentcuration/contentcuration/tests/test_chef_pipeline.py
+++ b/contentcuration/contentcuration/tests/test_chef_pipeline.py
@@ -3,7 +3,7 @@ import json
 from base import BaseAPITestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
-from testdata import create_temp_file
+from testdata import create_test_file
 from testdata import invalid_file_json
 from testdata import node_json
 from testdata import user
@@ -116,14 +116,14 @@ class ChefTestCase(BaseAPITestCase):
         assert response.status_code == 500
 
     def test_file_upload_bad_hash(self):
-        file_data = create_temp_file("Just some data.")  # replace this with barebones file
+        file_data = create_test_file("Just some data.")
         f = SimpleUploadedFile("myfile.txt", file_data['data'])
         response = self.post(self.file_upload_url, {'file': f}, format='multipart')
         # shoulf fail because api_file_upload calls write_file_to_storage with check_valid=True
         assert response.status_code == 500
 
     def test_file_upload(self):
-        file_data = create_temp_file("Just some data.")
+        file_data = create_test_file("Just some data.")
         f = SimpleUploadedFile(file_data['name'], file_data['data'])
         response = self.post(self.file_upload_url, {'file': f}, format='multipart')
         # TODO: check file content saved to storage

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -1,13 +1,12 @@
 import json
 
 import testdata
-from .testdata import create_temp_file
 from base import BaseAPITestCase
 from base import BaseTestCase
-
 from django.conf import settings
 from django.core.urlresolvers import reverse_lazy
 
+from .testdata import create_studio_file
 from contentcuration.models import Channel
 from contentcuration.models import ContentKind
 from contentcuration.models import ContentNode
@@ -380,7 +379,7 @@ class SyncNodesOperationTestCase(BaseTestCase):
 
     def _add_subs_to_video_node(self, video_node, lang):
         lang_obj = Language.objects.get(id=lang)
-        sub_file = create_temp_file('subsin'+lang, preset='video_subtitle', ext='vtt')['db_file']
+        sub_file = create_studio_file('subsin'+lang, preset='video_subtitle', ext='vtt')['db_file']
         sub_file.language = lang_obj
         sub_file.contentnode = video_node
         sub_file.save()
@@ -425,6 +424,3 @@ class SyncNodesOperationTestCase(BaseTestCase):
             assert fileA.checksum == fileB.checksum, 'different checksum found'
             assert fileA.preset == fileB.preset, 'different preset found'
             assert fileA.language == fileB.language, 'different language found'
-
-
-

--- a/contentcuration/contentcuration/tests/test_createchannel.py
+++ b/contentcuration/contentcuration/tests/test_createchannel.py
@@ -4,11 +4,10 @@ import json
 import requests
 from base import BaseTestCase
 from django.core.urlresolvers import reverse_lazy
-from testdata import create_temp_file
+from testdata import create_studio_file
 
 from contentcuration import models
 from contentcuration import models as cc
-
 
 ###
 # Test helper functions
@@ -59,10 +58,10 @@ class CreateChannelTestCase(BaseTestCase):
         super(CreateChannelTestCase, self).setUp()
         self.topic = cc.ContentKind.objects.get(kind='topic')
         self.license = cc.License.objects.all()[0]
-        self.fileobj_audio = create_temp_file("abc", preset='audio', ext='mp3')
-        self.fileobj_video = create_temp_file("def", preset='high_res_video', ext='mp4')
-        self.fileobj_document = create_temp_file("ghi", preset='document', ext='pdf')
-        self.fileobj_exercise = create_temp_file("jkl", preset='exercise', ext='perseus')
+        self.fileinfo_audio = create_studio_file("abc", preset='audio', ext='mp3')
+        self.fileinfo_video = create_studio_file("def", preset='high_res_video', ext='mp4')
+        self.fileinfo_document = create_studio_file("ghi", preset='document', ext='pdf')
+        self.fileinfo_exercise = create_studio_file("jkl", preset='exercise', ext='perseus')
 
     def create_channel(self):
         create_channel_url = str(reverse_lazy('api_create_channel'))
@@ -198,9 +197,9 @@ class CreateChannelTestCase(BaseTestCase):
                         "content_id": "fd373d00523b5484a5586c81e4004afb",
                         "author": "Aristotle",
                         "description": "The Nicomachean Ethics is the name normally given to ...",
-                        "files": [get_file_data(self.fileobj_document)],
+                        "files": [get_file_data(self.fileinfo_document)],
                         "license": self.license.license_name,
-                        "kind": self.fileobj_document['db_file'].preset.kind.pk,
+                        "kind": self.fileinfo_document['db_file'].preset.kind.pk,
                     },
                     {
                         "title": "The Critique of Pure Reason",
@@ -216,10 +215,10 @@ class CreateChannelTestCase(BaseTestCase):
                                 "node_id": "facefacefacefacefacefacefaceface",
                                 "content_id": "9ec91b66dc175c93a4c6a599a76cbc25",
                                 "related": "deaddeaddeaddeaddeaddeaddeaddead",
-                                "files": [get_file_data(self.fileobj_video)],
+                                "files": [get_file_data(self.fileinfo_video)],
                                 "author": "Immanuel Kant",
                                 "license": self.license.license_name,
-                                "kind": self.fileobj_video['db_file'].preset.kind.pk,
+                                "kind": self.fileinfo_video['db_file'].preset.kind.pk,
                             },
                             {
                                 "title": "02 - Preface to the Second Edition",
@@ -257,9 +256,9 @@ class CreateChannelTestCase(BaseTestCase):
                         "node_id": "beefbeefbeefbeefbeefbeefbeefbeef",
                         "content_id": "598fc2a55ea55f86bb7ce9008f34a9d0",
                         "author": "Bradley Smoker",
-                        "files": [get_file_data(self.fileobj_audio)],
+                        "files": [get_file_data(self.fileinfo_audio)],
                         "license": self.license.license_name,
-                        "kind": self.fileobj_audio['db_file'].preset.kind.pk,
+                        "kind": self.fileinfo_audio['db_file'].preset.kind.pk,
                     },
                     {
                         "title": "Food Mob Bites 10: Garlic Bread",
@@ -267,9 +266,9 @@ class CreateChannelTestCase(BaseTestCase):
                         "content_id": "7fc278d7dd31577da822e525ec67ee02",
                         "author": "Revision 3",
                         "description": "Basic garlic bread recipe.",
-                        "files": [get_file_data(self.fileobj_exercise)],
+                        "files": [get_file_data(self.fileinfo_exercise)],
                         "license": self.license.license_name,
-                        "kind": self.fileobj_exercise['db_file'].preset.kind.pk,
+                        "kind": self.fileinfo_exercise['db_file'].preset.kind.pk,
                     }
                 ]
             },

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -1,116 +1,44 @@
-import md5
 import os
 import random
 import string
 import tempfile
-from cStringIO import StringIO
 
 import pytest
 from base import StudioTestCase
-from django.core.files.storage import default_storage
 from django.test.utils import override_settings
 from kolibri_content import models
 from kolibri_content.router import using_content_database
 from mixer.backend.django import mixer
 from mock import patch
 
+from .testdata import create_temp_file
+from .testdata import exercise
+from .testdata import slideshow
+from .testdata import topic
+from .testdata import video
 from contentcuration import models as cc
 from contentcuration.utils.publish import convert_channel_thumbnail
+from contentcuration.utils.publish import create_bare_contentnode
 from contentcuration.utils.publish import create_content_database
 from contentcuration.utils.publish import create_slideshow_manifest
-from contentcuration.utils.publish import create_bare_contentnode
 from contentcuration.utils.publish import MIN_SCHEMA_VERSION
 
 pytestmark = pytest.mark.django_db
 
 
-def video():
-    """
-    Create a video content kind entry.
-    """
-    return mixer.blend(cc.ContentKind, kind='video')
-
-
-def preset_video():
-    """
-    Create a video format preset.
-    """
-    return mixer.blend(cc.FormatPreset, id='mp4', kind=video())
-
-
-def topic():
-    """
-    Create a topic content kind.
-    """
-    return mixer.blend(cc.ContentKind, kind='topic')
-
-
-def exercise():
-    """
-    Create a topic content kind.
-    """
-    return mixer.blend(cc.ContentKind, kind='exercise')
-
-
-def slideshow():
-    """
-    Create a slideshow content kind.
-    """
-    return mixer.blend(cc.ContentKind, kind='slideshow')
-
-
-def preset_exercise():
-    """
-    Create an exercise format preset.
-    """
-    return mixer.blend(cc.FormatPreset, id='exercise', kind=exercise())
-
-
-def fileformat_perseus():
-    """
-    Create a perseus FileFormat entry.
-    """
-    return mixer.blend(cc.FileFormat, extension='perseus', mimetype='application/exercise')
-
-
-def fileformat_mp4():
-    """
-    Create an mp4 FileFormat entry.
-    """
-    return mixer.blend(cc.FileFormat, extension='mp4', mimetype='application/video')
-
-
-def license_wtfpl():
-    """
-    Create a license object called WTF License.
-    """
-    return mixer.blend(cc.License, license_name="WTF License")
-
-
 def fileobj_video(contents=None):
     """
-    Create an "mp4" video file on storage, and then create a File model pointing to it.
-
-    if contents is given and is a string, then write said contents to the file. If not given,
-    a random string is generated and set as the contents of the file.
+    Create an mp4 video file in storage and then create a File model from it.
+    If contents is given and is a string, then write said contents to the file.
+    If not given, a random string is generated and set as the contents of the file.
     """
     if contents:
         filecontents = contents
     else:
         filecontents = "".join(random.sample(string.printable, 20))
-
-    fileobj = StringIO(filecontents)
-    digest = md5.new(filecontents).hexdigest()
-    filename = "{}.mp4".format(digest)
-    storage_file_path = cc.generate_object_storage_name(digest, filename)
-
-    # Write out the file bytes on to object storage, with a filename specified with randomfilename
-    default_storage.save(storage_file_path, fileobj)
-
-    # then create a File object with that
-    db_file_obj = mixer.blend(cc.File, file_format=fileformat_mp4(), preset=preset_video(), file_on_disk=storage_file_path)
-
-    return db_file_obj
+    # leverage existing function in testdata
+    file_data = create_temp_file(filecontents, preset='high_res_video', ext='mp4')
+    return file_data['db_file']
 
 
 def assessment_item():

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -11,7 +11,7 @@ from kolibri_content.router import using_content_database
 from mixer.backend.django import mixer
 from mock import patch
 
-from .testdata import create_temp_file
+from .testdata import create_studio_file
 from .testdata import exercise
 from .testdata import slideshow
 from .testdata import topic
@@ -37,7 +37,7 @@ def fileobj_video(contents=None):
     else:
         filecontents = "".join(random.sample(string.printable, 20))
     # leverage existing function in testdata
-    file_data = create_temp_file(filecontents, preset='high_res_video', ext='mp4')
+    file_data = create_studio_file(filecontents, preset='high_res_video', ext='mp4')
     return file_data['db_file']
 
 

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -42,11 +42,11 @@ def exercise():
     return mixer.blend(cc.ContentKind, kind='exercise')
 
 
-def preset_exercise():
+def slideshow():
     """
-    Create an exercise format preset.
+    Returns a slideshow content kind object.
     """
-    return mixer.blend(cc.FormatPreset, id='exercise', kind=exercise())
+    return mixer.blend(cc.ContentKind, kind='slideshow')
 
 
 def fileformat_perseus():

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -188,10 +188,11 @@ def channel():
 
 
 def user():
-    user = cc.User.objects.create(email='user@test.com')
-    user.set_password('password')
-    user.is_active = True
-    user.save()
+    user, is_new = cc.User.objects.get_or_create(email='user@test.com')
+    if is_new:
+        user.set_password('password')
+        user.is_active = True
+        user.save()
     return user
 
 

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -106,7 +106,13 @@ def node(data, parent=None):
     new_node = None
     # Create topics
     if data['kind_id'] == "topic":
-        new_node = cc.ContentNode(kind=topic(), parent=parent, title=data['title'], node_id=data['node_id'])
+        new_node = cc.ContentNode(
+            kind=topic(),
+            parent=parent,
+            title=data['title'],
+            node_id=data['node_id'],
+            content_id=data.get('content_id') or data['node_id']
+        )
         new_node.save()
 
         for child in data['children']:
@@ -114,7 +120,14 @@ def node(data, parent=None):
 
     # Create videos
     elif data['kind_id'] == "video":
-        new_node = cc.ContentNode(kind=video(), parent=parent, title=data['title'], node_id=data['node_id'], license=license_wtfpl())
+        new_node = cc.ContentNode(
+            kind=video(),
+            parent=parent,
+            title=data['title'],
+            node_id=data['node_id'],
+            license=license_wtfpl(),
+            content_id=data.get('content_id') or data['node_id'],
+        )
         new_node.save()
         video_file = fileobj_video(contents="Video File")
         video_file.contentnode = new_node
@@ -124,17 +137,33 @@ def node(data, parent=None):
     # Create exercises
     elif data['kind_id'] == "exercise":
         extra_fields = "{{\"mastery_model\":\"{}\",\"randomize\":true,\"m\":{},\"n\":{}}}".format(data['mastery_model'], data.get('m') or 0, data.get('n') or 0)
-        new_node = cc.ContentNode(kind=exercise(), parent=parent, title=data['title'], node_id=data[
-                                  'node_id'], license=license_wtfpl(), extra_fields=extra_fields)
+        new_node = cc.ContentNode(
+            kind=exercise(),
+            parent=parent,
+            title=data['title'],
+            node_id=data['node_id'],
+            license=license_wtfpl(),
+            extra_fields=extra_fields,
+            content_id=data.get('content_id') or data['node_id'],
+        )
         new_node.save()
         for assessment_item in data['assessment_items']:
-            mixer.blend(cc.AssessmentItem,
-                        contentnode=new_node,
-                        assessment_id=assessment_item['assessment_id'],
-                        question=assessment_item['question'],
-                        type=assessment_item['type'],
-                        answers=json.dumps(assessment_item['answers'])
-                        )
+            ai = cc.AssessmentItem(
+                contentnode=new_node,
+                assessment_id=assessment_item['assessment_id'],
+                question=assessment_item['question'],
+                type=assessment_item['type'],
+                answers=json.dumps(assessment_item['answers']),
+                hints=json.dumps(assessment_item.get('hints') or [])
+            )
+            ai.save()
+
+    if data.get('tags'):
+        for tag in data['tags']:
+            t = cc.ContentTag(tag_name=tag['tag_name'])
+            t.save()
+            new_node.tags.add(t)
+            new_node.save()
 
     return new_node
 

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -13,6 +13,7 @@ from ..base import StudioTestCase
 from ..testdata import fileobj_exercise_graphie
 from ..testdata import fileobj_exercise_image
 from ..testdata import fileobj_video
+from ..testdata import channel
 from ..testdata import tree
 from contentcuration import ricecooker_versions as rc
 from contentcuration.models import Channel
@@ -43,9 +44,12 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
 
     def setUp(self):
         super(ApiAddNodesToTreeTestCase, self).setUp()
+        # first setup a test channel...
+        self.channel = channel()
+        self.root_node = self.channel.main_tree
+
         # get our random data from mixer
         random_data = mixer.blend(SampleContentNodeDataSchema)
-        self.root_node = tree()
         self.fileobj = fileobj_video()
         self.title = random_data.title
         sample_data = {
@@ -126,9 +130,12 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
 
     def setUp(self):
         super(ApiAddExerciseNodesToTreeTestCase, self).setUp()
+        # first setup a test channel...
+        self.channel = channel()
+        self.root_node = self.channel.main_tree
+
         # get our random data from mixer
         random_data = mixer.blend(SampleContentNodeDataSchema)
-        self.root_node = tree()
         self.exercise_image = fileobj_exercise_image()          # a vanilla image file associated with question
         self.exercise_graphie = fileobj_exercise_graphie()      # a perseus image file associated with question
         self.title = random_data.title

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -409,9 +409,8 @@ if settings.DEBUG:
 
     try:
         import debug_toolbar
-    except ImportError:
-        pass
-    else:
         urlpatterns += [
             url(r'^__debug__/', include(debug_toolbar.urls)),
         ]
+    except ImportError:
+        pass


### PR DESCRIPTION
## Description

Various cleanup tasks and helper methods to be used 
  - Renamed create_temp_file to create_studio_file + refactor all references
  - Updated ChefTestCase to use only Token auth
  - remove code duplication in test_exportchannel.py
  - add some docstrings to models and views
  - Completely unrelated bunch of comment additions in `models.py` 


#### Issue Addressed

Prerequisite for https://github.com/learningequality/studio/issues/1438



## Steps to Test

Travis will do it

## Implementation Notes

The `BaseAPITestCase` was calls `client.force_authenticate` which then ensure all API calls go through. I intentionally disabled this feature in `ChefTestCase` in order to test the token-auth works. 

I removed the self.header propoerty of `BaseAPITestCase` because it doesn't work as expected with the client magic. Instead have to call client.credenials with header `HTTP_AUTHORIZATION` (the `HTTP_`  prefix is needed to make the client built in logic happy).




#### At a high level, how did you implement this?

Just cleanup.


#### Does this introduce any tech-debt items?

When writing test that involve authenticatoin (e.g. login, etc) test authors need to be aware of the  `client.force_authenticate` call in the base class and disable it (otherwise everyhign will go through).

