### PR TITLE
Add permissions to all nodes.py and internal.py endpoints

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -183,6 +183,17 @@ class User(AbstractBaseUser, PermissionsMixin):
             raise PermissionDenied("Cannot view content")
         return True
 
+    def can_edit_node(self, node):
+        if self.is_admin:
+            return True
+        root = node.get_root()
+        channel_id = Channel.objects.filter(Q(main_tree=root)
+                                            | Q(chef_tree=root)
+                                            | Q(trash_tree=root)
+                                            | Q(staging_tree=root)
+                                            | Q(previous_tree=root)).values_list("id", flat=True).first()
+        return self.can_edit(channel_id)
+
     def can_edit_nodes(self, nodes):
         if self.is_admin:
             return True

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -154,6 +154,17 @@ class User(AbstractBaseUser, PermissionsMixin):
             raise PermissionDenied("Cannot view content")
         return True
 
+    def can_view_node(self, node):
+        if self.is_admin:
+            return True
+        root = node.get_root()
+        channel_id = Channel.objects.filter(Q(main_tree=root)
+                                            | Q(chef_tree=root)
+                                            | Q(trash_tree=root)
+                                            | Q(staging_tree=root)
+                                            | Q(previous_tree=root)).values_list("id", flat=True).first()
+        return self.can_view(channel_id)
+
     def can_view_nodes(self, nodes):
         if self.is_admin:
             return True
@@ -170,6 +181,24 @@ class User(AbstractBaseUser, PermissionsMixin):
         # will be smaller.
         if channels.distinct().count() > channels_user_has_perms_for.distinct().count():
             raise PermissionDenied("Cannot view content")
+        return True
+
+    def can_edit_nodes(self, nodes):
+        if self.is_admin:
+            return True
+        root_nodes = ContentNode.objects.filter(parent=None, tree_id__in=nodes.values_list("tree_id", flat=True).distinct()).distinct()
+        channels = Channel.objects.filter(Q(main_tree__in=root_nodes)
+                                          | Q(chef_tree__in=root_nodes)
+                                          | Q(trash_tree__in=root_nodes)
+                                          | Q(staging_tree__in=root_nodes)
+                                          | Q(previous_tree__in=root_nodes))
+        channels_user_can_edit = channels.filter(editors__id__contains=self.id)
+        # The channel user has perms for is a subset of all the channels that were passed in.
+        # We check the count for simplicity, as if the user does not have permissions for
+        # even one of the channels the content is drawn from, then the number of channels
+        # will be smaller.
+        if channels.distinct().count() > channels_user_can_edit.distinct().count():
+            raise PermissionDenied("Cannot edit content")
         return True
 
     def check_space(self, size, checksum):

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -909,7 +909,7 @@ class InvitationSerializer(BulkSerializerMixin, serializers.ModelSerializer):
             'id', 'invited', 'email', 'sender', 'channel', 'first_name', 'last_name', 'share_mode', 'channel_name')
 
 
-class GetTreeDataSerizlizer(serializers.Serializer):
+class GetTreeDataSerializer(serializers.Serializer):
     """
     Used by get_*_tree_data endpoints to ontain "lightweight" tree data.
     """

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -523,12 +523,12 @@ var ContentNodeCollection = BaseCollection.extend({
         url: window.Urls.get_node_path(topic_id, tree_id, node_id),
         success: function(result) {
           var data = JSON.parse(result);
-          var returnCollection = new ContentNodeCollection(JSON.parse(data.path));
+          var returnCollection = new ContentNodeCollection(data.path);
           self.add(returnCollection.toJSON());
 
           var node = null;
           if (data.node) {
-            node = new ContentNodeModel(JSON.parse(data.node));
+            node = new ContentNodeModel(data.node);
             self.add(node);
           }
           resolve({
@@ -758,8 +758,8 @@ var ChannelModel = BaseModel.extend({
         success: function(data) {
           var nodes = JSON.parse(data);
           resolve({
-            original: new ContentNodeCollection(JSON.parse(nodes.original)),
-            changed: new ContentNodeCollection(JSON.parse(nodes.changed)),
+            original: new ContentNodeCollection(nodes.original),
+            changed: new ContentNodeCollection(nodes.changed),
           });
         },
         error: reject,

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -316,7 +316,7 @@ class NodeOperationsAPITestCase(BaseAPITestCase):
 
         response = self.post(reverse_lazy('delete_nodes'), delete_data)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
     def test_no_node_permission_delete_nodes(self):
         new_channel = Channel.objects.create()
@@ -329,7 +329,7 @@ class NodeOperationsAPITestCase(BaseAPITestCase):
 
         response = self.post(reverse_lazy('delete_nodes'), delete_data)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class SyncNodesOperationTestCase(BaseTestCase):

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from le_utils.constants import content_kinds
 from rest_framework.reverse import reverse
 
+from .testdata import tree
 from contentcuration.models import Channel
 from contentcuration.models import ContentKind
 from contentcuration.models import ContentNode
@@ -105,5 +106,22 @@ class GetNodeDiffEndpointTestCase(BaseAPITestCase):
         new_channel = Channel.objects.create()
         response = self.get(
             reverse("get_node_diff", kwargs={"channel_id": new_channel.id}),
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+class GetTotalSizeEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.get(
+            reverse("get_total_size", kwargs={"ids": self.channel.main_tree.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        new_channel.main_tree = tree()
+        new_channel.save()
+        response = self.get(
+            reverse("get_total_size", kwargs={"ids": new_channel.main_tree.id}),
         )
         self.assertEqual(response.status_code, 403)

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -92,7 +92,7 @@ class GetPrerequisitesTestCase(BaseAPITestCase):
         channel.main_tree = node
         channel.save()
         response = self.get(reverse("get_prerequisites", kwargs={"get_postrequisites": "false", "ids": node.id}))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetNodeDiffEndpointTestCase(BaseAPITestCase):
@@ -102,12 +102,12 @@ class GetNodeDiffEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         response = self.get(
             reverse("get_node_diff", kwargs={"channel_id": new_channel.id}),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetTotalSizeEndpointTestCase(BaseAPITestCase):
@@ -117,14 +117,14 @@ class GetTotalSizeEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         new_channel.main_tree = tree()
         new_channel.save()
         response = self.get(
             reverse("get_total_size", kwargs={"ids": new_channel.main_tree.id}),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetNodesByIdsEndpointTestCase(BaseAPITestCase):
@@ -134,14 +134,14 @@ class GetNodesByIdsEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         new_channel.main_tree = tree()
         new_channel.save()
         response = self.get(
             reverse("get_nodes_by_ids", kwargs={"ids": new_channel.main_tree.id}),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetNodesByIdsSimplifiedEndpointTestCase(BaseAPITestCase):
@@ -151,14 +151,14 @@ class GetNodesByIdsSimplifiedEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         new_channel.main_tree = tree()
         new_channel.save()
         response = self.get(
             reverse("get_nodes_by_ids_simplified", kwargs={"ids": new_channel.main_tree.id}),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetNodesByIdsCompleteEndpointTestCase(BaseAPITestCase):
@@ -168,14 +168,14 @@ class GetNodesByIdsCompleteEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         new_channel.main_tree = tree()
         new_channel.save()
         response = self.get(
             reverse("get_nodes_by_ids_complete", kwargs={"ids": new_channel.main_tree.id}),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetTopicDetailsEndpointTestCase(BaseAPITestCase):
@@ -185,11 +185,11 @@ class GetTopicDetailsEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         new_channel.main_tree = tree()
         new_channel.save()
         response = self.get(
             reverse("get_topic_details", kwargs={"contentnode_id": new_channel.main_tree.id}),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -92,3 +92,18 @@ class GetPrerequisitesTestCase(BaseAPITestCase):
         channel.save()
         response = self.get(reverse("get_prerequisites", kwargs={"get_postrequisites": "false", "ids": node.id}))
         self.assertEqual(response.status_code, 403)
+
+
+class GetNodeDiffEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.get(
+            reverse("get_node_diff", kwargs={"channel_id": self.channel.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.get(
+            reverse("get_node_diff", kwargs={"channel_id": new_channel.id}),
+        )
+        self.assertEqual(response.status_code, 403)

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -11,15 +11,13 @@ from rest_framework.reverse import reverse
 from contentcuration.models import Channel
 from contentcuration.models import ContentKind
 from contentcuration.models import ContentNode
-from contentcuration.views.nodes import get_topic_details
 
 
 class NodeViewsUtilityTestCase(BaseAPITestCase):
     def test_get_topic_details(self):
         node_pk = self.channel.main_tree.pk
         url = reverse('get_topic_details', [node_pk])
-        request = self.create_get_request(url)
-        response = get_topic_details(request, node_pk)
+        response = self.get(url)
 
         details = json.loads(response.content)
         assert details['resource_count'] > 0
@@ -37,8 +35,7 @@ class NodeViewsUtilityTestCase(BaseAPITestCase):
         cache.set(cache_key, json.dumps(data))
 
         url = reverse('get_topic_details', [node_pk])
-        request = self.create_get_request(url)
-        get_topic_details(request, node_pk)
+        self.get(url)
 
         # the response will contain the invalid cache entry that we set above, but if we retrieve the cache
         # now it will be updated with the correct values.

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -125,3 +125,20 @@ class GetTotalSizeEndpointTestCase(BaseAPITestCase):
             reverse("get_total_size", kwargs={"ids": new_channel.main_tree.id}),
         )
         self.assertEqual(response.status_code, 403)
+
+
+class GetNodesByIdsEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.get(
+            reverse("get_nodes_by_ids", kwargs={"ids": self.channel.main_tree.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        new_channel.main_tree = tree()
+        new_channel.save()
+        response = self.get(
+            reverse("get_nodes_by_ids", kwargs={"ids": new_channel.main_tree.id}),
+        )
+        self.assertEqual(response.status_code, 403)

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -142,3 +142,54 @@ class GetNodesByIdsEndpointTestCase(BaseAPITestCase):
             reverse("get_nodes_by_ids", kwargs={"ids": new_channel.main_tree.id}),
         )
         self.assertEqual(response.status_code, 403)
+
+
+class GetNodesByIdsSimplifiedEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.get(
+            reverse("get_nodes_by_ids_simplified", kwargs={"ids": self.channel.main_tree.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        new_channel.main_tree = tree()
+        new_channel.save()
+        response = self.get(
+            reverse("get_nodes_by_ids_simplified", kwargs={"ids": new_channel.main_tree.id}),
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+class GetNodesByIdsCompleteEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.get(
+            reverse("get_nodes_by_ids_complete", kwargs={"ids": self.channel.main_tree.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        new_channel.main_tree = tree()
+        new_channel.save()
+        response = self.get(
+            reverse("get_nodes_by_ids_complete", kwargs={"ids": new_channel.main_tree.id}),
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+class GetTopicDetailsEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.get(
+            reverse("get_topic_details", kwargs={"contentnode_id": self.channel.main_tree.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        new_channel.main_tree = tree()
+        new_channel.save()
+        response = self.get(
+            reverse("get_topic_details", kwargs={"contentnode_id": new_channel.main_tree.id}),
+        )
+        self.assertEqual(response.status_code, 403)

--- a/contentcuration/contentcuration/tests/test_sushibar_endpoints.py
+++ b/contentcuration/contentcuration/tests/test_sushibar_endpoints.py
@@ -129,10 +129,10 @@ class SushibarEndpointsTestCase(BaseAPITestCase):
         response = self.post(url, {})
         assert response.status_code == 400
         response = self.post(url, {'channel_id': 'NONEXISTENT'})
-        assert response.status_code == 500
+        assert response.status_code == 404
         channel_id = self.channel.id
         response = self.post(url, {'channel_id': channel_id, 'tree': 'NONEXISTENT'})
-        assert response.status_code == 500
+        assert response.status_code == 404
 
     def test_get_tree_data_method_onelevel(self):
         main_tree = self.channel.main_tree

--- a/contentcuration/contentcuration/tests/views/test_contentnode_views.py
+++ b/contentcuration/contentcuration/tests/views/test_contentnode_views.py
@@ -17,8 +17,7 @@ class BaseGetNodesByIdSerializerTestCaseMixin:
         when called without any ID arguments.
         """
         response = self.get('/api/{}/'.format(self.endpoint))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(response.status_code, 404)
 
     def test_get_nodes_by_ids_get_only(self):
         """
@@ -37,8 +36,7 @@ class BaseGetNodesByIdSerializerTestCaseMixin:
         but does not return any data.
         """
         response = self.get(reverse_lazy(self.endpoint, kwargs={"ids": ''}))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(response.status_code, 404)
 
     def test_get_nodes_by_ids_with_invalid_id(self):
         """
@@ -46,8 +44,7 @@ class BaseGetNodesByIdSerializerTestCaseMixin:
         does not return node data.
         """
         response = self.get(reverse_lazy(self.endpoint, kwargs={"ids": '1234'}))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(response.status_code, 404)
 
     def test_get_nodes_by_ids_single(self):
         """

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -28,6 +28,7 @@ class SampleContentNodeDataSchema:
     JSON data we send to api_add_nodes_to_tree. Pair this with
     mixer.blend to autogenerate the schema with random values.
     """
+
     title = str
     description = str
     node_id = str
@@ -72,7 +73,7 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                             "filename": self.fileobj.filename(),
                             "original_filename": self.fileobj.original_filename,
                             "language": self.fileobj.language,
-                            "source_url": self.fileobj.source_url
+                            "source_url": self.fileobj.source_url,
                         }
                     ],
                     "kind": "document",
@@ -81,14 +82,12 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                     "copyright_holder": random_data.copyright_holder,
                     "questions": [],
                     "extra_fields": "{}",
-                    "role": "learner"
+                    "role": "learner",
                 }
-            ]
+            ],
         }
         self.resp = self.admin_client().post(
-            "/api/internal/add_nodes",
-            data=sample_data,
-            format='json'
+            "/api/internal/add_nodes", data=sample_data, format="json"
         )
 
     def test_returns_200_status_code(self):
@@ -96,7 +95,9 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         Check that we return 200 if passed in a valid JSON.
         """
         # check that we returned 200 with that POST request
-        assert self.resp.status_code == 200, "Got a request error: {}".format(self.resp.content)
+        assert self.resp.status_code == 200, "Got a request error: {}".format(
+            self.resp.content
+        )
 
     def test_creates_nodes(self):
         """
@@ -104,7 +105,9 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         """
 
         # make sure a node with our given self.title exists, with the given parent.
-        assert ContentNode.get_nodes_with_title(title=self.title, limit_to_children_of=self.root_node.id).exists()
+        assert ContentNode.get_nodes_with_title(
+            title=self.title, limit_to_children_of=self.root_node.id
+        ).exists()
 
     def test_associates_file_with_created_node(self):
         """
@@ -137,8 +140,10 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
 
         # get our random data from mixer
         random_data = mixer.blend(SampleContentNodeDataSchema)
-        self.exercise_image = fileobj_exercise_image()          # a vanilla image file associated with question
-        self.exercise_graphie = fileobj_exercise_graphie()      # a perseus image file associated with question
+        # a vanilla image file associated with question
+        self.exercise_image = fileobj_exercise_image()
+        # a perseus image file associated with question
+        self.exercise_graphie = fileobj_exercise_graphie()
         self.title = random_data.title
         sample_data = {
             "root_id": self.root_node.id,
@@ -168,15 +173,16 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
                                     "filename": self.exercise_image.filename(),
                                     "original_filename": None,
                                     "language": None,
-                                    "source_url": None
+                                    "source_url": None,
                                 }
                             ],
-                            "question": u"Which numbers are even?\n\nTest local image include: ![](${☣ CONTENTSTORAGE}/%s)" % self.exercise_image.filename(),
+                            "question": u"Which numbers are even?\n\nTest local image include: ![](${☣ CONTENTSTORAGE}/%s)"
+                            % self.exercise_image.filename(),
                             "hints": "[]",
-                            "answers": "[{\"answer\": \"1\", \"correct\": false, \"order\": 0}, {\"answer\": \"2\", \"correct\": True, \"order\": 1}, {\"answer\": \"3\", \"correct\": false, \"order\": 2}, {\"answer\": \"4\", \"correct\": true, \"order\": 3}, {\"answer\": \"5\", \"correct\": false, \"order\": 4}]",  # noqa
+                            "answers": '[{"answer": "1", "correct": false, "order": 0}, {"answer": "2", "correct": True, "order": 1}, {"answer": "3", "correct": false, "order": 2}, {"answer": "4", "correct": true, "order": 3}, {"answer": "5", "correct": false, "order": 4}]',  # noqa
                             "raw_data": "",
                             "source_url": None,
-                            "randomize": False
+                            "randomize": False,
                         },
                         {
                             "assessment_id": "98856e24d53b57ea9023782ab6018767",
@@ -188,26 +194,25 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
                                     "filename": self.exercise_graphie.filename(),
                                     "original_filename": self.exercise_graphie.original_filename,
                                     "language": None,
-                                    "source_url": None
+                                    "source_url": None,
                                 }
                             ],
                             "question": "",
                             "hints": "[]",
                             "answers": "[]",
-                            "raw_data": u"{\"question\": {\"content\": \"What was the main idea in the passage you just read?\\n\\n[[☃ radio 1]]\\n\\n Test web+graphie image ![graph](web+graphie:${☣ CONTENTSTORAGE}/%s)\", \"images\": {}, \"widgets\": {\"radio 1\": {\"type\": \"radio\", \"alignment\": \"default\", \"static\": false, \"graded\": true, \"options\": {\"choices\": [{\"content\": \"The right answer\", \"correct\": true}, {\"content\": \"Another option\", \"correct\": false}, {\"isNoneOfTheAbove\": false, \"content\": \"Nope, not this\", \"correct\": false}], \"randomize\": false, \"multipleSelect\": false, \"countChoices\": false, \"displayCount\": null, \"hasNoneOfTheAbove\": false, \"deselectEnabled\": false}, \"version\": {\"major\": 1, \"minor\": 0}}}}, \"answerArea\": {\"calculator\": false, \"chi2Table\": false, \"periodicTable\": false, \"tTable\": false, \"zTable\": false}, \"itemDataVersion\": {\"major\": 0, \"minor\": 1}, \"hints\": []}" % self.exercise_graphie.original_filename,  # noqa
+                            "raw_data": u'{"question": {"content": "What was the main idea in the passage you just read?\\n\\n[[☃ radio 1]]\\n\\n Test web+graphie image ![graph](web+graphie:${☣ CONTENTSTORAGE}/%s)", "images": {}, "widgets": {"radio 1": {"type": "radio", "alignment": "default", "static": false, "graded": true, "options": {"choices": [{"content": "The right answer", "correct": true}, {"content": "Another option", "correct": false}, {"isNoneOfTheAbove": false, "content": "Nope, not this", "correct": false}], "randomize": false, "multipleSelect": false, "countChoices": false, "displayCount": null, "hasNoneOfTheAbove": false, "deselectEnabled": false}, "version": {"major": 1, "minor": 0}}}}, "answerArea": {"calculator": false, "chi2Table": false, "periodicTable": false, "tTable": false, "zTable": false}, "itemDataVersion": {"major": 0, "minor": 1}, "hints": []}'  # noqa
+                            % self.exercise_graphie.original_filename,  # noqa
                             "source_url": None,
-                            "randomize": False
-                        }
+                            "randomize": False,
+                        },
                     ],
-                    "extra_fields": "{\"mastery_model\": \"m_of_n\", \"randomize\": true, \"m\": 1, \"n\": 2}",
-                    "role": "learner"
+                    "extra_fields": '{"mastery_model": "m_of_n", "randomize": true, "m": 1, "n": 2}',
+                    "role": "learner",
                 }
-            ]
+            ],
         }
         self.resp = self.admin_client().post(
-            "/api/internal/add_nodes",
-            data=sample_data,
-            format='json'
+            "/api/internal/add_nodes", data=sample_data, format="json"
         )
 
     def test_returns_200_status_code(self):
@@ -215,14 +220,18 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
         Check that we return 200 if passed in a valid JSON.
         """
         # check that we returned 200 with that POST request
-        assert self.resp.status_code == 200, "Got a request error: {}".format(self.resp.content)
+        assert self.resp.status_code == 200, "Got a request error: {}".format(
+            self.resp.content
+        )
 
     def test_creates_nodes(self):
         """
         Test that it creates a node with the given title and parent.
         """
         # make sure a node with our given self.title exists, with the given parent.
-        assert ContentNode.get_nodes_with_title(title=self.title, limit_to_children_of=self.root_node.id).exists()
+        assert ContentNode.get_nodes_with_title(
+            title=self.title, limit_to_children_of=self.root_node.id
+        ).exists()
 
     def test_associated_assesment_items_with_created_node(self):
         """
@@ -232,17 +241,21 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
         c = ContentNode.objects.get(title=self.title)
 
         # there shold be no files associated with the condent node
-        assert len(c.files.all()) == 0, 'unexpected files created'
+        assert len(c.files.all()) == 0, "unexpected files created"
         # get the associated assessment items...
-        assessment_items = list(c.assessment_items.order_by('order'))
+        assessment_items = list(c.assessment_items.order_by("order"))
         # there should be two assesment items associated with the condent node
-        assert len(assessment_items) == 2, 'should have two assesment items'
+        assert len(assessment_items) == 2, "should have two assesment items"
         # created in right order?
-        assert assessment_items[0].assessment_id == 'abf45e8fd7f151adb1b3df2d751e945e', 'created in wrong order'
-        assert assessment_items[1].assessment_id == '98856e24d53b57ea9023782ab6018767', 'created in wrong order'
+        assert (
+            assessment_items[0].assessment_id == "abf45e8fd7f151adb1b3df2d751e945e"
+        ), "created in wrong order"
+        assert (
+            assessment_items[1].assessment_id == "98856e24d53b57ea9023782ab6018767"
+        ), "created in wrong order"
         # associated with content node c ?
         for assessment_item in assessment_items:
-            assert assessment_item.contentnode == c, 'not associated with content node'
+            assert assessment_item.contentnode == c, "not associated with content node"
 
     def test_exercise_image_files_associated_with_assesment_items(self):
         """
@@ -251,44 +264,67 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
         """
         c = ContentNode.objects.get(title=self.title)
 
-        question1 = c.assessment_items.get(assessment_id='abf45e8fd7f151adb1b3df2d751e945e')
-        assert len(question1.files.all()) == 1, 'wrong number of files'
+        question1 = c.assessment_items.get(
+            assessment_id="abf45e8fd7f151adb1b3df2d751e945e"
+        )
+        assert len(question1.files.all()) == 1, "wrong number of files"
         file1 = question1.files.all()[0]
-        assert file1.assessment_item == question1, 'not associated with right assessment item'
-        assert file1.filename() == self.exercise_image.filename(), 'wrong file'
-        assert file1.file_on_disk.read() == self.exercise_image.file_on_disk.read(), 'different contents'
+        assert (
+            file1.assessment_item == question1
+        ), "not associated with right assessment item"
+        assert file1.filename() == self.exercise_image.filename(), "wrong file"
+        assert (
+            file1.file_on_disk.read() == self.exercise_image.file_on_disk.read()
+        ), "different contents"
 
-        question2 = c.assessment_items.get(assessment_id='98856e24d53b57ea9023782ab6018767')
-        assert len(question2.files.all()) == 1, 'wrong number of files'
+        question2 = c.assessment_items.get(
+            assessment_id="98856e24d53b57ea9023782ab6018767"
+        )
+        assert len(question2.files.all()) == 1, "wrong number of files"
         file2 = question2.files.all()[0]
-        assert file2.assessment_item == question2, 'not associated with right assessment item'
-        assert file2.filename() == self.exercise_graphie.filename(), 'wrong file'
-        assert file2.file_on_disk.read() == self.exercise_graphie.file_on_disk.read(), 'different contents'
-        assert file2.original_filename == self.exercise_graphie.original_filename, 'wrong original_filename'
+        assert (
+            file2.assessment_item == question2
+        ), "not associated with right assessment item"
+        assert file2.filename() == self.exercise_graphie.filename(), "wrong file"
+        assert (
+            file2.file_on_disk.read() == self.exercise_graphie.file_on_disk.read()
+        ), "different contents"
+        assert (
+            file2.original_filename == self.exercise_graphie.original_filename
+        ), "wrong original_filename"
 
 
 class PublishEndpointTestCase(BaseAPITestCase):
-
     def test_404_non_existent(self):
-        response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": uuid.uuid4().hex})
+        response = self.post(
+            reverse_lazy("api_publish_channel"), {"channel_id": uuid.uuid4().hex}
+        )
         self.assertEqual(response.status_code, 404)
 
     def test_200_publish_successful(self):
         self.channel.editors.add(self.user)
-        response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": self.channel.id})
+        response = self.post(
+            reverse_lazy("api_publish_channel"), {"channel_id": self.channel.id}
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["success"])
 
     def test_404_not_authorized(self):
         new_channel = Channel.objects.create()
-        response = self.post(reverse_lazy("api_publish_channel"), {"channel_id": new_channel.id})
+        response = self.post(
+            reverse_lazy("api_publish_channel"), {"channel_id": new_channel.id}
+        )
         self.assertEqual(response.status_code, 404)
 
 
 class VersionEndpointTestCase(BaseAPITestCase):
-
     def test_better_than_OK(self):
-        with patch("contentcuration.views.internal.VERSION_OK", internal.VersionStatus(version="0.0.1", status=0, message=rc.VERSION_OK_MESSAGE)):
+        with patch(
+            "contentcuration.views.internal.VERSION_OK",
+            internal.VersionStatus(
+                version="0.0.1", status=0, message=rc.VERSION_OK_MESSAGE
+            ),
+        ):
             response = self.post(reverse_lazy("check_version"), {"version": "0.1.1"})
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json()["success"])
@@ -302,46 +338,65 @@ class VersionEndpointTestCase(BaseAPITestCase):
 
     def test_worse_than_OK_but_better_than_soft(self):
         with patch(
-                    "contentcuration.views.internal.VERSION_OK",
-                    internal.VersionStatus(version="1.0.0", status=0, message=rc.VERSION_OK_MESSAGE)
-                ), patch(
-                    "contentcuration.views.internal.VERSION_SOFT_WARNING",
-                    internal.VersionStatus(version="0.0.1", status=1, message=rc.VERSION_SOFT_WARNING_MESSAGE)
-                ):
+            "contentcuration.views.internal.VERSION_OK",
+            internal.VersionStatus(
+                version="1.0.0", status=0, message=rc.VERSION_OK_MESSAGE
+            ),
+        ), patch(
+            "contentcuration.views.internal.VERSION_SOFT_WARNING",
+            internal.VersionStatus(
+                version="0.0.1", status=1, message=rc.VERSION_SOFT_WARNING_MESSAGE
+            ),
+        ):
             response = self.post(reverse_lazy("check_version"), {"version": "0.1.1"})
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json()["success"])
-            self.assertEqual(response.json()["status"], internal.VERSION_SOFT_WARNING[1])
+            self.assertEqual(
+                response.json()["status"], internal.VERSION_SOFT_WARNING[1]
+            )
 
     def test_soft_warning(self):
-        response = self.post(reverse_lazy("check_version"), {"version": rc.VERSION_SOFT_WARNING})
+        response = self.post(
+            reverse_lazy("check_version"), {"version": rc.VERSION_SOFT_WARNING}
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["success"])
         self.assertEqual(response.json()["status"], internal.VERSION_SOFT_WARNING[1])
 
     def test_worse_than_soft_but_better_than_hard(self):
         with patch(
-                    "contentcuration.views.internal.VERSION_SOFT_WARNING",
-                    internal.VersionStatus(version="1.0.0", status=1, message=rc.VERSION_SOFT_WARNING_MESSAGE)
-                ), patch(
-                    "contentcuration.views.internal.VERSION_HARD_WARNING",
-                    internal.VersionStatus(version="0.0.1", status=2, message=rc.VERSION_HARD_WARNING_MESSAGE)
-                ):
+            "contentcuration.views.internal.VERSION_SOFT_WARNING",
+            internal.VersionStatus(
+                version="1.0.0", status=1, message=rc.VERSION_SOFT_WARNING_MESSAGE
+            ),
+        ), patch(
+            "contentcuration.views.internal.VERSION_HARD_WARNING",
+            internal.VersionStatus(
+                version="0.0.1", status=2, message=rc.VERSION_HARD_WARNING_MESSAGE
+            ),
+        ):
             response = self.post(reverse_lazy("check_version"), {"version": "0.1.1"})
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json()["success"])
-            self.assertEqual(response.json()["status"], internal.VERSION_HARD_WARNING[1])
+            self.assertEqual(
+                response.json()["status"], internal.VERSION_HARD_WARNING[1]
+            )
 
     def test_hard_warning(self):
-        response = self.post(reverse_lazy("check_version"), {"version": rc.VERSION_HARD_WARNING})
+        response = self.post(
+            reverse_lazy("check_version"), {"version": rc.VERSION_HARD_WARNING}
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["success"])
         self.assertEqual(response.json()["status"], internal.VERSION_HARD_WARNING[1])
 
     def test_worse_than_hard(self):
         with patch(
-                "contentcuration.views.internal.VERSION_HARD_WARNING",
-                internal.VersionStatus(version="1.0.0", status=2, message=rc.VERSION_HARD_WARNING_MESSAGE)):
+            "contentcuration.views.internal.VERSION_HARD_WARNING",
+            internal.VersionStatus(
+                version="1.0.0", status=2, message=rc.VERSION_HARD_WARNING_MESSAGE
+            ),
+        ):
             response = self.post(reverse_lazy("check_version"), {"version": "0.1.1"})
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json()["success"])

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -546,12 +546,12 @@ class CheckUserIsEditorEndpointTestCase(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_403_no_permission(self):
+    def test_404_no_permission(self):
         new_channel = Channel.objects.create()
         response = self.post(
             reverse_lazy("check_user_is_editor"), {"channel_id": new_channel.id}
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
 
 class GetTreeDataEndpointTestCase(BaseAPITestCase):

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -569,3 +569,20 @@ class GetTreeDataEndpointTestCase(BaseAPITestCase):
             {"channel_id": new_channel.id, "tree": "main"},
         )
         self.assertEqual(response.status_code, 404)
+
+
+class GetNodeTreeDataEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.post(
+            reverse_lazy("get_node_tree_data"),
+            {"channel_id": self.channel.id, "tree": "main"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("get_node_tree_data"),
+            {"channel_id": new_channel.id, "tree": "main"},
+        )
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -537,3 +537,18 @@ class APIActivateChannelEndpointTestCase(BaseAPITestCase):
             reverse_lazy("activate_channel_internal"), {"channel_id": new_channel.id}
         )
         self.assertEqual(response.status_code, 404)
+
+
+class CheckUserIsEditorEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.post(
+            reverse_lazy("check_user_is_editor"), {"channel_id": self.channel.id}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_403_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("check_user_is_editor"), {"channel_id": new_channel.id}
+        )
+        self.assertEqual(response.status_code, 403)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -552,3 +552,20 @@ class CheckUserIsEditorEndpointTestCase(BaseAPITestCase):
             reverse_lazy("check_user_is_editor"), {"channel_id": new_channel.id}
         )
         self.assertEqual(response.status_code, 403)
+
+
+class GetTreeDataEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.post(
+            reverse_lazy("get_tree_data"),
+            {"channel_id": self.channel.id, "tree": "main"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("get_tree_data"),
+            {"channel_id": new_channel.id, "tree": "main"},
+        )
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -520,3 +520,20 @@ class APICommitChannelEndpointTestCase(BaseAPITestCase):
             reverse_lazy("api_finish_channel"), {"channel_id": new_channel.id}
         )
         self.assertEqual(response.status_code, 404)
+
+
+class APIActivateChannelEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        self.channel.staging_tree = self.channel.main_tree
+        self.channel.save()
+        response = self.post(
+            reverse_lazy("activate_channel_internal"), {"channel_id": self.channel.id}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("activate_channel_internal"), {"channel_id": new_channel.id}
+        )
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -424,3 +424,39 @@ class FileDiffEndpointTestCase(BaseAPITestCase):
         self.client.logout()
         response = self.post(reverse_lazy("file_diff"), [])
         self.assertEqual(response.status_code, 401)
+
+
+class GetStagedDiffEndpointTestCase(BaseAPITestCase):
+    def test_200(self):
+        response = self.post(
+            reverse_lazy("get_staged_diff_internal"), {"channel_id": self.channel.id}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("get_staged_diff_internal"), {"channel_id": new_channel.id}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_200_all_new(self):
+        self.channel.staging_tree = self.channel.main_tree
+        self.channel.main_tree = None
+        self.channel.save()
+        response = self.post(
+            reverse_lazy("get_staged_diff_internal"), {"channel_id": self.channel.id}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        fields = [
+            u"File Size",
+            u"# of Topics",
+            u"# of Videos",
+            u"# of Exercises",
+            u"# of Questions",
+        ]
+        differences = [40, 2, 4, 1, 3]
+        for field, difference in zip(fields, differences):
+            diff = filter(lambda x: x["field"] == field, response.json())[0]
+            self.assertEqual(diff["difference"], difference)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -460,3 +460,27 @@ class GetStagedDiffEndpointTestCase(BaseAPITestCase):
         for field, difference in zip(fields, differences):
             diff = filter(lambda x: x["field"] == field, response.json())[0]
             self.assertEqual(diff["difference"], difference)
+
+
+class AuthenticateUserEndpointTestCase(BaseAPITestCase):
+    def test_200_get(self):
+        response = self.get(reverse_lazy("authenticate_user_internal"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_200_post(self):
+        response = self.post(reverse_lazy("authenticate_user_internal"), {})
+        self.assertEqual(response.status_code, 200)
+
+    def test_401_no_auth(self):
+        self.client.logout()
+        response = self.post(reverse_lazy("authenticate_user_internal"), {})
+        self.assertEqual(response.status_code, 401)
+
+    def test_200_response(self):
+        response = self.get(reverse_lazy("authenticate_user_internal"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["user_id"], self.user.id)
+        self.assertEqual(response.json()["username"], unicode(self.user))
+        self.assertEqual(response.json()["first_name"], self.user.first_name)
+        self.assertEqual(response.json()["last_name"], self.user.last_name)
+        self.assertEqual(response.json()["is_admin"], self.user.is_admin)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -586,3 +586,19 @@ class GetNodeTreeDataEndpointTestCase(BaseAPITestCase):
             {"channel_id": new_channel.id, "tree": "main"},
         )
         self.assertEqual(response.status_code, 404)
+
+
+class GetChannelStatusBulkEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        response = self.post(
+            reverse_lazy("get_channel_status_bulk"), {"channel_ids": [self.channel.id]}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("get_channel_status_bulk"),
+            {"channel_ids": [self.channel.id, new_channel.id]},
+        )
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -7,6 +7,7 @@ import uuid
 from django.core.urlresolvers import reverse_lazy
 from mixer.main import mixer
 from mock import patch
+from rest_framework.test import APIClient
 
 from ..base import BaseAPITestCase
 from ..base import StudioTestCase
@@ -16,6 +17,7 @@ from ..testdata import fileobj_exercise_image
 from ..testdata import fileobj_video
 from ..testdata import channel
 from ..testdata import tree
+from ..testdata import user
 from contentcuration import ricecooker_versions as rc
 from contentcuration.models import Channel
 from contentcuration.models import ContentNode
@@ -54,7 +56,7 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         random_data = mixer.blend(SampleContentNodeDataSchema)
         self.fileobj = fileobj_video()
         self.title = random_data.title
-        sample_data = {
+        self.sample_data = {
             "root_id": self.root_node.id,
             "content_data": [
                 {
@@ -87,8 +89,16 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
             ],
         }
         self.resp = self.admin_client().post(
-            "/api/internal/add_nodes", data=sample_data, format="json"
+            reverse_lazy("api_add_nodes_to_tree"), data=self.sample_data, format="json"
         )
+
+    def test_404_no_permission(self):
+        client = APIClient()
+        client.force_authenticate(user())
+        response = client.post(
+            reverse_lazy("api_add_nodes_to_tree"), self.sample_data, format="json"
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_returns_200_status_code(self):
         """
@@ -145,7 +155,7 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
         # a perseus image file associated with question
         self.exercise_graphie = fileobj_exercise_graphie()
         self.title = random_data.title
-        sample_data = {
+        self.sample_data = {
             "root_id": self.root_node.id,
             "content_data": [
                 {
@@ -212,8 +222,16 @@ class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
             ],
         }
         self.resp = self.admin_client().post(
-            "/api/internal/add_nodes", data=sample_data, format="json"
+            reverse_lazy("api_add_nodes_to_tree"), data=self.sample_data, format="json"
         )
+
+    def test_404_no_permission(self):
+        client = APIClient()
+        client.force_authenticate(user())
+        response = client.post(
+            reverse_lazy("api_add_nodes_to_tree"), self.sample_data, format="json"
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_returns_200_status_code(self):
         """

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -484,3 +484,21 @@ class AuthenticateUserEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.json()["first_name"], self.user.first_name)
         self.assertEqual(response.json()["last_name"], self.user.last_name)
         self.assertEqual(response.json()["is_admin"], self.user.is_admin)
+
+
+class APICommitChannelEndpointTestCase(BaseAPITestCase):
+    def test_200_post(self):
+        self.channel.chef_tree = self.channel.main_tree
+        self.channel.staging_tree = self.channel.main_tree
+        self.channel.save()
+        response = self.post(
+            reverse_lazy("api_finish_channel"), {"channel_id": self.channel.id}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_no_permission(self):
+        new_channel = Channel.objects.create()
+        response = self.post(
+            reverse_lazy("api_finish_channel"), {"channel_id": new_channel.id}
+        )
+        self.assertEqual(response.status_code, 404)

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -10,6 +10,7 @@ from mock import patch
 
 from ..base import BaseAPITestCase
 from ..base import StudioTestCase
+from ..testdata import create_temp_file
 from ..testdata import fileobj_exercise_graphie
 from ..testdata import fileobj_exercise_image
 from ..testdata import fileobj_video
@@ -345,3 +346,26 @@ class VersionEndpointTestCase(BaseAPITestCase):
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json()["success"])
             self.assertEqual(response.json()["status"], internal.VERSION_ERROR[1])
+
+
+class FileDiffEndpointTestCase(BaseAPITestCase):
+    def test_200_no_files(self):
+        response = self.post(reverse_lazy("file_diff"), [])
+        self.assertEqual(response.status_code, 200)
+
+    def test_200_1_file_present(self):
+        file = create_temp_file(b"test")
+        response = self.post(reverse_lazy("file_diff"), [file["name"]])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_200_1_file_present_1_missing(self):
+        file = create_temp_file(b"test")
+        response = self.post(reverse_lazy("file_diff"), [file["name"], "test_file"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), ["test_file"])
+
+    def test_401_no_auth(self):
+        self.client.logout()
+        response = self.post(reverse_lazy("file_diff"), [])
+        self.assertEqual(response.status_code, 401)

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -339,7 +339,7 @@ def check_user_is_editor(request):
             request.user.can_edit(channel_id)
             return Response({"success": True})
         except PermissionDenied:
-            return HttpResponseForbidden("User is not authorized to edit this channel")
+            return HttpResponseNotFound("Channel not found {}".format(channel_id))
 
     except KeyError:
         raise HttpResponseBadRequest("Missing attribute from data: {}".format(data))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -363,11 +363,15 @@ def get_tree_data(request):
         channel = Channel.objects.get(pk=channel_id)
         tree_name = "{}_tree".format(serializer.validated_data['tree'])
         tree_root = getattr(channel, tree_name, None)
+        if tree_root is None:
+            raise ValueError("Invalid tree name")
         tree_data = tree_root.get_tree_data()
         children_data = tree_data.get('children', [])
         return Response({"success": True, 'tree': children_data})
     except (Channel.DoesNotExist, PermissionDenied):
         return HttpResponseNotFound("No channel matching: {}".format(channel_id))
+    except ValueError:
+        return HttpResponseNotFound("No tree name matching: {}".format(tree_name))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -426,7 +426,8 @@ def get_channel_status_bulk(request):
             "success": True,
             'statuses': statuses,
         })
-
+    except (Channel.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No complete set of channels matching: {}".format(",".join(channel_ids)))
     except KeyError:
         raise ObjectDoesNotExist("Missing attribute from data: {}".format(data))
     except Exception as e:

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -37,7 +37,7 @@ from contentcuration.models import get_next_sort_order
 from contentcuration.models import License
 from contentcuration.models import SlideshowSlide
 from contentcuration.models import StagedFile
-from contentcuration.serializers import GetTreeDataSerizlizer
+from contentcuration.serializers import GetTreeDataSerializer
 from contentcuration.utils.files import get_file_diff
 from contentcuration.utils.garbage_collect import get_deleted_chefs_root
 from contentcuration.utils.nodes import map_files_to_assessment_item
@@ -354,7 +354,7 @@ def get_tree_data(request):
     WARNING: this endpoint timesouts for large channels.
     Returns { success: true, tree:[ nodes in channel_id ] }
     """
-    serializer = GetTreeDataSerizlizer(data=request.data)
+    serializer = GetTreeDataSerializer(data=request.data)
     if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     try:
@@ -366,6 +366,8 @@ def get_tree_data(request):
         tree_data = tree_root.get_tree_data()
         children_data = tree_data.get('children', [])
         return Response({"success": True, 'tree': children_data})
+    except (Channel.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No channel matching: {}".format(channel_id))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))
@@ -380,7 +382,7 @@ def get_node_tree_data(request):
     the `tree` tree associated with channel `data['channel_id']`.
     Returns { success: true, tree:[ children of node_id ] }
     """
-    serializer = GetTreeDataSerizlizer(data=request.data)
+    serializer = GetTreeDataSerializer(data=request.data)
     if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     try:

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -339,10 +339,10 @@ def check_user_is_editor(request):
             request.user.can_edit(channel_id)
             return Response({"success": True})
         except PermissionDenied:
-            return SuspiciousOperation("User is not authorized to edit this channel")
+            return HttpResponseForbidden("User is not authorized to edit this channel")
 
     except KeyError:
-        raise ObjectDoesNotExist("Missing attribute from data: {}".format(data))
+        raise HttpResponseBadRequest("Missing attribute from data: {}".format(data))
 
 
 @api_view(['POST'])

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -222,6 +222,8 @@ def api_commit_channel(request):
             "success": True,
             "new_channel": obj.pk,
         })
+    except (Channel.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No channel matching: {}".format(channel_id))
     except KeyError as e:
         return HttpResponseBadRequest("Required attribute missing: {}".format(e.message))
     except Exception as e:

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -320,6 +320,8 @@ def activate_channel_internal(request):
         channel = Channel.objects.get(pk=channel_id)
         activate_channel(channel, request.user)
         return Response({"success": True})
+    except (Channel.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No channel matching: {}".format(channel_id))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -298,6 +298,8 @@ def get_staged_diff_internal(request):
         channel_id = json.loads(request.body)['channel_id']
         request.user.can_edit(channel_id)
         return Response(get_staged_diff(channel_id))
+    except (Channel.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No channel matching: {}".format(channel_id))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -403,6 +403,8 @@ def get_node_tree_data(request):
             'staged': channel.staging_tree is not None
         }
         return Response(response_data)
+    except (Channel.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No channel matching: {}".format(channel_id))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -261,6 +261,8 @@ def api_add_nodes_to_tree(request):
                 "success": True,
                 "root_ids": convert_data_to_nodes(request.user, content_data, parent_id)
             })
+    except (ContentNode.DoesNotExist, PermissionDenied):
+        return HttpResponseNotFound("No content matching: {}".format(parent_id))
     except KeyError as e:
         return HttpResponseBadRequest("Required attribute missing: {}".format(e.message))
     except Exception as e:

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -8,7 +8,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import SuspiciousOperation
 from django.core.management import call_command
 from django.db import transaction
-from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseNotFound
@@ -63,14 +62,14 @@ def handle_server_error(request):
 def authenticate_user_internal(request):
     """ Verify user is valid """
     logging.debug("Logging in user")
-    return HttpResponse(json.dumps({
+    return Response({
         'success': True,
         'user_id': request.user.id,
         'username': unicode(request.user),
         'first_name': request.user.first_name,
         'last_name': request.user.last_name,
         'is_admin': request.user.is_admin,
-    }))
+    })
 
 
 @api_view(['POST'])
@@ -116,7 +115,7 @@ def file_diff(request):
         # for f in list(set(data) - set(in_db_list)):
         to_return = get_file_diff(data)
 
-        return HttpResponse(json.dumps(to_return))
+        return Response(to_return)
     except Exception as e:
         return HttpResponseServerError(content=str(e), reason=str(e))
 
@@ -141,9 +140,9 @@ def api_file_upload(request):
             uploaded_by=request.user
         )
 
-        return HttpResponse(json.dumps({
+        return Response({
             "success": True,
-        }))
+        })
     except KeyError:
         return HttpResponseBadRequest("Invalid file upload request")
     except Exception as e:
@@ -162,11 +161,11 @@ def api_create_channel_endpoint(request):
 
         obj = create_channel(channel_data, request.user)
 
-        return HttpResponse(json.dumps({
+        return Response({
             "success": True,
             "root": obj.chef_tree.pk,
             "channel_id": obj.pk,
-        }))
+        })
     except KeyError as e:
         return HttpResponseBadRequest("Required attribute missing: {}".format(e.message))
     except Exception as e:
@@ -185,6 +184,8 @@ def api_commit_channel(request):
     data = json.loads(request.body)
     try:
         channel_id = data['channel_id']
+
+        request.user.can_edit(channel_id)
 
         obj = Channel.objects.get(pk=channel_id)
 
@@ -215,13 +216,12 @@ def api_commit_channel(request):
             try:
                 activate_channel(obj, request.user)
             except PermissionDenied as e:
-                return HttpResponseForbidden(str(e))
+                return Response(str(e), status=e.status_code)
 
-        # Respond to ricecooker script to acknoledge commit is done
-        return HttpResponse(json.dumps({
+        return Response({
             "success": True,
             "new_channel": obj.pk,
-        }))
+        })
     except KeyError as e:
         return HttpResponseBadRequest("Required attribute missing: {}".format(e.message))
     except Exception as e:
@@ -252,11 +252,13 @@ def api_add_nodes_to_tree(request):
     try:
         content_data = data['content_data']
         parent_id = data['root_id']
+        node = ContentNode.objects.get(id=parent_id)
+        request.user.can_edit_node(node)
         with ContentNode.objects.disable_mptt_updates():
-            return HttpResponse(json.dumps({
+            return Response({
                 "success": True,
                 "root_ids": convert_data_to_nodes(request.user, content_data, parent_id)
-            }))
+            })
     except KeyError as e:
         return HttpResponseBadRequest("Required attribute missing: {}".format(e.message))
     except Exception as e:
@@ -277,7 +279,7 @@ def api_publish_channel(request):
         request.user.can_edit(channel_id)
         call_command("exportchannel", channel_id, user_id=request.user.pk)
 
-        return JsonResponse({
+        return Response({
             "success": True,
             "channel": channel_id
         })
@@ -293,7 +295,9 @@ def api_publish_channel(request):
 @permission_classes((IsAuthenticated,))
 def get_staged_diff_internal(request):
     try:
-        return HttpResponse(json.dumps(get_staged_diff(json.loads(request.body)['channel_id'])))
+        channel_id = json.loads(request.body)['channel_id']
+        request.user.can_edit(channel_id)
+        return Response(get_staged_diff(channel_id))
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))
@@ -305,9 +309,11 @@ def get_staged_diff_internal(request):
 def activate_channel_internal(request):
     try:
         data = json.loads(request.body)
-        channel = Channel.objects.get(pk=data['channel_id'])
+        channel_id = data['channel_id']
+        request.user.can_edit(channel_id)
+        channel = Channel.objects.get(pk=channel_id)
         activate_channel(channel, request.user)
-        return HttpResponse(json.dumps({"success": True}))
+        return Response({"success": True})
     except Exception as e:
         handle_server_error(request)
         return HttpResponseServerError(content=str(e), reason=str(e))
@@ -320,10 +326,11 @@ def check_user_is_editor(request):
     """ Create the channel node """
     data = json.loads(request.body)
     try:
-        obj = Channel.objects.get(pk=data['channel_id'])
-        if obj.editors.filter(pk=request.user.pk).exists():
-            return HttpResponse(json.dumps({"success": True}))
-        else:
+        channel_id = data['channel_id']
+        try:
+            request.user.can_edit(channel_id)
+            return Response({"success": True})
+        except PermissionDenied:
             return SuspiciousOperation("User is not authorized to edit this channel")
 
     except KeyError:
@@ -343,7 +350,9 @@ def get_tree_data(request):
     if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     try:
-        channel = Channel.objects.get(pk=serializer.validated_data['channel_id'])
+        channel_id = serializer.validated_data['channel_id']
+        request.user.can_edit(channel_id)
+        channel = Channel.objects.get(pk=channel_id)
         tree_name = "{}_tree".format(serializer.validated_data['tree'])
         tree_root = getattr(channel, tree_name, None)
         tree_data = tree_root.get_tree_data()
@@ -367,7 +376,9 @@ def get_node_tree_data(request):
     if not serializer.is_valid():
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     try:
-        channel = Channel.objects.get(pk=serializer.validated_data['channel_id'])
+        channel_id = serializer.validated_data['channel_id']
+        request.user.can_edit(channel_id)
+        channel = Channel.objects.get(pk=channel_id)
         tree_name = "{}_tree".format(serializer.validated_data['tree'])
         tree_root = getattr(channel, tree_name, None)
         if 'node_id' in serializer.validated_data:
@@ -394,12 +405,15 @@ def get_channel_status_bulk(request):
     """ Create the channel node """
     data = json.loads(request.body)
     try:
+        channel_ids = data['channel_ids']
+        for cid in channel_ids:
+            request.user.can_edit(cid)
         statuses = {cid: get_status(cid) for cid in data['channel_ids']}
 
-        return HttpResponse(json.dumps({
+        return Response({
             "success": True,
             'statuses': statuses,
-        }))
+        })
 
     except KeyError:
         raise ObjectDoesNotExist("Missing attribute from data: {}".format(data))


### PR DESCRIPTION
## Description

* Adds permissions checks to every endpoint in nodes.py and internal.py that did not previously have them, or did not check permissions for every entity it was accessing.
* Uses `api_view` decorator consistently to enforce allowed methods.
* Uses DRF Response constructor consistently to avoid manually invoking `json.dumps`
* Removes all instances where JSON is rendered and then inserted into another object that is then rendered to JSON again.
* Cleans up frontend logic that did double `JSON.parse` to handle this, so that JSON.parse is only required once now.

#### Issue Addressed (if applicable)

Fixes #1454 
Fixes #1412 
Fixes #1414 
Fixes #1416 
Fixes #1418

## Comments

I erred on the side of checking for editor permissions on the `internal.py` endpoints, with the assumption that only channel editors should generally be using those. Please note in review if this will be a problem.