### PR TITLE
Fix for legacy local files delete -- issue #1455

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -695,9 +695,9 @@ class Channel(models.Model):
             # Delete db if channel has been deleted and mark as unpublished
             if not original_channel.deleted and self.deleted:
                 self.pending_editors.all().delete()
-                channel_db_url = os.path.join(settings.DB_ROOT, self.id) + ".sqlite3"
-                if os.path.isfile(channel_db_url):
-                    os.unlink(channel_db_url)
+                export_db_storage_path = os.path.join(settings.DB_ROOT, "{channel_id}.sqlite3".format(channel_id=self.id))
+                if default_storage.exists(export_db_storage_path):
+                    default_storage.delete(export_db_storage_path)
                     self.main_tree.published = False
             self.main_tree.save()
 
@@ -1431,9 +1431,9 @@ def auto_delete_file_on_delete(sender, instance, **kwargs):
 def delete_empty_file_reference(checksum, extension):
     filename = checksum + '.' + extension
     if not File.objects.filter(checksum=checksum).exists() and not Channel.objects.filter(thumbnail=filename).exists():
-        file_on_disk_path = generate_file_on_disk_name(checksum, filename)
-        if os.path.isfile(file_on_disk_path):
-            os.remove(file_on_disk_path)
+        storage_path = generate_object_storage_name(checksum, filename)
+        if default_storage.exists(storage_path):
+            default_storage.delete(storage_path)
 
 
 class PrerequisiteContentRelationship(models.Model):

--- a/contentcuration/contentcuration/tests/test_files.py
+++ b/contentcuration/contentcuration/tests/test_files.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 from base import BaseAPITestCase
+from base import StudioTestCase
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse_lazy
@@ -15,9 +16,11 @@ from .testdata import fileobj_video
 from .testdata import generated_base64encoding
 from .testdata import node
 from .testdata import srt_subtitle
+from contentcuration.api import write_raw_content_to_storage
 from contentcuration.models import AssessmentItem
 from contentcuration.models import ContentNode
 from contentcuration.models import DEFAULT_CONTENT_DEFAULTS
+from contentcuration.models import delete_empty_file_reference
 from contentcuration.models import File
 from contentcuration.models import generate_object_storage_name
 from contentcuration.serializers import FileSerializer
@@ -30,6 +33,7 @@ from contentcuration.views.files import generate_thumbnail
 from contentcuration.views.files import image_upload
 from contentcuration.views.files import multilanguage_file_upload
 from contentcuration.views.files import thumbnail_upload
+
 
 pytestmark = pytest.mark.django_db
 
@@ -237,3 +241,14 @@ class FileSubtitleTestCase(BaseAPITestCase):
 
         file_response = multilanguage_file_upload(request)
         self.assertEqual(file_response.status_code, 200)
+
+
+class NodeFileDeletionTestCase(StudioTestCase):
+
+    def test_delete_empty_file_reference(self):
+        checksum, _, storage_path = write_raw_content_to_storage('some fake PDF data', ext='.pdf')
+        assert default_storage.exists(storage_path), 'file should be saved'
+        delete_empty_file_reference(checksum, 'pdf')
+        assert not default_storage.exists(storage_path), 'file should be deleted'
+
+


### PR DESCRIPTION
## Description

Fixes for two bug in deletion code that assumes files are in the local filesystem, but actually in a bucket.


#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1455

