### PR TITLE
Fix prober url and add clean-ups to Dockerfile

### DIFF
--- a/deploy/probers/base.py
+++ b/deploy/probers/base.py
@@ -6,7 +6,7 @@ import requests
 USERNAME = os.getenv("PROBER_STUDIO_USERNAME") or "a@a.com"
 PASSWORD = os.getenv("PROBER_STUDIO_PASSWORD") or "a"
 PRODUCTION_MODE_ON = os.getenv("PROBER_STUDIO_PRODUCTION_MODE_ON") or False
-STUDIO_BASE_URL = os.getenv("PROBER_STUDIO_BASE_URL") or "https://127.0.0.1:8080/{path}"
+STUDIO_BASE_URL = os.getenv("PROBER_STUDIO_BASE_URL") or "http://127.0.0.1:8080/{path}"
 
 
 class BaseProbe(object):

--- a/deploy/probers/login_page_probe.py
+++ b/deploy/probers/login_page_probe.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python
-import os
-import requests
-import datetime
-
 from base import BaseProbe
 
-STUDIO_BASE_URL = os.getenv("STUDIO_BASE_URL") or "https://studio.learningequality.org/{path}"
 
 class LoginProbe(BaseProbe):
 
     metric = "login_latency_msec"
 
     def do_probe(self):
-        r = self._login()
+        self._login()
 
 
 if __name__ == "__main__":

--- a/deploy/probers/postmark_api_probe.py
+++ b/deploy/probers/postmark_api_probe.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
-import os
 import requests
-import datetime
-
 from base import BaseProbe
 
 POSTMARK_SERVICE_STATUS_URL = "https://status.postmarkapp.com/api/1.0/services"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,9 @@ services:
   cloudprober:
     <<: *studio-worker
     working_dir: /src/deploy
-    command: /bin/cloudprober --config_file ./cloudprober.cfg
+    entrypoint: ""
+    # sleep 30 seconds allowing some time for the studio app to start up
+    command: '/bin/bash -c "sleep 30 && /bin/cloudprober --config_file ./cloudprober.cfg"'
     # wait until the main app and celery worker have started
     depends_on:
       - studio-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-studio-environment:
     CELERY_BROKER_ENDPOINT: redis
     CELERY_RESULT_BACKEND_ENDPOINT: redis
     CELERY_REDIS_PASSWORD: ""
+    PROBER_STUDIO_BASE_URL: http://studio-app:8080/{path}
 
 x-studio-worker:
   &studio-worker
@@ -27,6 +28,8 @@ x-studio-worker:
     volumes:
       - .:/src
     environment: *studio-environment
+    networks:
+      - studio-network
 
 services:
   studio-app:
@@ -35,6 +38,9 @@ services:
     command: yarn run devserver
     ports:
       - "8080:8080"
+    links:
+      - minio
+      - postgres
 
   celery-worker:
     <<: *studio-worker
@@ -48,8 +54,8 @@ services:
       MINIO_SECRET_KEY: development
     volumes:
       - minio_data:/data
-    ports:
-      - "9000:9000"
+    networks:
+      - studio-network
 
   postgres:
     image: postgres:9.6
@@ -60,9 +66,13 @@ services:
       POSTGRES_DB: kolibri-studio
     volumes:
       - pgdata:/var/lib/postgresql/data/pgdata
+    networks:
+      - studio-network
 
   redis:
     image: redis:4.0.9
+    networks:
+      - studio-network
 
   cloudprober:
     <<: *studio-worker
@@ -72,8 +82,13 @@ services:
     depends_on:
       - studio-app
       - celery-worker
+    links:
+      - studio-app
 
 
 volumes:
   minio_data:
   pgdata:
+
+networks:
+  studio-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ x-studio-worker:
     volumes:
       - .:/src
     environment: *studio-environment
-    networks:
-      - studio-network
 
 services:
   studio-app:
@@ -38,9 +36,6 @@ services:
     command: yarn run devserver
     ports:
       - "8080:8080"
-    links:
-      - minio
-      - postgres
 
   celery-worker:
     <<: *studio-worker
@@ -54,8 +49,6 @@ services:
       MINIO_SECRET_KEY: development
     volumes:
       - minio_data:/data
-    networks:
-      - studio-network
 
   postgres:
     image: postgres:9.6
@@ -66,13 +59,9 @@ services:
       POSTGRES_DB: kolibri-studio
     volumes:
       - pgdata:/var/lib/postgresql/data/pgdata
-    networks:
-      - studio-network
 
   redis:
     image: redis:4.0.9
-    networks:
-      - studio-network
 
   cloudprober:
     <<: *studio-worker
@@ -82,13 +71,8 @@ services:
     depends_on:
       - studio-app
       - celery-worker
-    links:
-      - studio-app
 
 
 volumes:
   minio_data:
   pgdata:
-
-networks:
-  studio-network:

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -23,7 +23,6 @@ RUN npm install -g yarn
 COPY ./package.json .
 COPY ./yarn.lock .
 RUN yarn install
-ENV PATH="/node_modules/.bin:$PATH"
 
 COPY Pipfile .
 COPY Pipfile.lock .

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -8,15 +8,18 @@ WORKDIR /src
 
 # System packages ##############################################################
 
-RUN apt-get update --fix-missing && apt-get -y install \
-    curl fish man \
-    python python-dev python-pip \
-    gcc libpq-dev ffmpeg imagemagick unzip \
-    ghostscript python-tk make git gettext openjdk-9-jre-headless libjpeg-dev \
-    wkhtmltopdf fonts-freefont-ttf xfonts-75dpi poppler-utils
+RUN apt-get update --fix-missing && \
+    apt-get -y install \
+        curl fish man \
+        python python-dev python-pip \
+        gcc libpq-dev ffmpeg imagemagick unzip \
+        ghostscript python-tk make git gettext openjdk-9-jre-headless libjpeg-dev \
+        wkhtmltopdf fonts-freefont-ttf xfonts-75dpi poppler-utils
 
 # Download and install wkhtmltox
-RUN curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb && dpkg -i wkhtmltox.deb
+RUN curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb && \
+    dpkg -i wkhtmltox.deb && \
+    rm wkhtmltox.deb
 
 # Download then install node
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
@@ -25,27 +28,31 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
 
 
 # Node packages ################################################################
-RUN npm install -g yarn
+RUN npm install -g yarn && npm cache clean --force
 COPY ./package.json ./yarn.lock   /src/
-RUN  yarn install --network-timeout 1000000 --pure-lockfile
+RUN  yarn install --network-timeout 1000000 --pure-lockfile && yarn cache clean
 ENV PATH="/src/node_modules/.bin:$PATH"
 ################################################################################
 
 
 # Python packages ##############################################################
 COPY Pipfile Pipfile.lock   /src/
-RUN pip install --upgrade pip
-RUN pip install -U pipenv
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir -U pipenv
 # install packages from Pipfile.lock into system
-RUN pipenv install --dev --system --ignore-pipfile
+RUN pipenv install --clear --dev --system --ignore-pipfile
 ################################################################################
 
 
 # Cloudprober binary ###########################################################
 RUN curl -L -o /cloudprober.zip https://github.com/google/cloudprober/releases/download/v0.10.2/cloudprober-v0.10.2-linux-x86_64.zip
-RUN unzip -p /cloudprober.zip > /bin/cloudprober
+RUN unzip -p /cloudprober.zip > /bin/cloudprober && rm /cloudprober.zip
 RUN chmod +x /bin/cloudprober
 ################################################################################
 
+
+# Final cleanup ################################################################
+RUN apt-get -y autoremove
+################################################################################
 
 CMD ["yarn", "run", "devserver"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -31,7 +31,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
 RUN npm install -g yarn && npm cache clean --force
 COPY ./package.json ./yarn.lock   /src/
 RUN  yarn install --network-timeout 1000000 --pure-lockfile && yarn cache clean
-ENV PATH="/src/node_modules/.bin:$PATH"
 ################################################################################
 
 

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -53,6 +53,8 @@ def check_minio_ready(minio_checks=CONNECT_TRIES):
     """
     while True:
         url = os.getenv("AWS_S3_ENDPOINT_URL") or "http://localhost:9000"
+
+        # Catch connection errors, as they will be thrown if minio is not ready
         try:
             robj = requests.get(url)
             if robj.status_code == 403:  # what we expect when we have no keys

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -8,7 +8,6 @@ It currently has the following responsibilities:
   - Runs the studio setup command
   - Run the CMD specified in the Dockerfile or passed in via docker compose file
 """
-
 import logging
 import os
 import subprocess
@@ -54,9 +53,12 @@ def check_minio_ready(minio_checks=CONNECT_TRIES):
     """
     while True:
         url = os.getenv("AWS_S3_ENDPOINT_URL") or "http://localhost:9000"
-        robj = requests.get(url)
-        if robj.status_code == 403:  # what we expect when we have no keys
-            return True
+        try:
+            robj = requests.get(url)
+            if robj.status_code == 403:  # what we expect when we have no keys
+                return True
+        except requests.exceptions.ConnectionError:
+            pass
 
         if not minio_checks:
             logging.error("Minio connection retries exceeded!")
@@ -83,7 +85,6 @@ def setup_studio():
 def run_cmd():
     cmd = sys.argv[1:]
     sys.exit(subprocess.call(cmd))
-
 
 
 if __name__ == "__main__":

--- a/k8s/images/app/Dockerfile
+++ b/k8s/images/app/Dockerfile
@@ -22,7 +22,6 @@ RUN npm install -g yarn
 COPY ./package.json .
 COPY ./yarn.lock .
 RUN yarn install
-ENV PATH="/node_modules/.bin:$PATH"
 
 COPY Pipfile .
 COPY Pipfile.lock .


### PR DESCRIPTION
## Description
- Fixed minio check throwing a connection error when waiting for minio container to start
- Added some clean-ups to the dev Dockerfile
- Fixed login prober constantly failing due to connection error
- Removed unused imports and formatting issues in probers
- Removed adding `node_modules/.bin` to beginning of path, [see discussion](https://learningequality.slack.com/archives/C0LK8QS9J/p1562955249484600) 

## Steps to Test
- [ ] (Re)Build docker containers `docker-compose build`
- [ ] Start studio `docker-compose up`
- [ ] Verify studio works and probers are not constantly failing after studio finally starts

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?
May be worthwhile porting some of the clean-ups in the dev Dockerfile to the prod Dockerfile but I default to leaving such things alone unless necessary.

## Checklist

- [X] Is the code clean and well-commented?
- [X] Delete most of the checklist

