### PR TITLE
Disable a couple infrequently used debug toolbar options…

### DIFF
--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -24,6 +24,12 @@ else:
     MIDDLEWARE_CLASSES += ('debug_panel.middleware.DebugPanelMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': custom_show_toolbar,
+
+        # When enabled, these settings significantly slow down page loads.
+        # It may be useful to temporarily enable them for specific debugging tasks,
+        # like template debugging or issues with SQL queries / caching.
+        # This URL has more details on each specific option:
+        # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html
         'RENDER_PANELS': False,
         'ENABLE_STACKTRACES': False,
         'SHOW_TEMPLATE_CONTEXT': False

--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -24,6 +24,9 @@ else:
     MIDDLEWARE_CLASSES += ('debug_panel.middleware.DebugPanelMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': custom_show_toolbar,
+        'RENDER_PANELS': False,
+        'ENABLE_STACKTRACES': False,
+        'SHOW_TEMPLATE_CONTEXT': False
     }
 
 DEBUG_TOOLBAR_PANELS = [


### PR DESCRIPTION
…  that were really slowing down page load.

## Description

After narrowing down the really slow time-to-render to Django Debug Toolbar, I checked their docs and they have a couple tips on how to speed up rendering in that case: 

https://django-debug-toolbar.readthedocs.io/en/latest/tips.html#solutions

This PR implements those solutions, and for me this results in a time-to-render speed increase of 3-4X, down to ~2s from 6-8s. I think it makes sense to have these features "off by default" due to the significant speed hit they incur, and then just temporarily enable them when we specifically need them to debug an issue.

## Steps to Test

- [ ] Load any page, but particularly the channel edit page, and see if you notice a speed difference with this PR.
