### PR TITLE
Added content nodes to global state

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/__tests__/ContentNodesState.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/__tests__/ContentNodesState.spec.js
@@ -1,0 +1,76 @@
+import _ from 'underscore';
+
+let State = require('../state');
+
+const exampleNodes = {
+  'node-1': {
+    title: 'Node 1',
+  },
+  'node-2': {
+    title: 'Node 2',
+  },
+};
+
+describe('ContentNodeState', () => {
+  beforeEach(() => {
+    State.Store.commit('SET_NODES', exampleNodes);
+  });
+  describe('getters', () => {
+    it('should return an array of nodes for contentNodeList', () => {
+      expect(_.isArray(State.Store.getters.contentNodeList)).toBe(true);
+      _.each(State.Store.getters.contentNodeList, node => {
+        let match = State.Store.state.topicTree.contentNodes[node.id];
+        expect(match).toBeTruthy();
+        expect(match.title === node.title).toBe(true);
+      });
+    });
+  });
+  describe('mutations', () => {
+    it('should set contentNodes on SET_NODES', () => {
+      _.each(_.pairs(State.Store.state.topicTree.contentNodes), pair => {
+        expect(exampleNodes[pair[0]]).toBeTruthy();
+        expect(_.isEqual(exampleNodes[pair[0]], pair[1])).toBe(true);
+      });
+    });
+    it('should remove contentNodeIDs from contentNodes on REMOVE_NODES', () => {
+      State.Store.commit('REMOVE_NODES', ['node-1']);
+      expect(State.Store.state.topicTree.contentNodes['node-1']).toBeFalsy();
+      expect(State.Store.state.topicTree.contentNodes['node-2']).toBeTruthy();
+    });
+  });
+  describe('actions', () => {
+    describe('basic loading', () => {
+      it('should load nodes based on contentNodeIDs on loadNodes', () => {
+        State.Store.dispatch('loadNodes', ['node-3']);
+        // TODO: mock ajax once we remove backbone, get_nodes_by_ids should be called
+        // and node with id `node-3` should be added
+      });
+      it('should reload nodes based on contentNodeIDs on reloadNodes', () => {
+        State.Store.dispatch('reloadNodes', ['node-1']);
+        // TODO: mock ajax once we remove backbone, get_nodes_by_ids should be called
+        // and node with id `node-1` should be updated
+      });
+    });
+
+    describe('simplified loading', () => {
+      it('should load nodes based on contentNodeIDs on loadNodesSimplified', () => {
+        State.Store.dispatch('loadNodesSimplified', ['node-3']);
+        // TODO: mock ajax once we remove backbone, get_nodes_by_ids_simplified should be called
+        // and node with id `node-3` should be added
+      });
+      it('should reload nodes based on contentNodeIDs on reloadNodesSimplified', () => {
+        State.Store.dispatch('reloadNodesSimplified', ['node-1']);
+        // TODO: mock ajax once we remove backbone, get_nodes_by_ids_simplified should be called
+        // and node with id `node-1` should be updated
+      });
+    });
+
+    describe('complete loading', () => {
+      it('should load nodes based on contentNodeIDs on loadNodesComplete', () => {
+        State.Store.dispatch('loadNodesComplete', ['node-1', 'node-3']);
+        // TODO: mock ajax once we remove backbone, get_nodes_by_ids_complete should be called
+        // and node with ids `node-1` and `node-3` should be added with file data
+      });
+    });
+  });
+});

--- a/contentcuration/contentcuration/static/js/edit_channel/__tests__/ContentNodesState.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/__tests__/ContentNodesState.spec.js
@@ -5,9 +5,11 @@ let State = require('../state');
 const exampleNodes = {
   'node-1': {
     title: 'Node 1',
+    id: 'node-1',
   },
   'node-2': {
     title: 'Node 2',
+    id: 'node-2',
   },
 };
 

--- a/contentcuration/contentcuration/static/js/edit_channel/state.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/state.js
@@ -3,6 +3,7 @@ let Vue = require('vue');
 const Models = require('./models');
 const Constants = require('./constants/index');
 const channelModule = require('./vuexModules/channel');
+const contentNodesModule = require('./vuexModules/contentNodes');
 const primaryModalModule = require('./vuexModules/primaryModal');
 
 if (Vue.default) {
@@ -16,6 +17,7 @@ Vue.use(Vuex);
 const Store = new Vuex.Store({
   modules: {
     channel: channelModule,
+    topicTree: contentNodesModule,
     dialog: primaryModalModule,
   },
 });

--- a/contentcuration/contentcuration/static/js/edit_channel/vuexModules/contentNodes.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/vuexModules/contentNodes.js
@@ -1,0 +1,99 @@
+import _ from 'underscore';
+
+function fetchNodes(state, contentNodeIDs, url, loadAll) {
+  return new Promise((resolve, reject) => {
+    let promises = _.chain(contentNodeIDs)
+      .filter(nodeID => loadAll || !state.contentNodes[nodeID])
+      .chunk(50) // Chunk requests to avoid "Request Line is too large"
+      .map(filteredIDs => {
+        return new Promise((fetchResolve, fetchReject) => {
+          // No need to make a call to the server when list is empty
+          if (filteredIDs.length === 0) fetchResolve([]);
+          $.ajax({
+            method: 'GET',
+            url: url(filteredIDs.join(',')),
+            error: fetchReject,
+            success: fetchResolve,
+          });
+        });
+      })
+      .value();
+
+    Promise.all(promises)
+      .then(values => {
+        let nodes = {};
+        _.each(_.flatten(values), node => {
+          nodes[node.id] = node;
+        });
+        resolve(nodes);
+      })
+      .catch(reject);
+  });
+}
+
+const contentNodesModule = {
+  state: {
+    contentNodes: {},
+  },
+  getters: {
+    contentNodeList(state) {
+      return _.map(_.pairs(state.contentNodes), pair => {
+        return {
+          id: pair[0],
+          ...pair[1],
+        };
+      });
+    },
+  },
+  mutations: {
+    SET_NODES(state, contentNodes) {
+      /*
+        Set nodes on global state
+        contentNodes = {id: <object>}
+      */
+      state.contentNodes = {
+        ...state.contentNodes,
+        ...contentNodes,
+      };
+    },
+    REMOVE_NODES(state, contentNodeIDs) {
+      _.each(contentNodeIDs, id => {
+        delete state.contentNodes[id];
+      });
+    },
+  },
+  actions: {
+    loadNodes(context, contentNodeIDs) {
+      // Load nodes that aren't already in the state
+      fetchNodes(context.state, contentNodeIDs, window.Urls.get_nodes_by_ids).then(nodes =>
+        context.commit('SET_NODES', nodes)
+      );
+    },
+    reloadNodes(context, contentNodeIDs) {
+      // Reload nodes
+      fetchNodes(context.state, contentNodeIDs, window.Urls.get_nodes_by_ids, true).then(nodes =>
+        context.commit('SET_NODES', nodes)
+      );
+    },
+    loadNodesSimplified(context, contentNodeIDs) {
+      // Load simplified data for nodes that aren't already in the state
+      fetchNodes(context.state, contentNodeIDs, window.Urls.get_nodes_by_ids_simplified).then(
+        nodes => context.commit('SET_NODES', nodes)
+      );
+    },
+    reloadNodesSimplified(context, contentNodeIDs) {
+      // Reload simplified nodes
+      fetchNodes(context.state, contentNodeIDs, window.Urls.get_nodes_by_ids_simplified, true).then(
+        nodes => context.commit('SET_NODES', nodes)
+      );
+    },
+    loadNodesComplete(context, contentNodeIDs) {
+      // Load nodes along with files, assessment_items, etc.
+      fetchNodes(context.state, contentNodeIDs, window.Urls.get_nodes_by_ids_complete, true).then(
+        nodes => context.commit('SET_NODES', nodes)
+      );
+    },
+  },
+};
+
+module.exports = contentNodesModule;

--- a/contentcuration/contentcuration/static/js/edit_channel/vuexModules/contentNodes.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/vuexModules/contentNodes.js
@@ -37,12 +37,7 @@ const contentNodesModule = {
   },
   getters: {
     contentNodeList(state) {
-      return _.map(_.pairs(state.contentNodes), pair => {
-        return {
-          id: pair[0],
-          ...pair[1],
-        };
-      });
+      return _.values(state.contentNodes);
     },
   },
   mutations: {


### PR DESCRIPTION
## Description

Added content nodes to global state to be used on channel edit page

## Steps to Test

- [ ] Run `yarn run test-jest`

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

Will need to update tests with ajax mocks, but can't do now as it messes with backbone methods

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
