### PR TITLE
Move channel import functionality to module

### DIFF
--- a/contentcuration/contentcuration/management/commands/restore_channel.py
+++ b/contentcuration/contentcuration/management/commands/restore_channel.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from contentcuration.utils.import_tools import import_channel
+
+logging.basicConfig()
+logger = logging.getLogger('command')
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        # ID of channel to read data from
+        parser.add_argument('source_id', type=str)
+
+        # ID of channel to write data to (can be same as source channel)
+        parser.add_argument('--target', help='restore channel db to TARGET CHANNEL ID')
+        parser.add_argument('--download-url', help='where to download db from')
+        parser.add_argument('--editor', help='add user as editor to channel')
+
+    def handle(self, *args, **options):
+        # Set up variables for restoration process
+        logger.info("\n\n********** STARTING CHANNEL RESTORATION **********")
+        source_id = options['source_id']
+        target_id = options.get('target') or source_id
+        download_url = options.get('download_url')
+        editor = options.get('editor')
+
+        import_channel(source_id, target_id, download_url, editor, logger=logger)

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -216,6 +216,11 @@ LOGGING = {
         }
     },
     'loggers': {
+        'command': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if globals().get('DEBUG') else 'INFO',
+            'propagate': True,
+        },
         'django': {
             'handlers': ['file', 'console'],
             'level': 'DEBUG' if globals().get('DEBUG') else 'INFO',

--- a/contentcuration/contentcuration/tests/test_restore_channel.py
+++ b/contentcuration/contentcuration/tests/test_restore_channel.py
@@ -1,17 +1,18 @@
 import datetime
 import uuid
-from base import StudioTestCase
-from mock import patch
-from mock import MagicMock
 
-from contentcuration.management.commands.restore_channel import create_channel
+from base import StudioTestCase
+from mock import MagicMock
+from mock import patch
+
+from contentcuration.utils.import_tools import create_channel
 
 
 thumbnail_path = "/content/thumbnail.png"
 
 
 class ChannelRestoreUtilityFunctionTestCase(StudioTestCase):
-    @patch("contentcuration.management.commands.restore_channel.write_to_thumbnail_file", return_value=thumbnail_path)
+    @patch("contentcuration.utils.import_tools.write_to_thumbnail_file", return_value=thumbnail_path)
     def setUp(self, thumb_mock):
         self.id = uuid.uuid4().hex
         self.name = "test name"


### PR DESCRIPTION
## Description

This PR moves channel import functionality to a module in preparation for unit tests and for use in the UI (for Studio Desktop!).

## Steps to Test

- [ ] Run the restore_channel command and make sure it still functions as expected

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
