### PR TITLE
Give each worker 2 threads to double the responses it can handle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 altprodserver: migrate collectstatic ensurecrowdinclient downloadmessages compilemessages
-	cd contentcuration/ && gunicorn contentcuration.wsgi:application --timeout=4000 --error-logfile=/var/log/gunicorn-error.log --workers=3 --bind=0.0.0.0:8081 --pid=/tmp/contentcuration.pid --log-level=debug || sleep infinity
+	cd contentcuration/ && gunicorn contentcuration.wsgi:application --timeout=4000 --error-logfile=/var/log/gunicorn-error.log --workers=3 --threads=2 --bind=0.0.0.0:8081 --pid=/tmp/contentcuration.pid --log-level=debug || sleep infinity
 
 contentnodegc:
 	cd contentcuration/ && python manage.py garbage_collect


### PR DESCRIPTION
## Description
 
Simple tweak to try and improve Studio server response times.

#### Issue Addressed (if applicable)

Addresses #1479

## Steps to Test

- [ ] Run the locust tests once this is merged

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
