### PR TITLE
Remove unused jsi18n reference and use static jsreverse in production.

### DIFF
--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -62,12 +62,14 @@
           window.ALL_MESSAGES = JSON.parse("{{ messages|escapejs}}");
         } catch (error) { /* Page does not require front-end translations */ }
       </script>
-      <!-- TODO work out why debug is not working here and use the static version -->
-      <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
+      {% if not debug %}
+        <script src={% static 'django_js_reverse/js/reverse.js' %}
+      {% else %}
+        <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
+      {% endif %}
+
 
       {% render_bundle 'common' 'js' %}
-
-      <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
         <!-- fullstory integration, only on develop until we add an opt-in option. -->
         {% if request.get_host == 'develop.studio.learningequality.org' %}

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -63,11 +63,10 @@
         } catch (error) { /* Page does not require front-end translations */ }
       </script>
       {% if not debug %}
-        <script src={% static 'django_js_reverse/js/reverse.js' %}
+        <script src={% static 'django_js_reverse/js/reverse.js' %}></script>
       {% else %}
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
       {% endif %}
-
 
       {% render_bundle 'common' 'js' %}
 

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -21,7 +21,6 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.core.urlresolvers import reverse_lazy
 from django.db.models import Q
-from django.views.i18n import javascript_catalog
 from rest_framework import permissions
 from rest_framework import routers
 from rest_framework import viewsets
@@ -394,7 +393,6 @@ js_info_dict = {
 }
 
 urlpatterns += [
-    url(r'^jsi18n/$', javascript_catalog, js_info_dict, name='javascript-catalog'),
     url(r'^i18n/', include('django.conf.urls.i18n')),
 ]
 

--- a/deploy/chaos/loadtest/locustfile.py
+++ b/deploy/chaos/loadtest/locustfile.py
@@ -38,10 +38,6 @@ class BaseTaskSet(TaskSet):
             }
         )
 
-    def i18n_requests(self):
-        self.client.get("/jsi18n/")
-        self.client.get("/jsreverse/")
-
 
 class ChannelListPage(BaseTaskSet):
     """
@@ -174,7 +170,6 @@ class LoginPage(BaseTaskSet):
         Visit the login page and the i18n endpoints without logging in.
         """
         self.client.get("/accounts/login/")
-        self.i18n_requests()
 
 
 class StudioDesktopBrowserUser(HttpLocust):


### PR DESCRIPTION
## Description

Stops the app server from loading an unused JS file for each page load, and offloads the jsreverse URL to nginx to be cached like other static files. 

## Steps to Test

- [ ] Load the login page and sign in, and ensure everything renders properly

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?