### PR TITLE
Read only ContentNode serializers

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -494,6 +494,14 @@ class ContentNodeFieldMixin(object):
             return generate_storage_url(str(thumbnail_file))
 
 
+class ReadOnlySimplifiedContentNodeSerializer(SimplifiedContentNodeSerializer):
+    class Meta:
+        model = ContentNode
+        fields = ('title', 'id', 'sort_order', 'kind', 'children', 'parent', 'metadata', 'content_id', 'prerequisite',
+                  'is_prerequisite_of', 'parent_title', 'ancestors', 'tree_id', 'language', 'role_visibility')
+        read_only_fields = ('title', 'id', 'sort_order', 'kind', 'children', 'parent', 'metadata', 'content_id', 'prerequisite',
+                  'is_prerequisite_of', 'parent_title', 'ancestors', 'tree_id', 'language', 'role_visibility')
+
 class RootNodeSerializer(SimplifiedContentNodeSerializer, ContentNodeFieldMixin):
     channel_name = serializers.SerializerMethodField('retrieve_channel_name')
 
@@ -605,6 +613,43 @@ class ContentNodeSerializer(SimplifiedContentNodeSerializer, ContentNodeFieldMix
                   'kind', 'parent', 'children', 'published', 'associated_presets', 'valid', 'metadata', 'original_source_node_id',
                   'tags', 'extra_fields', 'prerequisite', 'is_prerequisite_of', 'node_id', 'tree_id', 'publishing', 'freeze_authoring_data',
                   'role_visibility', 'provider', 'aggregator', 'thumbnail_src')
+
+
+class ReadOnlyContentNodeSerializer(ContentNodeSerializer, ContentNodeFieldMixin):
+    class Meta:
+        list_serializer_class = CustomListSerializer
+        model = ContentNode
+        fields = ('title', 'changed', 'id', 'description', 'sort_order', 'author', 'copyright_holder', 'license', 'language',
+                  'license_description', 'assessment_items', 'slideshow_slides', 'files', 'parent_title', 'ancestors', 'modified', 'original_channel',
+                  'kind', 'parent', 'children', 'published', 'associated_presets', 'valid', 'metadata', 'original_source_node_id',
+                  'tags', 'extra_fields', 'prerequisite', 'is_prerequisite_of', 'node_id', 'tree_id', 'publishing', 'freeze_authoring_data',
+                  'role_visibility', 'provider', 'aggregator', 'thumbnail_src')
+        read_only_fields = ('title', 'changed', 'id', 'description', 'sort_order', 'author', 'copyright_holder', 'license', 'language',
+                  'license_description', 'assessment_items', 'slideshow_slides', 'files', 'parent_title', 'ancestors', 'modified', 'original_channel',
+                  'kind', 'parent', 'children', 'published', 'associated_presets', 'valid', 'metadata', 'original_source_node_id',
+                  'tags', 'extra_fields', 'prerequisite', 'is_prerequisite_of', 'node_id', 'tree_id', 'publishing', 'freeze_authoring_data',
+                  'role_visibility', 'provider', 'aggregator', 'thumbnail_src')
+
+
+class ReadOnlyContentNodeFullSerializer(ContentNodeSerializer):
+    files = FileSerializer(many=True, read_only=True)
+    tags = TagSerializer(many=True)
+    assessment_items = AssessmentItemSerializer(many=True, read_only=True)
+    slideshow_slides = SlideshowSlideSerializer(many=True, read_only=True)
+
+    class Meta:
+        list_serializer_class = CustomListSerializer
+        model = ContentNode
+        fields = ('title', 'changed', 'id', 'description', 'sort_order', 'author', 'copyright_holder', 'license', 'language',
+                  'node_id', 'license_description', 'assessment_items', 'slideshow_slides', 'files', 'parent_title', 'content_id', 'modified',
+                  'kind', 'parent', 'children', 'published', 'associated_presets', 'valid', 'metadata', 'ancestors', 'tree_id',
+                  'tags', 'extra_fields', 'original_channel', 'prerequisite', 'is_prerequisite_of', 'thumbnail_encoding', 'thumbnail_src',
+                  'freeze_authoring_data', 'publishing', 'original_source_node_id', 'role_visibility', 'provider', 'aggregator')
+        read_only_fields = ('title', 'changed', 'id', 'description', 'sort_order', 'author', 'copyright_holder', 'license', 'language',
+                  'node_id', 'license_description', 'assessment_items', 'slideshow_slides', 'files', 'parent_title', 'content_id', 'modified',
+                  'kind', 'parent', 'children', 'published', 'associated_presets', 'valid', 'metadata', 'ancestors', 'tree_id',
+                  'tags', 'extra_fields', 'original_channel', 'prerequisite', 'is_prerequisite_of', 'thumbnail_encoding', 'thumbnail_src',
+                  'freeze_authoring_data', 'publishing', 'original_source_node_id', 'role_visibility', 'provider', 'aggregator')
 
 
 class ContentNodeEditSerializer(ContentNodeSerializer):

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -521,8 +521,7 @@ var ContentNodeCollection = BaseCollection.extend({
       $.ajax({
         method: 'GET',
         url: window.Urls.get_node_path(topic_id, tree_id, node_id),
-        success: function(result) {
-          var data = JSON.parse(result);
+        success: function(data) {
           var returnCollection = new ContentNodeCollection(data.path);
           self.add(returnCollection.toJSON());
 

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -36,6 +36,9 @@ from contentcuration.models import License
 from contentcuration.models import PrerequisiteContentRelationship
 from contentcuration.serializers import ContentNodeEditSerializer
 from contentcuration.serializers import ContentNodeSerializer
+from contentcuration.serializers import ReadOnlyContentNodeFullSerializer
+from contentcuration.serializers import ReadOnlyContentNodeSerializer
+from contentcuration.serializers import ReadOnlySimplifiedContentNodeSerializer
 from contentcuration.serializers import SimplifiedContentNodeSerializer
 from contentcuration.tasks import getnodedetails_task
 from contentcuration.utils.files import duplicate_file
@@ -93,8 +96,8 @@ def get_node_diff(request, channel_id):
                 changed.append(node)
 
     return Response({
-        "original": SimplifiedContentNodeSerializer(original, many=True).data,
-        "changed": SimplifiedContentNodeSerializer(changed, many=True).data,
+        "original": ReadOnlySimplifiedContentNodeSerializer(original, many=True).data,
+        "changed": ReadOnlySimplifiedContentNodeSerializer(changed, many=True).data,
     })
 
 
@@ -147,7 +150,7 @@ def get_prerequisites(request, get_postrequisites, ids):
     return Response({
         "prerequisite_mapping": prerequisite_mapping,
         "postrequisite_mapping": postrequisite_mapping,
-        "prerequisite_tree_nodes": SimplifiedContentNodeSerializer(prerequisite_tree_nodes, many=True).data,
+        "prerequisite_tree_nodes": ReadOnlySimplifiedContentNodeSerializer(prerequisite_tree_nodes, many=True).data,
     })
 
 
@@ -181,7 +184,7 @@ def get_nodes_by_ids(request, ids):
         request.user.can_view_nodes(nodes)
     except PermissionDenied:
         return HttpResponseNotFound("No nodes found for {}".format(ids))
-    serializer = ContentNodeSerializer(nodes, many=True)
+    serializer = ReadOnlyContentNodeSerializer(nodes, many=True)
     return Response(serializer.data)
 
 
@@ -204,8 +207,8 @@ def get_node_path(request, topic_id, tree_id, node_id):
             nodes = topic.get_ancestors(include_self=True, ascending=True)
 
         return Response({
-            'path': ContentNodeSerializer(nodes, many=True).data,
-            'node': node and ContentNodeEditSerializer(node).data,
+            'path': ReadOnlyContentNodeSerializer(nodes, many=True).data,
+            'node': node and ReadOnlyContentNodeFullSerializer(node).data,
             'parent_node_id': topic.kind_id != content_kinds.TOPIC and node.parent and node.parent.node_id
         })
     except ObjectDoesNotExist:
@@ -221,7 +224,7 @@ def get_nodes_by_ids_simplified(request, ids):
         request.user.can_view_nodes(nodes)
     except PermissionDenied:
         return HttpResponseNotFound("No nodes found for {}".format(ids))
-    serializer = SimplifiedContentNodeSerializer(nodes, many=True)
+    serializer = ReadOnlySimplifiedContentNodeSerializer(nodes, many=True)
     return Response(serializer.data)
 
 
@@ -234,7 +237,7 @@ def get_nodes_by_ids_complete(request, ids):
         request.user.can_view_nodes(nodes)
     except PermissionDenied:
         return HttpResponseNotFound("No nodes found for {}".format(ids))
-    serializer = ContentNodeEditSerializer(nodes, many=True)
+    serializer = ReadOnlyContentNodeFullSerializer(nodes, many=True)
     return Response(serializer.data)
 
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minio:test": "rm -rf ~/.minio_test && minio server ~/.minio_test/ || true",
     "minio": "MINIO_ACCESS_KEY=development MINIO_SECRET_KEY=development minio server ~/.minio_data/ || true",
     "runserver": "cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8080",
-    "gunicornserver": "cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.profile_settings gunicorn -b 0.0.0.0:8080 contentcuration.wsgi",
+    "gunicornserver": "cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.profile_settings gunicorn -b 0.0.0.0:8080 --workers=3 --threads=2 contentcuration.wsgi",
     "testserver": "cd contentcuration && python manage.py runserver --settings=contentcuration.test_settings 0.0.0.0:8081",
     "devserver": "npm-run-all --parallel build:dev runserver",
     "localprodserver": "npm-run-all build gunicornserver",


### PR DESCRIPTION
## Description

The `get_nodes_by_ids` family of calls all only accept GET requests, and so can safely be made read-only. Adding read-only versions of the serializers results in an overall 20-30% speedup in the locust tests, which means the actual API calls are likely sped up even more than that.

We already have tests to ensure that these calls only accept GET requests, and no serializer fields have been changed, so existing test coverage should suffice for this.

## Steps to Test

- [ ] Create and load a new channel
- [ ] Add some nodes and put some nodes on the clipboard.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
