### PR TITLE
Limit django prometheus to prod

### DIFF
--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -34,3 +34,20 @@ if key and release_commit:
         'release': release_commit,
         'environment': get_secret("BRANCH_ENVIRONMENT"),
     }
+
+# Activate django-prometheus
+INSTALLED_APPS = INSTALLED_APPS + (
+    "django_prometheus",
+)
+
+MIDDLEWARE_CLASSES = (
+    ("django_prometheus.middleware.PrometheusBeforeMiddleware",) +
+    MIDDLEWARE_CLASSES +
+    ("django_prometheus.middleware.PrometheusAfterMiddleware",)
+)
+
+CACHES["default"]["BACKEND"] = "django_prometheus.cache.backends.redis.RedisCache"
+if SITE_READ_ONLY:
+    CACHES['default']['BACKEND'] = "django_prometheus.cache.backends.locmem.LocMemCache"
+
+DATABASES["default"]["ENGINE"] = "django_prometheus.db.backends.postgresql"

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -85,7 +85,6 @@ INSTALLED_APPS = (
     'webpack_loader',
     'django_filters',
     'mathfilters',
-    'django_prometheus',
 )
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
@@ -98,7 +97,7 @@ CACHE_REDIS_DB = os.getenv("CACHE_REDIS_DB") or "1"
 
 CACHES = {
     'default': {
-        'BACKEND': 'django_prometheus.cache.backends.redis.RedisCache',
+        'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': '{url}{db}'.format(url=REDIS_URL, db=CACHE_REDIS_DB),
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
@@ -115,12 +114,11 @@ SITE_READ_ONLY = INCIDENT and INCIDENT['readonly']
 # If Studio is in readonly mode, it will throw a DatabaseWriteError
 # Use a local cache to bypass the readonly property
 if SITE_READ_ONLY:
-    CACHES['default']['BACKEND'] = 'django_prometheus.cache.backends.locmem.LocMemCache'
+    CACHES['default']['BACKEND'] = 'django.core.cache.backends.locmem.LocMemCache'
     CACHES['default']['LOCATION'] = 'readonly_cache'
 
 
 MIDDLEWARE_CLASSES = (
-    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     # 'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -135,7 +133,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
     'contentcuration.middleware.db_readonly.DatabaseReadOnlyMiddleware',
     # 'django.middleware.cache.FetchFromCacheMiddleware',
-    'django_prometheus.middleware.PrometheusAfterMiddleware',
 )
 
 if os.getenv("GCLOUD_ERROR_REPORTING"):
@@ -194,7 +191,7 @@ WSGI_APPLICATION = 'contentcuration.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django_prometheus.db.backends.postgresql',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': os.getenv("DATA_DB_NAME") or 'kolibri-studio',
         # For dev purposes only
         'USER': os.getenv('DATA_DB_USER') or 'learningequality',

--- a/contentcuration/contentcuration/tests/test_makemessages.py
+++ b/contentcuration/contentcuration/tests/test_makemessages.py
@@ -1,0 +1,28 @@
+import os
+import pathlib
+import subprocess
+
+from django.conf import settings
+from django.test import TestCase
+
+
+class MakeMessagesCommandRunTestCase(TestCase):
+    """
+    Sanity check to make sure makemessages runs to completion.
+    """
+
+    def test_command_succeeds_without_postgres(self):
+        """
+        Test that we can run makemessages when postgres is not activated.
+        """
+        repo_root = pathlib.Path(settings.BASE_DIR).parent
+        cmd = ["make", "makemessages"]
+        env = os.environ.copy()
+        # We fake postgres not being available, by setting the wrong IP address.
+        # hopefully postgres isn't running at 127.0.0.2!
+        env.update({"DATA_DB_HOST": "127.0.0.2"})
+        subprocess.check_output(
+            cmd,
+            env=env,
+            cwd=str(repo_root)
+        )

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -278,8 +278,13 @@ urlpatterns = [
     url(r'^api/set_channel_priority/$', views.set_channel_priority, name='set_channel_priority'),
     url(r'^api/download_channel_content_csv/(?P<channel_id>[^/]{32})$', views.download_channel_content_csv, name='download_channel_content_csv'),
     url(r'^api/probers/get_prober_channel', views.get_prober_channel, name='get_prober_channel'),
-    url('', include('django_prometheus.urls')),
 ]
+
+# if activated, turn on django prometheus urls
+if "django_prometheus" in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url('', include('django_prometheus.urls')),
+    ]
 
 
 # Add public api endpoints


### PR DESCRIPTION
The recent addition of django-prometheus is breaking the deployment by requiring postgres to run in management commands, even though it's unnecessary.

This PR moves django-prometheus to production_settings.py.


## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?