### PR TITLE
Hotfixes

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -158,7 +158,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         if self.is_admin:
             return True
         root = node.get_root()
-        if root == self.clipboard_tree:
+        if root == self.clipboard_tree or root.pk == settings.ORPHANAGE_ROOT_ID:
             return True
         channel_id = Channel.objects.filter(Q(main_tree=root)
                                             | Q(chef_tree=root)
@@ -175,9 +175,11 @@ class User(AbstractBaseUser, PermissionsMixin):
             return True
         root_nodes_all = ContentNode.objects.filter(parent=None, tree_id__in=nodes.values_list("tree_id", flat=True).distinct()).distinct()
         # If all the nodes belong to the clipboard, skip the channel check.
-        root_nodes = root_nodes_all.exclude(tree_id=self.clipboard_tree.tree_id)
+
+        root_nodes = root_nodes_all.exclude(tree_id=self.clipboard_tree.tree_id).exclude(pk=settings.ORPHANAGE_ROOT_ID)
         if root_nodes.count() == 0 and root_nodes_all.count() > 0:
             return True
+
         channels = Channel.objects.filter(Q(main_tree__in=root_nodes)
                                           | Q(chef_tree__in=root_nodes)
                                           | Q(trash_tree__in=root_nodes)
@@ -198,7 +200,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         if self.is_admin:
             return True
         root = node.get_root()
-        if root == self.clipboard_tree:
+        if root == self.clipboard_tree or root.pk == settings.ORPHANAGE_ROOT_ID:
             return True
 
         channel_id = Channel.objects.filter(Q(main_tree=root)
@@ -216,7 +218,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             return True
         root_nodes_all = ContentNode.objects.filter(parent=None, tree_id__in=nodes.values_list("tree_id", flat=True).distinct()).distinct()
         # If all the nodes belong to the clipboard, skip the channel check.
-        root_nodes = root_nodes_all.exclude(tree_id=self.clipboard_tree.tree_id)
+        root_nodes = root_nodes_all.exclude(tree_id=self.clipboard_tree.tree_id).exclude(pk=settings.ORPHANAGE_ROOT_ID)
         if root_nodes.count() == 0 and root_nodes_all.count() > 0:
             return True
         channels = Channel.objects.filter(Q(main_tree__in=root_nodes)

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -551,8 +551,10 @@ var ContentNodeCollection = BaseCollection.extend({
         method: 'POST',
         url: window.Urls.create_new_node(),
         data: JSON.stringify(data),
+        contentType: 'application/json',
+        dataType: 'json',
         success: function(data) {
-          var new_node = new ContentNodeModel(JSON.parse(data));
+          var new_node = new ContentNodeModel(data);
           self.add(new_node);
           resolve(new_node);
         },

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse_lazy
 
 from .testdata import create_studio_file
+from .testdata import node_json
 from .testdata import tree
 from contentcuration.models import Channel
 from contentcuration.models import ContentKind
@@ -14,6 +15,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import FormatPreset
 from contentcuration.models import generate_storage_url
 from contentcuration.models import Language
+from contentcuration.models import License
 from contentcuration.utils.files import create_thumbnail_from_base64
 from contentcuration.utils.nodes import duplicate_node_bulk
 from contentcuration.utils.nodes import move_nodes
@@ -280,6 +282,11 @@ class NodeOperationsTestCase(BaseTestCase):
 
 
 class NodeOperationsAPITestCase(BaseAPITestCase):
+
+    def test_create_new_node(self):
+        node = node_json({'kind': 'topic', 'license': License.objects.all()[0].license_name})
+        response = self.post(reverse_lazy('create_new_node'), data=node)
+        assert response.status_code == 200
 
     def test_delete_nodes(self):
         """

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -26,11 +26,9 @@ from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 from contentcuration.models import License
 from contentcuration.serializers import ContentNodeEditSerializer
-from contentcuration.serializers import ContentNodeSerializer
 from contentcuration.serializers import ReadOnlyContentNodeFullSerializer
 from contentcuration.serializers import ReadOnlyContentNodeSerializer
 from contentcuration.serializers import ReadOnlySimplifiedContentNodeSerializer
-from contentcuration.serializers import SimplifiedContentNodeSerializer
 from contentcuration.serializers import TaskSerializer
 from contentcuration.tasks import create_async_task
 from contentcuration.tasks import getnodedetails_task
@@ -97,7 +95,7 @@ def get_node_diff(request, channel_id):
 @permission_classes((IsAuthenticated,))
 @api_view(['POST'])
 def create_new_node(request):
-    data = json.loads(request.body)
+    data = request.data
     license = License.objects.filter(license_name=data.get('license_name')).first()  # Use filter/first in case preference hasn't been set
     license_id = license.pk if license else settings.DEFAULT_LICENSE
     new_node = ContentNode.objects.create(
@@ -290,7 +288,7 @@ def get_node_details_cached(node):
 @api_view(['POST'])
 def delete_nodes(request):
 
-    data = json.loads(request.body)
+    data = request.data
 
     try:
         nodes = data["nodes"]
@@ -455,7 +453,7 @@ def move_nodes(request):
 def sync_nodes(request):
     logging.debug("Entering the sync_nodes endpoint")
 
-    data = json.loads(request.body)
+    data = request.data
 
     try:
         nodes = data["nodes"]


### PR DESCRIPTION
## Description

Fix a couple uncaught issues introduced by recent PRs to develop. Namely, make sure that endpoints with the `@api_view` decorator send and expect proper JSON, and fix a permissions checking issue with the orphanage tree.

Note that the Django Rest Framework API tests appear to work with the native Python data, and so our unit tests didn't catch the issues with the frontend sending a JSON string as a multipart attachment as the tests properly serialize and deserialize the data as JSON internally.

## Steps to Test

- [ ] Create a new topic
- [ ] Delete nodes from trash

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
