### PR TITLE
Switch back to process pool workers for now as eventlet workers don't…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dummyusers:
 	cd contentcuration/ && python manage.py loaddata contentcuration/fixtures/admin_user_token.json
 
 prodceleryworkers:
-	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=200 --pool=eventlet
+	cd contentcuration/ && celery -A contentcuration worker -l info
 
 prodcelerydashboard:
 	# connect to the celery dashboard by visiting http://localhost:5555

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "devserver:hot": "npm-run-all --parallel build:dev:hot runserver",
     "devshell": "cd contentcuration && python manage.py shell --settings=contentcuration.dev_settings",
     "celery:dashboard": "cd contentcuration && celery -A contentcuration flower",
-    "celery": "(cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker -l info -c 200 --pool=eventlet) || true"
+    "celery": "(cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker -l info) || true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
… support task cancellation. Boo!

## Description

Switch back to our current approach of 8 concurrent worker processes until we can find a way to address the lack of task cancellation support when using eventlet pools.

We should have a follow up to discuss the best practice for making sure that we can fire up new workers if needed to scale operations.

## Steps to Test

- [ ] Start, and then cancel, an async task.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
