### PR TITLE
Make move nodes ops appear synchronous

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -657,6 +657,7 @@ var ContentNodeCollection = BaseCollection.extend({
         dataType: 'json',
         error: reject,
         success: function(data) {
+          data.noDialog = true;
           const payload = {
             task: data,
             resolveCallback: resolve,

--- a/contentcuration/contentcuration/static/js/edit_channel/sharedComponents/ProgressOverlay.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/sharedComponents/ProgressOverlay.vue
@@ -1,6 +1,6 @@
 <template>
   <VDialog
-    v-if="currentTask"
+    v-if="currentTask && !currentTask.noDialog"
     v-model="dialog"
     persistent
     light

--- a/contentcuration/contentcuration/static/js/edit_channel/vuexModules/asyncTask.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/vuexModules/asyncTask.js
@@ -83,6 +83,7 @@ const asyncTasksModule = {
     },
     updateTaskList(store) {
       let currentTask = store.getters.currentTask;
+      let currentTaskError = store.getters.currentTaskError;
       let url = '/api/task';
       // if we have a running task, only get status on it.
       if (currentTask && currentTask.id) {
@@ -138,12 +139,25 @@ const asyncTasksModule = {
                     callback();
                   }
                 }
+
+                // We add noDialog to the JSON data to override dialog handling. This
+                // property only exists on the task that was passed in, so make sure
+                // we check that by using currentTask rather than runningTask or task.
+                if (currentTask.noDialog) {
+                  store.dispatch('clearCurrentTask');
+                }
+              } else if (runningTask == task && currentTaskError) {
+                // If the task is still running and an error was set, that means it was
+                // an error during the polling process. This call means we are again
+                // polling successfully, so clear the error.
+                store.commit('SET_CURRENT_TASK_ERROR', null);
               }
             }
           }
 
           if (
             runningTask &&
+            currentTask.is_progress_tracking &&
             runningTask.metadata.progress &&
             runningTask.metadata.progress >= 0.0
           ) {

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -329,7 +329,7 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
 
     target_parent = ContentNode.objects.get(pk=target_parent_id)
     # last 20% is MPTT tree updates
-    total_percent = 80.0
+    total_percent = 100.0
     percent_per_node = math.ceil(total_percent / len(nodes))
     percent_done = 0.0
 
@@ -342,9 +342,6 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
             if task_object:
                 task_object.update_state(state='STARTED', meta={'progress': percent_done})
             all_ids.append(n['id'])
-
-        if task_object:
-            task_object.update_state(state='STARTED', meta={'progress': 80.0})
 
     return all_ids
 


### PR DESCRIPTION
## Description

Instead of showing the progress dialog, just show the 'saving, please wait' popup instead. The code already properly blocked interacting with the moved node while the op is in progress. Especially after Richard's recent PR speeding up move nodes, it is probably reasonable to assume that it will complete in a reasonably quick timeframe and have the UI designed accordingly.

Also fix an issue where a transient connectivity issue with the server appeared to be permanent on the progress dialog, even after the connection was restored, along with tweaking the task percentage to be more accurate.

## Steps to Test

- [ ] Move nodes to ensure dialog does not appear, copy / sync / publish to make sure dialog appears.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
