### PR TITLE
Limit Celery worker processes as we do with Gunicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dummyusers:
 	cd contentcuration/ && python manage.py loaddata contentcuration/fixtures/admin_user_token.json
 
 prodceleryworkers:
-	cd contentcuration/ && celery -A contentcuration worker -l info
+	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3
 
 prodcelerydashboard:
 	# connect to the celery dashboard by visiting http://localhost:5555


### PR DESCRIPTION

## Description

This ensures we consistently treat each Studio replica like a single-core machine, meaning we can scale up to 8 replicas per nodes. Hopefully I'm using the right terms consistently now! :p 

We may want to revisit this allocation after more doing some more load testing.

## Steps to Test

- [ ] Make sure async tasks still work

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
