### PR TITLE
Set studio's frontend and worker pods to a guaranteed allocation of 0.5 CPU and 2Gi of RAM

### DIFF
--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -45,7 +45,11 @@ spec:
         {{ include "studio.pvc.gdrive-creds" . | nindent 8 }}
         resources:
           requests:
-            cpu: 1000m
+            cpu: 0.5
+            memory: 2Gi
+          limits:
+            cpu: 0.5
+            memory: 2Gi
       - name: nginx-proxy
         image: {{ .Values.studioNginx.imageName }}
         env:
@@ -92,3 +96,10 @@ spec:
         volumeMounts:
         {{ include "studio.pvc.gcs-creds" . | nindent 10 }}
         env: {{ include "studio.sharedEnvs" . | nindent 10 }}
+        resources:
+          requests:
+            cpu: 0.5
+            memory: 2Gi
+          limits:
+            cpu: 0.5
+            memory: 2Gi


### PR DESCRIPTION
From a conversation with @kollivier, it's best to set keep Studio's current number of gunicorn processes (3) and worker processes (3), while only allocating 0.5 CPU per pod.

This change sets the 0.5 CPU per pod limit.