### PR TITLE
Quick fixes for issues identified during bash

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -185,7 +185,7 @@ class User(AbstractBaseUser, PermissionsMixin):
                                           | Q(trash_tree__in=root_nodes)
                                           | Q(staging_tree__in=root_nodes)
                                           | Q(previous_tree__in=root_nodes))
-        channels_user_has_perms_for = channels.filter(Q(editors__id__contains=self.id) | Q(viewers__id__contains=self.id))
+        channels_user_has_perms_for = channels.filter(Q(editors__id__contains=self.id) | Q(viewers__id__contains=self.id) | Q(public=True))
         # The channel user has perms for is a subset of all the channels that were passed in.
         # We check the count for simplicity, as if the user does not have permissions for
         # even one of the channels the content is drawn from, then the number of channels

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -150,6 +150,8 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def can_view(self, channel_id):
         channel = Channel.objects.filter(pk=channel_id).first()
+        if channel and channel.public:
+            return True
         if not self.is_admin and channel and not channel.editors.filter(pk=self.pk).exists() and not channel.viewers.filter(pk=self.pk).exists():
             raise PermissionDenied("Cannot view content")
         return True

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -680,6 +680,7 @@ var ContentNodeCollection = BaseCollection.extend({
       };
       $.ajax({
         method: 'POST',
+        contentType: 'application/json',
         url: window.Urls.delete_nodes(),
         data: JSON.stringify(data),
         success: resolve,

--- a/contentcuration/contentcuration/static/js/edit_channel/publish/tests/data.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/publish/tests/data.js
@@ -34,6 +34,21 @@ export const localStore = new Vuex.Store({
         ...publish.actions,
       },
     },
+    channel: {
+      state: {
+        canEdit: false,
+      },
+      getters: {
+        canEdit(state) {
+          return state.canEdit;
+        },
+      },
+      mutations: {
+        SET_EDIT_MODE(state, canEdit) {
+          state.canEdit = canEdit;
+        },
+      },
+    },
     publish: {
       namespaced: true,
       state: {

--- a/contentcuration/contentcuration/static/js/edit_channel/publish/tests/publishModal.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/publish/tests/publishModal.spec.js
@@ -21,6 +21,7 @@ function makeWrapper(channel = {}) {
     ...channel,
   };
   localStore.commit('publish/SET_CHANNEL', channelData);
+  localStore.commit('SET_EDIT_MODE', true);
 
   return mount(PublishModal, {
     store: localStore,

--- a/contentcuration/contentcuration/static/js/edit_channel/publish/views/PublishModal.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/publish/views/PublishModal.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="publish-items">
-    <label v-if="!isChanged" class="unchanged-label">
+    <label v-if="!isReadOnly && !isChanged" class="unchanged-label">
       {{ $tr('noChangesLabel') }}
     </label>
     <VBtn
+      v-if="!isReadOnly"
       flat
       dark
       class="open-modal-button publish-button"
@@ -86,6 +87,9 @@
       },
       isChanged() {
         return this.channel.main_tree.metadata.has_changed_descendant;
+      },
+      isReadOnly() {
+        return !this.$store.getters.canEdit;
       },
     },
     methods: {

--- a/contentcuration/contentcuration/static/js/edit_channel/router.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/router.js
@@ -74,16 +74,17 @@ var ChannelEditRouter = Backbone.Router.extend({
       });
     }
 
+    let store = State.Store;
+
+    store.commit('SET_EDIT_MODE', data.edit_mode_on);
     // TODO: Once topic tree has been migrated to vue, move this logic there
-    if (data.edit_mode_on) {
-      let store = State.Store;
-      store.commit('publish/SET_CHANNEL', State.current_channel.toJSON());
-      new Vue({
-        el: '#channel-publish-button',
-        store,
-        ...PublishWrapper,
-      });
-    }
+    store.commit('publish/SET_CHANNEL', State.current_channel.toJSON());
+
+    new Vue({
+      el: '#channel-publish-button',
+      store,
+      ...PublishWrapper,
+    });
   },
   update_url: function(topic, node, replacement) {
     State.updateUrl(topic, node, replacement);

--- a/contentcuration/contentcuration/static/js/edit_channel/tree_edit/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/tree_edit/views.js
@@ -94,7 +94,9 @@ var TreeEditView = BaseViews.BaseWorkspaceView.extend({
     this.staging = options.staging;
     this.path = options.path;
 
-    if (this.is_edit_page) {
+    // is_edit_page is false for ricecooker channels, even when the edit page is loaded,
+    // so use the edit state set on the Store to check instead of is_edit_page.
+    if (State.Store.getters.canEdit) {
       // Check if the user has any running tasks immediately so we know if we need to
       // show the update dialog.
       State.Store.dispatch('updateTaskList');

--- a/contentcuration/contentcuration/static/js/edit_channel/vuexModules/asyncTask.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/vuexModules/asyncTask.js
@@ -43,6 +43,9 @@ const asyncTasksModule = {
       store.commit('SET_CURRENT_TASK', payload);
       // force an immediate update to quickly get a first state update
       store.dispatch('updateTaskList');
+      if (!timerID) {
+        store.dispatch('activateTaskUpdateTimer');
+      }
     },
 
     clearCurrentTask(store) {

--- a/contentcuration/contentcuration/static/js/edit_channel/vuexModules/channel.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/vuexModules/channel.js
@@ -1,13 +1,20 @@
 const channelModule = {
   state: {
     contentTags: [],
+    canEdit: false,
   },
   getters: {
     contentTags(state) {
       return state.contentTags;
     },
+    canEdit(state) {
+      return state.canEdit;
+    },
   },
   mutations: {
+    SET_EDIT_MODE(state, canEdit) {
+      state.canEdit = canEdit;
+    },
     SET_CONTENT_TAGS(state, contentTags) {
       state.contentTags = contentTags || [];
     },

--- a/contentcuration/contentcuration/templates/channel_edit.html
+++ b/contentcuration/contentcuration/templates/channel_edit.html
@@ -66,7 +66,7 @@
 			</li>
 		{% else %}
 			<li id="hide-if-unpublished"><a id="get_published_id">{% trans "Show Token" %}</a></li>
-			{% if allow_edit %}<li><span id="channel-publish-button"></span></li>{% endif %}
+			<li><span id="channel-publish-button"></span></li>
 		{% endif %}
 		</ul>
 	</nav>

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -220,6 +220,10 @@ class TaskViewSet(viewsets.ModelViewSet):
                          user.is_admin
                 if has_access:
                     queryset = Task.objects.filter(metadata__affects__channels__contains=[channel_id])
+                else:
+                    # If the user doesn't have channel access permissions, they can still perform certain
+                    # operations, such as copy. So show them the status of any operation they started.
+                    queryset = Task.objects.filter(user=user, metadata__affects__channels__contains=[channel_id])
         else:
             queryset = Task.objects.filter(user=self.request.user)
 

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -354,7 +354,6 @@ def duplicate_nodes(request):
         raise ObjectDoesNotExist("Missing attribute from data: {}".format(data))
 
 
-@api_view(['POST'])
 @authentication_classes((TokenAuthentication, SessionAuthentication))
 @permission_classes((IsAuthenticated,))
 @api_view(['POST'])


### PR DESCRIPTION

## Description

Fixes a couple issues that arose during the bash, namely:

- 500 errors when calling duplicate_nodes_inline and delete_nodes
- No progress dialog when copying files in read-only mode
- Inability to view or copy content in read-only mode.

#### Issue Addressed (if applicable)

Addresses #1511, #1512, #1513, #1514

## Steps to Test

- [x] Right-click on a node and click "Make a copy"
- [x] Delete nodes from clipboard
- [x] Copy a node from a view-only channel
- [x] View content and copy a node from a public channel

#### Does this introduce any tech-debt items?

Once the Vue migration is complete, I suspect we will be able to manage state in a better way than we do now.

## Checklist

- [x] Is the code clean and well-commented?
