### PR TITLE
Disable mingle and gossip when running workers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dummyusers:
 	cd contentcuration/ && python manage.py loaddata contentcuration/fixtures/admin_user_token.json
 
 prodceleryworkers:
-	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3
+	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3 --without-mingle --without-gossip
 
 prodcelerydashboard:
 	# connect to the celery dashboard by visiting http://localhost:5555

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "devserver:hot": "npm-run-all --parallel build:dev:hot runserver",
     "devshell": "cd contentcuration && python manage.py shell --settings=contentcuration.dev_settings",
     "celery:dashboard": "cd contentcuration && celery -A contentcuration flower",
-    "celery": "(cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker -l info) || true"
+    "celery": "(cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker --without-mingle --without-gossip -l info) || true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

During the bug bash, we realized that workers mingling and gossiping was causing them to lose track of their tasks and leave them unprocessed. Make it so that workers can no longer mingle and gossip, so that they can focus on their work.

## Steps to Test

- [ ] Run any celery task, make sure it runs

## Checklist

- [ ] Is the code clean and well-commented?
