### PR TITLE
[Fixes #1520] Make sure we check the original channel still exists…

### DIFF
--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -67,7 +67,8 @@ def sync_node(node, channel_id, sync_attributes=False, sync_tags=False, sync_fil
               sync_assessment_items=False, sync_sort_order=False):
     parents_to_check = []
     original_node = node.get_original_node()
-    if original_node.node_id != node.node_id:  # Only update if node is not original
+    # Only update if node is not original and the originating channel node still exists.
+    if original_node.node_id != node.node_id and original_node.get_channel():
         logging.info("----- Syncing: {} from {}".format(node.title,
                                                         original_node.get_channel().name))
         if sync_attributes:  # Sync node metadata


### PR DESCRIPTION
… before trying to sync the original node.

## Description

Just adds a sanity check to make sure the original node is still connected to a channel before syncing it. Investigation showed the original nodes were somehow still around even though the original test channel they were part of appears to have been deleted.

#### Issue Addressed (if applicable)

Addresses #1520

## Steps to Test

- [ ] Sync the channel that generated the error in #1520

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
