### PR TITLE
Show the progress modal when using the move dialog.

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -640,7 +640,7 @@ var ContentNodeCollection = BaseCollection.extend({
       });
     });
   },
-  move: function(target_parent, max_order, min_order) {
+  move: function(target_parent, max_order, min_order, show_dialog) {
     const State = require('./state');
     var self = this;
     return new Promise(function(resolve, reject) {
@@ -659,7 +659,9 @@ var ContentNodeCollection = BaseCollection.extend({
         dataType: 'json',
         error: reject,
         success: function(data) {
-          data.noDialog = true;
+          if (!show_dialog) {
+            data.noDialog = true;
+          }
           const payload = {
             task: data,
             resolveCallback: resolve,

--- a/contentcuration/contentcuration/static/js/edit_channel/move/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/move/views.js
@@ -122,7 +122,7 @@ var MoveView = BaseViews.BaseListView.extend({
     var self = this;
 
     var sort_order = self.target_node.get('metadata').max_sort_order;
-    self.collection.move(self.target_node, null, sort_order);
+    self.collection.move(self.target_node, null, sort_order, true);
   },
   handle_target_selection: function(node, clipboard_selected) {
     // Set node to move items to


### PR DESCRIPTION

## Description

Restores the progress modal when using the move dialog after changes to make dnd move operations show progress as an inline UI.

#### Issue Addressed (if applicable)

Addresses #1525

## Steps to Test

- [ ] Right click on a node, select "Move", and move to clipboard.

## Checklist

- [ ] Is the code clean and well-commented?
