### PR TITLE
Pin Summernote version to 0.8.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "node-vibrant": "^3.0.0",
     "offline-js": "^0.7.19",
     "promise-polyfill": "^6.0.2",
-    "summernote": "^0.8.2",
+    "summernote": "0.8.10",
     "to-markdown": "^3.0.3",
     "underscore": "^1.9.0",
     "vue": "^2.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12784,9 +12784,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-summernote@^0.8.2:
+summernote@0.8.10:
   version "0.8.10"
   resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.10.tgz#21a5d7f18a3b07500b58b60d5907417a54897520"
+  integrity sha512-1b4ESCiY9HW+12HYXCntjbThVgeYNaYKfKL7pC4Jqjo/WDS4G4mMtd2kPuCw56HxeRT67d+zlehopaE+M4o6aQ==
 
 supports-color@5.1.0:
   version "5.1.0"


### PR DESCRIPTION
Pin Summernote version to 0.8.10 which is the version being currently used in `develop` and `master`.
This PR's purpose is only to prevent accidentall upgrade to latest 0.8.12 patch release that would break our editor (custom buttons would disappear)

https://github.com/summernote/summernote/issues/3249
https://github.com/summernote/summernote/pull/3284