### PR TITLE
Fix issue with two migrations numbered 0099.

### DIFF
--- a/contentcuration/contentcuration/migrations/0100_calculate_included_languages.py
+++ b/contentcuration/contentcuration/migrations/0100_calculate_included_languages.py
@@ -37,7 +37,7 @@ def calculate_included_languages(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contentcuration', '0098_auto_20190424_1709'),
+        ('contentcuration', '0099_auto_20190715_2201'),
     ]
 
     operations = [

--- a/contentcuration/contentcuration/tests/test_included_languages_migration.py
+++ b/contentcuration/contentcuration/tests/test_included_languages_migration.py
@@ -11,8 +11,8 @@ included_languages_should_up_date = datetime.datetime(2016, 11, 30)
 
 class TestForwardIncludedLanguagesMigrationPublishedChannel(MigrationTestCase):
 
-    migrate_from = '0098_auto_20190424_1709'
-    migrate_to = '0099_calculate_included_languages'
+    migrate_from = '0099_auto_20190715_2201'
+    migrate_to = '0100_calculate_included_languages'
     app = 'contentcuration'
 
     def setUpBeforeMigration(self, apps):
@@ -40,8 +40,8 @@ class TestForwardIncludedLanguagesMigrationPublishedChannel(MigrationTestCase):
 
 class TestForwardIncludedLanguagesMigrationNewlyPublishedChannel(MigrationTestCase):
 
-    migrate_from = '0098_auto_20190424_1709'
-    migrate_to = '0099_calculate_included_languages'
+    migrate_from = '0099_auto_20190715_2201'
+    migrate_to = '0100_calculate_included_languages'
     app = 'contentcuration'
 
     def setUpBeforeMigration(self, apps):
@@ -66,8 +66,8 @@ class TestForwardIncludedLanguagesMigrationNewlyPublishedChannel(MigrationTestCa
 
 class TestForwardIncludedLanguagesMigrationUnpublishedChannel(MigrationTestCase):
 
-    migrate_from = '0098_auto_20190424_1709'
-    migrate_to = '0099_calculate_included_languages'
+    migrate_from = '0099_auto_20190715_2201'
+    migrate_to = '0100_calculate_included_languages'
     app = 'contentcuration'
 
     def setUpBeforeMigration(self, apps):
@@ -91,8 +91,8 @@ class TestForwardIncludedLanguagesMigrationUnpublishedChannel(MigrationTestCase)
 
 class TestForwardIncludedLanguagesMigrationFile(MigrationTestCase):
 
-    migrate_from = '0098_auto_20190424_1709'
-    migrate_to = '0099_calculate_included_languages'
+    migrate_from = '0099_auto_20190715_2201'
+    migrate_to = '0100_calculate_included_languages'
     app = 'contentcuration'
 
     def setUpBeforeMigration(self, apps):


### PR DESCRIPTION

## Description

Fixes issue with conflicting migrations by renumbering the calculated languages migration and fixing the migration dependencies to reflect the new order.

## Steps to Test

- [ ] Run migrations

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
