### PR TITLE
Flesh out our liveness and readiness probes

### DIFF
--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           httpGet:
             path: /healthz
             port: {{ .Values.studioApp.appPort }}
-          initialDelaySeconds: 300
+          initialDelaySeconds: 120
           periodSeconds: 5
         ports:
         - containerPort: {{ .Values.studioApp.appPort }}

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -32,12 +32,21 @@ spec:
           periodSeconds: 5
         ports:
         - containerPort: {{ .Values.studioApp.appPort }}
+        # readiness probes are checks for when the pod is ready to serve traffic.
+        # Note that this runs even after a pod is Ready. Reaching the failure threshold
+        # means the pod is taken off the routing rules, but then once it's passing
+        # queries, it's allowed to serve traffic once more.
         readinessProbe:
           httpGet:
-            path: /
-            port: {{ .Values.studioNginx.port }}
-          initialDelaySeconds: 10
-          periodSeconds: 5
+            path: /healthz
+            port: {{ .Values.studioApp.appPort }}
+          # start pinging for readiness at the 5 second mark.
+          # Once it passes, add it to the routing table
+          initialDelaySeconds: 5
+          # Query every 2 seconds for readiness
+          periodSeconds: 2
+          # fail 3 times before taking this app off the routing table
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /app/contentworkshop_static/
           name: staticfiles

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -30,6 +30,8 @@ spec:
             port: {{ .Values.studioApp.appPort }}
           initialDelaySeconds: 120
           periodSeconds: 5
+          # fail 10 times before we restart the pod
+          failureThreshold: 10
         ports:
         - containerPort: {{ .Values.studioApp.appPort }}
         # readiness probes are checks for when the pod is ready to serve traffic.

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -24,6 +24,7 @@ spec:
           value: /app/contentworkshop_static/
         - name: SEND_USER_ACTIVATION_NOTIFICATION_EMAIL
           value: "true"
+        # liveness probes are checks for when a pod should be restarted.
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Optimize our readiness probes to both succeed and recover as fast as reasonable. Also use /healthz for our readiness probe.

Extend the failure threshold before we fail liveness probes. Liveness probes cause our pod to get restarted, so we wanna do that less often. 