### PR TITLE
Tweak network error reporting (e.g. /api/task)

### DIFF
--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -54,7 +54,7 @@ $(function() {
     }
 
     // Put the URL in the main message for timeouts so we can see which timeouts are most frequent.
-    if (jqXHR.status === 504) {
+    if (jqXHR.status === 504 || jqXHR.status === 522 || jqXHR.status === 524) {
       message = 'Request Timed Out: ' + ajaxSettings.url;
     }
 

--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -30,19 +30,19 @@ $(function() {
     }
 
     // Status 0 errors can happen for a couple different reasons:
-    // 1. An API call was made and then the page was refreshed (harmless, user-initiated)
+    // 1. An API call was made and then a navigation event happened (harmless, user-initiated)
     // 2. The browser didn't receive a response from the server on time (error text is 'timeout')
     // 3. DNS Resolution failed. Health checks should catch any issues on our end.
 
-    // This code does not try to send a report for non-timeout GET requests, as the cases
+    // This code does not try to send a report for non-timeout GET requests, as the notes
     // above indicate that there is likely nothing we can do about these cases. If it is
     // a failed PUT / POST, we still submit a report so we can make sure we are handling
     // that case properly in the front end and aware of cases where a post may fail.
     if (jqXHR.status === 0) {
       if (thrownError == 'timeout' || jqXHR.statusText === 'timeout') {
         message = 'Network Error: ' + ajaxSettings.url;
-      } else if (ajaxSettings.method != 'GET' && ajaxSettings.data) {
-        message = ajaxSettings.method + ' Error: ' + ajaxSettings.url;
+      } else if (ajaxSettings.type != 'GET' && ajaxSettings.data) {
+        message = ajaxSettings.type + ' Error: ' + ajaxSettings.url;
       } else {
         return;
       }

--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -29,8 +29,28 @@ $(function() {
       return;
     }
 
+    // Status 0 errors can happen for a couple different reasons:
+    // 1. An API call was made and then the page was refreshed (harmless, user-initiated)
+    // 2. The browser didn't receive a response from the server on time (error text is 'timeout')
+    // 3. DNS Resolution failed. Health checks should catch any issues on our end.
+
+    // This code does not try to send a report for non-timeout GET requests, as the cases
+    // above indicate that there is likely nothing we can do about these cases. If it is
+    // a failed PUT / POST, we still submit a report so we can make sure we are handling
+    // that case properly in the front end and aware of cases where a post may fail.
     if (jqXHR.status === 0) {
-      message = 'Network Error: ' + ajaxSettings.url;
+      if (thrownError == 'timeout' || jqXHR.statusText === 'timeout') {
+        message = 'Network Error: ' + ajaxSettings.url;
+      } else if (ajaxSettings.method != 'GET' && ajaxSettings.data) {
+        message = ajaxSettings.method + ' Error: ' + ajaxSettings.url;
+      } else {
+        return;
+      }
+    }
+
+    // If we have a signed in user, make sure we add them to the report.
+    if (window.user && window.user.id) {
+      Raven.setUserContext({ id: window.user.id, email: window.user.email });
     }
 
     // Put the URL in the main message for timeouts so we can see which timeouts are most frequent.

--- a/contentcuration/contentcuration/static/js/edit_channel/sharedComponents/ProgressOverlay.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/sharedComponents/ProgressOverlay.vue
@@ -140,6 +140,10 @@
       closeOverlay() {
         this.progress = false;
         window.location.reload();
+        // We keep the task set to make sure the overlay stays up,
+        // so explicitly turn off the task checking timer while we wait
+        // for refresh.
+        this.$store.dispatch('deactivateTaskUpdateTimer');
       },
       handleCancel() {
         let headerText = this.cancelHeaderText || this.$tr('cancelHeader');


### PR DESCRIPTION

## Description

While checking into why we were seeing a lot of `/api/task` errors, I discovered that a lot of the "Network Error" Sentry reports we receive are actually just canceled requests caused by page navigation events like browsing to another page or refreshing the page. (The latter is why `/api/task` triggers a lot, since we refresh upon completion.)

This code filters out any GET Network Error requests that are not reported as timeouts. One thing I did notice is that there was at least one form submission that showed a network error, so I've made sure any non-GET requests with data in them still generate an error report.

Also, upon refreshing after task completion, I stop the task polling timer so it is not making extraneous requests that will just be canceled anyway.

## Steps to Test

- [ ] Start a long running task, and refresh to see if an error report is generated.

## Checklist

- [ ] Is the code clean and well-commented?
