### PR TITLE
Switched channel id to token in published email text

### DIFF
--- a/contentcuration/contentcuration/templates/registration/channel_published_email.txt
+++ b/contentcuration/contentcuration/templates/registration/channel_published_email.txt
@@ -7,7 +7,7 @@
 
 {% blocktrans with channel_token=token %}Token: {{ channel_token }}{% endblocktrans %}
 
-{% blocktrans with channel_id=channel.pk %}ID: {{ channel_id }}{% endblocktrans %}
+{% blocktrans with channel_id=channel.pk %}ID (for Kolibri version 0.6.0 and below): {{ channel_id }}{% endblocktrans %}
 
 {% trans "Thanks for using our site!" %}
 

--- a/contentcuration/contentcuration/templates/registration/channel_published_email.txt
+++ b/contentcuration/contentcuration/templates/registration/channel_published_email.txt
@@ -3,9 +3,9 @@
 {% autoescape off %}
 {% trans "Hello" %} {{ user.first_name }},
 
-{% blocktrans with channel_name=channel.name %}{{ channel_name }} has finished publishing! Here is the published ID (for importing this channel into Kolibri):{% endblocktrans %}
+{% blocktrans with channel_name=channel.name %}{{ channel_name }} has finished publishing! Here is the published token (for importing this channel into Kolibri):{% endblocktrans %}
 
-{% blocktrans with channel_id=channel.id %}ID: {{ channel_id }}{% endblocktrans %}
+{% blocktrans with channel_token=token %}Token: {{ channel_token }}{% endblocktrans %}
 
 {% blocktrans with channel_name=channel.name %}Name: {{ channel_name }}{% endblocktrans %}
 

--- a/contentcuration/contentcuration/templates/registration/channel_published_email.txt
+++ b/contentcuration/contentcuration/templates/registration/channel_published_email.txt
@@ -7,7 +7,7 @@
 
 {% blocktrans with channel_token=token %}Token: {{ channel_token }}{% endblocktrans %}
 
-{% blocktrans with channel_name=channel.name %}Name: {{ channel_name }}{% endblocktrans %}
+{% blocktrans with channel_id=channel.pk %}ID: {{ channel_id }}{% endblocktrans %}
 
 {% trans "Thanks for using our site!" %}
 

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -58,15 +58,17 @@ class EarlyExit(BaseException):
 
 def send_emails(channel, user_id):
     subject = render_to_string('registration/custom_email_subject.txt', {'subject': _('Kolibri Studio Channel Published')})
+    token = channel.secret_tokens.filter(is_primary=True).first()
+    token = '{}-{}'.format(token.token[:5], token.token[-5:])
 
     if user_id:
         user = ccmodels.User.objects.get(pk=user_id)
-        message = render_to_string('registration/channel_published_email.txt', {'channel': channel, 'user': user})
+        message = render_to_string('registration/channel_published_email.txt', {'channel': channel, 'user': user, 'token': token})
         user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL, )
     else:
         # Email all users about updates to channel
         for user in itertools.chain(channel.editors.all(), channel.viewers.all()):
-            message = render_to_string('registration/channel_published_email.txt', {'channel': channel, 'user': user})
+            message = render_to_string('registration/channel_published_email.txt', {'channel': channel, 'user': user, 'token': token})
             user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL, )
 
 


### PR DESCRIPTION
## Description

Email now contains token instead of channel id

```
Hello Admin,

Published Channel has finished publishing! Here is the published token (for importing this channel into Kolibri):

Token: kogig-vasil

Name: Published Channel

Thanks for using our site!

The Learning Equality Team
```

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/1536

## Steps to Test

- [ ] Try publishing a channel

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
