### PR TITLE
Make ricecooker 0.6.20 and older raise a HARD warning

### DIFF
--- a/contentcuration/contentcuration/ricecooker_versions.py
+++ b/contentcuration/contentcuration/ricecooker_versions.py
@@ -1,7 +1,7 @@
 import xmlrpclib
 from socket import gaierror, error
 
-VERSION_OK = "0.6.0"
+VERSION_OK = "0.6.32"  # this gets overwritten to current v. after XML RPC call
 
 try:
     pypi = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
@@ -10,7 +10,7 @@ except (gaierror, error):
     pass
 
 VERSION_OK_MESSAGE = "Ricecooker v{} is up-to-date."
-VERSION_SOFT_WARNING = "0.5.6"
+VERSION_SOFT_WARNING = "0.6.21"
 VERSION_SOFT_WARNING_MESSAGE = "You are using Ricecooker v{}, however v{} is available. You should consider upgrading your Ricecooker."
 VERSION_HARD_WARNING = "0.3.13"
 VERSION_HARD_WARNING_MESSAGE = "Ricecooker v{} is deprecated. Any channels created with this version will be unlinked with any future upgrades. You are strongly recommended to upgrade to v{}."

--- a/contentcuration/contentcuration/ricecooker_versions.py
+++ b/contentcuration/contentcuration/ricecooker_versions.py
@@ -10,9 +10,9 @@ except (gaierror, error):
     pass
 
 VERSION_OK_MESSAGE = "Ricecooker v{} is up-to-date."
-VERSION_SOFT_WARNING = "0.6.21"
+VERSION_SOFT_WARNING = "0.6.30"
 VERSION_SOFT_WARNING_MESSAGE = "You are using Ricecooker v{}, however v{} is available. You should consider upgrading your Ricecooker."
-VERSION_HARD_WARNING = "0.3.13"
+VERSION_HARD_WARNING = "0.6.21"
 VERSION_HARD_WARNING_MESSAGE = "Ricecooker v{} is deprecated. Any channels created with this version will be unlinked with any future upgrades. You are strongly recommended to upgrade to v{}."
 VERSION_ERROR = None
 VERSION_ERROR_MESSAGE = "Ricecooker v{} is no longer compatible. You must upgrade to v{} to continue."


### PR DESCRIPTION
## Description

Setting "start of soft warning" version range to 0.6.21 means anyone using ricecooker 0.6.20 or older will get a hard warning. See [version logic code here](https://github.com/learningequality/studio/blob/develop/contentcuration/contentcuration/views/internal.py#L85-L92).

On the ricecooker side it will result in a prompt in case someone runs an old chef that uses `0.6.20` or older https://github.com/learningequality/ricecooker/blob/master/ricecooker/commands.py#L208-L211


#### Issue Addressed (if applicable)

As part of the deprecation strategy for the old Studio URL
https://contentworkshop.learningequality.org/
we want to throw HARD warnings for any ricecooker users that have the old version `0.6.20` (the last one to use the old URL).


