### PR TITLE
Fixed icon encodings not getting saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "node-vibrant": "^3.0.0",
     "offline-js": "^0.7.19",
     "promise-polyfill": "^6.0.2",
-    "summernote": "^0.8.2",
+    "summernote": "0.8.10",
     "to-markdown": "^3.0.3",
     "underscore": "^1.9.0",
     "vue": "^2.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12847,9 +12847,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-summernote@^0.8.2:
+summernote@0.8.10:
   version "0.8.10"
   resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.10.tgz#21a5d7f18a3b07500b58b60d5907417a54897520"
+  integrity sha512-1b4ESCiY9HW+12HYXCntjbThVgeYNaYKfKL7pC4Jqjo/WDS4G4mMtd2kPuCw56HxeRT67d+zlehopaE+M4o6aQ==
 
 supports-color@5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## Description

Persists save on channel thumbnail to end of the command

It turns out that Django's save function acts more like a POST request in that all fields get submitted, rather than those that have changed like a PATCH request. This was causing an issue as the `publish_channel` function had one version of the channel and the `create_content_database` had another version. The `create_content_database` method would save the icon_encoding. However, any saving after the `create_content_database` function would then use the outdated model from `publish_channel`, which caused icon_encoding to get set back to null

This just passes the model itself to `create_content_database` from `publish_channel` so they are working from the same object in memory

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1299

## Steps to Test

- [ ] Remove the thumbnail encoding from a channel
- [ ] Publish and check the public channels endpoint


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
