### PR TITLE
Fixed icon encodings not getting saved 

### DIFF
--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -70,8 +70,7 @@ def send_emails(channel, user_id):
             user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL, )
 
 
-def create_content_database(channel_id, force, user_id, force_exercises, task_object=None):
-    channel = ccmodels.Channel.objects.get(pk=channel_id)
+def create_content_database(channel, force, user_id, force_exercises, task_object=None):
     # increment the channel version
     if not force:
         raise_if_nodes_are_all_unchanged(channel)
@@ -91,7 +90,7 @@ def create_content_database(channel_id, force, user_id, force_exercises, task_ob
         if task_object:
             task_object.update_state(state='STARTED', meta={'progress': 90.0})
         map_prerequisites(channel.main_tree)
-        save_export_database(channel_id)
+        save_export_database(channel.pk)
 
 
 def create_kolibri_license_object(ccnode):
@@ -531,8 +530,6 @@ def map_prerequisites(root_node):
 
 def map_channel_to_kolibri_channel(channel):
     logging.debug("Generating the channel metadata.")
-    channel.icon_encoding = convert_channel_thumbnail(channel)
-    channel.save()
     kolibri_channel = kolibrimodels.ChannelMetadata.objects.create(
         id=channel.id,
         name=channel.name,
@@ -546,6 +543,11 @@ def map_channel_to_kolibri_channel(channel):
     logging.info("Generated the channel metadata.")
 
     return kolibri_channel
+
+
+def set_channel_icon_encoding(channel):
+    channel.icon_encoding = convert_channel_thumbnail(channel)
+    channel.save()
 
 
 def convert_channel_thumbnail(channel):
@@ -652,7 +654,8 @@ def publish_channel(user_id, channel_id, force=False, force_exercises=False, sen
     channel = ccmodels.Channel.objects.get(pk=channel_id)
 
     try:
-        create_content_database(channel_id, force, user_id, force_exercises, task_object)
+        set_channel_icon_encoding(channel)
+        create_content_database(channel, force, user_id, force_exercises, task_object)
         increment_channel_version(channel)
         mark_all_nodes_as_published(channel)
         add_tokens_to_channel(channel)


### PR DESCRIPTION
## Description

Persists save on channel thumbnail to end of the command

It turns out that Django's save function acts more like a POST request in that all fields get submitted, rather than those that have changed like a PATCH request. This was causing an issue as the `publish_channel` function had one version of the channel and the `create_content_database` had another version. The `create_content_database` method would save the icon_encoding. However, any saving after the `create_content_database` function would then use the outdated model from `publish_channel`, which caused icon_encoding to get set back to null

This just passes the model itself to `create_content_database` from `publish_channel` so they are working from the same object in memory

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/1299

## Steps to Test

- [ ] Remove the thumbnail encoding from a channel
- [ ] Publish and check the public channels endpoint


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
