### PR TITLE
Remove size calculation from import dialog…

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/import/views/ImportPreview.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/import/views/ImportPreview.vue
@@ -8,8 +8,7 @@
     <div>
       <div class="resources-msg">
         {{ $tr('resourcesSize', {
-          resources: importedItemCounts.resources,
-          fileSize: importFileSizeInWords
+          resources: importedItemCounts.resources
         })
         }}
       </div>
@@ -53,13 +52,11 @@
         },
       }
     ),
-    mounted() {
-      this.calculateImportSize();
-    },
-    methods: Object.assign(mapActions('import', ['calculateImportSize', 'goToPreviousPage']), {}),
+    mounted() {},
+    methods: Object.assign(mapActions('import', ['goToPreviousPage']), {}),
     $trs: {
       calculatingSizeText: 'Calculating Size...',
-      resourcesSize: '{ resources } Total resources selected ({ fileSize })',
+      resourcesSize: '{ resources } Total resources selected',
       back: 'Back',
       backWarning: 'Note: Your previous selections will be lost.',
     },

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -148,7 +148,7 @@ def get_prerequisites(request, get_postrequisites, ids):
 @permission_classes((IsAuthenticated,))
 @api_view(['GET'])
 def get_total_size(request, ids):
-    nodes = ContentNode.objects.prefetch_related('files', 'children')\
+    nodes = ContentNode.objects.prefetch_related('assessment_items', 'files', 'children')\
                        .exclude(kind_id=content_kinds.EXERCISE, published=False)\
                        .filter(id__in=ids.split(",")).get_descendants(include_self=True)\
                        .values('files__checksum', 'files__file_size')\

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -148,7 +148,7 @@ def get_prerequisites(request, get_postrequisites, ids):
 @permission_classes((IsAuthenticated,))
 @api_view(['GET'])
 def get_total_size(request, ids):
-    nodes = ContentNode.objects.prefetch_related('assessment_items', 'files', 'children')\
+    nodes = ContentNode.objects.prefetch_related('files', 'children')\
                        .exclude(kind_id=content_kinds.EXERCISE, published=False)\
                        .filter(id__in=ids.split(",")).get_descendants(include_self=True)\
                        .values('files__checksum', 'files__file_size')\


### PR DESCRIPTION
…and remove an unneeded prefetch from the API call.

## Description

This call takes a long time to complete for large content selections, and during trainings and other events the frequent calls can lead to slowdowns or even outages.

## Steps to Test

- [ ] Ensure content import still works as expected.

## Checklist

- [ ] Is the code clean and well-commented?
