### PR TITLE
Ensure slow task calls do not stack by switching to single-use timers…

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/tree_edit/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/tree_edit/views.js
@@ -100,8 +100,6 @@ var TreeEditView = BaseViews.BaseWorkspaceView.extend({
       // Check if the user has any running tasks immediately so we know if we need to
       // show the update dialog.
       State.Store.dispatch('updateTaskList');
-      // Also start the update check to run the check periodically.
-      State.Store.dispatch('activateTaskUpdateTimer');
 
       // When the page is not active or the frontmost tab, stop polling and restore
       // when it once again becomes frontmost.
@@ -130,7 +128,7 @@ var TreeEditView = BaseViews.BaseWorkspaceView.extend({
     if (document.visibilityState == 'hidden') {
       State.Store.dispatch('deactivateTaskUpdateTimer');
     } else {
-      State.Store.dispatch('activateTaskUpdateTimer');
+      State.Store.dispatch('updateTaskList');
     }
   },
   edit_content: function() {


### PR DESCRIPTION
…, and slow down the time check intervals a bit. Initial load always calls immediately so this will not delay initial dialog appearance.

## Steps to Test

- [ ] Import some content, or publish a channel. Make sure task status correctly updates and completes.


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
