### PR TITLE
Set extra_fields to an empty object if the node isn't an exercise

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -386,6 +386,8 @@ var ContentNodeModel = BaseModel.extend({
           ? data['randomize']
           : State.preferences.auto_randomize_questions;
       this.set('extra_fields', data);
+    } else {
+      this.set('extra_fields', {});
     }
   },
   make_copy: function(target_parent) {


### PR DESCRIPTION
#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/1596

## Steps to Test

- [ ] Try adding and saving a topic
- [ ] Upload and save a file

#### Does this introduce any tech-debt items?

Eventually, we may want to revisit this when we start making more use of extra_fields


## Checklist

- [ ] Is the code clean and well-commented?
