### PR TITLE
Filter out completed tasks when listing…

### DIFF
--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -224,6 +224,11 @@ class TaskViewSet(viewsets.ModelViewSet):
                     # If the user doesn't have channel access permissions, they can still perform certain
                     # operations, such as copy. So show them the status of any operation they started.
                     queryset = Task.objects.filter(user=user, metadata__affects__channels__contains=[channel_id])
+                # If we're getting a list of channel tasks, exclude finished tasks for now, as
+                # currently we only use this call to determine if there's a current or pending task.
+                # TODO: revisit this when we start displaying channel task history
+                if self.action == 'list':
+                    queryset = queryset.exclude(status__in=['SUCCESS', 'FAILURE'])
         else:
             queryset = Task.objects.filter(user=self.request.user)
 


### PR DESCRIPTION
…as currently we're only checking if there are tasks started or running.

## Description

This is an optimization for cases when the user or channel has a lot of associated tasks, which is causing the call to take long and in some cases a large list of tasks. 

## Steps to Test

- [ ] Run task and make sure it displays progress and completes successfully

#### Does this introduce any tech-debt items?

The longer-term solution is to write some filtering logic so we can run more specific queries and/or paginate the results.

## Checklist

- [ ] Is the code clean and well-commented?
