### PR TITLE
When we use a custom through model in a M2M field…

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1445,7 +1445,6 @@ class PrerequisiteContentRelationship(models.Model):
 
     class Meta:
         unique_together = ['target_node', 'prerequisite']
-        auto_created = True  # Avoids `AttributeError: Cannot set values on a ManyToManyField which specifies an intermediary model`
 
     def clean(self, *args, **kwargs):
         # self reference exception

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -27,6 +27,7 @@ from contentcuration.utils.publish import set_channel_icon_encoding
 
 pytestmark = pytest.mark.django_db
 
+
 def fileobj_video(contents=None):
     """
     Create an mp4 video file in storage and then create a File model from it.
@@ -223,5 +224,7 @@ class ChannelExportPrerequisiteTestCase(StudioTestCase):
     def test_nonexistent_prerequisites(self):
         channel = cc.Channel.objects.create()
         node1 = cc.ContentNode.objects.create(kind_id="exercise", parent_id=channel.main_tree.pk)
-        cc.ContentNode.objects.create(kind_id="exercise", prerequisite=[node1.pk])
+        exercise = cc.ContentNode.objects.create(kind_id="exercise")
+
+        cc.PrerequisiteContentRelationship.objects.create(target_node=exercise, prerequisite=node1)
         map_prerequisites(node1)

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -12,6 +12,7 @@ from .testdata import tree
 from contentcuration.models import Channel
 from contentcuration.models import ContentKind
 from contentcuration.models import ContentNode
+from contentcuration.models import PrerequisiteContentRelationship
 
 
 class NodeViewsUtilityTestCase(BaseAPITestCase):
@@ -53,9 +54,22 @@ class GetPrerequisitesTestCase(BaseAPITestCase):
         self.node1 = self.channel.main_tree.get_descendants().exclude(kind=ContentKind.objects.get(kind=content_kinds.TOPIC))[1:2][0]
         self.node2 = self.channel.main_tree.get_descendants().exclude(kind=ContentKind.objects.get(kind=content_kinds.TOPIC))[2:3][0]
         self.postreq = self.channel.main_tree.get_descendants().exclude(kind=ContentKind.objects.get(kind=content_kinds.TOPIC))[3:4][0]
-        self.node1.prerequisite.add(self.prereq)
-        self.node2.prerequisite.add(self.prereq)
-        self.postreq.prerequisite.add(self.node1, self.node2)
+        self.add_prereqs(self.node1, [self.prereq])
+        self.add_prereqs(self.node2, [self.prereq])
+        self.add_prereqs(self.postreq, [self.node1, self.node2])
+
+    def add_prereqs(self, target, prereqs):
+        """
+        Add one or more prerequisites to a ContentNode.
+
+        For info on why we cannot use ContentNode.prerequisite.add, see here:
+
+        https://stackoverflow.com/questions/34394323/how-to-correctly-use-auto-created-attribute-in-django
+        :param target: ContentNode on which to set prerequisites
+        :param prereqs: list of prerequisite ContentNodes to set
+        """
+        for prereq in prereqs:
+            PrerequisiteContentRelationship.objects.create(target_node=target, prerequisite=prereq)
 
     def test_get_prerequisites_only(self):
         response = self.get(reverse("get_prerequisites", kwargs={"get_postrequisites": "false", "ids": ",".join((self.node1.id, self.node2.id))}))
@@ -65,7 +79,7 @@ class GetPrerequisitesTestCase(BaseAPITestCase):
 
     def test_get_postrequisites(self):
         postpostreq = self.channel.main_tree.get_descendants().exclude(kind=ContentKind.objects.get(kind=content_kinds.TOPIC))[4:5][0]
-        postpostreq.prerequisite.add(self.postreq)
+        PrerequisiteContentRelationship.objects.create(target_node=postpostreq, prerequisite=self.postreq)
         response = self.get(reverse("get_prerequisites", kwargs={"get_postrequisites": "true", "ids": ",".join((self.node1.id, self.node2.id))}))
         postrequisites = response.json()["postrequisite_mapping"]
         self.assertTrue(postpostreq.id in postrequisites[self.postreq.id])


### PR DESCRIPTION
…we must always create objects in the M2M table explicitly.

## Description

Removes the `auto_created` property on `PrerequisiteContentRelationship`, which is undocumented and should not be used. The migration it generates also removes the `PrerequisiteContentRelationship` model, suggesting the `clean` code would never get run.

Also updates test code to explicitly create the through model objects, as suggested here:

https://stackoverflow.com/questions/34394323/how-to-correctly-use-auto-created-attribute-in-django

## Steps to Test

- [ ] Make sure the tests still pass!

## Checklist

- [ ] Is the code clean and well-commented?
