### PR TITLE
Add public channel list caching

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -45,6 +45,7 @@ from mptt.models import TreeManager
 from pg_utils import DistinctSum
 
 from contentcuration.statistics import record_channel_stats
+from contentcuration.utils.cache import delete_public_channel_cache_keys
 from contentcuration.utils.parser import load_json_string
 
 EDIT_ACCESS = "edit"
@@ -622,6 +623,10 @@ class Channel(models.Model):
         blank=True,
     )
 
+    def __init__(self, *args, **kwargs):
+        super(Channel, self).__init__(*args, **kwargs)
+        self._orig_public = self.public
+
     @classmethod
     def get_all_channels(cls):
         return cls.objects.select_related('main_tree').prefetch_related('editors', 'viewers').distinct()
@@ -703,6 +708,10 @@ class Channel(models.Model):
 
         super(Channel, self).save(*args, **kwargs)
 
+        # if this change affects the public channel list, clear the channel cache
+        if self.public or self._orig_public != self.public:
+            delete_public_channel_cache_keys()
+
     def get_thumbnail(self):
         if self.thumbnail_encoding:
             thumbnail_data = self.thumbnail_encoding
@@ -746,6 +755,8 @@ class Channel(models.Model):
         if bypass_signals:
             self.public = True     # set this attribute still, so the object will be updated
             Channel.objects.filter(id=self.id).update(public=True)
+            # clear the channel cache
+            delete_public_channel_cache_keys()
         else:
             self.public = True
             self.save()

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -382,3 +382,6 @@ ORPHANAGE_ROOT_ID = "00000000000000000000000000000000"
 # so we must be very careful to limit code that touches this tree and to carefully check code that does. If we
 # do choose to implement restore of old chefs, we will need to ensure moving nodes does not cause a tree sort.
 DELETED_CHEFS_ROOT_ID = "11111111111111111111111111111111"
+
+# How long we should cache any APIs that return public channel list details, which change infrequently
+PUBLIC_CHANNELS_CACHE_DURATION = 300

--- a/contentcuration/contentcuration/tests/test_channel_views.py
+++ b/contentcuration/contentcuration/tests/test_channel_views.py
@@ -6,12 +6,12 @@ from django.core.urlresolvers import reverse_lazy
 from django.db import connection
 from django.db import reset_queries
 
+from . import testdata
 from contentcuration.models import SecretToken
 from contentcuration.serializers import StudioChannelListSerializer
 from contentcuration.views.base import get_channels_by_token
 from contentcuration.views.base import get_user_bookmarked_channels
 from contentcuration.views.base import get_user_edit_channels
-from contentcuration.views.base import get_user_public_channels
 from contentcuration.views.base import get_user_view_channels
 
 
@@ -57,11 +57,19 @@ class ChannelListTestCase(BaseAPITestCase):
         response = self.client.get(reverse('get_user_public_channels'))
         self.assertEqual(len(response.data), 0)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Cache-Control'], 'max-age={}'.format(settings.PUBLIC_CHANNELS_CACHE_DURATION))
+        # we can't test the Vary header, because it will not match what we set it to
+        # see info in contentcuration.decorators.cache_no_user_data notes.
 
     def test_get_public_channel_list(self):
         """
         Ensure we get a valid response with channel information when we have one or more public channels.
         """
+        response = self.client.get(reverse('get_user_public_channels'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        # get_user_public_channels is cached, but changing public state blows the cache
         self.channel.make_public(bypass_signals=True)
 
         response = self.client.get(reverse('get_user_public_channels'))
@@ -77,14 +85,29 @@ class ChannelListTestCase(BaseAPITestCase):
         settings.DEBUG = True
 
         reset_queries()
-        request = self.create_get_request(reverse('get_user_public_channels'))
-        response = get_user_public_channels(request)
+        response = self.client.get(reverse('get_user_public_channels'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
         # This is a warning sign for performance problems, so if the number of queries goes above this
         # number, we need to evaluate the change and see if we can do something to optimize.
         self.assertQueriesLessThan(10)
+
+        # assert that subsequent calls hit the cache
+        reset_queries()
+        response = self.client.get(reverse('get_user_public_channels'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(connection.queries), 0)
+
+        # assert that calls by other users also hit the cache
+        reset_queries()
+        new_user = testdata.user('me@work.com')
+        self.client.force_authenticate(new_user)
+        response = self.client.get(reverse('get_user_public_channels'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(connection.queries), 0)
 
     def test_no_editable_channels(self):
         """

--- a/contentcuration/contentcuration/tests/test_public_api.py
+++ b/contentcuration/contentcuration/tests/test_public_api.py
@@ -1,4 +1,6 @@
 from base import BaseAPITestCase
+from django.conf import settings
+from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from testdata import generated_base64encoding
 
@@ -13,6 +15,7 @@ class PublicAPITestCase(BaseAPITestCase):
     def setUp(self):
         super(PublicAPITestCase, self).setUp()
         self.channel_list_url = reverse('get_public_channel_list', kwargs={'version': 'v1'})
+        cache.clear()
 
     def test_info_endpoint(self):
         """
@@ -32,15 +35,26 @@ class PublicAPITestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
+        self.assertEqual(response['Cache-Control'], 'max-age={}'.format(settings.PUBLIC_CHANNELS_CACHE_DURATION))
+        # we can't test the Vary header, because it will not match what we set it to
+        # see info in contentcuration.decorators.cache_no_user_data notes.
+
     def test_public_channels_endpoint(self):
         """
         Test that the public channels endpoint returns information about
         public channels and that this information is correct.
         """
+
+        # call with an empty list first to make sure we get a cached version
+        response = self.get(self.channel_list_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
         self.channel.public = True
         self.channel.thumbnail_encoding = {'base64': generated_base64encoding()}
         self.channel.main_tree.published = True
         self.channel.main_tree.save()
+        # this will clear the channel cache, so the next call should return the updated version
         self.channel.save()
 
         response = self.client.get(self.channel_list_url)

--- a/contentcuration/contentcuration/utils/cache.py
+++ b/contentcuration/contentcuration/utils/cache.py
@@ -1,0 +1,29 @@
+from django.core.cache import cache
+
+
+def delete_cache_keys(key_pattern):
+    """
+    Deletes all cache keys that match key_pattern, if found.
+
+    Note that not all cache backends support wildcards, or have a way to retrieve all keys.
+    In this case, this function will just check if the key specified by key_pattern exists,
+    and delete it if so.
+
+    :param key_pattern: A string with a key name, can contain wildcard (*) characters
+    :param for_view:
+    :return: Number of keys deleted
+    """
+    if hasattr(cache, 'delete_pattern'):
+        return cache.delete_pattern(key_pattern)
+    elif cache.has_key(key_pattern):
+        cache.delete(key_pattern)
+        return 1
+    return 0
+
+
+def delete_public_channel_cache_keys():
+    """
+    Delete all caches related to the public channel caching.
+    """
+    delete_cache_keys('*get_public_channel_list*')
+    delete_cache_keys('*get_user_public_channels*')

--- a/contentcuration/contentcuration/views/public.py
+++ b/contentcuration/contentcuration/views/public.py
@@ -1,18 +1,20 @@
 import json
 
+from django.conf import settings
 from django.db.models import Q
 from django.db.models import TextField
 from django.db.models import Value
 from django.http import HttpResponseNotFound
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.cache import cache_page
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+from contentcuration.decorators import cache_no_user_data
 from contentcuration.models import Channel
-from contentcuration.models import ContentNode
 from contentcuration.serializers import PublicChannelSerializer
 
 
@@ -49,8 +51,10 @@ def _get_channel_list_v1(params, identifier=None):
         .distinct()
 
 
+@cache_page(settings.PUBLIC_CHANNELS_CACHE_DURATION, key_prefix='get_public_channel_list')
 @api_view(['GET'])
 @permission_classes((AllowAny,))
+@cache_no_user_data
 def get_public_channel_list(request, version):
     """ Endpoint: /public/<version>/channels/?=<query params> """
     try:


### PR DESCRIPTION
## Description

Adds both browser and server (redis) caching for public channel list endpoints, and sets it to 5 minutes. Also provides a mechanism for clearing those cache keys when the public channel list is changed via the ORM.

These changes should all be covered by additions to current tests.

#### Issue Addressed (if applicable)

General performance / speed issues.

## Steps to Test

- [ ] Ensure the public channels list appears properly and is performant

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
