### PR TITLE
Make accessible_channels a lot faster :)

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/import/views/ImportDialogue.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/import/views/ImportDialogue.vue
@@ -156,6 +156,8 @@
 
   #import-from-channel-box {
     width: @uploader-width - 30px;
+    height: 500px;
+    overflow: scroll;
   }
 
   #import-content-submit {

--- a/deploy/chaos/loadtest/locustfile.py
+++ b/deploy/chaos/loadtest/locustfile.py
@@ -81,6 +81,18 @@ class ChannelPage(BaseTaskSet):
             channel_id = None
         return channel_id
 
+    def get_first_edit_channel_id(self):
+        """
+        Returns the id of the first available public channel
+        :returns: id of the first available public channel or None if there are not public channels
+        """
+        resp = self.client.get("/get_user_edit_channels/").json()
+        try:
+            channel_id = resp[0]['id']
+        except IndexError:
+            channel_id = None
+        return channel_id
+
     def get_topic_id(self, channel_id, random=False):
         """
         Returns the id of a randomly selected topic for the provided channel_id
@@ -121,6 +133,18 @@ class ChannelPage(BaseTaskSet):
             channel_id = self.get_first_public_channel_id()
         if channel_id:
             self.client.get('/channels/{}'.format(channel_id))
+
+    # This is hit hard during heavy usage, and is one of our slowest calls,
+    # so give it some extra weight.
+    @task(3)
+    def open_accessible_channels(self, channel_id=None):
+        """
+        Open to edit a channel, if channel_id is None it opens the first public channel
+        """
+        if not channel_id:
+            channel_id = self.get_first_edit_channel_id()
+        if channel_id:
+            self.client.get('/accessible_channels/{}'.format(channel_id))
 
     # This is the most frequently hit scenario outside of ricecooker usage, so give it more weight.
     @task(3)


### PR DESCRIPTION
## Description

I was checking for ways to speed up the `accessible_channels` call, and I realized that most of the code and queries were related to getting the resource count. I then checked the import modal, and realized it was not displaying the channel's resource count. So I tried removing the field entirely, and this caused no issues with the display or functioning of the import modal. It also caused a ~4X speedup in performance on my local tests!

This PR also adds accessible_channels to our locust tests, and fixes an issue where the import modal grows way beyond the page boundaries and requires the user to scroll to click Import.

## Steps to Test

- [ ] Load the import modal
- [ ] Browse, select and import content
- [ ] Search for and import content

## Tech Debt
We should add unit tests for `accessible_channels`, although a prerequisite would be to ensure there are multiple public and editable channels, so we need some more data fixtures for that.

## Checklist

- [ ] Is the code clean and well-commented?
