### PR TITLE
Don't delete multiple files of the same kind and language automatically

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -109,11 +109,6 @@ class FileListSerializer(serializers.ListSerializer):
                 if not default_storage.exists(file_path):
                     raise OSError("Error: file {} was not found".format(str(file_obj)))
 
-                # Replace existing files
-                files_to_replace = item['contentnode'].files.exclude(pk=file_obj.pk)\
-                    .filter(preset_id=file_obj.preset_id, language_id=file_obj.language_id)
-                files_to_replace.delete()
-
                 file_obj.save()
                 ret.append(file_obj)
 


### PR DESCRIPTION
## Description

We had several reports of 'File matching query not found' errors while trying to save a ContentNode. One such sample node is here:

https://studio.learningequality.org/channels/1ceff53605e55bef987d88e0908658c5/view/6702408/9c86703

Upon investigation, this happens when multiple subtitle files for the same language code exist. The reason this happens is that le-utils treats a couple different Chinese language codes as the same, so if subtitles for both exist for a particular video, two files with the same language code get created. The code that does so is here:

https://github.com/learningequality/le-utils/blob/619c9334fee03e450fe4039cfdb5ceb67756e846/le_utils/constants/languages.py#L208

In this case, when Studio updates the first subtitle file, it goes through and deletes the other one. However, the other one is still present in `validated_data`, so later, when it tries to run the File query to access the second file, it won't find it because we deleted it earlier. 

I think ultimately we want to have a way to alert the user to duplicate subtitle files in the UI, and possibly prevent save. However, given that:

1. This makes save impossible for the nodes affected by this, and there is no workaround;

2. The issue is limited to Chinese subtitles, and the subtitles appear to load properly in Kolibri even for nodes with this issue, and 

3. We have gotten 145 Sentry reports on this issue since June,

I made a PR to simply remove the deletion of the duplicate subtitle language files. We are discussing ways to fix it in ricecooker / the chefs, so once that's done a sync should fix the problem.

#### Issue Addressed (if applicable)

Addresses #1622

## Steps to Test

- [ ] Open and save the node above without error.

Note: this is hard to test without importing an affected channel or KA. I tested using the `restore_channel` management command to download an affected channel.

#### Does this introduce any tech-debt items?

Leaves proper Studio handling of 

## Checklist

- [ ] Is the code clean and well-commented?
