### PR TITLE
Delete initContainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 altprodserver: NUM_PROCS:=3
 altprodserver: NUM_THREADS:=5
-altprodserver: collectstatic ensurecrowdinclient downloadmessages compilemessages
+altprodserver: migrate collectstatic ensurecrowdinclient downloadmessages compilemessages
 	cd contentcuration/ && gunicorn contentcuration.wsgi:application --timeout=4000 --error-logfile=/var/log/gunicorn-error.log --workers=${NUM_PROCS} --threads=${NUM_THREADS} --bind=0.0.0.0:8081 --pid=/tmp/contentcuration.pid --log-level=debug || sleep infinity
 
 contentnodegc:

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -79,21 +79,6 @@ spec:
         volumeMounts:
         - mountPath: /app/contentworkshop_static/
           name: staticfiles
-      initContainers:
-      - name: db-migrate
-        image: {{ .Values.studioApp.imageName }}
-        command:
-          - make
-          - migrate
-        env: {{ include "studio.sharedEnvs" . | nindent 8 }}
-        volumeMounts: {{ include "studio.pvc.gcs-creds" . | nindent 10 }}
-        resources:
-          requests:
-            cpu: 1000m
-            memory: 2Gi
-          limits:
-            cpu: 1000m
-            memory: 2Gi
       volumes:
         - emptyDir: {}
           name: staticfiles


### PR DESCRIPTION
They break really easily when kubernetes thinks that it can spawn multiple pods at once, causing a race condition and a lock.

Will replace very soon with jobs.

