### PR TITLE
Raise CPU and memory limits so that worker pods can burst rather than crash …

### DIFF
--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -60,8 +60,8 @@ spec:
             cpu: 0.5
             memory: 2Gi
           limits:
-            cpu: 2
-            memory: 8Gi
+            cpu: 0.5
+            memory: 2Gi
       - name: nginx-proxy
         image: {{ .Values.studioNginx.imageName }}
         env:

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -60,8 +60,8 @@ spec:
             cpu: 0.5
             memory: 2Gi
           limits:
-            cpu: 0.5
-            memory: 2Gi
+            cpu: 2
+            memory: 8Gi
       - name: nginx-proxy
         image: {{ .Values.studioNginx.imageName }}
         env:
@@ -92,8 +92,8 @@ spec:
             cpu: 1000m
             memory: 2Gi
           limits:
-            cpu: 1000m
-            memory: 2Gi
+            cpu: 2000m
+            memory: 8Gi
       volumes:
         - emptyDir: {}
           name: staticfiles
@@ -128,5 +128,5 @@ spec:
             cpu: 0.5
             memory: 2Gi
           limits:
-            cpu: 0.5
-            memory: 2Gi
+            cpu: 2
+            memory: 8Gi


### PR DESCRIPTION
…when they are under a heavy CPU or RAM load.

## Description

Makes it so that our pods can burst CPU or RAM when they need to, as we found that some publish operations were causing pods to crash and hence weren't completing.

## Steps to Test

- [ ] Deploy Studio!

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
