### PR TITLE
Handle edge cases where extra_fields is stored as a string

### DIFF
--- a/contentcuration/contentcuration/utils/import_tools.py
+++ b/contentcuration/contentcuration/utils/import_tools.py
@@ -209,6 +209,8 @@ def create_nodes(cursor, target_id, parent, indent=1, download_url=None):
         assessment_query = "SELECT mastery_model, randomize FROM {table} WHERE contentnode_id='{node}'".format(table=ASSESSMENTMETADATA_TABLE, node=id)
         result = cursor.execute(assessment_query).fetchone()
         extra_fields = result[0] if result else {}
+        if isinstance(extra_fields, basestring):
+            extra_fields = json.loads(extra_fields)
         if result:
             extra_fields.update({"randomize": result[1]})
 


### PR DESCRIPTION
Some of the extra_fields might be stored as a string, so parse it as a dict under restore_channel