### PR TITLE
Minimize the credentials given to the DB migrate job

### DIFF
--- a/contentcuration/contentcuration/migration_production_settings.py
+++ b/contentcuration/contentcuration/migration_production_settings.py
@@ -3,3 +3,6 @@
 from .production_settings import *
 
 CACHES['default']['BACKEND'] = "django_prometheus.cache.backends.locmem.LocMemCache"
+
+# Remove the need for GCS as well
+DEFAULT_FILE_STORAGE = 'django_s3_storage.storage.S3Storage'

--- a/k8s/templates/job-template.yaml
+++ b/k8s/templates/job-template.yaml
@@ -15,9 +15,6 @@ data:
   MPLBACKEND: PS
   STUDIO_BETA_MODE: "yes"
   RUN_MODE: k8s
-  CELERY_REDIS_DB: "0"
-  CELERY_BROKER_ENDPOINT: {{ template "redis.fullname" . }}-master
-  CELERY_RESULT_BACKEND_ENDPOINT: {{ template "redis.fullname" . }}-master
   RELEASE_COMMIT_SHA: {{ .Values.studioApp.releaseCommit | default "" }}
   BRANCH_ENVIRONMENT: {{ .Release.Name }}
 ---
@@ -38,7 +35,6 @@ data:
   DATA_DB_NAME: {{ .Values.postgresql.postgresDatabase | default "" | b64enc }}
   DATA_DB_USER: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
   DATA_DB_PASS: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
-  CELERY_REDIS_PASSWORD: {{ .Values.redis.password | default "" | b64enc }}
   SENTRY_DSN_KEY: {{ .Values.sentry.dsnKey | default "" | b64enc }}
 ---
 apiVersion: batch/v1

--- a/k8s/templates/job-template.yaml
+++ b/k8s/templates/job-template.yaml
@@ -11,6 +11,7 @@ metadata:
 data:
   DJANGO_SETTINGS_MODULE: {{ .Values.settings }}
   DJANGO_LOG_FILE: /var/log/django.log
+  DATA_DB_PORT: "5432"
   MPLBACKEND: PS
   STUDIO_BETA_MODE: "yes"
   RUN_MODE: k8s
@@ -33,9 +34,8 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
-  DATA_DB_HOST: {{ .Values.postgresql.externalCloudSQL.proxyHostName | default (include "postgresql.fullname" .) }}
+  DATA_DB_HOST: {{ .Values.postgresql.externalCloudSQL.proxyHostName | default (include "postgresql.fullname" .) | b64enc }}
   DATA_DB_NAME: {{ .Values.postgresql.postgresDatabase | default "" | b64enc }}
-  DATA_DB_PORT: "5432"
   DATA_DB_USER: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
   DATA_DB_PASS: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
   CELERY_REDIS_PASSWORD: {{ .Values.redis.password | default "" | b64enc }}
@@ -64,12 +64,12 @@ spec:
         - migrate
         envFrom:
         - configMapRef:
-            name: {{ template "studio.fullname" . }}-django-config
+            name: {{ template "studio.fullname" . }}-db-migrate-config
+        - secretRef:
+            name: {{ template "studio.fullname" . }}-db-migrate-secrets
         env:
         - name: DJANGO_SETTINGS_MODULE
           value: contentcuration.migration_production_settings
-        volumeMounts:
-        {{ include "studio.pvc.gcs-creds" . | nindent 8 }}
         resources:
           requests:
             cpu: 1
@@ -77,8 +77,3 @@ spec:
           limits:
             cpu: 1
             memory: 2Gi
-      volumes:
-      - name: gcs-creds
-        secret:
-          secretName: {{ template "studio.fullname" . }}-gcs-creds-for-dbmigrate
-          optional: true

--- a/k8s/templates/job-template.yaml
+++ b/k8s/templates/job-template.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "studio.fullname" . }}-django-config
+  name: {{ template "studio.fullname" . }}-db-migrate-config
   labels:
     app: {{ template "studio.fullname" . }}
   annotations:
@@ -14,11 +14,16 @@ data:
   MPLBACKEND: PS
   STUDIO_BETA_MODE: "yes"
   RUN_MODE: k8s
+  CELERY_REDIS_DB: "0"
+  CELERY_BROKER_ENDPOINT: {{ template "redis.fullname" . }}-master
+  CELERY_RESULT_BACKEND_ENDPOINT: {{ template "redis.fullname" . }}-master
+  RELEASE_COMMIT_SHA: {{ .Values.studioApp.releaseCommit | default "" }}
+  BRANCH_ENVIRONMENT: {{ .Release.Name }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "studio.fullname" . }}
+  name: {{ template "studio.fullname" . }}-db-migrate-secrets
   labels:
     app: studio
     chart: {{ .Chart.Name }}
@@ -28,33 +33,15 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
-  postmark-api-key: {{ .Values.studioApp.postmarkApiKey | default "" | b64enc }}
-  redis-password: {{ .Values.redis.password | default "" | b64enc }}
-  postgres-user: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
-  postgres-password: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
-  postgres-database: {{ .Values.postgresql.postgresDatabase | default "" | b64enc }}
+  DATA_DB_HOST: {{ .Values.postgresql.externalCloudSQL.proxyHostName | default (include "postgresql.fullname" .) }}
+  DATA_DB_NAME: {{ .Values.postgresql.postgresDatabase | default "" | b64enc }}
+  DATA_DB_PORT: "5432"
+  DATA_DB_USER: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
+  DATA_DB_PASS: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
+  CELERY_REDIS_PASSWORD: {{ .Values.redis.password | default "" | b64enc }}
   {{ if .Values.sentry.dsnKey }}
-  sentry-dsn-key: {{ .Values.sentry.dsnKey }}
+  SENTRY_DSN_KEY: {{ .Values.sentry.dsnKey }}
   {{ end }}
----
-# this secret is for the dbmigrate job. This needs to exist alongside it
-{{- if .Values.minio.externalGoogleCloudStorage.gcsKeyJson }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "studio.fullname" . }}-gcs-creds-for-dbmigrate
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-  labels:
-    app: {{ template "studio.name" . }}
-    chart: {{ template "studio.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-type: Opaque
-data:
-  gcs_key.json: {{ .Values.minio.externalGoogleCloudStorage.gcsKeyJson }}
-{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -78,7 +65,7 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "studio.fullname" . }}-django-config
-        env: {{ include "studio.sharedEnvs" . | nindent 8 }}
+        env:
         - name: DJANGO_SETTINGS_MODULE
           value: contentcuration.migration_production_settings
         volumeMounts:
@@ -94,3 +81,4 @@ spec:
       - name: gcs-creds
         secret:
           secretName: {{ template "studio.fullname" . }}-gcs-creds-for-dbmigrate
+          optional: true

--- a/k8s/templates/job-template.yaml
+++ b/k8s/templates/job-template.yaml
@@ -44,7 +44,7 @@ metadata:
   labels:
     app: {{ template "studio.fullname" . }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": post-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:

--- a/k8s/templates/job-template.yaml
+++ b/k8s/templates/job-template.yaml
@@ -39,9 +39,7 @@ data:
   DATA_DB_USER: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
   DATA_DB_PASS: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
   CELERY_REDIS_PASSWORD: {{ .Values.redis.password | default "" | b64enc }}
-  {{ if .Values.sentry.dsnKey }}
-  SENTRY_DSN_KEY: {{ .Values.sentry.dsnKey }}
-  {{ end }}
+  SENTRY_DSN_KEY: {{ .Values.sentry.dsnKey | default "" | b64enc }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "studio.fullname" . }}
+  labels:
+    app: studio
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  postmark-api-key: {{ .Values.studioApp.postmarkApiKey | default "" | b64enc }}
+  redis-password: {{ .Values.redis.password | default "" | b64enc }}
+  postgres-user: {{ .Values.postgresql.postgresUser | default "" | b64enc }}
+  postgres-password: {{ .Values.postgresql.postgresPassword | default "" | b64enc }}
+  postgres-database: {{ .Values.postgresql.postgresDatabase | default "" | b64enc }}
+  {{ if .Values.sentry.dsnKey }}
+  sentry-dsn-key: {{ .Values.sentry.dsnKey }}
+  {{ end }}


### PR DESCRIPTION
The DB migrate job has too many credentials that it doesn't need, posing as a security issue. This PR restores the old secrets that the frontend pods need. We then expand on the config map and add a new secret for our migrate job, giving it only the credentials it needs to deploy.

To test:

if you have a local kubernetes cluster (minikube or microk8s), you can test this by running:
```bash
cd k8s/ && helm upgrade -i local .
```