### PR TITLE
add develop studio prober account

### DIFF
--- a/deploy/probers/base.py
+++ b/deploy/probers/base.py
@@ -45,6 +45,11 @@ class BaseProbe(object):
         )
         r.raise_for_status()
 
+        # Since logging into Studio with wrong username and password also returns 200
+        # status code, check the response url to see whether we have logged in or not.
+        if r.url == url:
+            raise Exception("Cannot log into Studio.")
+
         return r
 
     def _construct_studio_url(self, path):

--- a/k8s/templates/prober-deployment.yaml
+++ b/k8s/templates/prober-deployment.yaml
@@ -26,3 +26,7 @@ spec:
           value: http://{{ template "studio.fullname" . }}-celery-dashboard-service:5555/dashboard
         - name: PROBER_STUDIO_PRODUCTION_MODE_ON
           value: "yes"
+        - name: PROBER_STUDIO_USERNAME
+          value: lingyi+prober@learningequality.org
+        - name: PROBER_STUDIO_PASSWORD
+          value: "123456789"


### PR DESCRIPTION
## Description

This PR is to add develop studio prober account since a@a.com doesn't exist on develop Studio.
Based on Aron's [suggestion on Slack](https://learningequality.slack.com/archives/GBSTQ6P2P/p1571351967001000), the account is not encrypted. 

It also adds an additional check in the login prober because logging in with wrong username and password also returns 200 status code.

before the PR, the probers failed because user a@a.com doesn't exist:
<img width="216" alt="Screen Shot 2019-10-17 at 4 12 43 PM" src="https://user-images.githubusercontent.com/19424916/67054323-0866f980-f0f9-11e9-8b2c-9ba6bdebf7e8.png">


