### PR TITLE
Improve startup time and gunicorn configurability by running gunicorn directly through K8s

### DIFF
--- a/contentcuration/contentcuration/collectstatic_settings.py
+++ b/contentcuration/contentcuration/collectstatic_settings.py
@@ -1,0 +1,6 @@
+# Settings  used by containers running collectstatic. Scope our services
+# to the only ones needed to run collectstatic.
+
+from .settings import *
+
+CACHES['default']['BACKEND'] = "django_prometheus.cache.backends.locmem.LocMemCache"

--- a/contentcuration/contentcuration/templatetags/license_tags.py
+++ b/contentcuration/contentcuration/templatetags/license_tags.py
@@ -53,6 +53,7 @@ DESCRIPTION_MAPPING = {"CC BY": _("The Attribution License lets others distribut
 @register.filter(is_safe=True)
 @stringfilter
 def get_license_url(value):
+    global LICENSE_MAPPING
     if not LICENSE_MAPPING:
         LICENSE_MAPPING = {l.license_name: l.license_url for l in License.objects.all()}
 

--- a/contentcuration/contentcuration/templatetags/license_tags.py
+++ b/contentcuration/contentcuration/templatetags/license_tags.py
@@ -1,11 +1,11 @@
+from contentcuration.models import License
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.utils.translation import ugettext_lazy as _
 
-from contentcuration.models import License
 register = template.Library()
 
-LICENSE_MAPPING = {l.license_name: l.license_url for l in License.objects.all()}
+LICENSE_MAPPING = None
 
 DESCRIPTION_MAPPING = {"CC BY": _("The Attribution License lets others distribute, "
                                   "remix, tweak, and build upon your work, even commercially, "
@@ -53,6 +53,9 @@ DESCRIPTION_MAPPING = {"CC BY": _("The Attribution License lets others distribut
 @register.filter(is_safe=True)
 @stringfilter
 def get_license_url(value):
+    if not LICENSE_MAPPING:
+        LICENSE_MAPPING = {l.license_name: l.license_url for l in License.objects.all()}
+
     return LICENSE_MAPPING.get(value)
 
 

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -16,6 +16,22 @@ spec:
         app: {{ template "studio.fullname" . }}
         tier: app
     spec:
+      initContainers:
+      - name: collectstatic
+        image: {{ .Values.studioApp.imageName }}
+        workingDir: /contentcuration/
+        command:
+        - make
+        args:
+        - collectstatic
+        env:
+        - name: DJANGO_SETTINGS_MODULE
+          value: contentcuration.collectstatic_settings
+        - name: STATICFILES_DIR
+          value: /app/contentworkshop_static/
+        volumeMounts:
+        - mountPath: /app/contentworkshop_static/
+          name: staticfiles
       containers:
       - name: app
         image: {{ .Values.studioApp.imageName }}
@@ -30,8 +46,6 @@ spec:
         - --bind=0.0.0.0:8081
         - --pid=/tmp/contentcuration.pid
         env: {{ include "studio.sharedEnvs" . | nindent 8 }}
-        - name: STATICFILES_DIR
-          value: /app/contentworkshop_static/
         - name: SEND_USER_ACTIVATION_NOTIFICATION_EMAIL
           value: "true"
         # liveness probes are checks for when a pod should be restarted.
@@ -60,9 +74,6 @@ spec:
           periodSeconds: 2
           # fail 3 times before taking this app off the routing table
           failureThreshold: 3
-        volumeMounts:
-        - mountPath: /app/contentworkshop_static/
-          name: staticfiles
         {{ include "studio.pvc.gcs-creds" . | nindent 8 }}
         {{ include "studio.pvc.gdrive-creds" . | nindent 8 }}
         resources:

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -19,6 +19,16 @@ spec:
       containers:
       - name: app
         image: {{ .Values.studioApp.imageName }}
+        workingDir: /contentcuration/contentcuration/
+        command:
+        - gunicorn
+        args:
+        - contentcuration.wsgi:application
+        - --timeout=4000
+        - --workers=3
+        - --threads=5
+        - --bind=0.0.0.0:8081
+        - --pid=/tmp/contentcuration.pid
         env: {{ include "studio.sharedEnvs" . | nindent 8 }}
         - name: STATICFILES_DIR
           value: /app/contentworkshop_static/


### PR DESCRIPTION
This is another tweak I have while adding pgBouncer and the network connection backlog prober.

We remove the `make` indirection layer here by running Gunicorn directly as a command in the k8s manifest. This allows us to tweak its settings directly without waiting for builds. This makes our startup time much faster since we don't have all the other dependencies we have in `make altprodserver`.

However we still need to run collectstatic. I added a new initContainer that is responsible for collectstatic, and otherwise doesn't need any other credentials.