### PR TITLE
upgrade studio demo and prober docker image to bionic

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -1,19 +1,18 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update --fix-missing && apt-get -y install curl
 
-# Add the Cloud SDK distribution URI as a package source
-RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-
-# Import the Google Cloud Platform public key
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+# Set the timezone
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
 # install node
-ADD https://deb.nodesource.com/setup_10.x /tmp/node_setup
-RUN bash /tmp/node_setup
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
-RUN apt-get update && apt-get -y install nodejs python python-dev python-pip gcc libpq-dev ffmpeg imagemagick ghostscript python-tk make git gettext openjdk-9-jre-headless curl libjpeg-dev wkhtmltopdf google-cloud-sdk fonts-freefont-ttf xfonts-75dpi poppler-utils
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get -y install nodejs python python-dev python-pip gcc libpq-dev ffmpeg imagemagick ghostscript python-tk make git gettext curl libjpeg-dev wkhtmltopdf fonts-freefont-ttf xfonts-75dpi poppler-utils
 
+# install wkhtml, and libpng12 (its dependency)
+RUN curl -L -o libpng12.deb http://security.ubuntu.com/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb && dpkg -i libpng12.deb
 RUN curl -L -o wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb && dpkg -i wkhtmltox.deb
 
 RUN npm install -g yarn
@@ -25,12 +24,10 @@ RUN yarn install
 COPY Pipfile .
 COPY Pipfile.lock .
 
-# pip 18.1 gives an error with pipenv, so pin the version to 18.0 until there is a fix.
-# More info here: https://github.com/pypa/pipenv/issues/2924
-RUN pip install pip==18.0
+RUN pip install --upgrade pip
 RUN pip install -U pipenv
 # install the environment exactly as specified in the Pipfile.lock file
-RUN pipenv install --system --ignore-pipfile --keep-outdated
+RUN python -m pipenv install --system --ignore-pipfile --keep-outdated
 
 COPY  . /contentcuration/
 WORKDIR /contentcuration

--- a/k8s/images/prober/Dockerfile
+++ b/k8s/images/prober/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y curl python-pip unzip
 


### PR DESCRIPTION
This PR is to upgrade the studio demo and prober docker image to bionic due to the changes made in [this PR](https://github.com/learningequality/studio/pull/1649).

For the changes in Dockerfile.demo, I copied the app Dockerfile since the only change between the two is the make command.