### PR TITLE
remove get_user_edit_channels nginx caching

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -82,34 +82,5 @@ http {
             # show the cache status in a header
             add_header X-Cache-Status $upstream_cache_status;
         }
-
-        # cache the get_user_edit_channels endpoint.
-        # this is specific on a per-user basis. This might also change very frequently.
-        # We thus need to cache this with a very short duration (5 seconds), and key it by
-        # the session id.
-        # We still cache this through nginx to take advantage of the proxy_cache_background_update
-        # and the proxy_cache_use_stale header, allowing us to serve slightly stale content while
-        # still rate limiting the amount of queries being sent to the app server.
-        location /get_user_edit_channels/ {
-            proxy_cache public_channel_cache;
-            proxy_pass  http://studio/get_user_edit_channels/;
-
-            # cache any 200 OK status code values for 5 seconds
-            proxy_ignore_headers Cache-Control;
-            proxy_cache_valid 200 5s;
-
-            # ignore any get params, cache by our cookie sessionid value
-            proxy_cache_key $scheme$proxy_host$uri$cookie_kolibri_studio_sessionid;
-            # next two directives make nginx serve the cached value even when we're refreshing it
-            proxy_cache_use_stale updating error;
-            proxy_cache_background_update on;
-
-            # proxy_cache_lock sends only 1 query to the server if there's a lot of them at once,
-            # preventing stampedes
-            proxy_cache_lock on;
-
-            # show the cache status in a header
-            add_header X-Cache-Status $upstream_cache_status;
-        }
     }
 }


### PR DESCRIPTION
this causes issues with the user not seeing the new channel if they refresh immediately. From what we've seen in the field, this can lead to users creating multiple copies of a channel.

This is exacerbated when we have less frontend pods running, since users are more likely to hit the same studio frontend pod instance.

We need a smarter caching system to make this work. For now, we can deal with request stampedes by increasing our capacity.