### PR TITLE
Fallback in case extra_fields is string-like

### DIFF
--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -355,6 +355,8 @@ def process_assessment_metadata(ccnode, kolibrinode):
     # Get mastery model information, set to default if none provided
     assessment_items = ccnode.assessment_items.all().order_by('order')
     exercise_data = ccnode.extra_fields if ccnode.extra_fields else {}
+    if isinstance(exercise_data, basestring):
+        exercise_data = json.loads(exercise_data)
     randomize = exercise_data.get('randomize') if exercise_data.get('randomize') is not None else True
     assessment_item_ids = [a.assessment_id for a in assessment_items]
 


### PR DESCRIPTION
Certain exercise content nodes have `extra_fields` as str, not json. This avoids the error during publish.


## Description

During testing today, I encountered this error

```
celery-worker_1  |   File "/src/contentcuration/contentcuration/utils/publish.py", line 672, in publish_channel
celery-worker_1  |     create_content_database(channel, force, user_id, force_exercises, task_object)
celery-worker_1  |   File "/src/contentcuration/contentcuration/utils/publish.py", line 90, in create_content_database
celery-worker_1  |     force_exercises=force_exercises, task_object=task_object, starting_percent=10.0)
celery-worker_1  |   File "/src/contentcuration/contentcuration/utils/publish.py", line 149, in map_content_nodes
celery-worker_1  |     exercise_data = process_assessment_metadata(node, kolibrinode)
celery-worker_1  |   File "/src/contentcuration/contentcuration/utils/publish.py", line 358, in process_assessment_metadata
celery-worker_1  |     randomize = exercise_data.get('randomize') if exercise_data.get('randomize') is not None else True
celery-worker_1  | AttributeError: 'unicode' object has no attribute 'get'
```

This was for a recently created channel via ricecooker.



#### Issue Addressed (if applicable)

Imitating the fix implemented here https://github.com/learningequality/studio/commit/f033719a6ded5c2224b1f410ff47fd83d2413e9a




## Comments

There might be other places in the code that json/str confusing might occur. This is just a local fix for one issue I encountered today; a more throrough review might be necessary.


