### PR TITLE
Add a cache-control setting when we upload content databases

### DIFF
--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 from cStringIO import StringIO
 
-import pytest
-from django.core.files import File
-from django.test import TestCase
 from google.cloud.storage import Client
 from google.cloud.storage.blob import Blob
+
+import pytest
+from contentcuration.utils.gcs_storage import GoogleCloudStorage as gcs
+from django.core.files import File
+from django.test import TestCase
 from mixer.main import mixer
 from mock import create_autospec
-
-from contentcuration.utils.gcs_storage import GoogleCloudStorage as gcs
 
 
 class MimeTypesTestCase(TestCase):
@@ -82,6 +82,15 @@ class GoogleCloudStorageSaveTestCase(TestCase):
 
         # check that upload_from_file is never called
         self.blob_obj.upload_from_file.assert_not_called()
+
+    def test_uploads_max_age_of_5_if_content_database(self):
+        """
+        Check that we set a max-age of 5 if we're uploading a content database
+        """
+        filename = "content/databases/myfile.jpg"
+        self.storage.save(filename, self.content, blob_object=self.blob_obj)
+        assert "max-age=5" in self.blob_obj.cache_control
+
 
 
 class GoogleCloudStorageOpenTestCase(TestCase):

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -2,14 +2,17 @@ import logging
 import mimetypes
 import tempfile
 
-import backoff
-from django.core.files import File
-from django.core.files.storage import Storage
 from google.cloud.exceptions import InternalServerError
 from google.cloud.storage import Client
 from google.cloud.storage.blob import Blob
 
+import backoff
+from django.core.files import File
+from django.core.files.storage import Storage
+
 OLD_STUDIO_STORAGE_PREFIX = "/contentworkshop_content/"
+
+CONTENT_DATABASES_MAX_AGE = 5 # seconds
 
 MAX_RETRY_TIME = 60  # seconds
 
@@ -106,6 +109,10 @@ class GoogleCloudStorage(Storage):
             logging.warning("Stopping the upload of an empty file: {}".format(name))
             return name
 
+        # set a max-age of 5 if we're uploading to content/databases
+        if self.is_database_file(name):
+            blob.cache_control = 'public, max-age={}'.format(CONTENT_DATABASES_MAX_AGE)
+
         blob.upload_from_file(
             fobj,
             content_type=content_type,
@@ -155,6 +162,11 @@ class GoogleCloudStorage(Storage):
     def generate_filename(self, filename):
         # TODO(aron): can we move the generate_object_storage_name logic to here?
         return filename
+
+    # Aron: note: move to a studio_storage object, since this is studio-specific logic
+    @staticmethod
+    def is_database_file(filename):
+        return "content/databases" in filename
 
     @staticmethod
     def _is_file_empty(fobj):


### PR DESCRIPTION
**Please remove any unused sections**

## Description

*What does this PR do? Briefly describe in 1-2 sentences*

#### Issue Addressed (if applicable)

Addresses #*PR# HERE*

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
