### PR TITLE
Fix the deployment by adding in a missing manifest key

### DIFF
--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -42,5 +42,5 @@ helm upgrade --install $RELEASENAME . \
      --set studioApp.gDrive.keyJson=$(base64 $GDRIVE_SERVICE_ACCOUNT_JSON  --wrap=0) \
      --set sentry.dsnKey=$(echo "$SENTRY_DSN_KEY" | base64 --wrap=0) \
      --timeout 1500 \
-     --set studioProber.newrelicKey=$PROBER_NEWRELIC_KEY \
+     --set-string studioProber.newrelicKey=$PROBER_NEWRELIC_KEY \
      --set-string studioProber.newrelicAccountId=$PROBER_NEWRELIC_ACCOUNT_ID  # use set-string to resolve the issue https://github.com/helm/helm/issues/1707

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -74,6 +74,7 @@ spec:
           periodSeconds: 2
           # fail 3 times before taking this app off the routing table
           failureThreshold: 3
+        volumeMounts:
         {{ include "studio.pvc.gcs-creds" . | nindent 8 }}
         {{ include "studio.pvc.gdrive-creds" . | nindent 8 }}
         resources:

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -17,6 +17,6 @@ data:
   sentry-dsn-key: {{ .Values.sentry.dsnKey }}
   {{ end }}
   {{ if .Values.studioProber.newrelicKey }}
-  newrelic-key: {{ .Values.studioProber.newrelicKey | default "" | b64enc }}
-  newrelic-account-id: {{ .Values.studioProber.newrelicAccountId | default "" | b64enc}}
+  newrelic-key: !!str {{ .Values.studioProber.newrelicKey | default "" | b64enc }}
+  newrelic-account-id: !!str {{ .Values.studioProber.newrelicAccountId | default "" | b64enc}}
   {{ end }}


### PR DESCRIPTION
We accidentally removed a k8s manifest key. Deployments are failing because of that.

Re-add that in, and add other checks as well to force certain inputs to be parsed as strings.