### PR TITLE
add more cache-control headers to gcs

### DIFF
--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -111,7 +111,7 @@ class GoogleCloudStorage(Storage):
 
         # set a max-age of 5 if we're uploading to content/databases
         if self.is_database_file(name):
-            blob.cache_control = 'public, max-age={}'.format(CONTENT_DATABASES_MAX_AGE)
+            blob.cache_control = 'private, max-age={}, no-transform'.format(CONTENT_DATABASES_MAX_AGE)
 
         blob.upload_from_file(
             fobj,


### PR DESCRIPTION
Upon more testing by @jonboiser, looks like this time it's nginx who's caching our content DB. This time we now set cache-control to private, and set no-transform, to ensure that the DB is never cached downstream.