### PR TITLE
Use .sqlite3 extension to set custom cache-control

### DIFF
--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -87,7 +87,7 @@ class GoogleCloudStorageSaveTestCase(TestCase):
         """
         Check that we set a max-age of 5 if we're uploading a content database
         """
-        filename = "content/databases/myfile.jpg"
+        filename = "content/databases/myfile.sqlite3"
         self.storage.save(filename, self.content, blob_object=self.blob_obj)
         assert "max-age=5" in self.blob_obj.cache_control
 

--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -91,6 +91,15 @@ class GoogleCloudStorageSaveTestCase(TestCase):
         self.storage.save(filename, self.content, blob_object=self.blob_obj)
         assert "max-age=5" in self.blob_obj.cache_control
 
+    def test_uploads_cache_control_private_if_content_database(self):
+        """
+        Check that set set a cache-control of private if we're uploading a content database.
+        This ensures that no proxy will cache this file.
+        """
+        filename = "content/databases/myfile.sqlite3"
+        self.storage.save(filename, self.content, blob_object=self.blob_obj)
+        assert "private" in self.blob_obj.cache_control
+
 
 
 class GoogleCloudStorageOpenTestCase(TestCase):

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -166,7 +166,7 @@ class GoogleCloudStorage(Storage):
     # Aron: note: move to a studio_storage object, since this is studio-specific logic
     @staticmethod
     def is_database_file(filename):
-        return "content/databases" in filename
+        return filename.endswith(".sqlite3")
 
     @staticmethod
     def _is_file_empty(fobj):


### PR DESCRIPTION
The cache-control fixes we made previously still don't affect all sqlite3 files.

This time we check for the .sqlite3 extension when we apply the cache-control fix.