### PR TITLE
compress database files before uploading to GCS

### DIFF
--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 from cStringIO import StringIO
 
-from google.cloud.storage import Client
-from google.cloud.storage.blob import Blob
-
 import pytest
-from contentcuration.utils.gcs_storage import GoogleCloudStorage as gcs
 from django.core.files import File
 from django.test import TestCase
+from google.cloud.storage import Client
+from google.cloud.storage.blob import Blob
 from mixer.main import mixer
 from mock import create_autospec
+from mock import patch
+
+from contentcuration.utils.gcs_storage import GoogleCloudStorage as gcs
 
 
 class MimeTypesTestCase(TestCase):
@@ -100,6 +101,17 @@ class GoogleCloudStorageSaveTestCase(TestCase):
         self.storage.save(filename, self.content, blob_object=self.blob_obj)
         assert "private" in self.blob_obj.cache_control
 
+    @patch("contentcuration.utils.gcs_storage.StringIO")
+    @patch("contentcuration.utils.gcs_storage.GoogleCloudStorage._is_file_empty", return_value=False)
+    def test_gzip_if_content_database(self, stringio_mock, file_empty_mock):
+        """
+        Check that if we're uploading a gzipped content database and
+        if the StringIO object has been closed.
+        """
+        filename = "content/databases/myfile.sqlite3"
+        self.storage.save(filename, self.content, blob_object=self.blob_obj)
+        assert self.blob_obj.content_encoding == "gzip"
+        assert stringio_mock.called
 
 
 class GoogleCloudStorageOpenTestCase(TestCase):

--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -1,18 +1,19 @@
 import logging
 import mimetypes
 import tempfile
-
-from google.cloud.exceptions import InternalServerError
-from google.cloud.storage import Client
-from google.cloud.storage.blob import Blob
+from cStringIO import StringIO
+from gzip import GzipFile
 
 import backoff
 from django.core.files import File
 from django.core.files.storage import Storage
+from google.cloud.exceptions import InternalServerError
+from google.cloud.storage import Client
+from google.cloud.storage.blob import Blob
 
 OLD_STUDIO_STORAGE_PREFIX = "/contentworkshop_content/"
 
-CONTENT_DATABASES_MAX_AGE = 5 # seconds
+CONTENT_DATABASES_MAX_AGE = 5  # seconds
 
 MAX_RETRY_TIME = 60  # seconds
 
@@ -97,26 +98,40 @@ class GoogleCloudStorage(Storage):
         else:
             blob = blob_object
 
-        # force the current file to be at file location 0, to
-        # because that's what google wants
+        buffer = None
+        # set a max-age of 5 if we're uploading to content/databases
+        if self.is_database_file(name):
+            blob.cache_control = 'private, max-age={}, no-transform'.format(CONTENT_DATABASES_MAX_AGE)
+
+            # Compress the database file so that users can save bandwith and download faster.
+            buffer = StringIO()
+            compressed = GzipFile(fileobj=buffer, mode="w")
+            compressed.write(fobj.read())
+            compressed.close()
+
+            blob.content_encoding = "gzip"
+            fobj = buffer
 
         # determine the current file's mimetype based on the name
         content_type = self._determine_content_type(name)
 
+        # force the current file to be at file location 0, to
+        # because that's what google wants
         fobj.seek(0)
 
         if self._is_file_empty(fobj):
             logging.warning("Stopping the upload of an empty file: {}".format(name))
             return name
 
-        # set a max-age of 5 if we're uploading to content/databases
-        if self.is_database_file(name):
-            blob.cache_control = 'private, max-age={}, no-transform'.format(CONTENT_DATABASES_MAX_AGE)
-
         blob.upload_from_file(
             fobj,
             content_type=content_type,
         )
+
+        # Close StringIO object and discard memory buffer if created
+        if buffer:
+            buffer.close()
+
         return name
 
     def url(self, name):


### PR DESCRIPTION
## Description

This PR is to compress the database files before uploading to GCS so that
- Kolibri users can save time downloading the channel database files from Studio (major)
- The size of the file saved on GCS can be reduced, which can save some cost for GCS

#### Issue Addressed (if applicable)

It takes time for Kolibri users to download some large database files (e.g. Khan Academy) under slow network.


## Steps to Test

I tested it the compress and upload part separately on my local machine. I'm wondering if it would be helpful if we set up a demo server and test from there.
