### PR TITLE
add DATA_DB_HOST to celery and prober deployments

### DIFF
--- a/k8s/templates/celery-dashboard.yaml
+++ b/k8s/templates/celery-dashboard.yaml
@@ -23,7 +23,9 @@ spec:
           ports:
             - name: webui
               containerPort: 5555
-          env: {{ include "studio.sharedEnvs" . | nindent 12 }}
+          env: {{ include "studio.sharedEnvs" . | nindent 10 }}
+          - name: DATA_DB_HOST
+            value: {{ .Values.postgresql.externalCloudSQL.proxyHostName | default (include "postgresql.fullname" .) }}
           workingDir: /contentcuration/contentcuration
           command:
           - celery

--- a/k8s/templates/prober-deployment.yaml
+++ b/k8s/templates/prober-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         - containerPort: {{ .Values.studioProber.port }}
         command: ["/deploy/prober-entrypoint.sh"]
         env: {{ include "studio.sharedEnvs" . | nindent 8 }}
+        - name: DATA_DB_HOST
+          value: {{ .Values.postgresql.externalCloudSQL.proxyHostName | default (include "postgresql.fullname" .) }}
         - name: PROBER_STUDIO_BASE_URL
           value: http://{{ template "studio.fullname" . }}-app
         - name: CELERY_DASHBOARD_URL


### PR DESCRIPTION
The PR is to add DATA_DB_HOST to both celery-dashboard and prober deployments so that they can directly connect to the database.
Previously, the variable was not added to the deployments, which led the applications to connect to 127.0.0.1 by default.
Note that the changes are live on develop studio now.
I will set up a demo server to double-check if things are working. 
Please let me know if you have any questions! Thank you!