### PR TITLE
Create correlation IDs between web transactions

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -294,10 +294,14 @@ function fetch_nodes(ids, url) {
           if (id_list.length === 0) {
             promise_resolve([]); // No need to make a call to the server
           }
+          var transactionId = setTransactionId();
           $.ajax({
             method: 'GET',
             url: url(id_list.join(',')),
             error: promise_reject,
+            headers: {
+              'X-Transaction-ID': transactionId,
+            },
             success: promise_resolve,
           });
         });

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -8,14 +8,19 @@ const DEFAULT_ADMIN_PAGE_SIZE = 25;
 
 /**** BASE MODELS ****/
 
+function setTransactionId() {
+  var transactionId = Math.random().toString(36).substr(2, 9);
+  Raven.setTagsContext("transaction_id", transactionId);
+  return transactionId;
+};
+
 // Override the original backbone.sync code to include custom request transaction
 // headers.
 var _origBackboneSync = Backbone.sync
 Backbone.sync = function(method, model, options) {
   options.beforeSend = function(xhr) {
     // create a transaction ID, and associate this to this request.
-    var transactionId = Math.random().toString(36).substr(2, 9);
-    Raven.setTagsContext("transaction_id", transactionId);
+    var transactionId = setTransactionId();
     xhr.setRequestHeader("X-Transaction-ID", transactionId);
   };
   _origBackboneSync.call(this, method, model, options);

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -8,6 +8,19 @@ const DEFAULT_ADMIN_PAGE_SIZE = 25;
 
 /**** BASE MODELS ****/
 
+// Override the original backbone.sync code to include custom request transaction
+// headers.
+var _origBackboneSync = Backbone.sync
+Backbone.sync = function(method, model, options) {
+  options.beforeSend = function(xhr) {
+    // create a transaction ID, and associate this to this request.
+    var transactionId = Math.random().toString(36).substr(2, 9);
+    Raven.setTagsContext("transaction_id", transactionId);
+    xhr.setRequestHeader("X-Transaction-ID", transactionId);
+  };
+  _origBackboneSync.call(this, method, model, options);
+};
+
 var BaseModel = Backbone.Model.extend({
   root_list: null,
   model_name: 'Model',

--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -4,7 +4,7 @@ events {
     worker_connections 1024;
 }
 http {
-    proxy_cache_path /tmp/proxycache levels=1:2 keys_zone=public_channel_cache:10m max_size=10g 
+    proxy_cache_path /tmp/proxycache levels=1:2 keys_zone=public_channel_cache:10m max_size=10g
                     inactive=600m use_temp_path=off;
     include mime.types;
     sendfile on;
@@ -44,6 +44,8 @@ http {
             proxy_pass         http://studio;
             proxy_redirect     off;
             proxy_set_header   Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
         }
 
         location /content/ {
@@ -62,7 +64,7 @@ http {
         # and the return value should rarely change as well. This makes it
         # a candidate for long-running caches keyed simply by the URI.
         location /get_user_public_channels/ {
-            proxy_cache public_channel_cache; 
+            proxy_cache public_channel_cache;
             proxy_pass  http://studio/get_user_public_channels/;
 
             # cache any 200 OK status code values for 10 minutes
@@ -74,7 +76,7 @@ http {
             # next two directives make nginx serve the cached value even when we're refreshing it
             proxy_cache_use_stale updating error;
             proxy_cache_background_update on;
-            
+
             # proxy_cache_lock sends only 1 query to the server if there's a lot of them at once,
             # preventing stampedes
             proxy_cache_lock on;


### PR DESCRIPTION
# Problem

Errors in the client that are caused by the backend aren't easily correlated. We usually have to look at timestamps and problem familiarity in order to figure out what backend error has caused a timeout or frontend error.

# Description

This PR adds 2 headers that allow us to correlate performance issues or errors across different parts of studio.

1. `X-Transaction-ID`: this header is created by Javascript code. This allows us to tie certain user actions to web transactions. Right now the implementation is simple, where we generate this ID on every JS web request. However in the future we can also create this header for multiple web requests, allowing us to create a high level correlation between user actions and web transactions.
1. `X-Request-ID`: this header is generated by NGinx. For requests that aren't executed by JS, this allows us to track errors or performance issues as it propagates throughout the system.



