### PR TITLE
Change pgbouncer settings

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -187,8 +187,9 @@ WSGI_APPLICATION = 'contentcuration.wsgi.application'
 
 
 # Database
+# ensure persistent connections are disabled
+CONN_MAX_AGE = 0
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/k8s/templates/frontend-pgbouncer.yaml
+++ b/k8s/templates/frontend-pgbouncer.yaml
@@ -10,12 +10,16 @@ data:
   # Aron: I configured pgbouncer based on the settings
   # recommended by this article:
   # https://medium.com/futuretech-industries/postgres-raffle-10k-connections-35-mo-part-two-b4c2e0c86e37
-  POOL_MODE: "transaction"
+  # https://docs.djangoproject.com/en/1.11/ref/databases/#transaction-pooling-and-server-side-cursors
+  POOL_MODE: "session"
   SERVER_RESET_QUERY: "DISCARD ALL"
   # the custom listen backlog doesn't matter until we increase the nodes' somaxconn
   LISTEN_BACKLOG: "16384"
+  MAX_CLIENT_CONN: !!str {{ .Values.studioApp.pgbouncer.max_client_conn | default 100 }}
+  # set min pool size to the default, so the connections are held in pool if no activity
+  MIN_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.min_pool_size | default .Values.studioApp.pgbouncer.pool_size | default 10 }}
   DEFAULT_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.pool_size | default 10 }}
-  RESERVE_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.pool_size | default 5 }}
+  RESERVE_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.reserve_pool_size | default 5 }}
 ---
 apiVersion: v1
 kind: Secret

--- a/k8s/templates/frontend-pgbouncer.yaml
+++ b/k8s/templates/frontend-pgbouncer.yaml
@@ -17,7 +17,7 @@ data:
   LISTEN_BACKLOG: "16384"
   MAX_CLIENT_CONN: !!str {{ .Values.studioApp.pgbouncer.max_client_conn | default 100 }}
   # set min pool size to the default, so the connections are held in pool if no activity
-  MIN_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.min_pool_size | default .Values.studioApp.pgbouncer.pool_size | default 10 }}
+  MIN_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.min_pool_size | default 5 }}
   DEFAULT_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.pool_size | default 10 }}
   RESERVE_POOL_SIZE: !!str {{ .Values.studioApp.pgbouncer.reserve_pool_size | default 5 }}
 ---

--- a/k8s/values-prod-config.yaml
+++ b/k8s/values-prod-config.yaml
@@ -24,7 +24,9 @@ studioApp:
     keyJson:
   pgbouncer:
     replicas: 3
-    pool_size: 10
+    # 3 * 133 ~= 400 clients
+    max_client_conn: 133
+    pool_size: 50
     reserve_pool_size: 10
 
 sentry:

--- a/k8s/values-prod-config.yaml
+++ b/k8s/values-prod-config.yaml
@@ -24,10 +24,11 @@ studioApp:
     keyJson:
   pgbouncer:
     replicas: 3
-    # 3 * 133 ~= 400 clients
+    # 3 * 133 ~= 400 requests/clients
     max_client_conn: 133
-    pool_size: 50
-    reserve_pool_size: 10
+    min_pool_size: 10
+    pool_size: 25
+    reserve_pool_size: 15
 
 sentry:
   dsnKey: ""

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -19,6 +19,7 @@ studioApp:
     keyJson:
   pgbouncer:
     replicas: 1
+    max_client_conn: 100
     pool_size: 10
     reserve_pool_size: 5
 


### PR DESCRIPTION
**Please remove any unused sections**

## Description
- Fixes `RESERVE_POOL_SIZE` option that was referencing `pool_size` value
- Adds PGBouncer setting for `MIN_POOL_SIZE` so that connections are held in pool, which helps with periods of inactivity
- Adds PGBouncer setting for `MAX_CLIENT_CONN` so it's clearly defined
- Adds Django setting `CONN_MAX_AGE = 0` to ensure persistent connections are disabled
- Changes pooling mode to `session` instead of `transaction`

## Implementation Notes (optional)

Regarding changing the pooling mode, Django uses features that are [not friendly](https://docs.djangoproject.com/en/1.11/ref/databases/#transaction-pooling-and-server-side-cursors) with the transaction pooling mode. Instead of disabling server-side cursors, I changed the pool mode because I have concerns regarding how SQL queries in a request would then be processed due to using transaction pooling. With transaction pooling, any statement outside of a transaction keeps the connection just for the duration of that statement. Which means a request could get a connection to make a query, then "loses" it (with regards to the app, it doesn't know this) and could wait for a connection to run another query within that same request. That means DB state could more radically change within a request if it's not using transaction to ensure that state. Overall, session pooling more closely matches the existing behavior of the app and is probably a better option for initially rolling out PGBouncer

Ref: https://github.com/learningequality/studio/pull/1704

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
