### PR TITLE
Markdown editor improvements

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -45,7 +45,7 @@
   import formulasHtmlToMd from '../extensions/formulas/formula-html-to-md';
 
   import keyHandlers from './keyHandlers';
-  import { getFormulasMenuPosition, getFragmentText } from './utils';
+  import { clearNodeFormat, getFormulasMenuPosition } from './utils';
 
   export default {
     name: 'MarkdownEditor',
@@ -222,14 +222,12 @@
           event.stopPropagation();
         }
       },
-      /**
-       * Remove all formatting on paste.
-       */
       onPaste(event) {
-        event.preventDefault();
-
-        const text = getFragmentText(event.fragment);
-        this.editor.getSquire().insertHTML(text);
+        const fragment = clearNodeFormat({
+          node: event.fragment,
+          ignore: ['b', 'i'],
+        });
+        event.fragment = fragment;
       },
       onImageDrop() {
         alert('TBD - see onImageDrop');

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -270,6 +270,11 @@
       },
       insertFormula() {
         const formula = this.formulasMenu.formula;
+
+        if (!formula) {
+          return;
+        }
+
         const CLASS_MATH_FIELD_NEW = `${CLASS_MATH_FIELD}-new`;
 
         const formulaEl = document.createElement('span');

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -142,6 +142,8 @@
 
       this.initStaticMathFields();
 
+      this.editor.getSquire().addEventListener('willPaste', this.onPaste);
+
       // TUI's `addKeyEventHandler` is not sufficient because they internally
       // override some of actions that need to be customized from here
       // needs to be set on Squire level
@@ -155,6 +157,8 @@
       this.editor.focus();
     },
     beforeDestroy() {
+      this.editor.getSquire().removeEventListener('willPaste', this.onPaste);
+
       this.$el.removeEventListener(this.keyDownEventListener, this.onKeyDown);
       this.$el.removeEventListener(this.clickEventListener, this.onClick);
     },
@@ -192,6 +196,26 @@
       },
       onFormulasMenuCancel() {
         this.resetFormulasMenu();
+      },
+      /**
+       * Remove all formatting on paste.
+       */
+      onPaste(event) {
+        event.preventDefault();
+
+        let fragmentHTML = '';
+        event.fragment.childNodes.forEach(childNode => {
+          if (childNode.nodeType === childNode.TEXT_NODE) {
+            fragmentHTML += childNode.textContent;
+          } else {
+            fragmentHTML += childNode.outerHTML;
+          }
+        });
+
+        const doc = new DOMParser().parseFromString(fragmentHTML, 'text/html');
+        const text = doc.body.textContent || '';
+
+        this.editor.getSquire().insertHTML(text);
       },
       /**
        * Allow default keyboard shortcut handlers

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -142,12 +142,20 @@
 
       this.initStaticMathFields();
 
+      // TUI's `addKeyEventHandler` is not sufficient because they internally
+      // override some of actions that need to be customized from here
+      // needs to be set on Squire level
+      // modifying default Squire key events is not documented but there's
+      // a recommended solution here https://github.com/neilj/Squire/issues/107
+      this.keyDownEventListener = this.$el.addEventListener('keydown', this.onKeyDown, true);
+
       this.clickEventListener = this.$el.addEventListener('click', this.onClick);
     },
     activated() {
       this.editor.focus();
     },
     beforeDestroy() {
+      this.$el.removeEventListener(this.keyDownEventListener, this.onKeyDown);
       this.$el.removeEventListener(this.clickEventListener, this.onClick);
     },
     methods: {
@@ -184,6 +192,24 @@
       },
       onFormulasMenuCancel() {
         this.resetFormulasMenu();
+      },
+      /**
+       * Allow default keyboard shortcut handlers
+       * only for supported actions:
+       * bold (ctrl+b), italics (ctrl+i), select all (ctrl+a)
+       * copy (ctrl+c), cut (ctrl+x), paste (ctrl+v)
+       *
+       * Disable all remaining shortcuts.
+       */
+      onKeyDown(event) {
+        if (event.ctrlKey === true && ['b', 'i', 'a', 'c', 'x', 'v'].includes(event.key)) {
+          return;
+        }
+
+        if (event.ctrlKey === true) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
       },
       onClick(event) {
         let mathFieldEl = null;

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -496,6 +496,7 @@
     margin: 4px;
     font-family: Symbola;
     color: #333333;
+    cursor: pointer;
     background-color: #f9f2f4;
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/keyHandlers.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/keyHandlers.js
@@ -1,0 +1,74 @@
+import { CLASS_MATH_FIELD, KEY_ARROW_RIGHT, KEY_ARROW_LEFT, KEY_BACKSPACE } from '../constants';
+
+/**
+ * When arrow right pressed and next element is a math field
+ * then move cursor to a first position after the math field
+ *
+ * @param {Object} squire Squire instance
+ */
+const onArrowRight = squire => {
+  const selection = squire.getSelection();
+
+  if (
+    selection &&
+    selection.startContainer.nextSibling &&
+    selection.startOffset === selection.startContainer.length &&
+    selection.startContainer.nextSibling.classList.contains(CLASS_MATH_FIELD)
+  ) {
+    const rangeAfterMathField = new Range();
+    rangeAfterMathField.setStartAfter(selection.startContainer.nextSibling);
+
+    squire.setSelection(rangeAfterMathField);
+  }
+};
+
+/**
+ * When arrow left pressed and previous element is a math field
+ * then move cursor to a last position before the math field
+ *
+ * @param {Object} squire Squire instance
+ */
+const onArrowLeft = squire => {
+  const selection = squire.getSelection();
+
+  if (
+    selection &&
+    selection.startContainer.previousSibling &&
+    selection.startOffset === 1 &&
+    selection.startContainer.previousSibling.classList.contains(CLASS_MATH_FIELD)
+  ) {
+    const rangeBeforeMathField = new Range();
+    rangeBeforeMathField.setStartBefore(selection.startContainer.previousSibling);
+
+    squire.setSelection(rangeBeforeMathField);
+  }
+};
+
+/**
+ * When backspace pressed and previous element is a math field
+ * then remove the math field
+ *
+ * @param {Object} squire Squire instance
+ */
+const onBackspace = squire => {
+  const selection = squire.getSelection();
+
+  if (
+    selection &&
+    selection.startContainer.previousSibling &&
+    selection.startOffset === 1 &&
+    selection.startContainer.previousSibling.classList.contains(CLASS_MATH_FIELD)
+  ) {
+    const mathFieldRange = new Range();
+    mathFieldRange.setStartBefore(selection.startContainer.previousSibling);
+    mathFieldRange.setEndBefore(selection.startContainer);
+
+    mathFieldRange.deleteContents();
+  }
+};
+
+export default {
+  [KEY_ARROW_RIGHT]: onArrowRight,
+  [KEY_ARROW_LEFT]: onArrowLeft,
+  [KEY_BACKSPACE]: onBackspace,
+};

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/utils.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/MarkdownEditor/utils.js
@@ -1,0 +1,60 @@
+/**
+ * Calculate the formulas menu position within markdown editor.
+ * If the formulas menu is to be shown in the second half (horizontally)
+ * of the editor, it's right corner should be clipped to the target
+ * => this position of the right corner is returned as `right`.
+ * Otherwise left corner is used to clip the menu and position
+ * of the left corner is return as `left`.
+ * Position is returned relative to editor element.
+ *
+ * @param {Object} editor Markdown editor element
+ * @param {Number} targetX Viewport X position of a point in editor
+ *                         to which formulas menu should be clipped to
+ * @param {Number} targetY Viewport Y position of a point in editor
+ *                         to which formulas menu should be clipped to
+ */
+export const getFormulasMenuPosition = ({ editorEl, targetX, targetY }) => {
+  const editorWidth = editorEl.getBoundingClientRect().width;
+  const editorTop = editorEl.getBoundingClientRect().top;
+  const editorLeft = editorEl.getBoundingClientRect().left;
+  const editorRight = editorEl.getBoundingClientRect().right;
+  const editorMiddle = editorLeft + editorWidth / 2;
+
+  const menuTop = targetY - editorTop;
+
+  let menuLeft = null;
+  let menuRight = null;
+
+  if (targetX < editorMiddle) {
+    menuLeft = targetX - editorLeft;
+  } else {
+    menuRight = editorRight - targetX;
+  }
+
+  return {
+    top: menuTop,
+    left: menuLeft,
+    right: menuRight,
+  };
+};
+
+/**
+ * Extracts text content from document fragment
+ *
+ * @param {DocumentFragment} fragment
+ */
+export const getFragmentText = fragment => {
+  let fragmentHTML = '';
+  fragment.childNodes.forEach(childNode => {
+    if (childNode.nodeType === childNode.TEXT_NODE) {
+      fragmentHTML += childNode.textContent;
+    } else {
+      fragmentHTML += childNode.outerHTML;
+    }
+  });
+
+  const doc = new DOMParser().parseFromString(fragmentHTML, 'text/html');
+  const text = doc.body.textContent || '';
+
+  return text;
+};

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/__tests__/utils.spec.js
@@ -1,0 +1,58 @@
+import { clearNodeFormat } from '../MarkdownEditor/utils';
+
+const htmlStringToFragment = htmlString => {
+  const template = document.createElement('template');
+  template.innerHTML = htmlString;
+
+  return template.content;
+};
+
+const fragmentToHtmlString = fragment => {
+  let htmlString = '';
+
+  fragment.childNodes.forEach(childNode => {
+    if (childNode.nodeType === childNode.TEXT_NODE) {
+      htmlString += childNode.textContent;
+    } else {
+      htmlString += childNode.outerHTML;
+    }
+  });
+
+  return htmlString;
+};
+
+describe('clearNodeFormat', () => {
+  it('clears all tags by default', () => {
+    const fragment = htmlStringToFragment(
+      '<i>Wh</i>at <b>co<i>lo</i>r is </b>th<i>e <b>sky</b></i>'
+    );
+
+    const clearedFragment = clearNodeFormat({ node: fragment });
+
+    expect(fragmentToHtmlString(clearedFragment)).toBe('What color is the sky');
+  });
+
+  it('does not clear format that should be ignored - tag selector', () => {
+    const fragment = htmlStringToFragment(
+      '<i>Wh</i>at <b>co<i>lo</i>r is </b>th<i>e <b>sky</b></i>'
+    );
+    const ignore = ['b'];
+
+    const clearedFragment = clearNodeFormat({ node: fragment, ignore });
+
+    expect(fragmentToHtmlString(clearedFragment)).toBe('What <b>color is </b>the <b>sky</b>');
+  });
+
+  it('does not clear format that should be ignored - class selector', () => {
+    const fragment = htmlStringToFragment(
+      '<i>Wh</i>at <b>co<i class="keep">lo</i>r is </b>th<i class="keep">e <b>sky</b></i>'
+    );
+    const ignore = ['.keep'];
+
+    const clearedFragment = clearNodeFormat({ node: fragment, ignore });
+
+    expect(fragmentToHtmlString(clearedFragment)).toBe(
+      'What co<i class="keep">lo</i>r is th<i class="keep">e sky</i>'
+    );
+  });
+});

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/constants.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/constants.js
@@ -1,3 +1,7 @@
 export const CLASS_MATH_FIELD = 'math-field';
 export const CLASS_MATH_FIELD_ACTIVE = `${CLASS_MATH_FIELD}-active`;
 export const CLASS_MATH_FIELD_NEW = `${CLASS_MATH_FIELD}-new`;
+
+export const KEY_ARROW_RIGHT = 'ArrowRight';
+export const KEY_ARROW_LEFT = 'ArrowLeft';
+export const KEY_BACKSPACE = 'Backspace';

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/constants.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/constants.js
@@ -1,1 +1,3 @@
 export const CLASS_MATH_FIELD = 'math-field';
+export const CLASS_MATH_FIELD_ACTIVE = `${CLASS_MATH_FIELD}-active`;
+export const CLASS_MATH_FIELD_NEW = `${CLASS_MATH_FIELD}-new`;

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/extensions/formulas/formulas.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/extensions/formulas/formulas.js
@@ -1,14 +1,7 @@
 const EVENT_FORMULAS_TOOLBAR_BTN_CLICK = 'FormulasToolbarBtnClick';
 
 const onFormulasToolbarBtnClick = editor => {
-  let cursor = editor.wwEditor.getEditor().getCursorPosition();
-
-  editor.options.extOptions.formulas.onFormulasToolbarBtnClick({
-    editorCursorPosition: {
-      bottom: cursor.y + cursor.height,
-      left: cursor.x,
-    },
-  });
+  editor.options.extOptions.formulas.onFormulasToolbarBtnClick();
 };
 
 const formulasExtension = editor => {
@@ -28,9 +21,10 @@ const formulasExtension = editor => {
       type: 'button',
       options: {
         name: 'formulas',
+        // should match ./formulas.css
         className: 'tui-toolbar-btn-formulas',
         event: EVENT_FORMULAS_TOOLBAR_BTN_CLICK,
-        tooltip: 'Insert formula',
+        tooltip: editor.options.extOptions.formulas.toolbarBtnTooltip,
       },
     });
 };

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/extensions/image-upload/image-upload.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/extensions/image-upload/image-upload.js
@@ -1,16 +1,22 @@
-const IMAGE_UPLOAD_BTN_EVENT = 'ImageUploadBtnClick';
+const EVENT_IMAGE_UPLOAD_TOOLBAR_BTN_CLICK = 'ImageUploadToolbarBtnClick';
 
-const onImageUpload = () => {
-  alert('Image upload TBD');
+const onImageUploadToolbarBtnClick = editor => {
+  editor.options.extOptions.imageUpload.onImageUploadToolbarBtnClick();
 };
 
-const onImageDrop = () => {
-  alert('Image drop TBD');
+const onImageDrop = editor => {
+  editor.options.extOptions.imageUpload.onImageDrop();
 };
 
 const imageUploadExtension = editor => {
-  editor.eventManager.addEventType(IMAGE_UPLOAD_BTN_EVENT);
-  editor.eventManager.listen(IMAGE_UPLOAD_BTN_EVENT, onImageUpload);
+  editor.addHook('addImageBlobHook', () => {
+    onImageDrop(editor);
+  });
+
+  editor.eventManager.addEventType(EVENT_IMAGE_UPLOAD_TOOLBAR_BTN_CLICK);
+  editor.eventManager.listen(EVENT_IMAGE_UPLOAD_TOOLBAR_BTN_CLICK, () => {
+    onImageUploadToolbarBtnClick(editor);
+  });
 
   editor
     .getUI()
@@ -19,13 +25,12 @@ const imageUploadExtension = editor => {
       type: 'button',
       options: {
         name: 'image-upload',
+        // should match ./image-upload.css
         className: 'tui-toolbar-btn-image-upload',
-        event: IMAGE_UPLOAD_BTN_EVENT,
-        tooltip: 'Insert image',
+        event: EVENT_IMAGE_UPLOAD_TOOLBAR_BTN_CLICK,
+        tooltip: editor.options.extOptions.imageUpload.toolbarBtnTooltip,
       },
     });
-
-  editor.addHook('addImageBlobHook', onImageDrop);
 };
 
 export default imageUploadExtension;

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/extensions/minimize/minimize.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/components/MarkdownEditor/extensions/minimize/minimize.js
@@ -17,9 +17,10 @@ const minimizeExtension = editor => {
       type: 'button',
       options: {
         name: 'minimize',
+        // should match ./minimize.css
         className: 'tui-toolbar-btn-minimize',
         event: EVENT_MINIMIZE_TOOLBAR_BTN_CLICK,
-        tooltip: 'Minimize',
+        tooltip: editor.options.extOptions.minimize.toolbarBtnTooltip,
       },
     });
 };

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/directives/click-outside.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/directives/click-outside.js
@@ -2,7 +2,7 @@ export default {
   inserted: (el, binding) => {
     window.event = event => {
       if (el !== event.target && !el.contains(event.target)) {
-        binding.value();
+        binding.value(event);
       }
     };
 


### PR DESCRIPTION
## Description

A follow-up of #1688, It contains various improvements of markdown editor, especially in regards to formulas.

- md editor component code cleanup after PoC of formulas editor merge (#1688) - code better readable, fixes a couple of edge cases
- restrict default Ctrl md editor keyboard shortcuts only to actions allowed (Ctrl+A, Ctrl+C, Ctrl+X, Ctrl+V, Ctrl+B, Ctrl+I)
- add custom keyboard shortcuts for "Insert image" (Ctrl+P), "Insert formula" (Ctrl+F) and minimize (Ctrl+M) toolbar buttons
- show keyboard shortcuts tooltips for all toolbar buttons on hover
![labels](https://user-images.githubusercontent.com/13509191/72238931-9ad74600-35df-11ea-8760-5b53ed283908.png)

- custom copy-paste handler - clear all unsupported format
- handle cursor behaviour around math fields when navigating using arrow left/right and backspace

![cursor](https://user-images.githubusercontent.com/13509191/72239411-48972480-35e1-11ea-99f0-91699baf97bf.gif)

#### Issue Addressed (if applicable)

Addresses several [Vue Migration Issues](https://www.notion.so/learningequality/81de4de5dfcb4285a5e265ec4fc2343c?v=c172a92442414c27b16d3e8af30078a5) though I would prefer marking them as resolved after I am done with the whole exercise editor and have a chance to test everything properly as a whole as some of those issues are related to work that still needs to be done.

## Steps to Test

- [x] *Visit http://misrob-vueify-md-editor-i.studio.cd.learningequality.org/sandbox/ (you should be logged in)*
- [x] *Edit modal -> Sample Exercise -> Questions tab*
- [ ] *Open a question and try to edit its text while testing issues mentioned in the description*

## Tech debt

Please see[ follow-ups list](https://www.notion.so/learningequality/Exercise-creation-1a085a11eb494ccab3962a22c20dd202#e316fc05be704d729470393c985ea441) to have an overview of what's missing in terms of exercise creation including markdown editor.
