### PR TITLE
Switch webpack port to 4000, as Kolibri uses 3000 as well…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,10 +71,10 @@ module.exports = (env = {}) => {
     output: {
       filename: '[name]-[hash].js',
       path: bundleOutputDir,
-      publicPath: dev ? 'http://127.0.0.1:3000/dist/' : undefined,
+      publicPath: dev ? 'http://127.0.0.1:4000/dist/' : undefined,
     },
     devServer: {
-      port: 3000,
+      port: 4000,
       headers: {
         'Access-Control-Allow-Origin': '*',
       },
@@ -124,7 +124,12 @@ module.exports = (env = {}) => {
         },
         {
           test: /\.less?$/,
-          use: [hot ? `style-loader` : MiniCssExtractPlugin.loader, `css-loader`, postCSSLoader, 'less-loader'],
+          use: [
+            hot ? `style-loader` : MiniCssExtractPlugin.loader,
+            `css-loader`,
+            postCSSLoader,
+            'less-loader',
+          ],
         },
         {
           test: /\.css?$/,


### PR DESCRIPTION
…which allows only one to run at a time.

## Description

It switches the port that webpack uses to serve up built UI assets so that there is no conflict with Kolibri.

## Steps to Test

- [ ] Start Studio by running `yarn run devserver`
- [ ] Start Kolibri by running `yarn run devserver`


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
