### PR TITLE
Ignore the 'imports after statements warnings'…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: flake8
+        entry: flake8 --ignore E402
     -   id: check-added-large-files
         exclude: '^.+?\.ttf$'
     -   id: debug-statements


### PR DESCRIPTION
…that are being triggered when we set up the standard library aliases for Py 3 compatibility.

## Description

As part of our Python 3 compatibility, we bundle a new module called future, and one of the things it does is set up Python 2 aliases for standard library functions using an `install_aliases` function. Calling this at the top of a file triggers a bunch of flake8 E402 warnings about having statements before processing all imports. 

`install_aliases` is called from a couple dozen different source files, so rather than annotate them all with flake8 exceptions, I chose instead of simply ignore the E402 error.

## Steps to Test

- [ ] Change a file that imports the future module and calls `install_aliases`
## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
