### PR TITLE
Fix reading on fobj that wasn't opened as readable

### DIFF
--- a/contentcuration/contentcuration/management/commands/setup.py
+++ b/contentcuration/contentcuration/management/commands/setup.py
@@ -283,7 +283,7 @@ def create_contentnode(title, parent, file, kind_id, license_id, description="",
 
 
 def create_file(display_name, preset_id, ext, user=None):
-    with tempfile.NamedTemporaryFile(suffix=".{}".format(ext), mode='wb', delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=".{}".format(ext), mode='wb+', delete=False) as f:
         f.write(b":)")
         f.flush()
         size = f.tell()


### PR DESCRIPTION
## Description
Ran into the issue below running `yarn run devsetup` on the `develop` branch. I believe this may have been a side effect of the python 3 migration, but am unsure.

```
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/home/bjester/.local/share/virtualenvs/studio-HDUuBaY8/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/home/bjester/.local/share/virtualenvs/studio-HDUuBaY8/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/bjester/.local/share/virtualenvs/studio-HDUuBaY8/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/bjester/.local/share/virtualenvs/studio-HDUuBaY8/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/bjester/Projects/learningequality/studio/contentcuration/contentcuration/management/commands/setup.py", line 109, in handle
    document_file = create_file("Sample Document", format_presets.DOCUMENT, file_formats.PDF, user=admin)
  File "/home/bjester/Projects/learningequality/studio/contentcuration/contentcuration/management/commands/setup.py", line 290, in create_file
    filename = write_file_to_storage(f, name=f.name)
  File "/home/bjester/Projects/learningequality/studio/contentcuration/contentcuration/api.py", line 28, in write_file_to_storage
    for chunk in iter(lambda: fobj.read(4096), b""):
  File "/home/bjester/Projects/learningequality/studio/contentcuration/contentcuration/api.py", line 28, in <lambda>
    for chunk in iter(lambda: fobj.read(4096), b""):
IOError: File not open for reading
```

## Steps to Test
For python 2.7:
- [ ] *Create clean virtual env and install dependencies*
- [ ] *Run `yarn dev setup`*

For python 3.5, with its own challenges:
- [ ] *Create clean virtual env*
- [ ] *Remove python requirement from Pipfile*
- [ ] *Run `pipenv install`, it will partially fail*
- [ ] *Run `yarn dev setup`, it will partially fail but get past file creation*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
