### PR TITLE
Restore ChannelEdit tests and add content copy and channel deletion.

### DIFF
--- a/deploy/chaos/loadtest/locustfile.py
+++ b/deploy/chaos/loadtest/locustfile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import json
 import os
+import time
 from random import choice
 
 from locust import HttpLocust
@@ -35,7 +36,7 @@ class BaseTaskSet(TaskSet):
             data=formdata,
             headers={
                 "content-type": "application/x-www-form-urlencoded",
-                "referer": "https://develop.studio.learningequality.org/accounts/login/"
+                "referer": "{}/accounts/login/".format(self.client.base_url)
             }
         )
 
@@ -179,7 +180,7 @@ class ChannelPage(BaseTaskSet):
                         urlrequest.urlopen(storage_url).read()
 
 
-class ChannelCreate(BaseTaskSet):
+class ChannelEdit(BaseTaskSet):
     # This flag was recommended to ensure on_stop is always called, but it seems not to be enough
     # on its own to ensure this behavior. Leaving as it's possible this is needed, but along with
     # something else.
@@ -205,7 +206,7 @@ class ChannelCreate(BaseTaskSet):
             # TODO: check for deletion issues and report so that manual cleanup can be performed if needed.
 
     @task(6)
-    def create_channel(self):
+    def create_channel_and_copy_content(self):
         """
         Load the channel page and the important endpoints.
         """
@@ -227,15 +228,54 @@ class ChannelCreate(BaseTaskSet):
             headers={
                 "content-type": "application/json",
                 'X-CSRFToken': self.client.cookies.get('csrftoken'),
+                'Referer': self.client.base_url
             }
         )
 
         data = resp.json()
-        self.created_channels.append(data['id'])
+        channel_id = data["id"]
+
+        try:
+            copy_data = {
+                # KA Computing root node.
+                "node_ids": ["76d5fd8636004b459a09aecbb2f8294e"],
+                "sort_order": 1,
+                "target_parent": data["main_tree"]["id"],
+                "channel_id": channel_id
+            }
+
+            copy_resp = self.client.post("/api/duplicate_nodes/",
+                                         data=json.dumps(copy_data),
+                                         headers={
+                                             "content-type": "application/json",
+                                             'X-CSRFToken': self.client.cookies.get('csrftoken'),
+                                             'Referer': self.client.base_url
+                                         })
+            copy_resp_data = copy_resp.json()
+            task_id = copy_resp_data["id"]
+            finished = False
+            time_elapsed = 0
+            while not finished:
+                time.sleep(1)
+                time_elapsed += 1
+                task_resp = self.client.get("/api/task/{}?channel_id={}".format(task_id, channel_id))
+                task_data = task_resp.json()
+                if task_data["status"] in ["SUCCESS", "FAILED"] or time_elapsed > 120:
+                    finished = True
+
+        finally:
+            self.client.delete(
+                "/api/channel/{}".format(channel_id),
+                headers={
+                    "content-type": "application/json",
+                    'X-CSRFToken': self.client.cookies.get('csrftoken'),
+                    'Referer': self.client.base_url
+                }
+            )
 
 
 class LoginPage(BaseTaskSet):
-    tasks = [ChannelListPage, ChannelPage]
+    tasks = [ChannelListPage, ChannelPage, ChannelEdit]
 
     # This is by far our most hit endpoint, over 50% of all calls, so
     # weight it accordingly.


### PR DESCRIPTION

## Description

Adds an async task to our load testing script so that we can simulate lots of async tasks running in parallel. Also fixes channel deletion so that the script cleans up after itself.

## Steps to Test

- [ ] Run the locust tests!

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
