### PR TITLE
Fix license handling, and circular dependencies

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelModal.vue
@@ -162,7 +162,7 @@
           })
           .catch(() => {
             // Couldn't verify the channel details, so go back!
-            // We should probaly replace this with a 404 page, as
+            // We should probably replace this with a 404 page, as
             // when navigating in from an external link (as this behaviour
             // would often be from - it produces a confusing back step)
             vm.$router.back();

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -1,4 +1,5 @@
-import channelList, { channelLastSavedState } from '../index';
+import channelList from '../index';
+import { channelLastSavedState } from '../utils';
 import { generateTempId } from '../../../utils';
 import client from 'shared/client';
 import storeFactory from 'shared/vuex/baseStore';

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
@@ -1,5 +1,5 @@
 import { isTempId } from '../../utils';
-import { channelLastSavedState } from './index';
+import { channelLastSavedState } from './utils';
 import client from 'shared/client';
 
 /* CHANNEL LIST ACTIONS */

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/getters.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/getters.js
@@ -1,6 +1,6 @@
 import pick from 'lodash/pick';
 import { isTempId } from '../../utils';
-import { channelLastSavedState } from './index';
+import { channelLastSavedState } from './utils';
 
 export function channels(state) {
   return Object.values(state.channelsMap).filter(channel => !isTempId(channel.id));

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/index.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/index.js
@@ -1,9 +1,6 @@
-import { lastSavedStateFactory } from '../../utils';
 import * as getters from './getters';
 import * as mutations from './mutations';
 import * as actions from './actions';
-
-export const channelLastSavedState = lastSavedStateFactory();
 
 export default {
   namespaced: true,

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/mutations.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import map from 'lodash/map';
-import { channelLastSavedState } from './index';
+import { channelLastSavedState } from './utils';
 import { ContentDefaults } from 'shared/constants';
 
 /* CHANNEL LIST MUTATIONS */

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/utils.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/utils.js
@@ -1,0 +1,3 @@
+import { lastSavedStateFactory } from '../../utils';
+
+export const channelLastSavedState = lastSavedStateFactory();

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
@@ -1,4 +1,5 @@
-import channelSet, { channelSetLastSavedState } from '../index';
+import channelSet from '../index';
+import { channelSetLastSavedState } from '../utils';
 import { generateTempId } from '../../../utils';
 import client from 'shared/client';
 import storeFactory from 'shared/vuex/baseStore';

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/actions.js
@@ -1,5 +1,5 @@
 import { isTempId } from '../../utils';
-import { channelSetLastSavedState } from './index';
+import { channelSetLastSavedState } from './utils';
 import client from 'shared/client';
 
 /* CHANNEL SET ACTIONS */

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/getters.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/getters.js
@@ -1,5 +1,5 @@
 import { isTempId } from '../../utils';
-import { channelSetLastSavedState } from './index';
+import { channelSetLastSavedState } from './utils';
 
 export function channelSets(state) {
   return Object.values(state.channelSetsMap).filter(set => !isTempId(set.id));

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/index.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/index.js
@@ -1,9 +1,6 @@
-import { lastSavedStateFactory } from '../../utils';
 import * as mutations from './mutations';
 import * as actions from './actions';
 import * as getters from './getters';
-
-export const channelSetLastSavedState = lastSavedStateFactory();
 
 export default {
   namespaced: true,

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/mutations.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { channelSetLastSavedState } from './index';
+import { channelSetLastSavedState } from './utils';
 
 /* CHANNEL SET MUTATIONS */
 export function SET_CHANNELSET_LIST(state, channelSets) {

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/utils.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/utils.js
@@ -1,0 +1,3 @@
+import { lastSavedStateFactory } from '../../utils';
+
+export const channelSetLastSavedState = lastSavedStateFactory();

--- a/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
@@ -175,6 +175,9 @@
         return findLicense(this.license, { is_custom: false }).is_custom;
       },
     },
+    mounted() {
+      this.emitChange();
+    },
     methods: {
       emitChange() {
         // When any field in our component changes, this gets triggered which then triggers the

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -185,8 +185,7 @@ class ContentDefaultsSerializer(serializers.Serializer):
     aggregator = serializers.CharField(allow_null=True, required=False)
     provider = serializers.CharField(allow_null=True, required=False)
     copyright_holder = serializers.CharField(allow_null=True, required=False)
-    license = serializers.CharField(allow_null=True, required=False,
-                                    validators=[License.validate_name])
+    license = serializers.CharField(allow_null=True, required=False)
     license_description = serializers.CharField(allow_null=True, required=False)
     auto_derive_video_thumbnail = serializers.BooleanField(required=False)
     auto_derive_audio_thumbnail = serializers.BooleanField(required=False)
@@ -201,6 +200,9 @@ class ContentDefaultsSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         instance.update(validated_data)
         return instance
+
+    def validate_license(self, license):
+        return license is None or License.validate_name(license)
 
 
 class ContentDefaultsSerializerMixin(object):

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -202,7 +202,9 @@ class ContentDefaultsSerializer(serializers.Serializer):
         return instance
 
     def validate_license(self, license):
-        return license is None or License.validate_name(license)
+        if license is not None:
+            License.validate_name(license)
+        return license
 
 
 class ContentDefaultsSerializerMixin(object):


### PR DESCRIPTION
## Description
I noticed some circular dependencies being logged during the frontend build, I think from a package @micahscopes added, so I've resolved those. I also noticed an issue with the content defaults form where a blank license wasn't being saved. I didn't experience that before because I had actually a user preference for the license will building it, but that got cleared when I reset by DB.


## Steps to Test

- [ ] *Stop and "down" docker services*
- [ ] *Remove database volume `docker volume prune`*
- [ ] *Up docker services*
- [ ] *Run `yarn run devsetup` (note there is currently an issue https://github.com/learningequality/studio/pull/1748)*
- [ ] *Run `yarn run devserver`*
- [ ] *Verify no `circular dependency` loggings*
- [ ] *Log into local studio*
- [ ] *Create a channel and do not set any content defaults*
- [ ] *Verify channel is created successfully*

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
