### PR TITLE
Revert .gitignoreing of contentcuration/contentcuration/static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,6 @@ Thumbs.db
 # The following line doesn't do anything since currently `collectstatic` writes to /contentcuration/contentcuration/static
 /contentcuration/static/*
 
-# Ignore Django collectstatic output directories
-/contentcuration/contentcuration/static/admin
-/contentcuration/contentcuration/static/django_js_reverse
-/contentcuration/contentcuration/static/rest_framework
-
 # Ignore node_modules
 /node_modules
 nodeenv

--- a/.gitignore
+++ b/.gitignore
@@ -72,12 +72,16 @@ venv
 Thumbs.db
 
 # Ignore built javascript files
-/contentcuration/*/static/js/bundles
-/contentcuration/*/static/studio
+/contentcuration/contentcuration/static/js/bundles
+/contentcuration/contentcuration/static/studio
 
-# Ignore Django collected static files
+# The following line doesn't do anything since currently `collectstatic` writes to /contentcuration/contentcuration/static
 /contentcuration/static/*
-contentcuration/contentcuration/static
+
+# Ignore Django collectstatic output directories
+/contentcuration/contentcuration/static/admin
+/contentcuration/contentcuration/static/django_js_reverse
+/contentcuration/contentcuration/static/rest_framework
 
 # Ignore node_modules
 /node_modules


### PR DESCRIPTION
This PR reverts the mistaken ignore of `contentcuration/contentcuration/static`.

Currently this folder is both a source and a destination of the collectstatic command, so it cannot be .gitignored completely. Thx @kollivier for catching my mistake.

I'll open a [followup PR](https://github.com/ivanistheone/studio/commits/mv-cc_cc_static-to-cc_static) to discuss moving

     contentcuration/contentcuration/static --> contentcuration/static

but we don't need to do that today.

