### PR TITLE
Move static output dir to contentcuration/static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,11 +71,11 @@ venv
 
 Thumbs.db
 
-# Ignore built javascript files
+# Ignore javascript bundle output dirs
 /contentcuration/contentcuration/static/js/bundles
 /contentcuration/contentcuration/static/studio
 
-# The following line doesn't do anything since currently `collectstatic` writes to /contentcuration/contentcuration/static
+# Ignore Django collectstatic output dir
 /contentcuration/static/*
 
 # Ignore node_modules

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endtoendtest:
 	# create a shared directory accessible from within Docker so that it can pass the
 	# coverage report back for uploading.
 	mkdir -p shared
-	docker-compose run -v "${PWD}/shared:/shared" studio-app make test -e DJANGO_SETTINGS_MODULE=contentcuration.test_settings
+	docker-compose run -v "${PWD}/shared:/shared" studio-app make collectstatic test -e DJANGO_SETTINGS_MODULE=contentcuration.test_settings
 	bash <(curl -s https://codecov.io/bash)
 	rm -rf shared
 

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -30,7 +30,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 STORAGE_ROOT = "storage"
 DB_ROOT = "databases"
 
-STATIC_ROOT = os.getenv("STATICFILES_DIR") or os.path.join(BASE_DIR, "contentcuration", "static")
+STATIC_ROOT = os.getenv("STATICFILES_DIR") or os.path.join(BASE_DIR, "static")
 CSV_ROOT = "csvs"
 EXPORT_ROOT = "exports"
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = (env = {}) => {
     output: {
       filename: '[name]-[hash].js',
       path: bundleOutputDir,
-      publicPath: dev ? 'http://127.0.0.1:4000/dist/' : undefined,
+      publicPath: dev ? 'http://127.0.0.1:4000/dist/' : '/static/studio/',
     },
     devServer: {
       port: 4000,


### PR DESCRIPTION
## Description

Changes settings so `collectstatic` and webpack build outputs go in `contentcuration/static` instead of `contentcuration/contentcuration/static`.


#### Issue Addressed (if applicable)

Addresses  https://github.com/learningequality/studio/issues/1761

## Steps to Test

- [ ] Try in dev mode
- [ ] Try Docker prod-like build


## Reviewers

@aronasorman  || @lyw07  Please check that production setup is going to be OK with new directory.
