### PR TITLE
remove probers from demo servers

### DIFF
--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -28,18 +28,6 @@ steps:
   ]
 
 - name: 'gcr.io/cloud-builders/docker'
-  id: build-prober-image
-  waitFor: ['-']              # don't wait for previous steps
-  args: [
-    'build',
-    '-f', 'k8s/images/prober/Dockerfile',
-    '--cache-from', 'gcr.io/$PROJECT_ID/learningequality-studio-prober:latest',
-    '-t', 'gcr.io/$PROJECT_ID/learningequality-studio-prober:$COMMIT_SHA',
-    '-t', 'gcr.io/$PROJECT_ID/learningequality-studio-prober:latest',
-    '.'
-  ]
-
-- name: 'gcr.io/cloud-builders/docker'
   id: push-app-image
   waitFor: ['build-app-image']
   args: ['push', 'gcr.io/$PROJECT_ID/learningequality-studio-app:$COMMIT_SHA']
@@ -48,11 +36,6 @@ steps:
   id: push-nginx-image
   waitFor: ['build-nginx-image']
   args: ['push', 'gcr.io/$PROJECT_ID/learningequality-studio-nginx:$COMMIT_SHA']
-
-- name: 'gcr.io/cloud-builders/docker'
-  id: push-prober-image
-  waitFor: ['build-prober-image']
-  args: ['push', 'gcr.io/$PROJECT_ID/learningequality-studio-prober:$COMMIT_SHA']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: decrypt-gcs-service-account
@@ -81,7 +64,7 @@ steps:
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
   - 'CLOUDSDK_CONTAINER_CLUSTER=dev-qa-cluster'
-  secretEnv: ['POSTMARK_API_KEY', 'PROBER_NEWRELIC_KEY', 'PROBER_NEWRELIC_ACCOUNT_ID']
+  secretEnv: ['POSTMARK_API_KEY']
   entrypoint: 'bash'
   args:
     - -c
@@ -92,8 +75,8 @@ steps:
       $_STORAGE_BUCKET
       $COMMIT_SHA
       $$POSTMARK_API_KEY
-      $$PROBER_NEWRELIC_KEY
-      $$PROBER_NEWRELIC_ACCOUNT_ID
+      ""
+      ""
       $_POSTGRES_USERNAME
       $_RELEASE_NAME
       $_POSTGRES_PASSWORD
@@ -111,17 +94,9 @@ secrets:
 - kmsKeyName: projects/ops-central/locations/global/keyRings/builder-secrets/cryptoKeys/secret-encrypter
   secretEnv:
     POSTMARK_API_KEY: CiQA7z1GH3QhvCEWNn6KS64t/c8BEQng5I4CdMC6VGNxJkWmZrwSTgB+R8mv/PSrzlDmCYSOZc4bugWA+K+lJ8nIll1BBsZZEV5M9GuOCYVn6sVWg9pCIVujwyb4EvEy1QaKmZCzAnTw9aHEXDH0sruAUHBaTA==
-- kmsKeyName: projects/ops-central/locations/global/keyRings/builder-secrets/cryptoKeys/proberNewrelicKey
-  secretEnv:
-    PROBER_NEWRELIC_KEY: CiQAfPus0ALc6lu6q1UWqlXy2GSlIpoP8Ld7sAaQvYpWX/rIBGESSgC/YPuCpL13usytN/eOPJV2Z3SqXloUpghwRiDEeO7tUobUmVjuo46eezP9l2Xek6RbNvRVCOgotgEYgQDoua8AVveIsQKEI+J0
-- kmsKeyName: projects/ops-central/locations/global/keyRings/builder-secrets/cryptoKeys/proberNewrelicAccountId
-  secretEnv:
-    PROBER_NEWRELIC_ACCOUNT_ID: CiQA3yNuVig7N0+JW78z+is/ujBnD/3U4buHKj7oJ5ObzSLc6toSMQBoDQ+Cv13BID7dgu/rQ4NZq3yozpZqm9mf6H7+jGXP0gvC0mzNjVfvVq545Ei+Bwc=
 
 images:
   - 'gcr.io/$PROJECT_ID/learningequality-studio-nginx:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/learningequality-studio-nginx:latest'
   - 'gcr.io/$PROJECT_ID/learningequality-studio-app:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/learningequality-studio-app:latest'
-  - 'gcr.io/$PROJECT_ID/learningequality-studio-prober:$COMMIT_SHA'
-  - 'gcr.io/$PROJECT_ID/learningequality-studio-prober:latest'

--- a/k8s/templates/prober-deployment.yaml
+++ b/k8s/templates/prober-deployment.yaml
@@ -1,3 +1,5 @@
+# Deploy probers only in production environment.
+{{- if .Values.productionIngress -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -32,3 +34,4 @@ spec:
           value: lingyi+prober@learningequality.org
         - name: PROBER_STUDIO_PASSWORD
           value: "123456789"
+{{- end }}

--- a/k8s/templates/prober-metrics-to-newrelic-cron-job.yaml
+++ b/k8s/templates/prober-metrics-to-newrelic-cron-job.yaml
@@ -1,3 +1,5 @@
+# Deploy probers only in production environment.
+{{- if .Values.productionIngress -}}
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -29,3 +31,4 @@ spec:
                   key: newrelic-account-id
                   name: {{ template "studio.fullname" . }}
           restartPolicy: OnFailure
+{{- end }}

--- a/k8s/templates/prober-service.yaml
+++ b/k8s/templates/prober-service.yaml
@@ -1,3 +1,5 @@
+# Deploy probers only in production environment.
+{{- if .Values.productionIngress -}}
 ---
 apiVersion: v1
 kind: Service
@@ -11,4 +13,5 @@ spec:
     targetPort: {{ .Values.studioProber.port }}
   selector:
     app: {{ template "studio.fullname" . }}-prober
-  type: NodePort
+  type: ClusterIP
+{{- end }}


### PR DESCRIPTION
## Description

This PR is to remove probers from demo servers because:
1. probers are supposed to run in the production environment
2. need to save resources for demo server cluster since we don't use probers much


## Steps to Test

- [X] *Step 1*: Please check if demo server doesn't include probers now

## Implementation Notes (optional)

Enable prober related k8s scripts only when in production


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
