### PR TITLE
Forward port 4000 as well on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     command: yarn run devserver
     ports:
       - "8080:8080"
+      - "4000:4000"
 
   celery-worker:
     <<: *studio-worker


### PR DESCRIPTION
There was a change on which port nodejs listens to, but we didn't update the docker-compose file. This adds the port-forwarding, and allows devs to work entirely using docker-compose.