### PR TITLE
SyncResourcesModal component

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ChannelEditIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ChannelEditIndex.vue
@@ -64,7 +64,7 @@
             <VListTile v-if="canView || canEdit" @click.stop>
               <VListTileTitle>{{ $tr('shareChannel') }}</VListTileTitle>
             </VListTile>
-            <VListTile v-if="canEdit" @click.stop>
+            <VListTile v-if="canEdit" @click="showSyncModal = true;">
               <VListTileTitle>{{ $tr('syncChannel') }}</VListTileTitle>
             </VListTile>
           </VList>
@@ -82,6 +82,7 @@
     <template v-if="isPublished">
       <ChannelTokenModal v-model="showTokenModal" :channel="currentChannel" />
     </template>
+    <SyncResourcesModal v-if="currentChannel" v-model="showSyncModal" :channel="currentChannel" />
   </VApp>
 
 </template>
@@ -95,6 +96,7 @@
   import ChannelNavigationDrawer from './ChannelNavigationDrawer';
   import PublishModal from './publish/PublishModal';
   import ProgressModal from './progress/ProgressModal';
+  import SyncResourcesModal from './sync/SyncResourcesModal';
   import GlobalSnackbar from 'shared/views/GlobalSnackbar';
   import IconButton from 'shared/views/IconButton';
   import ToolBar from 'shared/views/ToolBar';
@@ -112,12 +114,14 @@
       ProgressModal,
       ChannelTokenModal,
       MoveModal,
+      SyncResourcesModal,
     },
     data() {
       return {
         drawer: false,
         showPublishModal: false,
         showTokenModal: false,
+        showSyncModal: false,
       };
     },
     computed: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -1,0 +1,219 @@
+<template>
+
+  <div>
+    <!-- STEP 1 of 3: Sync dialog -->
+    <PrimaryDialog v-model="syncModal" :title="$tr('syncModalTitle')" lazy>
+      <VList subheader two-line>
+        <VSubheader>{{ $tr('syncModalExplainer') }}</VSubheader>
+
+        <VListTile @click.stop>
+          <VListTileAction>
+            <VCheckbox v-model="syncFiles" color="primary" />
+          </VListTileAction>
+          <VListTileContent @click="syncFiles = !syncFiles">
+            <VListTileTitle>{{ $tr('syncFilesTitle') }}</VListTileTitle>
+            <VListTileSubTitle>{{ $tr('syncFilesExplainer') }}</VListTileSubTitle>
+          </VListTileContent>
+        </VListTile>
+
+        <VListTile @click.stop>
+          <VListTileAction>
+            <VCheckbox v-model="syncTags" color="primary" />
+          </VListTileAction>
+          <VListTileContent @click="syncTags = !syncTags">
+            <VListTileTitle>{{ $tr('syncTagsTitle') }}</VListTileTitle>
+            <VListTileSubTitle>{{ $tr('syncTagsExplainer') }}</VListTileSubTitle>
+          </VListTileContent>
+        </VListTile>
+
+        <VListTile @click.stop>
+          <VListTileAction>
+            <VCheckbox v-model="syncTitlesAndDescriptions" color="primary" />
+          </VListTileAction>
+          <VListTileContent @click="syncTitlesAndDescriptions = !syncTitlesAndDescriptions">
+            <VListTileTitle>{{ $tr('syncTitlesAndDescriptionsTitle') }}</VListTileTitle>
+            <VListTileSubTitle>{{ $tr('syncTitlesAndDescriptionsExplainer') }}</VListTileSubTitle>
+          </VListTileContent>
+        </VListTile>
+
+        <VListTile @click.stop>
+          <VListTileAction>
+            <VCheckbox v-model="syncExercises" color="primary" />
+          </VListTileAction>
+          <VListTileContent @click="syncExercises = !syncExercises">
+            <VListTileTitle>{{ $tr('syncExercisesTitle') }}</VListTileTitle>
+            <VListTileSubTitle>{{ $tr('syncExercisesExplainer') }}</VListTileSubTitle>
+          </VListTileContent>
+        </VListTile>
+      </VList>
+      <VSpacer />
+      <template v-slot:actions>
+        <VSpacer />
+        <VBtn flat @click="syncModal=false">
+          {{ $tr('cancelButtonLabel') }}
+        </VBtn>
+        <VBtn color="primary" :disabled="!continueAllowed" @click="handleContinue">
+          {{ $tr('continueButtonLabel') }}
+        </VBtn>
+      </template>
+    </PrimaryDialog>
+
+    <!-- STEP 2 of 3: Confirm sync dialog -->
+    <PrimaryDialog v-model="confirmSyncModal" :title="$tr('confirmSyncModalTitle')" lazy>
+      <VSubheader>{{ $tr('confirmSyncModalExplainer') }}</VSubheader>
+      <VCardText>
+        <ul class="ml-3 mt-2 mb-4">
+          <li v-if="syncFiles" class="font-weight-bold">
+            {{ $tr('syncFilesTitle') }}
+          </li>
+          <li v-if="syncTags" class="font-weight-bold">
+            {{ $tr('syncTagsTitle') }}
+          </li>
+          <li v-if="syncTitlesAndDescriptions" class="font-weight-bold">
+            {{ $tr('syncTitlesAndDescriptionsTitle') }}
+          </li>
+          <li v-if="syncExercises" class="font-weight-bold">
+            {{ $tr('syncExercisesTitle') }}
+          </li>
+        </ul>
+      </VCardText>
+      <VSpacer />
+      <template v-slot:actions>
+        <VSpacer />
+        <VBtn flat @click="handleBack">
+          {{ $tr('backButtonLabel') }}
+        </VBtn>
+        <VBtn color="primary" @click="handleSync">
+          {{ $tr('syncButtonLabel') }}
+        </VBtn>
+      </template>
+    </PrimaryDialog>
+
+    <!-- STEP 3 of 3: Syncing progress dialog -->
+    <!-- Handled by the asyncTasksModule, see channelEdit/vuex/task/index.js -->
+  </div>
+
+</template>
+
+<script>
+
+  import { mapActions } from 'vuex';
+  import PrimaryDialog from 'shared/views/PrimaryDialog';
+
+  export default {
+    name: 'SyncResourcesModal',
+    components: {
+      PrimaryDialog,
+    },
+    props: {
+      value: {
+        type: Boolean,
+        default: false,
+      },
+      channel: {
+        type: Object,
+        required: true,
+        validator(channel) {
+          return channel.id;
+        },
+      },
+    },
+    data() {
+      return {
+        // the should show modal first step state is the value prop
+        confirmSyncModal: false, // the should show second step
+        // user choices about which kind of resources to sync
+        syncFiles: false,
+        syncTags: false,
+        syncTitlesAndDescriptions: false,
+        syncExercises: false,
+      };
+    },
+    computed: {
+      syncModal: {
+        get() {
+          return this.value;
+        },
+        set(value) {
+          this.$emit('input', value);
+        },
+      },
+      channelId() {
+        return this.channel.id;
+      },
+      continueAllowed() {
+        // allow CONTINUE button to appear only if something will be synced
+        return (
+          this.syncFiles || this.syncTags || this.syncTitlesAndDescriptions || this.syncExercises
+        );
+      },
+    },
+    methods: {
+      ...mapActions('currentChannel', ['syncChannel']),
+      handleContinue() {
+        this.syncModal = false;
+        this.$nextTick(() => {
+          this.confirmSyncModal = true;
+        });
+      },
+      handleBack() {
+        this.confirmSyncModal = false;
+        // allow time for modal to close, via https://stackoverflow.com/a/47636157
+        this.$nextTick(() => {
+          this.syncModal = true;
+        });
+      },
+      handleSync() {
+        const syncChennelPostData = {
+          channel_id: this.channelId,
+          attributes: this.syncTitlesAndDescriptions,
+          tags: this.syncTags,
+          files: this.syncFiles,
+          assessment_items: this.syncExercises,
+          sort: false, // Setting to false. This prop. was previously undefined,
+          // which becames None in Pythonland (treated as falsy by the backend)
+        };
+        this.syncChannel(syncChennelPostData).then(() => {
+          this.confirmSyncModal = false;
+        });
+      },
+    },
+    $trs: {
+      // Sync modal (Step 1 of 3)
+      syncModalTitle: 'Sync resources',
+      syncModalExplainer: 'Sync and update your resources with their original source.',
+      syncFilesTitle: 'Files',
+      syncFilesExplainer: 'Update all file information',
+      syncTagsTitle: 'Tags',
+      syncTagsExplainer: 'Update all tags',
+      syncTitlesAndDescriptionsTitle: 'Titles and descriptions',
+      syncTitlesAndDescriptionsExplainer: 'Update resource verbiage',
+      syncExercisesTitle: 'Assessment details',
+      syncExercisesExplainer: 'Update questions, answers, and hints',
+      cancelButtonLabel: 'cancel',
+      continueButtonLabel: 'continue',
+      //
+      // Confirm sync (Step 2 of 3)
+      confirmSyncModalTitle: 'Confirm sync',
+      confirmSyncModalExplainer: 'You are about to sync and update the following:',
+      backButtonLabel: 'back',
+      syncButtonLabel: 'sync',
+      //
+      // Syncing content (Step 3 of 3) (handled by the asyncTasksModule)
+      // syncingContentTitle: 'Syncing content',
+      // syncingContentModalExplainer: 'Syncing task is in progres, please wait...',
+      // stopSyncButtonLabel: 'stop sync',
+    },
+  };
+
+</script>
+
+
+<style lang="less">
+
+  // counteract the effect of the VCardText that is wrapping the VList component
+  .v-card /deep/ .v-card__text {
+    padding: 0;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
@@ -15,3 +15,9 @@ export function publishChannel(context, version_notes) {
     context.dispatch('task/startTask', { task: response.data }, { root: true });
   });
 }
+
+export function syncChannel(context, syncChennelPostData) {
+  return client.post(window.Urls.sync_channel(), syncChennelPostData).then(response => {
+    context.dispatch('task/startTask', { task: response.data }, { root: true });
+  });
+}


### PR DESCRIPTION
## Description

Implements the sync resources workflow that consists of four modals:
  - sync what? (this PR)
  - confirm (this PR)
  - sync task progress (handled by asyncTasksModule)
  - sync done (handled by asyncTasksModule)



#### Before/After Screenshots (if applicable)

![sync resources modal](https://user-images.githubusercontent.com/163966/78053800-1cbd4c80-734f-11ea-883e-8f00f06eb5e8.gif)



## Steps to Test

 - [ ] God to any channel page ([example](http://localhost:8080/channels/66a31fdbdd745c7c9e499206f3c4cced/#/00200b203d6a43f89b1f79d37ea969bf))
 - [ ] Choose `Sync channel` from options menu
 - [ ] choose which attributes to test
 - [ ] clock CONTINUE
 - [ ] click SYNC (should take < 10 seconds)
 - [ ] click REFRESH when done


## Implementation Notes

Relies on asyncTasksModule for steps 3 and 4 of the workflow.


#### Does this introduce any tech-debt items?

No tests.




## Comments



## Reviewers
- JB
- Jordan
