### PR TITLE
add user guide link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Kolibri Studio is a web application designed to deliver educational materials to
 
 Kolibri Studio uses [Django](https://www.djangoproject.com/) for the backend and is transitioning from [Backbone.js](https://backbonejs.org/) to [Vue.js](https://vuejs.org/) for the frontend.
 
+If you are looking for help setting up custom content channels, uploading and organizing resources using Kolibri Studio, please refer to the [User Guide](https://kolibri-studio.readthedocs.io/en/latest/).
+
 
 ## Getting started
 


### PR DESCRIPTION
## Description

Added link to Kolibri Studio user guide in the README file.

## Issue Addressed 

Addresses  #1783 

## Checklist

- [X] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
