### PR TITLE
fix webpack devtool source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,6 +180,7 @@ module.exports = (env = {}) => {
       // carryover of path resolution from build.js
       modules: ['node_modules', staticLessDir],
     },
+    devtool: 'cheap-module-source-map',
     plugins: [
       new VueLoaderPlugin(),
       new VuetifyLoaderPlugin(),
@@ -200,9 +201,6 @@ module.exports = (env = {}) => {
         chunkFilename: '[name]-[hash]-[id].css',
       }),
       new WebpackRTLPlugin(),
-      new webpack.SourceMapDevToolPlugin({
-        filename: '[name]-[hash].js.map',
-      }),
       new CircularDependencyPlugin({
         // exclude detection of files based on a RegExp
         exclude: /a\.js|node_modules/,


### PR DESCRIPTION


## Description

Updates the webpack generation of source maps

#### Issue Addressed (if applicable)

https://learningequality.slack.com/archives/C0LK8QS9J/p1583787369110800

## Steps to Test

* do source maps load?
* can you view line numbers in source as expected?

## Implementation Notes (optional)


see https://webpack.js.org/configuration/devtool/

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
