### PR TITLE
Makefile command to destroy/recreate the db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ setup:
 
 export COMPOSE_PROJECT_NAME=studio_$(shell git rev-parse --abbrev-ref HEAD)
 
+purge-postgres:
+	-PGPASSWORD=kolibri dropdb -U learningequality "kolibri-studio" --port 5432 -h localhost
+	PGPASSWORD=kolibri createdb -U learningequality "kolibri-studio" --port 5432 -h localhost
+
+destroy-and-recreate-database: purge-postgres setup
 
 dcbuild:
 	# build all studio docker image and all dependent services using docker-compose


### PR DESCRIPTION
## Description

This adds a shortcut for purging a Studio development database.  It's helpful if there are a lot of changes and you just want to start over from scratch.