### PR TITLE
Switched get_node_ancestors on serializer to use metadata annotations

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -41,6 +41,7 @@ from contentcuration.models import SecretToken
 from contentcuration.models import SlideshowSlide
 from contentcuration.models import Task
 from contentcuration.models import User
+from contentcuration.node_metadata.annotations import AncestorSubquery
 from contentcuration.node_metadata.annotations import AssessmentCount
 from contentcuration.node_metadata.annotations import CoachCount
 from contentcuration.node_metadata.annotations import DescendantCount
@@ -357,9 +358,15 @@ class SimplifiedContentNodeSerializer(BulkSerializerMixin, serializers.ModelSeri
         resource_count=ResourceCount(),
         coach_count=CoachCount(),
     )
+    ancestor_query = Metadata(
+        ancestors=AncestorSubquery()
+    )
 
     def retrieve_metadata(self, node):
         return self.metadata_query.get(node.pk)
+
+    def get_node_ancestors(self, node):
+        return filter(lambda a: a, self.ancestor_query.get(node.pk).get('ancestors', []))
 
     @staticmethod
     def setup_eager_loading(queryset):
@@ -463,9 +470,6 @@ class SimplifiedContentNodeSerializer(BulkSerializerMixin, serializers.ModelSeri
             setattr(instance, attr, value)
         instance.save()
         return instance
-
-    def get_node_ancestors(self, node):
-        return list(node.get_ancestors().values_list('id', flat=True))
 
     class Meta:
         model = ContentNode

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -369,7 +369,7 @@ class SimplifiedContentNodeSerializer(BulkSerializerMixin, serializers.ModelSeri
         return self.metadata_query.get(node.pk)
 
     def get_node_ancestors(self, node):
-        return self.ancestor_query.get(node.pk).get('ancestors', [])
+        return filter(lambda a: a, self.ancestor_query.get(node.pk).get('ancestors', []))
 
     @staticmethod
     def setup_eager_loading(queryset):

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import IntegerField
-from django.db.models import Manager
 from django.db.models import QuerySet
 from django.db.models import Value
 from le_utils.constants import content_kinds
@@ -269,9 +268,7 @@ class CustomListSerializer(serializers.ListSerializer):
         if self.child:
             query = data
 
-            if isinstance(data, Manager):
-                query = data.all()
-            elif not isinstance(data, QuerySet) and isinstance(data, (list, tuple)):
+            if not isinstance(data, QuerySet) and isinstance(data, (list, tuple)):
                 query = ContentNode.objects.filter(pk__in=[n.pk for n in data])
 
             # update metadata_query with queryset for all data such that it minimizes queries


### PR DESCRIPTION
## Description

Optimizes ancestor field on simplified content node serializer with faster querying methods


## Steps to Test

- [ ] Update a node in a topic
- [ ] Make sure ancestors of node are updated properly (e.g. resource counts are updated)

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
