### PR TITLE
Fixes duplication of children ID's

### DIFF
--- a/contentcuration/contentcuration/db/models/aggregates.py
+++ b/contentcuration/contentcuration/db/models/aggregates.py
@@ -1,0 +1,9 @@
+from django.contrib.postgres.aggregates import ArrayAgg as BaseArrayAgg
+
+
+class ArrayAgg(BaseArrayAgg):
+    template = "%(function)s(%(distinct)s%(expressions)s)"
+
+    def __init__(self, *args, **kwargs):
+        kwargs.update(distinct='DISTINCT ' if kwargs.pop('distinct') else '')
+        super(ArrayAgg, self).__init__(*args, **kwargs)

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -269,7 +269,7 @@ var ChannelSetCollection = BaseCollection.extend({
 function fetch_nodes(ids, url) {
   return new Promise(function(resolve) {
     // Getting "Request Line is too large" error on some channels, so chunk the requests
-    var promises = _.chain(ids)
+    var promises = _.chain(_.uniq(ids))
       .chunk(50)
       .map(function(id_list) {
         return new Promise(function(promise_resolve, promise_reject) {

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -3,7 +3,6 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
@@ -39,6 +38,7 @@ from rest_framework.response import Response
 from contentcuration.api import activate_channel
 from contentcuration.api import add_editor_to_channel
 from contentcuration.api import get_staged_diff
+from contentcuration.db.models.aggregates import ArrayAgg
 from contentcuration.decorators import browser_is_supported
 from contentcuration.decorators import cache_no_user_data
 from contentcuration.decorators import can_access_channel
@@ -383,7 +383,7 @@ def accessible_channels(request, channel_id):
     # id, title, resource_count, children
     channels = Channel.objects.filter(Q(deleted=False) & (Q(public=True) | Q(editors=request.user.id) | Q(viewers=request.user.id))).exclude(pk=channel_id)
     channels = channels.annotate(
-        children=ArrayAgg("main_tree__children"),
+        children=ArrayAgg("main_tree__children", distinct=True),
     )
     channels_data = channels.values("name", "children", "main_tree__id")
 


### PR DESCRIPTION
## Description
The accessible channel list returns a list of children in the tree, but wasn't returning it distinctly. Due to some Django magic it was doing to satisfy other parts of the query, the addition of joins causes duplication of children ID's which then gets passed directly back to the server in requests, which are significantly higher in volume than they need to be due to duplication of ID's.

## Steps to Test

- [ ] *Open a channel*
- [ ] *Click the + Add button*
- [ ] *Click Import from Channels*
- [ ] *Open African Storybook at the bottom
- [ ] *How long does it take to load?*

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
