### PR TITLE
Fixed multiple copies of nodes getting copied to clipboard

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/tree_edit/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/tree_edit/views.js
@@ -334,14 +334,8 @@ var TreeEditView = BaseViews.BaseWorkspaceView.extend({
   },
   call_duplicate: function() {
     var self = this;
-    var promises = [];
-    for (var i = 0; i < self.lists.length; i++) {
-      promises.push(self.lists[i].copy_selected());
-      if (self.lists[i].current_node) {
-        break;
-      }
-    }
-    Promise.all(promises)
+    this.lists[0]
+      .copy_selected()
       .then(function(lists) {
         var nodeCollection = new Models.ContentNodeCollection();
         lists.forEach(function(list) {

--- a/contentcuration/contentcuration/static/js/edit_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/views.js
@@ -453,6 +453,7 @@ var BaseWorkspaceView = BaseView.extend({
         break;
       }
     }
+    selected_list = _.uniq(selected_list, true, item => item.model.id);
     return selected_list;
   },
   open_archive: function() {


### PR DESCRIPTION
#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/1080

## Steps to Test

- [ ] Open a topic and select content in subtopic
- [ ] Copy multiple items at once

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
