### PR TITLE
In Nginx, block access to `/content/` root

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -49,7 +49,7 @@ http {
         # Don't allow access to the `/content/` path so that
         # we don't leak which channels are available for download
         
-        rewrite ^/content(/*)$ /
+        rewrite ^/content(/*)$ /;
 
         # Map `/content/*` to the storage bucket
         location ~ ^/content/(.+)$ {

--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -46,9 +46,15 @@ http {
             proxy_set_header   Host $host;
         }
 
-        location /content/ {
+        # Don't allow access to the `/content/` path so that
+        # we don't leak which channels are available for download
+        
+        rewrite ^/content(/*)$ /
+
+        # Map `/content/*` to the storage bucket
+        location ~ ^/content/(.+)$ {
             proxy_http_version 1.1;
-            proxy_pass         {{ $aws_s3_endpoint_url }}/{{ $aws_s3_bucket_name }}/;
+            proxy_pass         {{ $aws_s3_endpoint_url }}/{{ $aws_s3_bucket_name }}/$1;
             proxy_set_header   Host $proxy_host;
             proxy_set_header   Accept-Encoding Identity;
             proxy_redirect     off;


### PR DESCRIPTION
Previously we were using CloudFlare to block access to `/content/`.  With this PR, instead Nginx is used.

See here: https://github.com/learningequality/studio/issues/1838