### PR TITLE
run setup command when not in prod mode

### DIFF
--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -123,6 +123,9 @@ spec:
         image: {{ .Values.studioApp.imageName }}
         command:
         - make
+        {{- if not .Values.productionIngress }}
+        - setup
+        {{- end }}
         - prodceleryworkers
         volumeMounts:
         {{ include "studio.pvc.gcs-creds" . | nindent 10 }}


### PR DESCRIPTION
## Description

This PR is to fix the issue we have on demo servers that the admin account a@a.com is not set up.
It is because we call the command `make setup` in Dockerfile but overwrite it in k8s scripts. 

I made changes so that k8s script checks whether we are in demo server mode or not by checking the value of `productionIngress`, which is set to be true in servers such as production, develop, and some more when we use `cloudbuild-production.yaml`.
Since we use `cloudbuild-pr.yaml` for demo servers, the value of `productionIngress` is set to be false, so we will run an additional command `make setup` when setting up workers.

## Steps to Test

- [ ] *Step 1*: please check that the demo server of this PR has a@a.com admin account

