### PR TITLE
Exercise creation validation improvements

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
@@ -39,7 +39,7 @@
             >
               <AssessmentItemEditor
                 :item="item"
-                :errors="itemErrors(idx)"
+                :errors="itemErrors(item)"
                 :openDialog="openDialog"
                 data-test="editor"
                 @update="onItemUpdate"
@@ -151,17 +151,8 @@
       items: {
         type: Array,
       },
-      /**
-       * An array of assessment items errors.
-       * Each assessment item is assigned an array containing
-       * all validation errors related to that item:
-       * [
-       *   [], // first assessment item errors
-       *   []  // second assessment item errors
-       * ]
-       */
-      itemsValidation: {
-        type: Array,
+      itemsErrors: {
+        type: Object,
       },
       /**
        * Inject a function that opens a dialog that should
@@ -234,14 +225,14 @@
       isItemLast(item) {
         return areItemsEqual(this.lastItem, item);
       },
-      itemErrors(itemIdx) {
-        if (!this.itemsValidation || !this.itemsValidation[itemIdx]) {
+      itemErrors(item) {
+        if (!this.itemsErrors || !this.itemsErrors[item.assessment_id]) {
           return [];
         }
-        return this.itemsValidation[itemIdx];
+        return this.itemsErrors[item.assessment_id];
       },
-      isItemValid(itemIdx) {
-        return this.itemErrors(itemIdx).length === 0;
+      isItemValid(item) {
+        return this.itemErrors(item).length === 0;
       },
       itemClasses(item) {
         const classes = ['item'];

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
@@ -199,6 +199,17 @@
         return this.sortedItems.length ? this.sortedItems[this.sortedItems.length - 1] : null;
       },
     },
+    watch: {
+      items(newItems) {
+        if (!newItems) {
+          return;
+        }
+        const updatedActiveItem = newItems.find(item => areItemsEqual(item, this.activeItem));
+        if (updatedActiveItem) {
+          this.activeItem = updatedActiveItem;
+        }
+      },
+    },
     methods: {
       /**
        * @public
@@ -211,9 +222,17 @@
         return this.sortedItems.findIndex(i => areItemsEqual(i, item));
       },
       openItem(item) {
+        this.closeActiveItem();
         this.activeItem = item;
       },
       closeActiveItem() {
+        if (this.activeItem === null) {
+          return;
+        }
+        this.$emit('updateItem', {
+          ...this.activeItem,
+          isNew: false,
+        });
         this.activeItem = null;
       },
       isItemActive(item) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
@@ -92,14 +92,15 @@
         return this.getAssessmentItems(this.nodeId);
       },
       areAssessmentItemsValid() {
-        return this.getAssessmentItemsAreValid({ contentNodeId: this.nodeId });
+        return this.getAssessmentItemsAreValid({ contentNodeId: this.nodeId, ignoreNew: true });
       },
       assessmentItemsErrors() {
-        return this.getAssessmentItemsErrors({ contentNodeId: this.nodeId });
+        return this.getAssessmentItemsErrors({ contentNodeId: this.nodeId, ignoreNew: true });
       },
       invalidItemsErrorMessage() {
         const invalidItemsCount = this.getInvalidAssessmentItemsCount({
           contentNodeId: this.nodeId,
+          ignoreNew: true,
         });
 
         if (!invalidItemsCount) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
@@ -92,13 +92,15 @@
         return this.getAssessmentItems(this.nodeId);
       },
       areAssessmentItemsValid() {
-        return this.getAssessmentItemsAreValid(this.nodeId);
+        return this.getAssessmentItemsAreValid({ contentNodeId: this.nodeId });
       },
       assessmentItemsErrors() {
-        return this.getAssessmentItemsErrors(this.nodeId);
+        return this.getAssessmentItemsErrors({ contentNodeId: this.nodeId });
       },
       invalidItemsErrorMessage() {
-        const invalidItemsCount = this.getInvalidAssessmentItemsCount(this.nodeId);
+        const invalidItemsCount = this.getInvalidAssessmentItemsCount({
+          contentNodeId: this.nodeId,
+        });
 
         if (!invalidItemsCount) {
           return '';

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
@@ -13,9 +13,9 @@
 
     <AssessmentEditor
       ref="assessmentEditor"
-      :items="assessmentItems"
       :nodeId="nodeId"
-      :itemsValidation="assessmentItemsValidation"
+      :items="assessmentItems"
+      :itemsErrors="assessmentItemsErrors"
       :openDialog="openDialog"
       @addItem="onAddAssessmentItem"
       @updateItem="onUpdateAssessmentItem"
@@ -94,7 +94,7 @@
       areAssessmentItemsValid() {
         return this.getAssessmentItemsAreValid(this.nodeId);
       },
-      assessmentItemsValidation() {
+      assessmentItemsErrors() {
         return this.getAssessmentItemsErrors(this.nodeId);
       },
       invalidItemsErrorMessage() {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/__tests__/getters.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/__tests__/getters.spec.js
@@ -44,6 +44,7 @@ describe('assessmentItem getters', () => {
           'assessment-id-3': {
             assessment_id: 'assessment-id-3',
             contentnode: 'content-node-id-2',
+            isNew: true,
             type: AssessmentItemTypes.SINGLE_SELECTION,
             question: 'What color are minions?',
             answers: [
@@ -60,13 +61,31 @@ describe('assessmentItem getters', () => {
             ],
           },
         },
+        'content-node-id-3': {
+          'assessment-id-4': {
+            assessment_id: 'assessment-id-4',
+            contentnode: 'content-node-id-3',
+            isNew: true,
+            type: AssessmentItemTypes.SINGLE_SELECTION,
+            question: '',
+            answers: [],
+          },
+          'assessment-id-5': {
+            assessment_id: 'assessment-id-5',
+            contentnode: 'content-node-id-3',
+            isNew: true,
+            type: AssessmentItemTypes.SINGLE_SELECTION,
+            question: '',
+            answers: [],
+          },
+        },
       },
     };
   });
 
   describe('getAssessmentItems', () => {
     it('returns an empty array if a content node not found', () => {
-      expect(getAssessmentItems(state)('content-node-id-3')).toEqual([]);
+      expect(getAssessmentItems(state)('content-node-id-4')).toEqual([]);
     });
 
     it('returns an array of assessment items belonging to a content node', () => {
@@ -81,6 +100,7 @@ describe('assessmentItem getters', () => {
         {
           assessment_id: 'assessment-id-3',
           contentnode: 'content-node-id-2',
+          isNew: true,
           type: AssessmentItemTypes.SINGLE_SELECTION,
           question: 'What color are minions?',
           answers: [
@@ -102,7 +122,7 @@ describe('assessmentItem getters', () => {
 
   describe('getAssessmentItemsCount', () => {
     it('returns 0 if a content node not found', () => {
-      expect(getAssessmentItemsCount(state)('content-node-id-3')).toBe(0);
+      expect(getAssessmentItemsCount(state)('content-node-id-4')).toBe(0);
     });
 
     it('returns correct total number of assessment items belonging to a content node', () => {
@@ -112,7 +132,7 @@ describe('assessmentItem getters', () => {
 
   describe('getAssessmentItemsErrors', () => {
     it('returns validation codes corresponding to invalid assessment items of a content node', () => {
-      expect(getAssessmentItemsErrors(state)('content-node-id-2')).toEqual({
+      expect(getAssessmentItemsErrors(state)({ contentNodeId: 'content-node-id-2' })).toEqual({
         'assessment-id-2': [
           ValidationErrors.QUESTION_REQUIRED,
           ValidationErrors.INVALID_NUMBER_OF_CORRECT_ANSWERS,
@@ -120,21 +140,48 @@ describe('assessmentItem getters', () => {
         'assessment-id-3': [ValidationErrors.INVALID_NUMBER_OF_CORRECT_ANSWERS],
       });
     });
+
+    it("doesn't include invalid nodes errors that are new if `ignoreNew` set to true", () => {
+      expect(
+        getAssessmentItemsErrors(state)({ contentNodeId: 'content-node-id-2', ignoreNew: true })
+      ).toEqual({
+        'assessment-id-2': [
+          ValidationErrors.QUESTION_REQUIRED,
+          ValidationErrors.INVALID_NUMBER_OF_CORRECT_ANSWERS,
+        ],
+        'assessment-id-3': [],
+      });
+    });
   });
 
   describe('getInvalidAssessmentItemsCount', () => {
     it('returns a correct number of invalid assessment items of a content node', () => {
-      expect(getInvalidAssessmentItemsCount(state)('content-node-id-2')).toBe(2);
+      expect(getInvalidAssessmentItemsCount(state)({ contentNodeId: 'content-node-id-2' })).toBe(2);
+    });
+
+    it("doesn't count invalid nodes that are new if `ignoreNew` set to true", () => {
+      expect(
+        getInvalidAssessmentItemsCount(state)({
+          contentNodeId: 'content-node-id-2',
+          ignoreNew: true,
+        })
+      ).toBe(1);
     });
   });
 
   describe('getAssessmentItemsAreValid', () => {
     it('returns true if all assessment items of a content node are valid', () => {
-      expect(getAssessmentItemsAreValid(state)('content-node-id-1')).toBe(true);
+      expect(getAssessmentItemsAreValid(state)({ contentNodeId: 'content-node-id-1' })).toBe(true);
     });
 
     it('returns false if all assessment items of a content node are not valid', () => {
-      expect(getAssessmentItemsAreValid(state)('content-node-id-2')).toBe(false);
+      expect(getAssessmentItemsAreValid(state)({ contentNodeId: 'content-node-id-2' })).toBe(false);
+    });
+
+    it('returns true if all assessment items are not valid and marked as new if `ignoreNew` set to true', () => {
+      expect(
+        getAssessmentItemsAreValid(state)({ contentNodeId: 'content-node-id-4', ignoreNew: true })
+      ).toBe(true);
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/__tests__/getters.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/__tests__/getters.spec.js
@@ -54,7 +54,7 @@ describe('assessmentItem getters', () => {
               },
               {
                 answer: 'Yellow',
-                correct: true,
+                correct: false,
                 order: 2,
               },
             ],
@@ -91,7 +91,7 @@ describe('assessmentItem getters', () => {
             },
             {
               answer: 'Yellow',
-              correct: true,
+              correct: false,
               order: 2,
             },
           ],
@@ -112,16 +112,19 @@ describe('assessmentItem getters', () => {
 
   describe('getAssessmentItemsErrors', () => {
     it('returns validation codes corresponding to invalid assessment items of a content node', () => {
-      expect(getAssessmentItemsErrors(state)('content-node-id-2')).toEqual([
-        [ValidationErrors.QUESTION_REQUIRED, ValidationErrors.INVALID_NUMBER_OF_CORRECT_ANSWERS],
-        [],
-      ]);
+      expect(getAssessmentItemsErrors(state)('content-node-id-2')).toEqual({
+        'assessment-id-2': [
+          ValidationErrors.QUESTION_REQUIRED,
+          ValidationErrors.INVALID_NUMBER_OF_CORRECT_ANSWERS,
+        ],
+        'assessment-id-3': [ValidationErrors.INVALID_NUMBER_OF_CORRECT_ANSWERS],
+      });
     });
   });
 
   describe('getInvalidAssessmentItemsCount', () => {
     it('returns a correct number of invalid assessment items of a content node', () => {
-      expect(getInvalidAssessmentItemsCount(state)('content-node-id-2')).toBe(1);
+      expect(getInvalidAssessmentItemsCount(state)('content-node-id-2')).toBe(2);
     });
   });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/getters.js
@@ -25,17 +25,21 @@ export function getAssessmentItemsCount(state) {
 
 /**
  * Get a map of assessment items errors where keys are assessment ids.
+ * Consider new assessment items as valid if `ignoreNew` is true.
  */
 export function getAssessmentItemsErrors(state) {
-  return function(contentNodeId) {
+  return function({ contentNodeId, ignoreNew = false }) {
     const assessmentItemsErrors = {};
     if (!state.assessmentItemsMap || !state.assessmentItemsMap[contentNodeId]) {
       return assessmentItemsErrors;
     }
     Object.keys(state.assessmentItemsMap[contentNodeId]).forEach(assessmentItemId => {
-      assessmentItemsErrors[assessmentItemId] = validateAssessmentItem(
-        state.assessmentItemsMap[contentNodeId][assessmentItemId]
-      );
+      const assessmentItem = state.assessmentItemsMap[contentNodeId][assessmentItemId];
+      if (ignoreNew && assessmentItem.isNew) {
+        assessmentItemsErrors[assessmentItemId] = [];
+      } else {
+        assessmentItemsErrors[assessmentItemId] = validateAssessmentItem(assessmentItem);
+      }
     });
     return assessmentItemsErrors;
   };
@@ -43,11 +47,12 @@ export function getAssessmentItemsErrors(state) {
 
 /**
  * Get total number of invalid assessment items of a node.
+ * Consider new assessment items as valid if `ignoreNew` is true.
  */
 export function getInvalidAssessmentItemsCount(state) {
-  return function(contentNodeId) {
+  return function({ contentNodeId, ignoreNew = false }) {
     let count = 0;
-    const assessmentItemsErrors = getAssessmentItemsErrors(state)(contentNodeId);
+    const assessmentItemsErrors = getAssessmentItemsErrors(state)({ contentNodeId, ignoreNew });
 
     for (const assessmentItemId in assessmentItemsErrors) {
       if (assessmentItemsErrors[assessmentItemId].length) {
@@ -61,9 +66,10 @@ export function getInvalidAssessmentItemsCount(state) {
 
 /**
  * Are all assessment items of a node valid?
+ * Consider new assessment items as valid if `ignoreNew` is true.
  */
 export function getAssessmentItemsAreValid(state) {
-  return function(contentNodeId) {
-    return getInvalidAssessmentItemsCount(state)(contentNodeId) === 0;
+  return function({ contentNodeId, ignoreNew = false }) {
+    return getInvalidAssessmentItemsCount(state)({ contentNodeId, ignoreNew }) === 0;
   };
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/getters.js
@@ -29,7 +29,7 @@ export function getAssessmentItemsCount(state) {
 export function getAssessmentItemsErrors(state) {
   return function(contentNodeId) {
     const assessmentItemsErrors = {};
-    if (!state.assessmentItemsMap[contentNodeId]) {
+    if (!state.assessmentItemsMap || !state.assessmentItemsMap[contentNodeId]) {
       return assessmentItemsErrors;
     }
     Object.keys(state.assessmentItemsMap[contentNodeId]).forEach(assessmentItemId => {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/getters.js
@@ -24,11 +24,20 @@ export function getAssessmentItemsCount(state) {
 }
 
 /**
- * Get an array of nested arrays containing error codes for corresponding assessment items.
+ * Get a map of assessment items errors where keys are assessment ids.
  */
 export function getAssessmentItemsErrors(state) {
   return function(contentNodeId) {
-    return getAssessmentItems(state)(contentNodeId).map(validateAssessmentItem);
+    const assessmentItemsErrors = {};
+    if (!state.assessmentItemsMap[contentNodeId]) {
+      return assessmentItemsErrors;
+    }
+    Object.keys(state.assessmentItemsMap[contentNodeId]).forEach(assessmentItemId => {
+      assessmentItemsErrors[assessmentItemId] = validateAssessmentItem(
+        state.assessmentItemsMap[contentNodeId][assessmentItemId]
+      );
+    });
+    return assessmentItemsErrors;
   };
 }
 
@@ -37,7 +46,16 @@ export function getAssessmentItemsErrors(state) {
  */
 export function getInvalidAssessmentItemsCount(state) {
   return function(contentNodeId) {
-    return getAssessmentItemsErrors(state)(contentNodeId).filter(arr => arr.length).length;
+    let count = 0;
+    const assessmentItemsErrors = getAssessmentItemsErrors(state)(contentNodeId);
+
+    for (const assessmentItemId in assessmentItemsErrors) {
+      if (assessmentItemsErrors[assessmentItemId].length) {
+        count += 1;
+      }
+    }
+
+    return count;
   };
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/index.js
@@ -9,7 +9,7 @@ export default {
     return {
       // Unlike other maps, this is a nested map
       // the top level key is the content node id
-      // then assessent ids are used as keys in
+      // then assessment ids are used as keys in
       // the subsidiary maps
       assessmentItemsMap: {},
     };

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -100,7 +100,7 @@ export function getContentNodeIsValid(state, getters, rootState, rootGetters) {
       (contentNode.isNew ||
         (getContentNodeDetailsAreValid(state)(contentNodeId) &&
           getContentNodeFilesAreValid(state, getters, rootState, rootGetters)(contentNodeId) &&
-          rootGetters['assessmentItem/getAssessmentItemsAreValid'](contentNodeId)))
+          rootGetters['assessmentItem/getAssessmentItemsAreValid']({ contentNodeId })))
     );
   };
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -100,7 +100,10 @@ export function getContentNodeIsValid(state, getters, rootState, rootGetters) {
       (contentNode.isNew ||
         (getContentNodeDetailsAreValid(state)(contentNodeId) &&
           getContentNodeFilesAreValid(state, getters, rootState, rootGetters)(contentNodeId) &&
-          rootGetters['assessmentItem/getAssessmentItemsAreValid']({ contentNodeId })))
+          rootGetters['assessmentItem/getAssessmentItemsAreValid']({
+            contentNodeId,
+            ignoreNew: true,
+          })))
     );
   };
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -99,7 +99,8 @@ export function getContentNodeIsValid(state, getters, rootState, rootGetters) {
       contentNode &&
       (contentNode.isNew ||
         (getContentNodeDetailsAreValid(state)(contentNodeId) &&
-          getContentNodeFilesAreValid(state, getters, rootState, rootGetters)(contentNodeId)))
+          getContentNodeFilesAreValid(state, getters, rootState, rootGetters)(contentNodeId) &&
+          rootGetters['assessmentItem/getAssessmentItemsAreValid'](contentNodeId)))
     );
   };
 }

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views/EditView.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views/EditView.vue
@@ -155,7 +155,8 @@
       },
       areAssessmentItemsValid() {
         return (
-          !this.oneSelected || this.getAssessmentItemsAreValid({ contentNodeId: this.nodeIds[0] })
+          !this.oneSelected ||
+          this.getAssessmentItemsAreValid({ contentNodeId: this.nodeIds[0], ignoreNew: true })
         );
       },
       areFilesValid() {

--- a/contentcuration/contentcuration/static/js/edit_channel/uploader/views/EditView.vue
+++ b/contentcuration/contentcuration/static/js/edit_channel/uploader/views/EditView.vue
@@ -154,7 +154,9 @@
         return !this.oneSelected || this.getContentNodeDetailsAreValid(this.nodeIds[0]);
       },
       areAssessmentItemsValid() {
-        return !this.oneSelected || this.getAssessmentItemsAreValid(this.nodeIds[0]);
+        return (
+          !this.oneSelected || this.getAssessmentItemsAreValid({ contentNodeId: this.nodeIds[0] })
+        );
       },
       areFilesValid() {
         return !this.oneSelected || this.getContentNodeFilesAreValid(this.nodeIds[0]);


### PR DESCRIPTION
## Description

- base validation on assessment ids
- do not show validation errors for newly added items (first validation run for these items is triggered after a new item closed)

Closes #1848.

#### Before/After Screenshots

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/13509191/79969151-60f4c600-8491-11ea-9056-5b5dfd0af747.png) | ![after](https://user-images.githubusercontent.com/13509191/79969149-605c2f80-8491-11ea-9a8f-390f99456ce5.png) |
