### PR TITLE
Node parents getters cleanup

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
@@ -130,7 +130,7 @@
       ...mapState('currentChannel', ['currentChannelId']),
       ...mapGetters('contentNode', [
         'getContentNode',
-        'getContentNodeParents',
+        'getContentNodeAncestors',
         'isPreviousStep',
         'isNextStep',
       ]),
@@ -147,7 +147,8 @@
         channel_id: this.currentChannelId,
       });
 
-      this.selectedNodeId = this.getContentNodeParents(this.targetNodeId)[0].id;
+      const ancestors = this.getContentNodeAncestors(this.targetNodeId);
+      this.selectedNodeId = ancestors[ancestors.length - 2].id;
     },
     methods: {
       ...mapActions('contentNode', ['loadAncestors']),

--- a/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
@@ -53,35 +53,33 @@
     computed: {
       ...mapGetters('contentNode', [
         'getContentNode',
-        'getContentNodeParents',
+        'getContentNodeAncestors',
         'getContentNodeChildren',
       ]),
       selectedNode() {
         return this.getContentNode(this.selectedNodeId);
       },
-      selectedNodeParents() {
-        return this.getContentNodeParents(this.selectedNodeId) || [];
+      selectedNodeAncestors() {
+        return this.getContentNodeAncestors(this.selectedNodeId) || [];
       },
       selectedNodeChildren() {
         return this.getContentNodeChildren(this.selectedNodeId) || [];
       },
       breadcrumbsItems() {
-        return [
-          ...this.selectedNodeParents
-            .map(node => {
-              return {
-                nodeId: node.id,
-                title: node.title,
-                disabled: false,
-              };
-            })
-            .reverse(),
-          {
-            nodeId: this.selectedNodeId,
-            title: this.selectedNode ? this.selectedNode.title : '',
-            disabled: true,
-          },
+        const items = [
+          ...this.selectedNodeAncestors.map(node => {
+            return {
+              nodeId: node.id,
+              title: node.title,
+              disabled: false,
+            };
+          }),
         ];
+        if (items.length > 0) {
+          items[items.length - 1].disabled = true;
+        }
+
+        return items;
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/getters.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/getters.spec.js
@@ -1,5 +1,5 @@
 import {
-  getContentNodeParents,
+  getContentNodeAncestors,
   getImmediatePreviousStepsList,
   getImmediateNextStepsList,
   getImmediateRelatedResourcesCount,
@@ -8,27 +8,32 @@ import {
 } from '../getters';
 
 describe('contentNode getters', () => {
-  describe('getContentNodeParents', () => {
+  describe('getContentNodeAncestors', () => {
     let state;
 
     beforeEach(() => {
       state = {
+        // English -> Elementary -> Literacy -> Reading
         treeNodesMap: {
           'id-elementary': {
             id: 'id-elementary',
-            parent: 'id-english',
+            lft: 2,
+            rght: 7,
           },
           'id-literacy': {
             id: 'id-literacy',
-            parent: 'id-elementary',
+            lft: 3,
+            rght: 6,
           },
           'id-reading': {
             id: 'id-reading',
-            parent: 'id-literacy',
+            lft: 4,
+            rght: 5,
           },
           'id-english': {
             id: 'id-english',
-            parent: null,
+            lft: 1,
+            rght: 8,
           },
         },
         contentNodesMap: {
@@ -53,20 +58,16 @@ describe('contentNode getters', () => {
     });
 
     it('returns an empty array if a content node not found', () => {
-      expect(getContentNodeParents(state)('id-math')).toEqual([]);
+      expect(getContentNodeAncestors(state)('id-math')).toEqual([]);
     });
 
-    it('returns an empty array if a content node has no parents', () => {
-      expect(getContentNodeParents(state)('id-english')).toEqual([]);
-    });
-
-    it(`returns an array containing all parents of a content node
-        sorted from the immediate parent to the most distant parent`, () => {
-      expect(getContentNodeParents(state)('id-reading')).toEqual([
+    it(`returns an array containing a content node and all its parents
+        sorted from the most distant parent to the node itself`, () => {
+      expect(getContentNodeAncestors(state)('id-literacy')).toEqual([
         {
-          id: 'id-literacy',
+          id: 'id-english',
           thumbnail_encoding: {},
-          title: 'Literacy',
+          title: 'English',
         },
         {
           id: 'id-elementary',
@@ -74,9 +75,9 @@ describe('contentNode getters', () => {
           title: 'Elementary',
         },
         {
-          id: 'id-english',
+          id: 'id-literacy',
           thumbnail_encoding: {},
-          title: 'English',
+          title: 'Literacy',
         },
       ]);
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -61,37 +61,6 @@ export function getContentNodeAncestors(state) {
   };
 }
 
-/**
- * Returns an array of all parent nodes of a node.
- * Parent nodes are sorted from the immmediate parent
- * to the most distant parent.
- */
-export function getContentNodeParents(state) {
-  return function(contentNodeId) {
-    const getParentId = nodeId => {
-      const treeNode = Object.values(state.treeNodesMap).find(
-        contentNode => contentNode.id === nodeId
-      );
-
-      if (!treeNode || !treeNode.parent) {
-        return null;
-      }
-
-      return treeNode.parent;
-    };
-
-    const parents = [];
-    let parentId = getParentId(contentNodeId);
-
-    while (parentId !== null) {
-      parents.push(getContentNode(state)(parentId));
-      parentId = getParentId(parentId);
-    }
-
-    return parents;
-  };
-}
-
 export function getContentNodeIsValid(state, getters, rootState, rootGetters) {
   return function(contentNodeId) {
     const contentNode = state.contentNodesMap[contentNodeId];


### PR DESCRIPTION
## Description

Remove `getContentNodeParents` in favour of `getContentNodeAncestors`.
Closes #1815.