### PR TITLE
Preserve the current mode in "Add previous/next steps" modals

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
@@ -91,10 +91,7 @@
 
   import { mapState, mapGetters, mapActions } from 'vuex';
 
-  import { RouterNames } from '../constants';
   import NodeTreeNavigation from './NodeTreeNavigation';
-  import { TabNames } from 'edit_channel/uploader/constants';
-
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
 
   export default {
@@ -190,13 +187,7 @@
         return '';
       },
       onCancelClick() {
-        this.$router.push({
-          name: RouterNames.CONTENTNODE_DETAILS,
-          params: {
-            detailNodeIds: this.targetNodeId,
-            tab: TabNames.RELATED,
-          },
-        });
+        this.$emit('cancel');
       },
       onListItemClick(node) {
         if (!this.isTopic(node) || this.isTargetResource(node) || this.isListItemDisabled(node)) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
@@ -207,6 +207,9 @@
           params: {
             targetNodeId: this.nodeId,
           },
+          query: {
+            back: this.$route.name,
+          },
         });
       },
       onAddNextStepClick() {
@@ -214,6 +217,9 @@
           name: RouterNames.ADD_NEXT_STEPS,
           params: {
             targetNodeId: this.nodeId,
+          },
+          query: {
+            back: this.$route.name,
           },
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsModal.vue
@@ -6,6 +6,7 @@
     :selectedAsPreviousStepTooltip="$tr('selectedAsPreviousStep')"
     :selectedAsNextStepTooltip="$tr('selectedAsNextStep')"
     @addStep="onAddStepClick"
+    @cancel="onCancelClick"
   />
 
 </template>
@@ -14,7 +15,9 @@
 
   import { mapActions } from 'vuex';
 
+  import { RouterNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
+  import { TabNames } from 'edit_channel/uploader/constants';
 
   export default {
     name: 'AddNextStepsModal',
@@ -36,6 +39,20 @@
         this.addNextStepToNode({
           targetId: this.targetNodeId,
           nextStepId: node.id,
+        });
+      },
+      onCancelClick() {
+        let routeName = RouterNames.CONTENTNODE_DETAILS;
+        if (this.$route.query && this.$route.query.back) {
+          routeName = this.$route.query.back;
+        }
+
+        this.$router.push({
+          name: routeName,
+          params: {
+            detailNodeIds: this.targetNodeId,
+            tab: TabNames.RELATED,
+          },
         });
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsModal.vue
@@ -6,6 +6,7 @@
     :selectedAsPreviousStepTooltip="$tr('selectedAsPreviousStep')"
     :selectedAsNextStepTooltip="$tr('selectedAsNextStep')"
     @addStep="onAddStepClick"
+    @cancel="onCancelClick"
   />
 
 </template>
@@ -14,7 +15,9 @@
 
   import { mapActions } from 'vuex';
 
+  import { RouterNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
+  import { TabNames } from 'edit_channel/uploader/constants';
 
   export default {
     name: 'AddPreviousStepsModal',
@@ -36,6 +39,20 @@
         this.addPreviousStepToNode({
           targetId: this.targetNodeId,
           previousStepId: node.id,
+        });
+      },
+      onCancelClick() {
+        let routeName = RouterNames.CONTENTNODE_DETAILS;
+        if (this.$route.query && this.$route.query.back) {
+          routeName = this.$route.query.back;
+        }
+
+        this.$router.push({
+          name: routeName,
+          params: {
+            detailNodeIds: this.targetNodeId,
+            tab: TabNames.RELATED,
+          },
         });
       },
     },


### PR DESCRIPTION
## Description

Preserve the current _Edit Modal_ mode in _Add previous/next steps_ modals so users will be navigated back to the right place after clicking _Cancel_ button in _Add previous/next steps_ modals.

#### Issue Addressed

Addresses #1816

## Steps to Test

- [ ] *Navigate to related resource tab for all edit modal modes (edit details, upload file, ...)*
- [ ] *Click "Add previous/next step" button*
- [ ] *Click Cancel button on "Add previous/next steps" modals*
- [ ] *Check that you are back on Edit Modal page in a mode that had been active before you left*

## Implementation Notes

#### At a high level, how did you implement this?

`back` query parameter