### PR TITLE
Various reactivity and asynchronicity fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
@@ -139,10 +139,7 @@
       },
     },
     async created() {
-      await this.loadAncestors({
-        id: this.targetNodeId,
-        channel_id: this.currentChannelId,
-      });
+      await this.loadAncestors({ id: this.targetNodeId });
 
       const ancestors = this.getContentNodeAncestors(this.targetNodeId, false);
       this.selectedNodeId = ancestors[ancestors.length - 1].id;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
@@ -34,7 +34,7 @@
       <NodeTreeNavigation
         v-if="selectedNodeId"
         v-model="selectedNodeId"
-        :channelId="currentChannelId"
+        :treeId="rootId"
       >
         <VListTile
           slot="child"
@@ -124,7 +124,7 @@
       };
     },
     computed: {
-      ...mapState('currentChannel', ['currentChannelId']),
+      ...mapState('currentChannel', ['rootId']),
       ...mapGetters('contentNode', [
         'getContentNode',
         'getContentNodeAncestors',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
@@ -41,7 +41,7 @@
       event: 'updateSelectedNodeId',
     },
     props: {
-      channelId: {
+      treeId: {
         type: String,
         required: true,
       },
@@ -102,7 +102,7 @@
         if (this.selectedNode.has_children) {
           this.loadChildren({
             parent: nodeId,
-            channel_id: this.channelId,
+            tree_id: this.treeId,
           });
         }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
@@ -108,7 +108,6 @@
 
         this.loadAncestors({
           id: nodeId,
-          channel_id: this.channelId,
           includeSelf: true,
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/move/MoveModal.vue
@@ -252,7 +252,7 @@
           this.loading = true;
           return this.loadChildren({
             parent: this.targetNodeId,
-            channel_id: this.currentChannel.id,
+            tree_id: this.rootId,
           }).then(() => {
             this.loading = false;
           });

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -92,12 +92,16 @@ const router = new VueRouter({
       component: TreeView,
       beforeEnter: (to, from, next) => {
         const { currentChannelId } = store.state.currentChannel;
-        return Promise.all([
-          store.dispatch('channel/loadChannel', currentChannelId),
-          store.dispatch('contentNode/loadClipboardTree'),
-          store.dispatch('contentNode/loadChannelTree', currentChannelId),
-          store.dispatch('contentNode/loadTrashTree', currentChannelId),
-        ])
+
+        return store
+          .dispatch('channel/loadChannel', currentChannelId)
+          .then(() => {
+            return Promise.all([
+              store.dispatch('contentNode/loadClipboardTree'),
+              store.dispatch('contentNode/loadChannelTree', currentChannelId),
+              store.dispatch('contentNode/loadTrashTree', currentChannelId),
+            ]);
+          })
           .catch(error => {
             throw new Error(error);
           })

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -98,8 +98,10 @@ const router = new VueRouter({
           store.dispatch('contentNode/loadChannelTree', currentChannelId),
           store.dispatch('contentNode/loadTrashTree', currentChannelId),
         ])
-          .then(() => next())
-          .catch(() => {});
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
       },
       children: [
         {

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -95,12 +95,15 @@ const router = new VueRouter({
 
         return store
           .dispatch('channel/loadChannel', currentChannelId)
-          .then(() => {
-            return Promise.all([
+          .then(channel => {
+            const promises = [
               store.dispatch('contentNode/loadClipboardTree'),
               store.dispatch('contentNode/loadChannelTree', currentChannelId),
-              store.dispatch('contentNode/loadTrashTree', currentChannelId),
-            ]);
+            ];
+            if (channel.trash_root_id) {
+              promises.push(store.dispatch('contentNode/loadTrashTree', channel.trash_root_id));
+            }
+            return Promise.all(promises);
           })
           .catch(error => {
             throw new Error(error);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -274,7 +274,7 @@
         this.selected = [];
 
         this.loadingAncestors = true;
-        this.loadAncestors({ id: this.topicId, channel_id: this.currentChannel.id }).then(() => {
+        this.loadAncestors({ id: this.topicId }).then(() => {
           this.loadingAncestors = false;
         });
       },
@@ -293,7 +293,7 @@
     },
     created() {
       this.loadingAncestors = true;
-      this.loadAncestors({ id: this.topicId, channel_id: this.currentChannel.id }).then(() => {
+      this.loadAncestors({ id: this.topicId }).then(() => {
         this.loadingAncestors = false;
       });
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -272,15 +272,11 @@
     watch: {
       topicId() {
         this.selected = [];
-      },
-      ancestors(value) {
-        // Full ancestor path hasn't been loaded
-        if (!value.some(a => a.id === this.topicId)) {
-          this.loadingAncestors = true;
-          this.loadAncestors({ id: this.topicId, channel_id: this.currentChannel.id }).then(() => {
-            this.loadingAncestors = false;
-          });
-        }
+
+        this.loadingAncestors = true;
+        this.loadAncestors({ id: this.topicId, channel_id: this.currentChannel.id }).then(() => {
+          this.loadingAncestors = false;
+        });
       },
       detailNodeId(nodeId) {
         if (nodeId) {
@@ -294,6 +290,12 @@
           });
         }
       },
+    },
+    created() {
+      this.loadingAncestors = true;
+      this.loadAncestors({ id: this.topicId, channel_id: this.currentChannel.id }).then(() => {
+        this.loadingAncestors = false;
+      });
     },
     methods: {
       ...mapActions(['showSnackbar']),
@@ -425,7 +427,6 @@
         this.elevated = this.$refs.resources.scrollTop > 0;
       },
     },
-
     $trs: {
       addTopic: 'New subtopic',
       addExercise: 'New exercise',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -73,7 +73,7 @@
     },
     computed: {
       ...mapGetters(['isCompactViewMode']),
-      ...mapGetters('currentChannel', ['currentChannel', 'rootId']),
+      ...mapGetters('currentChannel', ['rootId']),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeChildren']),
       node() {
         return this.getContentNode(this.parentId);
@@ -88,11 +88,9 @@
     mounted() {
       if (this.node && this.node.total_count && !this.children.length) {
         this.loading = true;
-        this.loadChildren({ parent: this.parentId, channel_id: this.currentChannel.id }).then(
-          () => {
-            this.loading = false;
-          }
-        );
+        this.loadChildren({ parent: this.parentId, tree_id: this.rootId }).then(() => {
+          this.loading = false;
+        });
       }
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/StudioTree.vue
@@ -79,6 +79,7 @@
             v-for="child in children"
             v-show="child.kind === 'topic'"
             :key="child.id"
+            :treeId="treeId"
             :nodeId="child.id"
           />
         </div>
@@ -102,6 +103,10 @@
       ContentNodeOptions,
     },
     props: {
+      treeId: {
+        type: String,
+        required: true,
+      },
       nodeId: {
         type: String,
         required: true,
@@ -170,7 +175,7 @@
           this.loading = true;
           return this.loadChildren({
             parent: this.nodeId,
-            channel_id: this.$store.state.currentChannel.currentChannelId,
+            tree_id: this.treeId,
           }).then(() => {
             this.loading = false;
             this.loaded = true;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView.vue
@@ -29,7 +29,11 @@
         />
       </VLayout>
       <div style="margin-left: -24px;">
-        <StudioTree :nodeId="rootId" :root="true" />
+        <StudioTree
+          :treeId="rootId"
+          :nodeId="rootId"
+          :root="true"
+        />
       </div>
     </ResizableNavigationDrawer>
     <VContainer fluid class="pa-0 ma-0" style="height: calc(100vh - 64px);">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -213,7 +213,11 @@
     },
     mounted() {
       this.loading = true;
-      this.loadTrashTree(this.currentChannel.id)
+      if (!this.trashId) {
+        this.loading = false;
+        return;
+      }
+      this.loadTrashTree(this.trashId)
         .then(nodes => {
           return nodes.length ? this.loadContentNodes({ id__in: nodes.map(node => node.id) }) : [];
         })

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -1,8 +1,43 @@
-import { mount } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
 import VueRouter from 'vue-router';
 import TrashModal from '../TrashModal';
-import store from '../../../store';
 import { RouterNames } from '../../../constants';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(VueRouter);
+
+const currentChannelGetters = {
+  currentChannel: jest.fn(),
+  trashId: jest.fn(),
+};
+const contentNodeGetters = {
+  getContentNodeChildren: jest.fn(),
+};
+const contentNodeActions = {
+  deleteContentNodes: jest.fn(),
+  loadTrashTree: jest.fn(),
+  loadContentNodes: jest.fn(),
+};
+const contentNodeMutations = {
+  SET_MOVE_NODES: jest.fn(),
+};
+
+const store = new Store({
+  modules: {
+    currentChannel: {
+      namespaced: true,
+      getters: currentChannelGetters,
+    },
+    contentNode: {
+      namespaced: true,
+      getters: contentNodeGetters,
+      mutations: contentNodeMutations,
+      actions: contentNodeActions,
+    },
+  },
+});
 
 const testChildren = [
   {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -55,15 +55,10 @@ export function loadClipboardTree(context) {
   return tree_id ? context.dispatch('loadTree', { tree_id }) : Promise.resolve([]);
 }
 
-export function loadChildren(context, { parent, channel_id }) {
-  const channel = context.rootGetters['channel/getChannel'](channel_id);
-  if (!channel) {
-    throw new Error('[loadChildren] Channel data are not loaded');
-  }
-
-  return Tree.where({ parent, tree_id: channel.root_id }).then(nodes => {
+export function loadChildren(context, { parent, tree_id }) {
+  return Tree.where({ parent, tree_id }).then(nodes => {
     if (!nodes || !nodes.length) {
-      return Promise.resolve();
+      return Promise.resolve([]);
     }
     context.commit('ADD_TREENODES', nodes);
     return loadContentNodes(context, { id__in: nodes.map(node => node.id) });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -65,6 +65,7 @@ export function loadChildren(context, { parent, channel_id }) {
     if (!nodes || !nodes.length) {
       return Promise.resolve();
     }
+    context.commit('ADD_TREENODES', nodes);
     return loadContentNodes(context, { id__in: nodes.map(node => node.id) });
   });
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -73,13 +73,21 @@ export function loadClipboardTree(context) {
 export function loadChildren(context, { parent, channel_id }) {
   return getChannel(context, channel_id)
     .then(channel => Tree.where({ parent, tree_id: channel.root_id }))
-    .then(nodes => loadContentNodes(context, { id__in: nodes.map(node => node.id) }));
+    .then(nodes => {
+      if (!nodes || !nodes.length) {
+        return Promise.resolve();
+      }
+      return loadContentNodes(context, { id__in: nodes.map(node => node.id) });
+    });
 }
 
 export function loadAncestors(context, { id, includeSelf = false }) {
-  return loadTreeNodeAncestors(context, { id, includeSelf }).then(nodes =>
-    loadContentNodes(context, { id__in: nodes.map(node => node.id) })
-  );
+  return loadTreeNodeAncestors(context, { id, includeSelf }).then(nodes => {
+    if (!nodes || !nodes.length) {
+      return Promise.resolve();
+    }
+    return loadContentNodes(context, { id__in: nodes.map(node => node.id) });
+  });
 }
 
 export function loadTreeNodeAncestors(context, { id, includeSelf = false }) {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -42,12 +42,8 @@ export function loadChannelTree(context, channel_id) {
   return context.dispatch('loadTree', { channel_id });
 }
 
-export function loadTrashTree(context, channelId) {
-  const channel = context.rootGetters['channel/getChannel'](channelId);
-  if (!channel) {
-    throw new Error('[loadTrashTree] Channel data are not loaded');
-  }
-  return context.dispatch('loadTree', { tree_id: channel.trash_root_id });
+export function loadTrashTree(context, tree_id) {
+  return context.dispatch('loadTree', { tree_id });
 }
 
 export function loadClipboardTree(context) {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -58,7 +58,7 @@ export function loadClipboardTree(context) {
 export function loadChildren(context, { parent, channel_id }) {
   const channel = context.rootGetters['channel/getChannel'](channel_id);
   if (!channel) {
-    throw new Error('[loadTrashTree] Channel data are not loaded');
+    throw new Error('[loadChildren] Channel data are not loaded');
   }
 
   return Tree.where({ parent, tree_id: channel.root_id }).then(nodes => {


### PR DESCRIPTION
## Description

This PR contains various fixes related mostly to tree navigation within channel edit page mentioned yesterday [here](https://learningequality.slack.com/archives/C0LK8QS9J/p1589354076000300). Those issues showed up to be a composition of more smaller problems with asynchronous and reactive behavior. The diff is not large though to understand particular issues, please review commit by commit - I tried to explain what was the problem in detail in commit messages as we should be aware of these things in general. There are better solutions to some of those issues though I am currently actively working on staging channel that uses some of the functionality affected and will need to do some more updates - for now I just wanted to get these fixes merged to `vue-refactor` for everyone.

This also seems to fix https://github.com/learningequality/studio/issues/1877 (I guess missing channel data required for other data to be fetched and related swallowed Promise rejection was the source of this problem too) though please check it locally too, I sometimes experience random behavior probably due to caching maybe.

It would be good to discuss some systematic way of preventing these types of problems - some async stuff would be probably hard to detect (I hope that Gherkin e2e will help us here) though after having closer look today I assume that we could prevent some of them by adding Jest tests for core functionality - I can offer some help with it after I am done with staging channel (if nothing more urgent is needed).