### PR TITLE
nginx: use an allow list for the catalog server

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -24,6 +24,25 @@ http {
         server 127.0.0.1:8081;
     }
 
+    # Allow-list filter for content catalog paths
+    server {
+        listen 8080;
+        server_name catalog.learningequality.org;
+        location = / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_pass http://127.0.0.1;
+        }
+        location ~ ^/(api/catalog|stealthz|healthz|api/get_channel_details|jsreverse|i18n) {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_pass http://127.0.0.1;
+        }
+        location / {
+            deny all;
+        }
+    }
+
     # Configuration for Nginx
     server {
         # Listen on port 8080


### PR DESCRIPTION
## Description

This ensures that only the following paths are allowed for requests to `catalog.learningequality.org`:

```
/
/api/catalog
/healthz
/stealthz
/api/get_channel_details
/jsreverse
/i18n
```

This is to ensure that Studio's WIP refactor isn't exposed prematurely!  [See here](https://www.notion.so/learningequality/Make-sure-all-non-catalog-related-urls-are-blocked-9ce74987da3e4a1fb0498414195a04c6) for more info.