### PR TITLE
nginx: fix catalog allow-list proxy_pass configuration

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -29,14 +29,14 @@ http {
         listen 8080;
         server_name catalog.learningequality.org;
         location = / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_pass http://127.0.0.1;
+            proxy_pass         http://studio;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
         }
         location ~ ^/(api/catalog|stealthz|healthz|api/get_channel_details|jsreverse|i18n) {
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_pass http://127.0.0.1;
+            proxy_pass         http://studio;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
         }
         location / {
             deny all;


### PR DESCRIPTION
## Description

This is a fix to the `proxy_pass` configuration for the catalog server nginx allowlist.  See [here](https://github.com/learningequality/studio/pull/1908) for details.