### PR TITLE
nginx: block /content/ root, round two

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -50,7 +50,11 @@ http {
         # we don't leak which channels are available for download
         
         location = /content/ {
-            deny all;
+            return 301 https://$host/;
+        }
+        
+        location = /content {
+            return 301 https://$host/;
         }
 
         # Map `/content/*` to the storage bucket

--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -49,12 +49,14 @@ http {
         # Don't allow access to the `/content/` path so that
         # we don't leak which channels are available for download
         
-        rewrite ^/content(/*)$ /;
+        location = /content/ {
+            deny all;
+        }
 
         # Map `/content/*` to the storage bucket
-        location ~ ^/content/(.+)$ {
+        location /content/ {
             proxy_http_version 1.1;
-            proxy_pass         {{ $aws_s3_endpoint_url }}/{{ $aws_s3_bucket_name }}/$1;
+            proxy_pass         {{ $aws_s3_endpoint_url }}/{{ $aws_s3_bucket_name }}/;
             proxy_set_header   Host $proxy_host;
             proxy_set_header   Accept-Encoding Identity;
             proxy_redirect     off;


### PR DESCRIPTION
## Description

This denies access to the `/content/` root while still allowing access to `/content/*`.  It's way simpler than the approach tried previously, which relied on regex.

#### Issue Addressed (if applicable)
The original changes, which used regex, and evidently were stirring up trouble, were reverted here: https://github.com/learningequality/studio/pull/1913
