### PR TITLE
Permissions and filtering

### DIFF
--- a/contentcuration/contentcuration/tests/test_urlendpoints.py
+++ b/contentcuration/contentcuration/tests/test_urlendpoints.py
@@ -33,7 +33,7 @@ class AllUrlsTest(StudioTestCase):
             print the status code.
         """
         if not allowed_http_codes:
-            allowed_http_codes = [200, 302, 400, 401, 403, 404, 405]
+            allowed_http_codes = [200, 302, 400, 401, 403, 404, 405, 412]
 
         if not default_kwargs:
             default_kwargs = {}

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -5,7 +5,6 @@ from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import ObjectDoesNotExist
 from django_filters.rest_framework import DjangoFilterBackend
-from django_filters.rest_framework import FilterSet
 from django_s3_storage.storage import S3Error
 from le_utils.constants import exercises
 from le_utils.constants import format_presets
@@ -19,6 +18,7 @@ from contentcuration.models import generate_object_storage_name
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.common import NotNullArrayAgg
 from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.sync.constants import ASSESSMENTITEM
@@ -33,13 +33,18 @@ exercise_image_filename_regex = re.compile(
 )
 
 
-class AssessmentItemFilter(FilterSet):
+class AssessmentItemFilter(RequiredFilterSet):
     id__in = UUIDInFilter(name="id")
     contentnode__in = UUIDInFilter(name="contentnode")
 
     class Meta:
         model = AssessmentItem
-        fields = ("id", "id__in", "contentnode", "contentnode__in",)
+        fields = (
+            "id",
+            "id__in",
+            "contentnode",
+            "contentnode__in",
+        )
 
 
 def get_filenames_from_assessment(assessment_item):
@@ -186,19 +191,16 @@ class AssessmentItemViewSet(ValuesViewset):
             e = e if isinstance(e, ValidationError) else ValidationError(e)
 
             # if contentnode doesn't exist
-            return str(e), [
+            return str(e), [dict(key=pk, table=ASSESSMENTITEM, type=DELETED,)]
+
+        return (
+            None,
+            [
                 dict(
                     key=pk,
                     table=ASSESSMENTITEM,
-                    type=DELETED,
+                    type=CREATED,
+                    obj=AssessmentItemSerializer(instance=new_item),
                 )
-            ]
-
-        return None, [
-            dict(
-                key=pk,
-                table=ASSESSMENTITEM,
-                type=CREATED,
-                obj=AssessmentItemSerializer(instance=new_item)
-            )
-        ]
+            ],
+        )

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -9,6 +9,7 @@ from django_filters.rest_framework import FilterSet
 from django_s3_storage.storage import S3Error
 from le_utils.constants import exercises
 from le_utils.constants import format_presets
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import ValidationError
 
 from contentcuration.models import AssessmentItem
@@ -130,6 +131,7 @@ class AssessmentItemSerializer(BulkModelSerializer):
 class AssessmentItemViewSet(ValuesViewset):
     queryset = AssessmentItem.objects.all()
     serializer_class = AssessmentItemSerializer
+    permission_classes = [IsAuthenticated]
     filter_backends = (DjangoFilterBackend,)
     filter_class = AssessmentItemFilter
     values = (

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -4,18 +4,15 @@ from django.db.models import IntegerField
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
-from django.db.models import Value
 from django.db.models.functions import Cast
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
-from django_filters.rest_framework import FilterSet
 from le_utils.constants import content_kinds
 from le_utils.constants import roles
 from rest_framework import serializers
-from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAuthenticated
@@ -31,6 +28,7 @@ from contentcuration.models import User
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.common import ContentDefaultsSerializer
 from contentcuration.viewsets.common import DistinctNotNullArrayAgg
 from contentcuration.viewsets.common import SQCount
@@ -64,7 +62,7 @@ primary_token_subquery = Subquery(
 )
 
 
-class ChannelFilter(FilterSet):
+class ChannelFilter(RequiredFilterSet):
     edit = BooleanFilter(method="filter_edit")
     view = BooleanFilter(method="filter_view")
     bookmark = BooleanFilter(method="filter_bookmark")
@@ -326,7 +324,7 @@ def format_domain(item):
 class ChannelViewSet(ValuesViewset):
     queryset = Channel.objects.all()
     serializer_class = ChannelSerializer
-    filter_backends = (DjangoFilterBackend, SearchFilter)
+    filter_backends = (DjangoFilterBackend,)
     permission_classes = [IsAuthenticated]
     pagination_class = CatalogListPagination
     filter_class = ChannelFilter

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -18,6 +18,7 @@ from rest_framework import serializers
 from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import PrimaryKeyRelatedField
 
@@ -326,7 +327,7 @@ class ChannelViewSet(ValuesViewset):
     queryset = Channel.objects.all()
     serializer_class = ChannelSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter)
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
     pagination_class = CatalogListPagination
     filter_class = ChannelFilter
     values = (

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -1,6 +1,7 @@
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
+from rest_framework.permissions import IsAuthenticated
 from rest_framework import serializers
 
 from contentcuration.models import Channel
@@ -20,11 +21,11 @@ class ChannelSetSerializer(BulkModelSerializer):
         Check that the user has permission to view these channels
         """
         try:
-            self.context["request"].user.can_view_channel_ids(
-                value
-            )
+            self.context["request"].user.can_view_channel_ids(value)
         except (PermissionDenied, AttributeError, KeyError):
-            raise serializers.ValidationError("User does not have permission to view these channels")
+            raise serializers.ValidationError(
+                "User does not have permission to view these channels"
+            )
         return value
 
     def create(self, validated_data):
@@ -48,6 +49,7 @@ def clean_channels(item):
 class ChannelSetViewSet(ValuesViewset):
     queryset = ChannelSet.objects.all()
     serializer_class = ChannelSetSerializer
+    permission_classes = [IsAuthenticated]
     values = ("id", "name", "description", "channels", "secret_token__token")
 
     field_map = {"secret_token": "secret_token__token", "channels": clean_channels}

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -14,6 +14,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from le_utils.constants import content_kinds
 from le_utils.constants import roles
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import empty
 from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.serializers import ValidationError
@@ -216,6 +217,7 @@ copy_ignore_fields = {
 class ContentNodeViewSet(ValuesViewset):
     queryset = ContentNode.objects.all()
     serializer_class = ContentNodeSerializer
+    permission_classes = [IsAuthenticated]
     filter_backends = (DjangoFilterBackend,)
     filter_class = ContentNodeFilter
     values = (

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -1,5 +1,6 @@
 from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import FilterSet
 from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.serializers import ValidationError
@@ -58,6 +59,7 @@ def retrieve_storage_url(item):
 class FileViewSet(ValuesViewset):
     queryset = File.objects.all()
     serializer_class = FileSerializer
+    permission_classes = [IsAuthenticated]
     filter_backends = (DjangoFilterBackend,)
     filter_class = FileFilter
     values = (

--- a/contentcuration/contentcuration/viewsets/tree.py
+++ b/contentcuration/contentcuration/viewsets/tree.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 from django_cte import With
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.viewsets import GenericViewSet
@@ -27,7 +28,10 @@ _valid_positions = {"first-child", "last-child", "left", "right"}
 class TreeFilter(FilterSet):
     class Meta:
         model = ContentNode
-        fields = ("id", "parent",)
+        fields = (
+            "id",
+            "parent",
+        )
 
 
 def validate_targeting_args(target, position):
@@ -65,10 +69,7 @@ class Mapper(object):
         self.tree_id = tree_id
 
     def __call__(self, item):
-        item.update({
-            key: mapping(item)
-            for key, mapping in self.field_map.items()
-        })
+        item.update({key: mapping(item) for key, mapping in self.field_map.items()})
 
         item["channel_id"] = self.channel_id or item["channel_id"]
         item["tree_id"] = self.tree_id
@@ -76,6 +77,7 @@ class Mapper(object):
 
 
 class TreeViewSet(GenericViewSet):
+    permission_classes = [IsAuthenticated]
     filter_backends = (DjangoFilterBackend,)
     filter_class = TreeFilter
     values = (
@@ -89,27 +91,30 @@ class TreeViewSet(GenericViewSet):
         "lft",
     )
 
-    field_map = {
-        "source_id": map_source_id,
-        "channel_id": map_channel_id
-    }
+    field_map = {"source_id": map_source_id, "channel_id": map_channel_id}
 
     def add_source_cte(self, queryset, field):
         cte = With(
-            ContentNode.objects.filter(node_id__in=queryset.values(field)).values("id", "node_id"),
-            name='{}_cte'.format(field)
+            ContentNode.objects.filter(node_id__in=queryset.values(field)).values(
+                "id", "node_id"
+            ),
+            name="{}_cte".format(field),
         )
 
-        queryset = cte.join(queryset, _join_type=LOUTER, **{field: cte.col.node_id})\
-            .with_cte(cte)
+        queryset = cte.join(
+            queryset, _join_type=LOUTER, **{field: cte.col.node_id}
+        ).with_cte(cte)
         return queryset, cte
 
     def annotate_queryset(self, queryset):
         queryset, source_node_cte = self.add_source_cte(queryset, "source_node_id")
-        queryset, original_node_cte = self.add_source_cte(queryset, "original_source_node_id")
+        queryset, original_node_cte = self.add_source_cte(
+            queryset, "original_source_node_id"
+        )
 
-        real_source_id = Coalesce(source_node_cte.col.id, original_node_cte.col.id,
-                                  output_field=CharField())
+        real_source_id = Coalesce(
+            source_node_cte.col.id, original_node_cte.col.id, output_field=CharField()
+        )
         return queryset.annotate(real_source_id=real_source_id)
 
     @classmethod
@@ -143,9 +148,11 @@ class TreeViewSet(GenericViewSet):
 
     def map_model(self, node):
         tree_id = node.get_root_id()
-        channel_id = Channel.objects.filter(main_tree_id=tree_id)\
-            .values_list("pk", flat=True)\
+        channel_id = (
+            Channel.objects.filter(main_tree_id=tree_id)
+            .values_list("pk", flat=True)
             .first()
+        )
 
         mapper = Mapper(self.field_map, channel_id=channel_id, tree_id=tree_id)
         queryset = self.annotate_queryset(ContentNode.objects.filter(pk=node.pk))
@@ -168,11 +175,11 @@ class TreeViewSet(GenericViewSet):
                 )
 
             contentnode.refresh_from_db()
-            return None, dict(
-                key=pk,
-                table=TREE,
-                type=UPDATED,
-                mods=self.map_model(contentnode)
+            return (
+                None,
+                dict(
+                    key=pk, table=TREE, type=UPDATED, mods=self.map_model(contentnode)
+                ),
             )
         except ValidationError as e:
             return str(e), None
@@ -187,16 +194,8 @@ class TreeViewSet(GenericViewSet):
         channel_id = mods.pop("channel_id")
 
         delete_response = [
-            dict(
-                key=pk,
-                table=TREE,
-                type=DELETED,
-            ),
-            dict(
-                key=pk,
-                table=CONTENTNODE,
-                type=DELETED,
-            ),
+            dict(key=pk, table=TREE, type=DELETED,),
+            dict(key=pk, table=CONTENTNODE, type=DELETED,),
         ]
 
         try:
@@ -236,18 +235,20 @@ class TreeViewSet(GenericViewSet):
             if not new_node.original_channel_id or not new_node.original_source_node_id:
                 original_node = source.get_original_node()
                 original_channel = original_node.get_channel()
-                new_node.original_channel_id = original_channel.id if original_channel else None
+                new_node.original_channel_id = (
+                    original_channel.id if original_channel else None
+                )
                 new_node.original_source_node_id = original_node.node_id
 
             new_node.insert_at(target, position, save=False, allow_existing_pk=True)
             new_node.save(force_insert=True)
             new_node.refresh_from_db()
 
-            return None, [
-                dict(
-                    key=pk,
-                    table=TREE,
-                    type=UPDATED,
-                    mods=self.map_model(new_node)
-                ),
-            ]
+            return (
+                None,
+                [
+                    dict(
+                        key=pk, table=TREE, type=UPDATED, mods=self.map_model(new_node)
+                    ),
+                ],
+            )


### PR DESCRIPTION
## Description

* Adds basic IsAuthenticated permissions to every ValuesViewset endpoint.
* Creates RequiredFilterSet that will error if a filtering filter is not specified!

#### Issue Addressed (if applicable)

Fixes #1890

## Steps to Test

- Login
- Try loading /api/channels - see a 412
- Try loading /api/channels?id_in= - see a 412
- Try loading /api/channels?public=true - see results
- Try loading the endpoint for a single channel: /api/channels/<channel_id>

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Checks when filtering that at least one valid filter has been specified.
Removes filter_queryset call when retrieving a single object - wasn't quite sure why DRF does this by default, seemed OK to remove.