### PR TITLE
Channel edit page fix - last item missing in breadcrumbs

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -237,7 +237,7 @@
         return this.getContentNode(this.topicId);
       },
       ancestors() {
-        return this.getContentNodeAncestors(this.topicId).map(ancestor => {
+        return this.getContentNodeAncestors(this.topicId, true).map(ancestor => {
           return {
             id: ancestor.id,
             to: this.treeLink({ nodeId: ancestor.id }),
@@ -274,7 +274,7 @@
         this.selected = [];
 
         this.loadingAncestors = true;
-        this.loadAncestors({ id: this.topicId }).then(() => {
+        this.loadAncestors({ id: this.topicId, includeSelf: true }).then(() => {
           this.loadingAncestors = false;
         });
       },
@@ -293,7 +293,7 @@
     },
     created() {
       this.loadingAncestors = true;
-      this.loadAncestors({ id: this.topicId }).then(() => {
+      this.loadAncestors({ id: this.topicId, includeSelf: true }).then(() => {
         this.loadingAncestors = false;
       });
     },


### PR DESCRIPTION
## Description

Last/current item was missing in breadcrumbs on channel edit page.

#### Before/After Screenshots
| Before | After |
|----------|-------- |
|![before](https://user-images.githubusercontent.com/13509191/82887072-c08a3980-9f47-11ea-94a5-3b1531dec28b.png)|![after](https://user-images.githubusercontent.com/13509191/82887110-d1d34600-9f47-11ea-8219-6620057c6f00.png)|

## Steps to Test

- [ ] *Go to [Published Channel page](http://127.0.0.1:8080/channels/66a31fdbdd745c7c9e499206f3c4cced/#/49e53cd37df04f43a67386e1da87fee5)*
- [ ] *Check breadcrumbs behavior - navigate subtopics, page refresh..*

