### PR TITLE
set the second nginx server block to be the default for port 8080.

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -58,8 +58,14 @@ http {
 
     # Configuration for Nginx
     server {
+
         # Listen on port 8080
-        listen 8080;
+        # See https://nginx.org/en/docs/http/server_names.html for how this interacts with server_name
+        listen 8080 default_server;
+
+        # Explicitly set server_name to be empty.
+        server_name "";
+
         # Settings to serve static files
         location /static/  {
             autoindex on;


### PR DESCRIPTION
We now have 2 nginx server blocks on studio:
- the regular studio block, which allows most endpoints
- the catalog studio block, which blocks almost everything except a certain whitelist.

They're both listening on port 8080.

This PR sets the default block for port 8080 to be the regular studio block.