### PR TITLE
Remove stop calls and wait for revert/dismiss

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -266,17 +266,17 @@
       },
       saveChannel() {
         if (this.$refs.detailsform.validate()) {
-          this.tracker.stop();
-          this.tracker.dismiss();
-          this.changed = false;
+          this.tracker.dismiss().then(() => {
+            this.changed = false;
 
-          if (this.channel.new) {
-            // TODO: Make sure channel gets created before navigating to channel
-            this.updateChannel({ id: this.channelId, new: false });
-            window.location = window.Urls.channel(this.channelId);
-          } else {
-            this.close();
-          }
+            if (this.channel.new) {
+              // TODO: Make sure channel gets created before navigating to channel
+              this.updateChannel({ id: this.channelId, new: false });
+              window.location = window.Urls.channel(this.channelId);
+            } else {
+              this.close();
+            }
+          });
         } else {
           // Go back to Details tab to show validation errors
           this.currentTab = false;
@@ -298,9 +298,7 @@
       confirmCancel() {
         this.changed = false;
         this.showUnsavedDialog = false;
-        this.tracker.stop();
-        this.tracker.revert();
-        this.close();
+        this.tracker.revert().then(() => this.close());
       },
       verifyChannel(channelId) {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description
Fixes lingering lock records on saving channel changes.

#### Issue Addressed (if applicable)

Addresses #*PR# HERE*

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
