### PR TITLE
Don't swamp local changes on fetch

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -3,7 +3,7 @@ import merge from 'lodash/merge';
 import sortBy from 'lodash/sortBy';
 import { CHANGE_TYPES, IGNORED_SOURCE } from './constants';
 import db from './db';
-import { INDEXEDDB_RESOURCES } from './resources';
+import { INDEXEDDB_RESOURCES } from './registry';
 
 const { CREATED, DELETED, UPDATED, MOVED } = CHANGE_TYPES;
 
@@ -79,7 +79,11 @@ export default function applyChanges(changes) {
         sortBy(moveChangesToApply, 'rev').forEach(change => {
           if (INDEXEDDB_RESOURCES[change.table] && INDEXEDDB_RESOURCES[change.table].tableMove) {
             promises.push(
-              INDEXEDDB_RESOURCES[change.table].tableMove(change.key, change.target, change.position)
+              INDEXEDDB_RESOURCES[change.table].tableMove(
+                change.key,
+                change.target,
+                change.position
+              )
             );
           }
         });

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -37,17 +37,22 @@ function bulkUpdate(table, changes) {
     });
 }
 
-/*
- * Modified from https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
- */
-export default function applyChanges(changes) {
-  let collectedChanges = {};
+export function collectChanges(changes) {
+  const collectedChanges = {};
   changes.forEach(change => {
     if (!collectedChanges.hasOwnProperty(change.table)) {
       collectedChanges[change.table] = { [CREATED]: [], [DELETED]: [], [UPDATED]: [], [MOVED]: [] };
     }
     collectedChanges[change.table][change.type].push(change);
   });
+  return collectedChanges;
+}
+
+/*
+ * Modified from https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
+ */
+export default function applyChanges(changes) {
+  const collectedChanges = collectChanges(changes);
   let table_names = Object.keys(collectedChanges);
   let tables = table_names.map(table => db.table(table));
 

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -8,6 +8,20 @@ export const CHANGE_TYPES = {
   DELETED_RELATION: 7,
 };
 
+export const TABLE_NAMES = {
+  CHANNEL: 'channel',
+  INVITATION: 'invitation',
+  CONTENTNODE: 'contentnode',
+  CHANNELSET: 'channelset',
+  TREE: 'tree',
+  ASSESSMENTITEM: 'assessmentitem',
+  FILE: 'file',
+  USER: 'user',
+  CHANNELUSER: 'channeluser',
+  EDITOR_M2M: 'editor_m2m',
+  VIEWER_M2M: 'viewer_m2m',
+};
+
 export const MESSAGES = {
   FETCH_COLLECTION: 'FETCH_COLLECTION',
   FETCH_MODEL: 'FETCH_MODEL',

--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -20,7 +20,7 @@ export function setupSchema() {
     // but it seems to squash and remove changes in ways
     // that I do not currently understand, so we engage
     // in somewhat duplicative behaviour instead.
-    [CHANGES_TABLE]: 'rev++',
+    [CHANGES_TABLE]: 'rev++,[table+key]',
     // A special table for keeping track of change locks
     [CHANGE_LOCKS_TABLE]: 'id++,tracker_id,expiry',
     ...mapValues(INDEXEDDB_RESOURCES, value => value.schema),

--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -4,12 +4,12 @@ import { createLeaderElection } from './leaderElection';
 import channel from './broadcastChannel';
 import { CHANGE_LOCKS_TABLE, CHANGE_TYPES, CHANGES_TABLE } from './constants';
 import db, { CLIENTID } from './db';
-import { INDEXEDDB_RESOURCES } from './resources';
+import { INDEXEDDB_RESOURCES } from './registry';
 import { startSyncing, stopSyncing } from './serverSync';
 
 // Re-export for ease of reference.
-export { CHANGE_TYPES } from './constants';
-export { TABLE_NAMES, API_RESOURCES, INDEXEDDB_RESOURCES } from './resources';
+export { CHANGE_TYPES, TABLE_NAMES } from './constants';
+export { API_RESOURCES, INDEXEDDB_RESOURCES } from './registry';
 
 const LISTENERS = {};
 

--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -21,7 +21,7 @@
 import Dexie from 'dexie';
 import flatMap from 'lodash/flatMap';
 import { CHANGE_TYPES } from './constants';
-import { INDEXEDDB_RESOURCES } from './resources';
+import { INDEXEDDB_RESOURCES } from './registry';
 
 function applyModifications(obj, modifications) {
   Object.keys(modifications).forEach(function(keyPath) {
@@ -118,7 +118,11 @@ function mergeChanges(oldChange, newChange) {
   }
 }
 
-const mergeableChanges = new Set([CHANGE_TYPES.CREATED, CHANGE_TYPES.UPDATED, CHANGE_TYPES.DELETED]);
+const mergeableChanges = new Set([
+  CHANGE_TYPES.CREATED,
+  CHANGE_TYPES.UPDATED,
+  CHANGE_TYPES.DELETED,
+]);
 
 export default function mergeAllChanges(changes, flatten = false, changesToSync = null) {
   if (!changesToSync) {

--- a/contentcuration/contentcuration/frontend/shared/data/registry.js
+++ b/contentcuration/contentcuration/frontend/shared/data/registry.js
@@ -1,0 +1,4 @@
+// Put resource registry objects in here to avoid circular import issues
+export const API_RESOURCES = {};
+
+export const INDEXEDDB_RESOURCES = {};

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -17,15 +17,14 @@ import {
   MESSAGES,
   RELATIVE_TREE_POSITIONS,
   STATUS,
+  TABLE_NAMES,
 } from './constants';
+import applyChanges from './applyRemoteChanges';
 import db, { CLIENTID, Collection } from './db';
+import { API_RESOURCES, INDEXEDDB_RESOURCES } from './registry';
 import client from 'shared/client';
 import { constantStrings } from 'shared/mixins';
 import { promiseChunk } from 'shared/utils';
-
-export const API_RESOURCES = {};
-
-export const INDEXEDDB_RESOURCES = {};
 
 // Number of seconds after which data is considered stale.
 const REFRESH_INTERVAL = 60;
@@ -49,20 +48,6 @@ const validPositions = new Set(Object.values(RELATIVE_TREE_POSITIONS));
 export function uuid4() {
   return uuidv4().replace(/-/g, '');
 }
-
-export const TABLE_NAMES = {
-  CHANNEL: 'channel',
-  INVITATION: 'invitation',
-  CONTENTNODE: 'contentnode',
-  CHANNELSET: 'channelset',
-  TREE: 'tree',
-  ASSESSMENTITEM: 'assessmentitem',
-  FILE: 'file',
-  USER: 'user',
-  CHANNELUSER: 'channeluser',
-  EDITOR_M2M: 'editor_m2m',
-  VIEWER_M2M: 'viewer_m2m',
-};
 
 /**
  * @param {Function|Object} updater

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -19,7 +19,8 @@ import {
   STATUS,
   TABLE_NAMES,
 } from './constants';
-import applyChanges from './applyRemoteChanges';
+import applyChanges, { collectChanges } from './applyRemoteChanges';
+import mergeAllChanges from './mergeChanges';
 import db, { CLIENTID, Collection } from './db';
 import { API_RESOURCES, INDEXEDDB_RESOURCES } from './registry';
 import client from 'shared/client';
@@ -422,30 +423,66 @@ class Resource extends mix(APIResource, IndexedDBResource) {
         itemData = pageData.results;
       }
       const annotatedFilters = pick(params, this.annotatedFilters);
-      const data = itemData.map(datum => {
-        datum[LAST_FETCHED] = now;
-        Object.assign(datum, annotatedFilters);
-        return datum;
-      });
       return db.transaction('rw', this.tableName, CHANGES_TABLE, () => {
         // Explicitly set the source of this as a fetch
         // from the server, to prevent us from trying
         // to sync these changes back to the server!
         Dexie.currentTransaction.source = IGNORED_SOURCE;
         // Get any relevant changes that would be overwritten by this bulkPut
-        const changesPromise = db[CHANGES_TABLE].where('[table+key]')
-          .anyOf(data.map(datum => [this.tableName, datum[this.idField]]))
-          .toArray();
-        const putPromise = this.table.bulkPut(data);
-        return Promise.all([changesPromise, putPromise]).then(([changes]) => {
-          const appliedChangesPromise = changes.length ? applyChanges(changes) : Promise.resolve();
-          return appliedChangesPromise.then(() => {
-            // If someone has requested a paginated response,
-            // they will be expecting the page data object,
-            // not the results object.
-            return pageData ? pageData : itemData;
+        return db[CHANGES_TABLE].where('[table+key]')
+          .anyOf(itemData.map(datum => [this.tableName, datum[this.idField]]))
+          .toArray(changes => {
+            changes = mergeAllChanges(changes, true);
+            const collectedChanges = collectChanges(changes)[this.tableName] || {};
+            for (let changeType of Object.keys(collectedChanges)) {
+              const map = {};
+              for (let change of collectedChanges[changeType]) {
+                map[change.key] = change;
+              }
+              collectedChanges[changeType] = map;
+            }
+            const data = itemData
+              .map(datum => {
+                datum[LAST_FETCHED] = now;
+                Object.assign(datum, annotatedFilters);
+                const id = datum[this.idField];
+                // If we have a created change, apply the whole object here
+                if (
+                  collectedChanges[CHANGE_TYPES.CREATED] &&
+                  collectedChanges[CHANGE_TYPES.CREATED][id]
+                ) {
+                  Object.assign(datum, collectedChanges[CHANGE_TYPES.CREATED][id].obj);
+                }
+                // If we have an updated change, apply the modifications here
+                if (
+                  collectedChanges[CHANGE_TYPES.UPDATED] &&
+                  collectedChanges[CHANGE_TYPES.UPDATED][id]
+                ) {
+                  Object.assign(datum, collectedChanges[CHANGE_TYPES.UPDATED][id].mods);
+                }
+                return datum;
+                // If we have a deleted change, just filter out this object so we don't reput it
+              })
+              .filter(
+                datum =>
+                  !collectedChanges[CHANGE_TYPES.DELETED] ||
+                  !collectedChanges[CHANGE_TYPES.DELETED][datum[this.idField]]
+              );
+            return this.table.bulkPut(data).then(() => {
+              // Move changes need to be reapplied on top of fetched data in case anything
+              // has happened on the backend.
+              const changes = Object.values(collectedChanges[CHANGE_TYPES.MOVED] || {});
+              const appliedChangesPromise = changes.length
+                ? applyChanges(changes)
+                : Promise.resolve();
+              return appliedChangesPromise.then(() => {
+                // If someone has requested a paginated response,
+                // they will be expecting the page data object,
+                // not the results object.
+                return pageData ? pageData : itemData;
+              });
+            });
           });
-        });
       });
     });
   }

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
@@ -336,17 +336,11 @@ describe('Channel sharing vuex', () => {
     });
   });
   describe('makeEditor action', () => {
-    it('should call ChannelUser.makeEditor', () => {
-
-    });
-    it('should set the editors and viewers according to update', () => {
-
-    });
+    it('should call ChannelUser.makeEditor', () => {});
+    it('should set the editors and viewers according to update', () => {});
   });
   describe('removeViewer action', () => {
-    it('should call Channel.removeViewer with removed viewer permission', () => {
-    });
-    it('should set the viewers according to update', () => {
-    });
+    it('should call Channel.removeViewer with removed viewer permission', () => {});
+    it('should set the viewers according to update', () => {});
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -176,13 +176,17 @@ export function deleteInvitation(context, invitationId) {
 }
 
 export function makeEditor(context, { channelId, userId }) {
-  return ChannelUser.makeEditor(channelId, userId).then(() => {
-    context.commit('ADD_EDITOR_TO_CHANNEL', { channelId, userId });
-  }).catch(() => {});
+  return ChannelUser.makeEditor(channelId, userId)
+    .then(() => {
+      context.commit('ADD_EDITOR_TO_CHANNEL', { channelId, userId });
+    })
+    .catch(() => {});
 }
 
 export function removeViewer(context, { channelId, userId }) {
-  return ChannelUser.removeViewer(channelId, userId).then(() => {
-    context.commit('REMOVE_VIEWER_FROM_CHANNEL', { channelId, userId });
-  }).catch(() => {});
+  return ChannelUser.removeViewer(channelId, userId)
+    .then(() => {
+      context.commit('REMOVE_VIEWER_FROM_CHANNEL', { channelId, userId });
+    })
+    .catch(() => {});
 }


### PR DESCRIPTION
## Description

* Reapplies any unsynced local changes when data is refreshed from the server

## Steps to Test

- Load channel list page.
- Wait 60 seconds
- Edit a channel's details
- Save changes
- See the changes persisted on the list page

#### At a high level, how did you implement this?

Reapplies any relevant changes for fetched data.

For Create, Update, and Delete changes, applies this before the bulkPut.

For Moved changes, applies after the bulkPut as requires database access anyway.
