### PR TITLE
Diff tracking and rollback

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -28,6 +28,10 @@ export const ContentDefaultsDefaults = {
 // for a symbol but have it be identifiable as a fill in.
 export const NOVALUE = Symbol('No value default');
 
+// This symbol is used as a key on objects that are new to indicate
+// that they have not yet been committed to our IndexedDB layer.
+export const NEW_OBJECT = Symbol('New object');
+
 export const kindToIconMap = {
   audio: 'headset',
   channel: 'apps',

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -16,7 +16,7 @@
           </Icon>
         </VBtn>
         <VToolbarTitle>
-          <template v-if="channel.new">
+          <template v-if="isNew">
             {{ $tr('creatingHeader') }}
           </template>
           <template v-else>
@@ -25,9 +25,9 @@
         </VToolbarTitle>
         <VSpacer />
         <VBtn flat @click="saveChannel">
-          {{ channel.new? $tr('createButton') : $tr('saveChangesButton' ) }}
+          {{ isNew? $tr('createButton') : $tr('saveChangesButton' ) }}
         </VBtn>
-        <template v-if="!channel.new" #extension>
+        <template v-if="!isNew" #extension>
           <VTabs
             v-model="currentTab"
             color="primary"
@@ -126,10 +126,11 @@
 
 <script>
 
+  import Vue from 'vue';
   import { mapActions, mapGetters, mapState } from 'vuex';
   import ChannelThumbnail from './ChannelThumbnail';
   import ChannelSharing from './ChannelSharing';
-  import { ChangeTracker } from 'shared/data/changes';
+  import { NEW_OBJECT } from 'shared/constants';
   import MessageDialog from 'shared/views/MessageDialog';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
   import ContentDefaults from 'shared/views/form/ContentDefaults';
@@ -151,10 +152,10 @@
     data() {
       return {
         loading: false,
-        tracker: null,
         header: '',
         changed: false,
         showUnsavedDialog: false,
+        diffTracker: {},
       };
     },
     computed: {
@@ -162,6 +163,9 @@
       ...mapGetters('channel', ['getChannel']),
       channel() {
         return this.getChannel(this.channelId) || {};
+      },
+      isNew() {
+        return Boolean(this.channel[NEW_OBJECT]);
       },
       routeParamID() {
         return this.$route.params.channelId;
@@ -183,9 +187,10 @@
       thumbnail: {
         get() {
           return {
-            thumbnail: this.channel.thumbnail,
-            thumbnail_url: this.channel.thumbnail_url,
-            thumbnail_encoding: this.channel.thumbnail_encoding,
+            thumbnail: this.diffTracker.thumbnail || this.channel.thumbnail,
+            thumbnail_url: this.diffTracker.thumbnail_url || this.channel.thumbnail_url,
+            thumbnail_encoding:
+              this.diffTracker.thumbnail_encoding || this.channel.thumbnail_encoding,
           };
         },
         set(thumbnailData) {
@@ -194,7 +199,7 @@
       },
       name: {
         get() {
-          return this.channel.name || '';
+          return this.diffTracker.name || this.channel.name || '';
         },
         set(name) {
           this.setChannel({ name });
@@ -202,7 +207,7 @@
       },
       description: {
         get() {
-          return this.channel.description || '';
+          return this.diffTracker.description || this.channel.description || '';
         },
         set(description) {
           this.setChannel({ description });
@@ -210,7 +215,7 @@
       },
       language: {
         get() {
-          return this.channel.language || this.currentLanguage;
+          return this.diffTracker.language || this.channel.language || this.currentLanguage;
         },
         set(language) {
           this.setChannel({ language });
@@ -218,7 +223,10 @@
       },
       contentDefaults: {
         get() {
-          return this.channel.content_defaults || {};
+          return {
+            ...(this.diffTracker.content_defaults || {}),
+            ...(this.channel.content_defaults || {}),
+          };
         },
         set(contentDefaults) {
           this.setChannel({ contentDefaults });
@@ -254,11 +262,9 @@
 
       // Set expiry to 1ms
       this.header = this.channel.name; // Get channel name when user enters modal
-      this.tracker = new ChangeTracker(1);
-      this.tracker.start();
     },
     methods: {
-      ...mapActions('channel', ['updateChannel', 'loadChannel', 'deleteChannel']),
+      ...mapActions('channel', ['updateChannel', 'loadChannel', 'deleteChannel', 'commitChannel']),
       hideHTMLScroll(hidden) {
         document.querySelector('html').style = hidden
           ? 'overflow-y: hidden !important;'
@@ -266,30 +272,28 @@
       },
       saveChannel() {
         if (this.$refs.detailsform.validate()) {
-          this.tracker.dismiss().then(() => {
-            this.changed = false;
-
-            if (this.channel.new) {
+          this.changed = false;
+          if (this.isNew) {
+            return this.commitChannel(this.channelId).then(() => {
               // TODO: Make sure channel gets created before navigating to channel
-              this.updateChannel({ id: this.channelId, new: false });
               window.location = window.Urls.channel(this.channelId);
-            } else {
-              this.close();
-            }
-          });
+            });
+          } else {
+            return this.updateChannel({ id: this.channelId, ...this.diffTracker }).then(this.close);
+          }
         } else {
           // Go back to Details tab to show validation errors
           this.currentTab = false;
         }
       },
       setChannel(data) {
+        for (let key in data) {
+          Vue.set(this.diffTracker, key, data[key]);
+        }
         this.changed = true;
-        this.updateChannel({ id: this.channelId, ...data });
       },
       cancelChanges() {
-        if (this.channel.new) {
-          this.deleteChannel(this.channelId);
-        } else if (this.changed) {
+        if (this.changed) {
           this.showUnsavedDialog = true;
         } else {
           this.confirmCancel();
@@ -298,7 +302,10 @@
       confirmCancel() {
         this.changed = false;
         this.showUnsavedDialog = false;
-        this.tracker.revert().then(() => this.close());
+        if (this.isNew) {
+          return this.deleteChannel(this.channelId).then(this.close);
+        }
+        this.close();
       },
       verifyChannel(channelId) {
         return new Promise((resolve, reject) => {

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -50,13 +50,18 @@ export function createChannel(context) {
     viewers: [],
     new: true,
   };
-  return Channel.put(channelData).then(id => {
-    context.commit('ADD_CHANNEL', {
-      id,
-      ...channelData,
+  const channel = Channel.createObj(channelData);
+  context.commit('ADD_CHANNEL', channel);
+  return channel.id;
+}
+
+export function commitChannel(context, channelId) {
+  const channel = context.state.channelsMap[channelId];
+  if (channel) {
+    return Channel.put(channel).then(() => {
+      context.commit('SET_CHANNEL_NOT_NEW', channelId);
     });
-    return id;
-  });
+  }
 }
 
 export function updateChannel(

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import pick from 'lodash/pick';
-import { ContentDefaults } from 'shared/constants';
+import { ContentDefaults, NEW_OBJECT } from 'shared/constants';
 import { mergeMapItem } from 'shared/vuex/utils';
 
 /* CHANNEL LIST MUTATIONS */
@@ -24,6 +24,12 @@ export function ADD_CHANNELS(state, channels = []) {
 
 export function REMOVE_CHANNEL(state, channel) {
   Vue.delete(state.channelsMap, channel.id);
+}
+
+export function SET_CHANNEL_NOT_NEW(state, channelId) {
+  if (state.channelsMap[channelId]) {
+    Vue.delete(state.channelsMap[channelId], NEW_OBJECT);
+  }
 }
 
 export function UPDATE_CHANNEL(state, { id, content_defaults = {}, ...payload } = {}) {


### PR DESCRIPTION
## Description

* Change channel editing to simple, in component diff tracking.

## Steps to Test

- Creating a channel then canceling works
- Creating a channel then saving works and redirects you to a 404 - on returning back to list page it is present
- Editing a channel then canceling works
- Editing a channel then saving works

## Implementation Notes (optional)

#### At a high level, how did you implement this?

The original plan to implement changes in the vuex state broke down, because changes would get swamped by any background fetch events (so if the browser had initiated a fetch in order to refresh a stale cache item, the successful resolution of that fetch could swamp a recent edit).

Just implementing a simple diffTracker object in the component then became the simplest way, preferring values from the diffTracker, then the vuex object. All edits are then tracked in the diffTracker on the component and can be either saved or discarded afterwards.

#### Does this introduce any tech-debt items?

No - this actually seems the simplest way to manage this, given that we don't want to save to indexedDB within a non-autosave paradigm.
