### PR TITLE
change the login prober credential to another account

### DIFF
--- a/cloudbuild-production.yaml
+++ b/cloudbuild-production.yaml
@@ -85,7 +85,7 @@ steps:
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
   - 'CLOUDSDK_CONTAINER_CLUSTER=contentworkshop-central'
-  secretEnv: ['POSTMARK_API_KEY', 'PROBER_NEWRELIC_KEY', 'PROBER_NEWRELIC_ACCOUNT_ID', 'POSTGRES_USERNAME', 'POSTGRES_DATABASE', 'POSTGRES_PASSWORD', 'SENTRY_DSN_KEY', 'LOGIN_PROBER_PASSWORD']
+  secretEnv: ['POSTMARK_API_KEY', 'PROBER_NEWRELIC_KEY', 'PROBER_NEWRELIC_ACCOUNT_ID', 'POSTGRES_USERNAME', 'POSTGRES_DATABASE', 'POSTGRES_PASSWORD', 'SENTRY_DSN_KEY', 'LOGIN_PROBER_PASSWORD', 'LOGIN_PROBER_USERNAME']
   entrypoint: 'bash'
   args:
     - -c
@@ -107,6 +107,7 @@ steps:
       is_production
       ../gdrive-service-account.json
       $$SENTRY_DSN_KEY
+      $$LOGIN_PROBER_USERNAME
       $$LOGIN_PROBER_PASSWORD
 
 substitutions:
@@ -146,6 +147,9 @@ secrets:
 - kmsKeyName: projects/contentworkshop-159920/locations/global/keyRings/prod-secrets/cryptoKeys/loginProberPassword
   secretEnv:
     LOGIN_PROBER_PASSWORD: CiQA3oNoVQ7v8iyyUoj5vB+04OxkGy/oPgChsG1gSCX5d3xEpBQSRwAEAfM0skxSUwCIjET7vMMJtV9Jgc7rCminCu4gk0sMfvHJdmDXymKdfVVzTcDZzx9I7mlQO/gKfQ/JO6aPrD96ZISFVrka
+- kmsKeyName: projects/contentworkshop-159920/locations/global/keyRings/prod-secrets/cryptoKeys/loginProberUsername
+  secretEnv:
+    LOGIN_PROBER_USERNAME: CiQAwWg5LcWJOOQ7SYg0oShtNAg1tGYBZ4KktLy7ongMhlodlQESSgDU9hgXUWgV51S5lTSgxHMpkgHxh4PZfji6rCb2fGGt//07qTE3v5H2KFFe4obsvUct9dZD3stYtTqEjPFVfktxk2WnP3i0cF79
 
 images:
   - gcr.io/$PROJECT_ID/learningequality-studio-nginx:latest

--- a/cloudbuild-production.yaml
+++ b/cloudbuild-production.yaml
@@ -85,7 +85,7 @@ steps:
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
   - 'CLOUDSDK_CONTAINER_CLUSTER=contentworkshop-central'
-  secretEnv: ['POSTMARK_API_KEY', 'PROBER_NEWRELIC_KEY', 'PROBER_NEWRELIC_ACCOUNT_ID', 'POSTGRES_USERNAME', 'POSTGRES_DATABASE', 'POSTGRES_PASSWORD', 'SENTRY_DSN_KEY']
+  secretEnv: ['POSTMARK_API_KEY', 'PROBER_NEWRELIC_KEY', 'PROBER_NEWRELIC_ACCOUNT_ID', 'POSTGRES_USERNAME', 'POSTGRES_DATABASE', 'POSTGRES_PASSWORD', 'SENTRY_DSN_KEY', 'LOGIN_PROBER_PASSWORD']
   entrypoint: 'bash'
   args:
     - -c
@@ -107,6 +107,7 @@ steps:
       is_production
       ../gdrive-service-account.json
       $$SENTRY_DSN_KEY
+      $$LOGIN_PROBER_PASSWORD
 
 substitutions:
   _DATABASE_INSTANCE_NAME: develop  # by default, connect to the develop DB
@@ -142,6 +143,9 @@ secrets:
 - kmsKeyName: projects/contentworkshop-159920/locations/global/keyRings/prod-secrets/cryptoKeys/proberNewrelicAccountId
   secretEnv:
     PROBER_NEWRELIC_ACCOUNT_ID: CiQABHUEtnX2wWjYdaZqsxEoZ6nWfuX1eY6Ht8frTZYcCXCqSkESMQCySb5xJhy4EPt0AFsAJZwkkZEqL8T9XsWtTMafvau2UXFDiHCZtneBxPocRdzMEIQ=
+- kmsKeyName: projects/contentworkshop-159920/locations/global/keyRings/prod-secrets/cryptoKeys/loginProberPassword
+  secretEnv:
+    LOGIN_PROBER_PASSWORD: CiQA3oNoVQ7v8iyyUoj5vB+04OxkGy/oPgChsG1gSCX5d3xEpBQSRwAEAfM0skxSUwCIjET7vMMJtV9Jgc7rCminCu4gk0sMfvHJdmDXymKdfVVzTcDZzx9I7mlQO/gKfQ/JO6aPrD96ZISFVrka
 
 images:
   - gcr.io/$PROJECT_ID/learningequality-studio-nginx:latest

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -24,6 +24,7 @@ fi
 
 GDRIVE_SERVICE_ACCOUNT_JSON=${14}
 SENTRY_DSN_KEY=${15}
+LOGIN_PROBER_PASSWORD=${16}
 
 helm upgrade --install $RELEASENAME . \
      -f values-prod-config.yaml \
@@ -43,4 +44,5 @@ helm upgrade --install $RELEASENAME . \
      --set sentry.dsnKey=$(echo "$SENTRY_DSN_KEY" | base64 --wrap=0) \
      --timeout 1500 \
      --set-string studioProber.newrelicKey=$PROBER_NEWRELIC_KEY \
-     --set-string studioProber.newrelicAccountId=$PROBER_NEWRELIC_ACCOUNT_ID  # use set-string to resolve the issue https://github.com/helm/helm/issues/1707
+     --set-string studioProber.newrelicAccountId=$PROBER_NEWRELIC_ACCOUNT_ID \ # use set-string to resolve the issue https://github.com/helm/helm/issues/1707
+     --set studioProber.loginProberPassword=$LOGIN_PROBER_PASSWORD

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -24,7 +24,8 @@ fi
 
 GDRIVE_SERVICE_ACCOUNT_JSON=${14}
 SENTRY_DSN_KEY=${15}
-LOGIN_PROBER_PASSWORD=${16}
+LOGIN_PROBER_USERNAME=${16}
+LOGIN_PROBER_PASSWORD=${17}
 
 helm upgrade --install $RELEASENAME . \
      -f values-prod-config.yaml \
@@ -45,4 +46,5 @@ helm upgrade --install $RELEASENAME . \
      --timeout 1500 \
      --set-string studioProber.newrelicKey=$PROBER_NEWRELIC_KEY \
      --set-string studioProber.newrelicAccountId=$PROBER_NEWRELIC_ACCOUNT_ID \ # use set-string to resolve the issue https://github.com/helm/helm/issues/1707
+     --set studioProber.loginProberUsername=$LOGIN_PROBER_USERNAME
      --set studioProber.loginProberPassword=$LOGIN_PROBER_PASSWORD

--- a/k8s/templates/prober-deployment.yaml
+++ b/k8s/templates/prober-deployment.yaml
@@ -31,7 +31,10 @@ spec:
         - name: PROBER_STUDIO_PRODUCTION_MODE_ON
           value: "yes"
         - name: PROBER_STUDIO_USERNAME
-          value: lingyi+prober@learningequality.org
+          value: channeladmin@learningequality.org
         - name: PROBER_STUDIO_PASSWORD
-          value: "123456789"
+          valueFrom:
+            secretKeyRef:
+              key: login-prober-password
+              name: {{ template "studio.fullname" . }}
 {{- end }}

--- a/k8s/templates/prober-deployment.yaml
+++ b/k8s/templates/prober-deployment.yaml
@@ -31,7 +31,10 @@ spec:
         - name: PROBER_STUDIO_PRODUCTION_MODE_ON
           value: "yes"
         - name: PROBER_STUDIO_USERNAME
-          value: channeladmin@learningequality.org
+          valueFrom:
+            secretKeyRef:
+              key: login-prober-username
+              name: {{ template "studio.fullname" . }}
         - name: PROBER_STUDIO_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -20,6 +20,7 @@ data:
   newrelic-key: !!str {{ .Values.studioProber.newrelicKey | default "" | b64enc }}
   newrelic-account-id: !!str {{ .Values.studioProber.newrelicAccountId | default "" | b64enc}}
   {{ end }}
-  {{ if .Values.studioProber.loginProberPassword }}
+  {{ if .Values.studioProber.loginProberUsername }}
+  login-prober-username: {{ .Values.studioProber.loginProberUsername | default "" | b64enc}}
   login-prober-password: {{ .Values.studioProber.loginProberPassword | default "" | b64enc}}
   {{ end }}

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -20,3 +20,6 @@ data:
   newrelic-key: !!str {{ .Values.studioProber.newrelicKey | default "" | b64enc }}
   newrelic-account-id: !!str {{ .Values.studioProber.newrelicAccountId | default "" | b64enc}}
   {{ end }}
+  {{ if .Values.studioProber.loginProberPassword }}
+  login-prober-password: {{ .Values.studioProber.loginProberPassword | default "" | b64enc}}
+  {{ end }}

--- a/k8s/values-prod-config.yaml
+++ b/k8s/values-prod-config.yaml
@@ -56,5 +56,6 @@ studioProber:
   imageName: "REPLACEME"
   newrelicKey: "REPLACEME"
   newrelicAccountId: "REPLACEME"
+  loginProberUsername: "REPLACEME"
   loginProberPassword: "REPLACEME"
   port: 9313

--- a/k8s/values-prod-config.yaml
+++ b/k8s/values-prod-config.yaml
@@ -56,4 +56,5 @@ studioProber:
   imageName: "REPLACEME"
   newrelicKey: "REPLACEME"
   newrelicAccountId: "REPLACEME"
+  loginProberPassword: "REPLACEME"
   port: 9313

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -70,5 +70,6 @@ studioProber:
   imageName: gcr.io/github-learningequality-studio/prober:nlatest
   newrelicKey:
   newrelicAccountId:
+  loginProberUsername:
   loginProberPassword:
   port: 9313

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -70,4 +70,5 @@ studioProber:
   imageName: gcr.io/github-learningequality-studio/prober:nlatest
   newrelicKey:
   newrelicAccountId:
+  loginProberPassword:
   port: 9313


### PR DESCRIPTION
## Description

Previously we use the account lingyi+prober@learningequality.org for the login prober. But it does not work anymore. Changing the account to sushi chef admin account so we can have the probers running successfully.


## Implementation Notes (optional)

#### At a high level, how did you implement this?

Create keys `loginProberUsername` and `loginProberPassword` in google cloud KMS and fetch it in Cloud Build


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
