### PR TITLE
Allow user to add Kolibri URLs or ids to the search field.

### DIFF
--- a/contentcuration/search/views.py
+++ b/contentcuration/search/views.py
@@ -1,7 +1,10 @@
+import logging
+
 from django.db.models import Q
-from contentcuration import models as cc_models
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+
+from contentcuration import models as cc_models
 from contentcuration import serializers
 
 
@@ -34,7 +37,33 @@ def search_items(request):
         return Response([])
 
     queryset = get_accessible_contentnodes(request).exclude(kind='topic')
-    queryset = queryset.filter(title__icontains=search_query)
+
+    filter = Q(title__icontains=search_query)
+
+    # Check if we have a Kolibri URL or a node id or ids and add them to the search if so.
+    # Add to, rather than replace, the filters so that we never misinterpret a search term as a UUID.
+    try:
+        if search_query.lower().startswith('http://') or search_query.lower().startswith('https://') or \
+                len(search_query) >= 32:  # 32 is UUID length
+            node_ids = []
+            if search_query.startswith('http'):
+                base, node_id = search_query.split("/topics/c/")
+                node_ids.append(node_id)
+            else:
+                node_ids = search_query.split(',')
+
+            if len(node_ids) > 0:
+                for node_id in node_ids:
+                    # check for the major ID types
+                    filter |= Q(node_id=node_id)
+                    filter |= Q(content_id=node_id)
+                    filter |= Q(id=node_id)
+
+    except Exception as e:
+        # if we fail, just continue and try a regular search
+        logging.warning("failed parsing possible URL: {}".format(e))
+
+    queryset = queryset.filter(filter)
     # Using same serializer as Tree View UI to match props of ImportListItem
     serializer = serializers.SimplifiedContentNodeSerializer(queryset[:50], many=True)
     return Response(serializer.data)

--- a/contentcuration/search/views.py
+++ b/contentcuration/search/views.py
@@ -61,7 +61,7 @@ def search_items(request):
 
     except Exception as e:
         # if we fail, just continue and try a regular search
-        logging.warning("failed parsing possible URL: {}".format(e))
+        logging.warning("failed parsing possible URL or ID(s): {}".format(e))
 
     queryset = queryset.filter(filter)
     # Using same serializer as Tree View UI to match props of ImportListItem

--- a/contentcuration/search/views.py
+++ b/contentcuration/search/views.py
@@ -43,14 +43,8 @@ def search_items(request):
     # Check if we have a Kolibri URL or a node id or ids and add them to the search if so.
     # Add to, rather than replace, the filters so that we never misinterpret a search term as a UUID.
     try:
-        if search_query.lower().startswith('http://') or search_query.lower().startswith('https://') or \
-                len(search_query) >= 32:  # 32 is UUID length
-            node_ids = []
-            if search_query.startswith('http'):
-                base, node_id = search_query.split("/topics/c/")
-                node_ids.append(node_id)
-            else:
-                node_ids = search_query.split(',')
+        if len(search_query) >= 32:  # 32 is UUID length
+            node_ids = search_query.split(',')
 
             if len(node_ids) > 0:
                 for node_id in node_ids:


### PR DESCRIPTION
## Description

Title says it all! 

## Steps to Test

- [ ] Add a Kolibri URL or node id to the Import from Channels modal.

#### Does this introduce any tech-debt items?

It appears we don't have a unit test suite for search, so it rather adds to that tech debt. Probably not worth addressing in this branch, but we should make sure we have coverage for that in develop.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
