### PR TITLE
Flatten routes 3 - channel list - collections

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/router.js
+++ b/contentcuration/contentcuration/frontend/channelList/router.js
@@ -35,14 +35,12 @@ const router = new VueRouter({
       name: RouterNames.CHANNEL_SETS,
       path: '/collections',
       component: ChannelSetList,
-      children: [
-        {
-          name: RouterNames.CHANNEL_SET_DETAILS,
-          path: ':channelSetId',
-          component: ChannelSetModal,
-          props: true,
-        },
-      ],
+    },
+    {
+      name: RouterNames.CHANNEL_SET_DETAILS,
+      path: '/collections/:channelSetId',
+      component: ChannelSetModal,
+      props: true,
     },
     {
       name: RouterNames.CATALOG_ITEMS,

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -64,9 +64,6 @@
             </template>
           </VDataTable>
         </template>
-        <keep-alive>
-          <router-view v-if="$route.params.channelSetId" :key="$route.params.channelSetId" />
-        </keep-alive>
       </VFlex>
     </VLayout>
   </VContainer>

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -170,6 +170,7 @@
     },
     data() {
       return {
+        dialog: true,
         loadingChannels: true,
         step: 1,
         title: '',
@@ -180,16 +181,6 @@
     },
     computed: {
       ...mapGetters('channelSet', ['getChannelSet']),
-      dialog: {
-        get() {
-          return this.$route.params.channelSetId == this.channelSetId;
-        },
-        set(value) {
-          if (!value) {
-            this.cancelChanges();
-          }
-        },
-      },
       name: {
         get() {
           return this.channelSet.name || '';
@@ -219,6 +210,13 @@
       },
       saveText() {
         return this.channelSet.isNew ? this.$tr('createButton') : this.$tr('saveButton');
+      },
+    },
+    watch: {
+      dialog(newValue) {
+        if (!newValue) {
+          this.cancelChanges();
+        }
       },
     },
     beforeRouteEnter(to, from, next) {


### PR DESCRIPTION
## Description

Fatten `/collections` routes in channel list app + related refactoring and cleanup.

## Steps to Test

Click through the collections tab on the channel list page. Check that back navigation works properly. Try to reload pages.