### PR TITLE
Fix bugs on channel edit

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -133,7 +133,7 @@ export async function loadRelatedResources(context, nodeId) {
   if (relatedNodesIds.length) {
     // Make sure that client has all related nodes data available
     try {
-      await loadContentNodes(context, { id: relatedNodesIds });
+      await loadContentNodes(context, { id__in: relatedNodesIds });
     } catch (error) {
       return Promise.reject(error);
     }

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -670,7 +670,6 @@ export const Channel = new Resource({
   tableName: TABLE_NAMES.CHANNEL,
   urlName: 'channel',
   indexFields: ['name', 'language'],
-  annotatedFilters: ['bookmark', 'edit', 'view'],
   searchCatalog(params) {
     params.page_size = params.page_size || 100;
     params.public = true;


### PR DESCRIPTION
## Description

* Fixes two bugs caused by previous work:
    * Reinstates backend annotation of view, edit, and bookmark by using a more efficient subquery - this now improves performance when filtering by any of the three compared to previously, and does not degrade performance otherwise.
    * Reinstating this fixes a bug where the channel edit page would always appear in view only mode for a fresh user - even if the channel was editable

    * Updates the fetching code for related resources to filter on `id__in` rather than `id` previous edit to this was either missed or got squashed somewhere.
