### PR TITLE
API/Viewsets updates

### DIFF
--- a/contentcuration/contentcuration/debug_panel_settings.py
+++ b/contentcuration/contentcuration/debug_panel_settings.py
@@ -5,6 +5,8 @@ EXCLUDED_DEBUG_URLS = [
     "/content/storage",
 ]
 
+DEBUG_PANEL_ACTIVE = True
+
 
 def custom_show_toolbar(request):
     return not any(

--- a/contentcuration/contentcuration/debug_panel_settings.py
+++ b/contentcuration/contentcuration/debug_panel_settings.py
@@ -14,41 +14,11 @@ def custom_show_toolbar(request):
     )  # noqa F405
 
 
-try:
-    import debug_panel  # noqa
-except ImportError:
-    # no debug panel, no use trying to add it to our middleware
-    pass
-else:
-    # if debug_panel exists, add it to our INSTALLED_APPS
-    INSTALLED_APPS += ("debug_panel", "debug_toolbar", "pympler")  # noqa F405
-    MIDDLEWARE += (  # noqa F405
-        "contentcuration.debug.middleware.CustomDebugPanelMiddleware",
-    )
-    DEBUG_TOOLBAR_CONFIG = {
-        "SHOW_TOOLBAR_CALLBACK": custom_show_toolbar,
-        # When enabled, these settings significantly slow down page loads.
-        # It may be useful to temporarily enable them for specific debugging tasks,
-        # like template debugging or issues with SQL queries / caching.
-        # This URL has more details on each specific option:
-        # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html
-        "RENDER_PANELS": False,
-        "ENABLE_STACKTRACES": False,
-        "SHOW_TEMPLATE_CONTEXT": False,
-    }
-
-DEBUG_TOOLBAR_PANELS = [
-    "debug_toolbar.panels.versions.VersionsPanel",
-    "debug_toolbar.panels.profiling.ProfilingPanel",
-    "debug_toolbar.panels.timer.TimerPanel",
-    "debug_toolbar.panels.settings.SettingsPanel",
-    "debug_toolbar.panels.headers.HeadersPanel",
-    "debug_toolbar.panels.request.RequestPanel",
-    "debug_toolbar.panels.sql.SQLPanel",
-    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
-    "debug_toolbar.panels.templates.TemplatesPanel",
-    "debug_toolbar.panels.cache.CachePanel",
-    "debug_toolbar.panels.signals.SignalsPanel",
-    "debug_toolbar.panels.logging.LoggingPanel",
-    "debug_toolbar.panels.redirects.RedirectsPanel",
-]
+# if debug_panel exists, add it to our INSTALLED_APPS
+INSTALLED_APPS += ("debug_panel", "debug_toolbar", "pympler")  # noqa F405
+MIDDLEWARE += (  # noqa F405
+    "contentcuration.debug.middleware.CustomDebugPanelMiddleware",
+)
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": custom_show_toolbar,
+}

--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -4,3 +4,7 @@ from .not_production_settings import *  # noqa
 DEBUG = True
 
 LANGUAGES += (("ar", ugettext("Arabic")),)  # noqa
+
+ROOT_URLCONF = "contentcuration.dev_urls"
+
+INSTALLED_APPS += ("drf_yasg",)

--- a/contentcuration/contentcuration/dev_urls.py
+++ b/contentcuration/contentcuration/dev_urls.py
@@ -1,0 +1,71 @@
+from django.conf import settings
+from django.conf.urls import include
+from django.conf.urls import url
+from django.http.response import HttpResponseRedirect
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
+
+import contentcuration.views.base as views
+import contentcuration.views.files as file_views
+from .urls import urlpatterns
+
+
+def webpack_redirect_view(request):
+    return HttpResponseRedirect(
+        "http://127.0.0.1:4000/__open-in-editor?{query}".format(
+            query=request.GET.urlencode()
+        )
+    )
+
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Kolibri Studio API",
+        default_version="v0",
+        description="Kolibri Studio Swagger API",
+        license=openapi.License(name="MIT"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
+urlpatterns = urlpatterns + [
+    url(r"^__open-in-editor/", webpack_redirect_view),
+    url(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    url(
+        r"^api_explorer/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    url(
+        r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"
+    ),
+    url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    url(
+        r"^" + settings.STORAGE_URL[1:] + "(?P<path>.*)$",
+        file_views.debug_serve_file,
+        name="debug_serve_file",
+    ),
+    url(
+        r"^" + settings.CONTENT_DATABASE_URL[1:] + "(?P<path>.*)$",
+        file_views.debug_serve_content_database_file,
+        name="content_database_debug_serve_file",
+    ),
+    url(
+        r"^" + settings.CSV_URL[1:] + "(?P<path>.*)$",
+        file_views.debug_serve_file,
+        name="csv_debug_serve_file",
+    ),
+    url(r"^sandbox/$", views.SandboxView.as_view()),
+]
+
+if getattr(settings, "DEBUG_PANEL_ACTIVE", False):
+
+    import debug_toolbar
+
+    urlpatterns = [url(r"^__debug__/", include(debug_toolbar.urls))] + urlpatterns

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -174,7 +174,6 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/', include(router.urls)),
     url(r'^api/publish_channel/$', views.publish_channel, name='publish_channel'),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^channels/$', views.channel_list, name='channels'),
     url(r'^channels/(?P<channel_id>[^/]{32})/$', views.channel, name='channel'),
     url(r'^accessible_channels/(?P<channel_id>[^/]{32})$', views.accessible_channels, name='accessible_channels'),
@@ -308,20 +307,3 @@ js_info_dict = {
 urlpatterns += [
     url(r'^i18n/', include('django.conf.urls.i18n')),
 ]
-
-if settings.DEBUG:
-    # static files (images, css, javascript, etc.)
-    urlpatterns += [
-        url(r'^' + settings.STORAGE_URL[1:] + '(?P<path>.*)$', file_views.debug_serve_file, name='debug_serve_file'),
-        url(r'^' + settings.CONTENT_DATABASE_URL[1:] + '(?P<path>.*)$', file_views.debug_serve_content_database_file, name='content_database_debug_serve_file'),
-        url(r'^' + settings.CSV_URL[1:] + '(?P<path>.*)$', file_views.debug_serve_file, name='csv_debug_serve_file'),
-        url(r'^sandbox/$', views.SandboxView.as_view()),
-    ]
-
-    try:
-        import debug_toolbar
-        urlpatterns += [
-            url(r'^__debug__/', include(debug_toolbar.urls)),
-        ]
-    except ImportError:
-        pass

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -367,7 +367,7 @@ class ChannelViewSet(ValuesViewset):
     filter_class = ChannelFilter
 
     field_map = channel_field_map
-    values = base_channel_values + ("edit",)
+    values = base_channel_values + ("edit", "view", "bookmark")
 
     def get_queryset(self):
         user_id = not self.request.user.is_anonymous() and self.request.user.id
@@ -488,7 +488,7 @@ class AdminChannelViewSet(ChannelViewSet):
         DjangoFilterBackend,
         OrderingFilter,
     )
-    values = ChannelViewSet.values + ("editors_count", "viewers_count", "size",)
+    values = base_channel_values + ("editors_count", "viewers_count", "size",)
     ordering_fields = (
         "name",
         "id",

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -46,11 +46,7 @@ class ChannelSetSerializer(BulkModelSerializer):
         instance.secret_token.save()
         self.changes.append(
             generate_update_event(
-                instance.id,
-                CHANNELSET,
-                {
-                    "secret_token": instance.secret_token.token,
-                },
+                instance.id, CHANNELSET, {"secret_token": instance.secret_token.token,},
             )
         )
         return instance
@@ -82,18 +78,17 @@ class ChannelSetViewSet(ValuesViewset):
     field_map = {"secret_token": "secret_token__token", "channels": clean_channels}
 
     def get_queryset(self):
-        queryset = ChannelSet.objects.prefetch_related('secret_token') \
-            .filter(
-                id__in=ChannelSet.objects.filter(editors=self.request.user)
-                    .distinct()
-                    .values_list("id", flat=True)
-            )
+        queryset = ChannelSet.objects.prefetch_related("secret_token").filter(
+            id__in=ChannelSet.objects.filter(editors=self.request.user)
+            .distinct()
+            .values_list("id", flat=True)
+        )
 
         queryset = queryset.annotate(
             channels=DistinctNotNullArrayAgg(
-                'secret_token__channels__id',
+                "secret_token__channels__id",
                 filter=Q(main_tree__published=True, deleted=False),
-                output_field=CharField()
+                output_field=CharField(),
             )
         )
         return queryset

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -1,3 +1,6 @@
+from django.db.models import Exists
+from django.db.models import OuterRef
+from django.db.models import Q
 from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
@@ -5,6 +8,7 @@ from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.serializers import ValidationError
 
 from contentcuration.models import AssessmentItem
+from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 from contentcuration.models import File
 from contentcuration.models import generate_storage_url
@@ -63,6 +67,49 @@ def retrieve_storage_url(item):
     return generate_storage_url("{}.{}".format(item["checksum"], item["file_format"]))
 
 
+channel_trees = (
+    "main_tree",
+    "chef_tree",
+    "trash_tree",
+    "staging_tree",
+    "previous_tree",
+)
+
+edit_filter = Q()
+for tree_name in channel_trees:
+    edit_filter |= Q(
+        **{
+            "editable_channels__{}__tree_id".format(tree_name): OuterRef(
+                "contentnode__tree_id"
+            )
+        }
+    )
+    edit_filter |= Q(
+        **{
+            "editable_channels__{}__tree_id".format(tree_name): OuterRef(
+                "assessment_item__contentnode__tree_id"
+            )
+        }
+    )
+
+view_filter = Q()
+for tree_name in channel_trees:
+    view_filter |= Q(
+        **{
+            "view_only_channels__{}__tree_id".format(tree_name): OuterRef(
+                "contentnode__tree_id"
+            )
+        }
+    )
+    view_filter |= Q(
+        **{
+            "view_only_channels__{}__tree_id".format(tree_name): OuterRef(
+                "assessment_item__contentnode__tree_id"
+            )
+        }
+    )
+
+
 class FileViewSet(ValuesViewset):
     queryset = File.objects.all()
     serializer_class = FileSerializer
@@ -91,6 +138,34 @@ class FileViewSet(ValuesViewset):
         "contentnode": "contentnode_id",
         "assessment_item": "assessment_item_id",
     }
+
+    def get_queryset(self):
+        user_id = not self.request.user.is_anonymous() and self.request.user.id
+        user_queryset = User.objects.filter(id=user_id)
+
+        queryset = File.objects.annotate(
+            edit=Exists(user_queryset.filter(edit_filter)),
+            view=Exists(user_queryset.filter(view_filter)),
+            public=Exists(
+                Channel.objects.filter(
+                    public=True, main_tree__tree_id=OuterRef("contentnode__tree_id")
+                )
+            ),
+        )
+        queryset = queryset.filter(Q(view=True) | Q(edit=True) | Q(public=True))
+
+        return queryset
+
+    def get_edit_queryset(self):
+        user_id = not self.request.user.is_anonymous() and self.request.user.id
+        user_queryset = User.objects.filter(id=user_id)
+
+        queryset = File.objects.annotate(
+            edit=Exists(user_queryset.filter(edit_filter)),
+        )
+        queryset = queryset.filter(edit=True)
+
+        return queryset
 
     def copy(self, pk, user=None, from_key=None, **mods):
         delete_response = [dict(key=pk, table=FILE, type=DELETED,)]

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -120,5 +120,12 @@ class InvitationViewSet(ValuesViewset):
             | Q(channel__viewers=self.request.user)
         ).distinct()
 
+    def get_edit_queryset(self):
+        return Invitation.objects.filter(
+            Q(email__iexact=self.request.user.email)
+            | Q(sender=self.request.user)
+            | Q(channel__editors=self.request.user)
+        ).distinct()
+
     def prefetch_queryset(self, queryset):
         return queryset.select_related("sender", "channel")

--- a/contentcuration/contentcuration/viewsets/tree.py
+++ b/contentcuration/contentcuration/viewsets/tree.py
@@ -10,6 +10,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.serializers import Serializer
 from rest_framework.serializers import ValidationError
 from rest_framework.viewsets import GenericViewSet
 
@@ -80,6 +81,7 @@ class TreeViewSet(GenericViewSet):
     permission_classes = [IsAuthenticated]
     filter_backends = (DjangoFilterBackend,)
     filter_class = TreeFilter
+    serializer_class = Serializer
     values = (
         "id",
         "tree_id",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "minio:test": "rm -rf ~/.minio_test && minio server ~/.minio_test/ || true",
     "minio": "MINIO_ACCESS_KEY=development MINIO_SECRET_KEY=development minio server ~/.minio_data/ || true",
     "runserver": "cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8080",
+    "runserver:debug-panel": "cd contentcuration && python manage.py runserver --settings=contentcuration.debug_panel_settings 0.0.0.0:8080",
     "gunicornserver": "cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.profile_settings gunicorn -b 0.0.0.0:8080 --workers=3 --threads=2 contentcuration.wsgi",
     "testserver": "cd contentcuration && python manage.py runserver --settings=contentcuration.test_settings 0.0.0.0:8081",
     "devserver": "npm-run-all --parallel build:dev runserver",

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,8 +1,8 @@
 -c requirements.txt
 ipdb
 python-language-server
-django-debug-panel
-django-debug-toolbar
+django-debug-panel==0.8.3
+django-debug-toolbar==1.9.1
 flake8==3.4.1
 Pympler
 importmagic

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -30,3 +30,4 @@ coverage
 pytest-cov
 nodeenv
 pip-tools
+drf-yasg

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ coverage==5.0.3
 decorator==4.4.1          # via ipython, traitlets
 distlib==0.3.0            # via virtualenv
 django-debug-panel==0.8.3
-django-debug-toolbar==2.2
+django-debug-toolbar==1.9.1
 django==1.11.29           # via django-debug-toolbar, drf-yasg
 djangorestframework==3.9.1  # via drf-yasg
 docopt==0.6.2             # via pytest-watch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,13 +17,17 @@ chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 codecov==2.0.15
 colorama==0.4.3           # via pytest-watch
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==5.0.3
 decorator==4.4.1          # via ipython, traitlets
 distlib==0.3.0            # via virtualenv
 django-debug-panel==0.8.3
 django-debug-toolbar==2.2
-django==1.11.29           # via django-debug-toolbar
+django==1.11.29           # via django-debug-toolbar, drf-yasg
+djangorestframework==3.9.1  # via drf-yasg
 docopt==0.6.2             # via pytest-watch
+drf-yasg==1.17.1
 faker==0.7.3
 filelock==3.0.12          # via virtualenv
 flake8==3.4.1
@@ -32,19 +36,23 @@ idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via pluggy, pre-commit, pytest, virtualenv
 importlib-resources==1.0.2  # via pre-commit, virtualenv
 importmagic==0.1.7
+inflection==0.5.0         # via drf-yasg
 ipdb==0.12.3
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.12.0           # via ipdb
 isort==4.3.21
+itypes==1.2.0             # via coreapi
 jedi==0.15.2
+jinja2==2.11.2            # via coreschema
 json-rpc==1.13.0
 lazy-object-proxy==1.4.3  # via astroid
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8, pylint
 mixer==5.6.6
 mock==4.0.1
 more-itertools==8.2.0     # via pytest
 nodeenv==1.3.5
-packaging==20.1           # via pytest
+packaging==20.1           # via drf-yasg, pytest
 parso==0.6.1              # via jedi
 pathtools==0.1.2          # via watchdog
 pexpect==4.8.0            # via ipython
@@ -73,15 +81,18 @@ python-jsonrpc-server==0.3.4  # via python-language-server
 python-language-server==0.31.8
 pytz==2019.3              # via django
 pyyaml==5.3               # via aspy.yaml, pre-commit
-requests==2.22.0          # via codecov
+requests==2.22.0          # via codecov, coreapi
 rope==0.16.0
+ruamel.yaml.clib==0.2.0   # via ruamel.yaml
+ruamel.yaml==0.16.10      # via drf-yasg
 service-factory==0.1.6
-six==1.14.0               # via astroid, faker, packaging, pip-tools, pre-commit, python-dateutil, traitlets, virtualenv
+six==1.14.0               # via astroid, drf-yasg, faker, packaging, pip-tools, pre-commit, python-dateutil, traitlets, virtualenv
 sqlparse==0.3.0           # via django-debug-toolbar
 toml==0.10.0              # via pre-commit
 traitlets==4.3.3          # via ipython
 typed-ast==1.4.1          # via astroid
 ujson==1.35               # via python-jsonrpc-server, python-language-server
+uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.8           # via requests
 virtualenv==20.0.3        # via pre-commit
 watchdog==0.10.2          # via pytest-watch


### PR DESCRIPTION
## Description
Adds various updates to our API/DRF Viewsets

* Adds support for individual CRUD operations on ValuesViewsets
* Adds a read only values viewset that prevents C, U, and D operations
* Uses the read only values viewset for some viewsets
* Adds Swagger for API exploration
* Adds first pass permission filtering to ContentNode, File, and AssessmentItem endpoints - with differential filtering for view and edit
* Makes debug panel work again, adds command in package.json to run with it enabled

#### Issue Addressed (if applicable)

Fixes #2034 

Starts work needed for #2015 