### PR TITLE
File upload fixes for GCS

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -124,10 +124,10 @@ function hexToBase64(str) {
   );
 }
 
-export function uploadFileToStorage(context, { checksum, file, url }) {
+export function uploadFileToStorage(context, { checksum, file, url, contentType }) {
   return client.put(url, file, {
     headers: {
-      'Content-Type': 'application/octet-stream',
+      'Content-Type': contentType,
       'Content-MD5': hexToBase64(checksum),
     },
     onUploadProgress: progressEvent => {
@@ -178,7 +178,12 @@ export function uploadFile(context, { file }) {
             }
             // 3. Upload file
             return context
-              .dispatch('uploadFileToStorage', { checksum, file, url: response.data })
+              .dispatch('uploadFileToStorage', {
+                checksum,
+                file,
+                url: response.data['uploadURL'],
+                contentType: response.data['mimetype'],
+              })
               .then(response => {
                 context.commit('ADD_FILEUPLOAD', { checksum, file_on_disk: response.data });
               })

--- a/contentcuration/contentcuration/management/commands/set_content_mimetypes.py
+++ b/contentcuration/contentcuration/management/commands/set_content_mimetypes.py
@@ -9,16 +9,14 @@ Sets the following attributes:
     - if it ends in any other file extension, then we cache the file for a month.
 """
 import concurrent.futures
-import pathlib
 import os
-import sys
-from multiprocessing.pool import Pool
 
 import progressbar
-from django.core.management.base import BaseCommand
 from django.core.files.storage import default_storage
+from django.core.management.base import BaseCommand
 
-from contentcuration.utils.gcs_storage import GoogleCloudStorage as gcs
+from contentcuration.utils.storage_common import determine_content_type
+
 
 class Command(BaseCommand):
 
@@ -55,7 +53,7 @@ class Command(BaseCommand):
     def _update_metadata(self, blob):
         name = str(blob.name)
 
-        content_type = gcs._determine_content_type(name)
+        content_type = determine_content_type(name)
         cache_control = self._determine_cache_control(name)
         blob_update = {
             "Content-Type": content_type,

--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object
 from io import BytesIO
 
 import pytest
@@ -14,36 +13,6 @@ from mock import create_autospec
 from mock import patch
 
 from contentcuration.utils.gcs_storage import GoogleCloudStorage as gcs
-
-
-class MimeTypesTestCase(TestCase):
-    """
-    Tests for determining and setting mimetypes.
-    """
-
-    def test_determine_function_returns_a_string(self):
-        """
-        Sanity check that _determine_content_type returns a string
-        for the happy path.
-        """
-        typ = gcs._determine_content_type("me.pdf")
-
-        assert isinstance(typ, str)
-
-    def test_determine_function_returns_pdf_for_pdfs(self):
-        """
-        Check that _determine_content_type returns an application/pdf
-        for .pdf suffixed strings.
-        """
-        assert gcs._determine_content_type("me.pdf") == "application/pdf"
-
-    def test_determine_function_returns_octet_stream_for_unknown_formats(self):
-        """
-        Check that we return application/octet-stream when we give a filename
-        with an unknown extension.
-        """
-        typ = gcs._determine_content_type("unknown.format")
-        assert typ == "application/octet-stream"
 
 
 class GoogleCloudStorageSaveTestCase(TestCase):

--- a/contentcuration/contentcuration/tests/test_storage_common.py
+++ b/contentcuration/contentcuration/tests/test_storage_common.py
@@ -13,9 +13,40 @@ from mock import MagicMock
 from .base import StudioTestCase
 from contentcuration.models import generate_object_storage_name
 from contentcuration.utils.storage_common import _get_gcs_presigned_put_url
+from contentcuration.utils.storage_common import determine_content_type
 from contentcuration.utils.storage_common import get_presigned_upload_url
 from contentcuration.utils.storage_common import UnknownStorageBackendError
 # The modules we'll test
+
+
+class MimeTypesTestCase(TestCase):
+    """
+    Tests for determining and setting mimetypes.
+    """
+
+    def test_determine_function_returns_a_string(self):
+        """
+        Sanity check that _etermine_content_type returns a string
+        for the happy path.
+        """
+        typ = determine_content_type("me.pdf")
+
+        assert isinstance(typ, str)
+
+    def test_determine_function_returns_pdf_for_pdfs(self):
+        """
+        Check that determine_content_type returns an application/pdf
+        for .pdf suffixed strings.
+        """
+        assert determine_content_type("me.pdf") == "application/pdf"
+
+    def test_determine_function_returns_octet_stream_for_unknown_formats(self):
+        """
+        Check that we return application/octet-stream when we give a filename
+        with an unknown extension.
+        """
+        typ = determine_content_type("unknown.format")
+        assert typ == "application/octet-stream"
 
 
 class FileSystemStoragePresignedURLTestCase(TestCase):

--- a/contentcuration/contentcuration/tests/test_storage_common.py
+++ b/contentcuration/contentcuration/tests/test_storage_common.py
@@ -160,7 +160,9 @@ class S3StoragePresignedURLUnitTestCase(StudioTestCase):
         ret = get_presigned_upload_url(
             "a/b/abc.jpg", "aBc", 10, 1, storage=self.STORAGE, client=None
         )
-        assert isinstance(ret, str)
+        url = ret["uploadURL"]
+
+        assert isinstance(url, str)
 
     def test_can_upload_file_to_presigned_url(self):
         """
@@ -176,10 +178,15 @@ class S3StoragePresignedURLUnitTestCase(StudioTestCase):
         filename = "blahfile.jpg"
         filepath = generate_object_storage_name(md5_checksum, filename)
 
-        url = get_presigned_upload_url(filepath, md5_checksum_base64, 1000, len(file_contents))
+        ret = get_presigned_upload_url(filepath, md5_checksum_base64, 1000, len(file_contents))
+        url = ret["uploadURL"]
+        content_type = ret["mimetype"]
 
         resp = requests.put(
             url,
             data=file,
+            headers={
+                "Content-Type": content_type,
+            }
         )
         resp.raise_for_status()

--- a/contentcuration/contentcuration/utils/storage_common.py
+++ b/contentcuration/contentcuration/utils/storage_common.py
@@ -31,11 +31,14 @@ def get_presigned_upload_url(
 
     :raises: :class:`UnknownStorageBackendError`: If the storage backend is not S3 or GCS.
     """
+
+    # Aron: note that content_length is not used right now because
+    # both storage types are having difficulties enforcing it.
+
     if isinstance(storage, GoogleCloudStorage):
         client = client or storage.client
         bucket = settings.AWS_S3_BUCKET_NAME
-        return _get_gcs_presigned_put_url(client, bucket, filepath, md5sum_b64, lifetime_sec,
-                                          content_length=content_length)
+        return _get_gcs_presigned_put_url(client, bucket, filepath, md5sum_b64, lifetime_sec)
     elif isinstance(storage, S3Storage):
         bucket = settings.AWS_S3_BUCKET_NAME
         client = client or storage.s3_connection
@@ -46,7 +49,7 @@ def get_presigned_upload_url(
         )
 
 
-def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_sec, content_length):
+def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_sec):
     bucket_obj = gcs_client.get_bucket(bucket)
     blob_obj = bucket_obj.blob(filepath)
 

--- a/contentcuration/contentcuration/utils/storage_common.py
+++ b/contentcuration/contentcuration/utils/storage_common.py
@@ -60,9 +60,13 @@ def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_se
     # from unix time
     lifetime_timedelta = timedelta(seconds=lifetime_sec)
 
+    # enforce a mimetype as well
+    mimetype = GoogleCloudStorage._determine_content_type(filepath)
+
     url = blob_obj.generate_signed_url(
         method="PUT",
         content_md5=md5sum_stripped,
+        content_type=mimetype,
         expiration=lifetime_timedelta,
     )
 

--- a/contentcuration/contentcuration/utils/storage_common.py
+++ b/contentcuration/contentcuration/utils/storage_common.py
@@ -1,3 +1,4 @@
+import mimetypes
 from datetime import timedelta
 
 from django.conf import settings
@@ -9,6 +10,22 @@ from .gcs_storage import GoogleCloudStorage
 
 class UnknownStorageBackendError(Exception):
     pass
+
+
+def determine_content_type(filename):
+    """
+    Guesses the content type of a filename. Returns the mimetype of a file.
+
+    Returns "application/octet-stream" if the type can't be guessed.
+    Raises an AssertionError if filename is not a string.
+    """
+
+    typ, _ = mimetypes.guess_type(filename)
+
+    if not typ:
+        return "application/octet-stream"
+    else:
+        return typ
 
 
 def get_presigned_upload_url(

--- a/contentcuration/contentcuration/utils/storage_common.py
+++ b/contentcuration/contentcuration/utils/storage_common.py
@@ -49,6 +49,12 @@ def get_presigned_upload_url(
 def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_sec, content_length):
     bucket_obj = gcs_client.get_bucket(bucket)
     blob_obj = bucket_obj.blob(filepath)
+
+    # ensure the md5sum doesn't have any whitespace, including newlines.
+    # We should do the same whitespace stripping as well on any client that actually
+    # uses the returned presigned url.
+    md5sum_stripped = md5sum.strip()
+
     # convert the lifetime to a timedelta, so gcloud library will interpret the lifetime
     # as the seconds from right now. If we use an absolute integer, it's the number of seconds
     # from unix time
@@ -56,8 +62,10 @@ def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_se
 
     url = blob_obj.generate_signed_url(
         method="PUT",
+        content_md5=md5sum_stripped,
         expiration=lifetime_timedelta,
     )
+
     return url
 
 

--- a/contentcuration/contentcuration/utils/storage_common.py
+++ b/contentcuration/contentcuration/utils/storage_common.py
@@ -44,7 +44,9 @@ def get_presigned_upload_url(
     :param: client: the storage client that will be used to gennerate the presigned URL.
     This must have an API that's similar to either the GCS client or the boto3 client.
 
-    :returns: the signed PUT upload URL, as a string.
+    :returns: a dictionary containing 2 keys:
+        mimetype: the mimetype that will be required to send as part of the file upload's mimetype header
+        uploadURL: the URL to upload the file to.
 
     :raises: :class:`UnknownStorageBackendError`: If the storage backend is not S3 or GCS.
     """
@@ -52,21 +54,27 @@ def get_presigned_upload_url(
     # Aron: note that content_length is not used right now because
     # both storage types are having difficulties enforcing it.
 
+    mimetype = determine_content_type(filepath)
     if isinstance(storage, GoogleCloudStorage):
         client = client or storage.client
         bucket = settings.AWS_S3_BUCKET_NAME
-        return _get_gcs_presigned_put_url(client, bucket, filepath, md5sum_b64, lifetime_sec)
+        upload_url = _get_gcs_presigned_put_url(client, bucket, filepath, md5sum_b64, lifetime_sec, mimetype=mimetype)
     elif isinstance(storage, S3Storage):
         bucket = settings.AWS_S3_BUCKET_NAME
         client = client or storage.s3_connection
-        return _get_s3_presigned_put_url(client, bucket, filepath, md5sum_b64, lifetime_sec)
+        upload_url = _get_s3_presigned_put_url(client, bucket, filepath, md5sum_b64, lifetime_sec)
     else:
         raise UnknownStorageBackendError(
             "Please ensure your storage backend is either Google Cloud Storage or S3 Storage!"
         )
 
+    return {
+        "mimetype": mimetype,
+        "uploadURL": upload_url
+    }
 
-def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_sec):
+
+def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_sec, mimetype="application/octet-stream"):
     bucket_obj = gcs_client.get_bucket(bucket)
     blob_obj = bucket_obj.blob(filepath)
 
@@ -79,9 +87,6 @@ def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_se
     # as the seconds from right now. If we use an absolute integer, it's the number of seconds
     # from unix time
     lifetime_timedelta = timedelta(seconds=lifetime_sec)
-
-    # enforce a mimetype as well
-    mimetype = GoogleCloudStorage._determine_content_type(filepath)
 
     url = blob_obj.generate_signed_url(
         method="PUT",

--- a/contentcuration/contentcuration/utils/storage_common.py
+++ b/contentcuration/contentcuration/utils/storage_common.py
@@ -48,7 +48,7 @@ def get_presigned_upload_url(
 
 def _get_gcs_presigned_put_url(gcs_client, bucket, filepath, md5sum, lifetime_sec, content_length):
     bucket_obj = gcs_client.get_bucket(bucket)
-    blob_obj = bucket_obj.get_blob(filepath)
+    blob_obj = bucket_obj.blob(filepath)
     # convert the lifetime to a timedelta, so gcloud library will interpret the lifetime
     # as the seconds from right now. If we use an absolute integer, it's the number of seconds
     # from unix time

--- a/contentcuration/contentcuration/views/files.py
+++ b/contentcuration/contentcuration/views/files.py
@@ -53,10 +53,6 @@ def upload_url(request):
     checksum_base64 = codecs.encode(codecs.decode(checksum, "hex"), "base64").decode()
     retval = get_presigned_upload_url(filepath, checksum_base64, 600, content_length=size)
 
-    # make sure we have both the mimetype and uploadURL values returned
-    assert isinstance(retval["mimetype"], str), "No mimetype present on get_presigned_upload_url return value!"
-    assert isinstance(retval["uploadURL"], str), "No uploadURL present on get_presigned_upload_url return value!"
-
     return JsonResponse(retval)
 
 


### PR DESCRIPTION
This PR contains various fixes to fix file presigned url creation.

- Use `blob` instead of `get_blob` to instantiate GCS `Blob` objects. `get_blob` returns `None` if the file doesn't exist yet on GCS.
- Enforce a mimetype during upload by using the `content_type` argument.
- Use the `content_md5` and `content_type` arguments to enforce these 2 headers during upload, rather than using the `headers` argument of `get_presigned_url`.
- use a python `TimeDelta` object to calculate the expiration date of the URL `x` number of seconds from now, rather than at the start of the unix epoch.

Note to @rtibbles: we will have to ensure that the client-side file upload code **only sends the following headers**:

- `Content-MD5` -- has to match the checksum we sent during signed url creation
- `Content-Type` -- has to match what python determined the mimetype to be, based on its file extension
- `Host` -- this always needs to be `storage.googleapis.com`, but i'm assuming that the AJAX library would handle this properly
- `User-Agent` -- GCS doesn't check the value of this, but this needs to be present
- `Content-Length` -- this needs to be here, but GCS doesn't enforce a certain value because I haven't figured out yet how to enforce this yet.

