### PR TITLE
Flatten routes - trash modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -127,6 +127,20 @@ const router = new VueRouter({
       },
     },
     {
+      name: RouterNames.TRASH,
+      path: '/:nodeId/:detailNodeId?/trash',
+      component: TrashModal,
+      props: true,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
       name: RouterNames.TREE_VIEW,
       path: '/:nodeId/:detailNodeId?',
       props: true,
@@ -136,14 +150,11 @@ const router = new VueRouter({
 
         return store
           .dispatch('currentChannel/loadChannel')
-          .then(channel => {
+          .then(() => {
             const promises = [
               store.dispatch('contentNode/loadClipboardTree'),
               store.dispatch('contentNode/loadChannelTree', currentChannelId),
             ];
-            if (channel.trash_root_id) {
-              promises.push(store.dispatch('contentNode/loadTrashTree', channel.trash_root_id));
-            }
             return Promise.all(promises);
           })
           .catch(error => {
@@ -186,12 +197,6 @@ const router = new VueRouter({
           name: ChannelRouterNames.CHANNEL_EDIT,
           path: 'channel/:channelId/edit',
           component: ChannelModal,
-          props: true,
-        },
-        {
-          name: RouterNames.TRASH,
-          path: 'trash',
-          component: TrashModal,
           props: true,
         },
       ],

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -1,7 +1,6 @@
 <template>
 
   <FullscreenModal v-model="dialog" :header="$tr('trashModalTitle')">
-    <router-view />
     <VContent>
       <VLayout row>
         <LoadingText v-if="loading" data-test="loading" />
@@ -150,6 +149,7 @@
     },
     data() {
       return {
+        dialog: true,
         loading: false,
         previewNodeId: null,
         selected: [],
@@ -159,16 +159,6 @@
     computed: {
       ...mapGetters('currentChannel', ['currentChannel', 'trashId']),
       ...mapGetters('contentNode', ['getContentNodeChildren']),
-      dialog: {
-        get() {
-          return this.$route.name === RouterNames.TRASH;
-        },
-        set(value) {
-          if (!value) {
-            this.$router.push(this.backLink);
-          }
-        },
-      },
       headers() {
         return [
           {
@@ -190,12 +180,17 @@
         return sortBy(this.getContentNodeChildren(this.trashId), 'modified').reverse();
       },
       backLink() {
-        const lastIndex = Math.max(0, this.$route.matched.length - 2);
         return {
-          name: this.$route.matched[lastIndex].name,
-          query: this.$route.query,
+          name: RouterNames.TREE_VIEW,
           params: this.$route.params,
         };
+      },
+    },
+    watch: {
+      dialog(newValue) {
+        if (!newValue) {
+          this.$router.push(this.backLink);
+        }
       },
     },
     mounted() {


### PR DESCRIPTION
## Description

Flatten trash routes in the channel edit app.

## Steps to Test

Visit the trash modal. Check that back navigation works properly. Try to reload.