### PR TITLE
Flatten routes - channel edit - trash, channel details and edit modals

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -141,6 +141,34 @@ const router = new VueRouter({
       },
     },
     {
+      name: ChannelRouterNames.CHANNEL_DETAILS,
+      path: '/:nodeId/:detailNodeId?/channel/:channelId/details',
+      component: ChannelDetailsModal,
+      props: true,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
+      name: ChannelRouterNames.CHANNEL_EDIT,
+      path: '/:nodeId/:detailNodeId?/channel/:channelId/edit',
+      component: ChannelModal,
+      props: true,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
       name: RouterNames.TREE_VIEW,
       path: '/:nodeId/:detailNodeId?',
       props: true,
@@ -186,18 +214,6 @@ const router = new VueRouter({
           path: 'upload/:detailNodeIds?/:tab?',
           props: true,
           component: EditModal,
-        },
-        {
-          name: ChannelRouterNames.CHANNEL_DETAILS,
-          path: 'channel/:channelId/details',
-          component: ChannelDetailsModal,
-          props: true,
-        },
-        {
-          name: ChannelRouterNames.CHANNEL_EDIT,
-          path: 'channel/:channelId/edit',
-          component: ChannelModal,
-          props: true,
         },
       ],
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -127,6 +127,20 @@ const router = new VueRouter({
       },
     },
     {
+      name: RouterNames.TRASH,
+      path: '/:nodeId/:detailNodeId?/trash',
+      component: TrashModal,
+      props: true,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
       name: RouterNames.TREE_VIEW,
       path: '/:nodeId/:detailNodeId?',
       props: true,
@@ -136,14 +150,11 @@ const router = new VueRouter({
 
         return store
           .dispatch('currentChannel/loadChannel')
-          .then(channel => {
+          .then(() => {
             const promises = [
               store.dispatch('contentNode/loadClipboardTree'),
               store.dispatch('contentNode/loadChannelTree', currentChannelId),
             ];
-            if (channel.trash_root_id) {
-              promises.push(store.dispatch('contentNode/loadTrashTree', channel.trash_root_id));
-            }
             return Promise.all(promises);
           })
           .catch(error => {
@@ -186,12 +197,6 @@ const router = new VueRouter({
           name: ChannelRouterNames.CHANNEL_EDIT,
           path: 'channel/:channelId/edit',
           component: ChannelModal,
-          props: true,
-        },
-        {
-          name: RouterNames.TRASH,
-          path: 'trash',
-          component: TrashModal,
           props: true,
         },
       ],

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -165,7 +165,11 @@
       viewChannelDetailsLink() {
         return {
           name: ChannelRouterNames.CHANNEL_DETAILS,
+          query: {
+            last: this.$route.name,
+          },
           params: {
+            ...this.$route.params,
             channelId: this.currentChannel.id,
           },
         };
@@ -173,7 +177,11 @@
       editChannelLink() {
         return {
           name: ChannelRouterNames.CHANNEL_EDIT,
+          query: {
+            last: this.$route.name,
+          },
           params: {
+            ...this.$route.params,
             channelId: this.currentChannel.id,
           },
         };

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -181,6 +181,7 @@
       trashLink() {
         return {
           name: RouterNames.TRASH,
+          params: this.$route.params,
         };
       },
       shareChannelLink() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -1,7 +1,6 @@
 <template>
 
   <FullscreenModal v-model="dialog" :header="$tr('trashModalTitle')">
-    <router-view />
     <VContent>
       <VLayout row>
         <LoadingText v-if="loading" data-test="loading" />
@@ -150,6 +149,7 @@
     },
     data() {
       return {
+        dialog: true,
         loading: false,
         previewNodeId: null,
         selected: [],
@@ -159,16 +159,6 @@
     computed: {
       ...mapGetters('currentChannel', ['currentChannel', 'trashId']),
       ...mapGetters('contentNode', ['getContentNodeChildren']),
-      dialog: {
-        get() {
-          return this.$route.name === RouterNames.TRASH;
-        },
-        set(value) {
-          if (!value) {
-            this.$router.push(this.backLink);
-          }
-        },
-      },
       headers() {
         return [
           {
@@ -190,12 +180,17 @@
         return sortBy(this.getContentNodeChildren(this.trashId), 'modified').reverse();
       },
       backLink() {
-        const lastIndex = Math.max(0, this.$route.matched.length - 2);
         return {
-          name: this.$route.matched[lastIndex].name,
-          query: this.$route.query,
+          name: RouterNames.TREE_VIEW,
           params: this.$route.params,
         };
+      },
+    },
+    watch: {
+      dialog(newValue) {
+        if (!newValue) {
+          this.$router.push(this.backLink);
+        }
       },
     },
     mounted() {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelDetailsModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelDetailsModal.vue
@@ -84,6 +84,7 @@
       backLink() {
         return {
           name: this.$route.query.last,
+          params: this.$route.params,
           query: {
             // we can navigate to this component
             // from the catalog search page =>

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -311,6 +311,7 @@
       close() {
         this.$router.push({
           name: this.$route.query.last,
+          params: this.$route.params,
           query: {
             // we can navigate to this component
             // from the catalog search page =>


### PR DESCRIPTION
## Description

Flatten trash, channel details and channel edit modal routes in the channel edit app.

## Steps to Test

Visit the modals from the channel edit root tree page. Check that back navigation works properly.