### PR TITLE
Flatten routes - channel edit - nodes edit modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -169,6 +169,62 @@ const router = new VueRouter({
       },
     },
     {
+      name: RouterNames.CONTENTNODE_DETAILS,
+      path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/:tab?',
+      props: true,
+      component: EditModal,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
+      name: RouterNames.ADD_TOPICS,
+      path: '/:nodeId/:detailNodeId?/topics/:detailNodeIds/:tab?',
+      props: true,
+      component: EditModal,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
+      name: RouterNames.ADD_EXERCISE,
+      path: '/:nodeId/:detailNodeId?/exercise/:detailNodeIds/:tab?',
+      props: true,
+      component: EditModal,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
+      name: RouterNames.UPLOAD_FILES,
+      path: '/:nodeId/:detailNodeId?/upload/:detailNodeIds?/:tab?',
+      props: true,
+      component: EditModal,
+      beforeEnter: (to, from, next) => {
+        return store
+          .dispatch('currentChannel/loadChannel')
+          .catch(error => {
+            throw new Error(error);
+          })
+          .then(() => next());
+      },
+    },
+    {
       name: RouterNames.TREE_VIEW,
       path: '/:nodeId/:detailNodeId?',
       props: true,
@@ -190,32 +246,6 @@ const router = new VueRouter({
           })
           .then(() => next());
       },
-      children: [
-        {
-          name: RouterNames.CONTENTNODE_DETAILS,
-          path: 'details/:detailNodeIds/:tab?',
-          props: true,
-          component: EditModal,
-        },
-        {
-          name: RouterNames.ADD_TOPICS,
-          path: 'topics/:detailNodeIds/:tab?',
-          props: true,
-          component: EditModal,
-        },
-        {
-          name: RouterNames.ADD_EXERCISE,
-          path: 'exercise/:detailNodeIds/:tab?',
-          props: true,
-          component: EditModal,
-        },
-        {
-          name: RouterNames.UPLOAD_FILES,
-          path: 'upload/:detailNodeIds?/:tab?',
-          props: true,
-          component: EditModal,
-        },
-      ],
     },
   ],
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -67,7 +67,6 @@
         <VContainer fluid class="pa-0 ma-0" style="height: calc(100vh - 64px);">
           <CurrentTopicView :topicId="nodeId" :detailNodeId="detailNodeId" />
         </VContainer>
-        <router-view />
       </VLayout>
     </VContainer>
   </TreeViewBase>


### PR DESCRIPTION
## Description

Flatten nodes edit modal routes in the channel edit app.

## Steps to Test

Visit the edit modal from various parts of the channel edit root tree page (edit node/s, file upload, create an exercise, add a new topic). Check that back navigation works properly.