### PR TITLE
Update duplicate node task to no longer rely on deprecated sort_order property.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
@@ -3,30 +3,17 @@ import { NOVALUE, ChannelListTypes } from 'shared/constants';
 
 import { Channel, SavedSearch } from 'shared/data/resources';
 
-// Function that calls the get_nodes_by_ids_complete endpoint
-export function getCompleteContentNode(context, nodeId) {
-  return client.get(`/api/get_nodes_by_ids_complete/${nodeId}`).then(response => {
-    return response.data[0];
-  });
-}
-
 // Function that calls the duplicate_nodes endpoint to add new nodes to the channel/topic
 export function duplicateNodesToTarget(context, { nodeIds, targetNodeId }) {
-  // get targetNodeId metadata.max_sort_order
-  return getCompleteContentNode(context, targetNodeId).then(targetNode => {
-    const maxSortOrder = targetNode.metadata.max_sort_order || 0;
-    return client
-      .post(window.Urls.duplicate_nodes(), {
-        node_ids: nodeIds,
-        sort_order: maxSortOrder + 1,
-        target_parent: targetNodeId,
-        channel_id: context.rootState.currentChannel.currentChannelId,
-      })
-      .then(response => {
-        context.dispatch('task/startTask', { task: response.data }, { root: true });
-        return response.data;
-      });
-  });
+  return client
+    .post(window.Urls.duplicate_nodes(), {
+      node_ids: nodeIds,
+      target_parent: targetNodeId,
+    })
+    .then(response => {
+      context.dispatch('task/startTask', { task: response.data }, { root: true });
+      return response.data;
+    });
 }
 
 export function fetchResourceSearchResults(context, params) {

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -56,7 +56,7 @@ if settings.RUNNING_TESTS:
 
 
 @task(bind=True, name='duplicate_nodes_task')
-def duplicate_nodes_task(self, user_id, channel_id, target_parent, node_ids, sort_order=1):
+def duplicate_nodes_task(self, user_id, channel_id, target_parent, node_ids):
     new_nodes = []
     user = User.objects.get(id=user_id)
     self.progress = 0.0
@@ -68,10 +68,9 @@ def duplicate_nodes_task(self, user_id, channel_id, target_parent, node_ids, sor
     with transaction.atomic():
         with ContentNode.objects.disable_mptt_updates():
             for node_id in node_ids:
-                new_node = duplicate_node_bulk(node_id, sort_order=sort_order, parent=target_parent,
+                new_node = duplicate_node_bulk(node_id, parent=target_parent,
                                                channel_id=channel_id, user=user, task_object=self)
                 new_nodes.append(new_node.pk)
-                sort_order += 1
 
     return ContentNodeSerializer(ContentNode.objects.filter(pk__in=new_nodes), many=True).data
 

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -337,8 +337,6 @@ def duplicate_nodes(request):
 
     try:
         node_ids = data["node_ids"]
-        sort_order = data.get("sort_order") or 1
-        channel_id = data["channel_id"]
         target_parent = ContentNode.objects.get(pk=data["target_parent"])
         channel = target_parent.get_channel()
         try:
@@ -350,7 +348,7 @@ def duplicate_nodes(request):
             'user': request.user,
             'metadata': {
                 'affects': {
-                    'channels': [channel_id],
+                    'channels': [channel.pk],
                     'nodes': node_ids,
                 }
             }
@@ -358,10 +356,9 @@ def duplicate_nodes(request):
 
         task_args = {
             'user_id': request.user.pk,
-            'channel_id': channel_id,
+            'channel_id': channel.pk,
             'target_parent': target_parent.pk,
             'node_ids': node_ids,
-            'sort_order': sort_order
         }
 
         task, task_info = create_async_task('duplicate-nodes', task_info, task_args)


### PR DESCRIPTION
## Description

* Removes use of sort order in the duplicate nodes task
* Removes call to backend to get sort order value when calling duplicate nodes task from the frontend

## Steps to Test

* Import a node

## Implementation Notes (optional)

#### At a high level, how did you implement this?

The sort_order property is deprecated and no longer has any impact on ordering in the tree, so this removes that.

What I am not sure of is with MPTT updates disabled and using bulk_create, how the task is currently working - but nothing that this PR does makes that any worse.
