### PR TITLE
Added questions to resource panel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -90,6 +90,12 @@
             :label="$tr('questions')"
             :text="$formatNumber(node.assessment_items.length)"
           />
+          <DetailsRow
+            v-if="isExercise"
+            :label="$tr('masteryCriteria')"
+          >
+            {{ masteryCriteria }}
+          </DetailsRow>
           <DetailsRow :label="$tr('description')" :text="getText('description')" />
           <DetailsRow :label="$tr('tags')">
             <div v-if="!sortedTags.length">
@@ -100,7 +106,7 @@
               v-else
               :key="tag"
               class="notranslate"
-              color="grey lighten-2"
+              color="grey lighten-4"
             >
               {{ tag }}
             </VChip>
@@ -244,6 +250,8 @@
   import Licenses from 'shared/leUtils/Licenses';
   import Checkbox from 'shared/views/form/Checkbox';
   import { constantsTranslationMixin, fileSizeMixin } from 'shared/mixins';
+  import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
+  import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
   export default {
     name: 'ResourcePanel',
@@ -291,10 +299,10 @@
         return this.contentNodesTotalSize([this.nodeId]);
       },
       isTopic() {
-        return this.node.kind === 'topic';
+        return this.node.kind === ContentKindsNames.TOPIC;
       },
       isExercise() {
-        return this.node.kind === 'exercise';
+        return this.node.kind === ContentKindsNames.EXERCISE;
       },
       isResource() {
         return !this.isTopic && !this.isExercise;
@@ -315,6 +323,17 @@
           return `/channels/${this.node.original_channel_id}/${clientPath.href}`;
         }
         return null;
+      },
+      masteryCriteria() {
+        if (!this.isExercise) {
+          return '';
+        }
+
+        const masteryModel = this.node.extra_fields.type;
+        if (masteryModel === MasteryModelsNames.M_OF_N) {
+          return this.$tr('masteryMofN', this.node.extra_fields);
+        }
+        return this.translateConstant(masteryModel);
       },
       sortedTags() {
         return sortBy(this.node.tags, '-count');
@@ -410,6 +429,8 @@
     },
     $trs: {
       questions: 'Questions',
+      masteryCriteria: 'Mastery criteria',
+      masteryMofN: '{m} out of {n}',
       details: 'Details',
       showAnswers: 'Show answers',
       questionCount: '{value, number, integer} {value, plural, one {question} other {questions}}',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -98,10 +98,11 @@
             <VChip
               v-for="tag in sortedTags"
               v-else
-              :key="tag.tag_name"
+              :key="tag"
+              class="notranslate"
               color="grey lighten-2"
             >
-              {{ tag.tag_name }}
+              {{ tag }}
             </VChip>
           </DetailsRow>
           <DetailsRow v-if="isResource" :label="$tr('fileSize')" :text="formatFileSize(fileSize)" />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -99,7 +99,7 @@
           <DetailsRow :label="$tr('description')" :text="getText('description')" />
           <DetailsRow :label="$tr('tags')">
             <div v-if="!sortedTags.length">
-              {{ $tr('defaultNoItemsText') }}
+              {{ defaultText }}
             </div>
             <VChip
               v-for="tag in sortedTags"
@@ -127,7 +127,7 @@
             </div>
             <DetailsRow :label="$tr('previousSteps')">
               <div v-if="!previousSteps.length">
-                {{ $tr('defaultNoItemsText') }}
+                {{ defaultText }}
               </div>
               <VList v-else dense class="pa-0 mb-2">
                 <VListTile v-for="prerequisite in previousSteps" :key="prerequisite.id">
@@ -142,7 +142,7 @@
             </DetailsRow>
             <DetailsRow :label="$tr('nextSteps')">
               <div v-if="!nextSteps.length">
-                {{ $tr('defaultNoItemsText') }}
+                {{ defaultText }}
               </div>
               <VList v-else dense class="pa-0 mb-2">
                 <VListTile v-for="postrequisite in nextSteps" :key="postrequisite.id">
@@ -215,14 +215,14 @@
             </div>
             <DetailsRow v-if="primaryFiles.length" :label="$tr('availableFormats')">
               <ExpandableList
-                :noItemsText="$tr('defaultNoItemsText')"
+                :noItemsText="defaultText"
                 :items="availableFormats"
                 inline
               />
             </DetailsRow>
             <DetailsRow v-if="node.kind === 'video'" :label="$tr('subtitles')">
               <ExpandableList
-                :noItemsText="$tr('defaultNoItemsText')"
+                :noItemsText="defaultText"
                 :items="subtitleFileLanguages"
                 inline
               />
@@ -292,6 +292,9 @@
       files() {
         return sortBy(this.getContentNodeFiles(this.nodeId), f => f.preset.order);
       },
+      defaultText() {
+        return '-';
+      },
       assessmentItems() {
         return this.getAssessmentItems(this.nodeId);
       },
@@ -329,8 +332,10 @@
           return '';
         }
 
-        const masteryModel = this.node.extra_fields.type;
-        if (masteryModel === MasteryModelsNames.M_OF_N) {
+        const masteryModel = this.node.extra_fields.type || this.node.extra_fields.mastery_model;
+        if (!masteryModel) {
+          return this.defaultText;
+        } else if (masteryModel === MasteryModelsNames.M_OF_N) {
           return this.$tr('masteryMofN', this.node.extra_fields);
         }
         return this.translateConstant(masteryModel);
@@ -342,7 +347,7 @@
         return Licenses.get(this.node.license);
       },
       languageName() {
-        return this.translateLanguage(this.node.language) || this.$tr('defaultNoItemsText');
+        return this.translateLanguage(this.node.language) || this.defaultText;
       },
       licenseDescription() {
         return (
@@ -354,12 +359,11 @@
       },
       licenseName() {
         return (
-          (this.license && this.translateConstant(this.license.license_name)) ||
-          this.$tr('defaultNoItemsText')
+          (this.license && this.translateConstant(this.license.license_name)) || this.defaultText
         );
       },
       roleName() {
-        return this.translateConstant(this.node.role_visibility) || this.$tr('defaultNoItemsText');
+        return this.translateConstant(this.node.role_visibility) || this.defaultText;
       },
       previousSteps() {
         return this.getContentNodes(uniq(this.node.prerequisite));
@@ -400,7 +404,7 @@
       ...mapActions('file', ['loadFiles']),
       ...mapActions('assessmentItem', ['loadNodeAssessmentItems']),
       getText(field) {
-        return this.node[field] || this.$tr('defaultNoItemsText');
+        return this.node[field] || this.defaultText;
       },
       loadNode() {
         // Load related models
@@ -437,7 +441,6 @@
       noQuestionsFound: 'There are no questions',
       description: 'Description',
       tags: 'Tags',
-      defaultNoItemsText: '-',
       audience: 'Audience',
       language: 'Language',
       visibleTo: 'Visible to',

--- a/contentcuration/contentcuration/frontend/shared/views/ContentNodeIcon.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContentNodeIcon.vue
@@ -109,6 +109,7 @@
 
   .iconOnly {
     /deep/ .v-chip__content {
+      height: 22px;
       padding: 0 5px;
     }
   }


### PR DESCRIPTION

## Description

Added the questions preview to the resource drawer

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2057

#### Screenshots

![image](https://user-images.githubusercontent.com/7447496/90189925-e8cd4b80-dd72-11ea-8b86-751e2c32e54b.png)

Or for empty exercises
![image](https://user-images.githubusercontent.com/7447496/90189978-026e9300-dd73-11ea-8186-9e2379f970a8.png)


## Steps to Test

- [ ] Click on an exercise in the channel editor

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?

