### PR TITLE
Don't show node options for a channel in breadcrumbs

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -10,7 +10,7 @@
             <VFlex class="font-weight-bold text-truncate notranslate" shrink>
               {{ props.item.title }}
             </VFlex>
-            <VMenu offset-y right>
+            <VMenu v-if="props.item.displayNodeOptions" offset-y right>
               <template #activator="{ on }">
                 <VBtn icon flat small v-on="on">
                   <Icon>arrow_drop_down</Icon>
@@ -244,6 +244,7 @@
             id: ancestor.id,
             to: this.treeLink({ nodeId: ancestor.id }),
             title: ancestor.title,
+            displayNodeOptions: Boolean(ancestor.parent_id),
           };
         });
       },


### PR DESCRIPTION
## Description

#### Issue Addressed

Fixes #2041 

#### Before/After Screenshots

| Before | After |
| --------- | ------ |
| ![before](https://user-images.githubusercontent.com/13509191/90249148-41b3e700-de3a-11ea-83c3-48907f9f93c1.png) | ![after](https://user-images.githubusercontent.com/13509191/90249179-4b3d4f00-de3a-11ea-98fb-d6cf492c723b.png) |

## Steps to Test

- [ ] *Visit a channel edit page*
- [ ] *Check that content node options menu is not displayed for a root channel and is displayed for its sub-topics*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

