### PR TITLE
Remove file auto delete signal to preserve files on GCS until further notice.

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1456,16 +1456,6 @@ class File(models.Model):
         super(File, self).save(*args, **kwargs)
 
 
-@receiver(models.signals.post_delete, sender=File)
-def auto_delete_file_on_delete(sender, instance, **kwargs):
-    """
-    Deletes file from filesystem if no other File objects are referencing the same file on disk
-    when corresponding `File` object is deleted.
-    Be careful! we don't know if this will work when perform bash delete on File obejcts.
-    """
-    delete_empty_file_reference(instance.checksum, instance.file_format.extension)
-
-
 def delete_empty_file_reference(checksum, extension):
     filename = checksum + '.' + extension
     if not File.objects.filter(checksum=checksum).exists() and not Channel.objects.filter(thumbnail=filename).exists():


### PR DESCRIPTION

## Description

* Removes the Django signal that causes files to be removed from GCS storage when the last File object referencing it is deleted.

#### Issue Addressed (if applicable)

* Resolves decision at post-mortem that decided we should preserve files on GCS in order to assist in restoration processes for users.

## Steps to Test

- Delete every File object referencing a particular checksum and extension
- Confirm that the file still exists in storage

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Deleted the signal that does this, but left the utility function in place so that we can implement cleanup commands in the future.

#### Does this introduce any tech-debt items?

Still need to implement the later cleanup command
