### PR TITLE
Prevent non-integer M of N criteria on exercises

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MasteryDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MasteryDropdown.vue
@@ -63,6 +63,8 @@
             :disabled="disabled"
             :hint="$tr('mHint')"
             persistentHint
+            @keypress="isIntegerInput($event)"
+            @paste="isIntegerPaste($event)"
           />
         </VFlex>
         <VFlex xs2 justifyCenter class="out-of">
@@ -83,6 +85,8 @@
             :placeholder="nPlaceholder"
             :rules="nRules"
             :disabled="disabled"
+            @keypress="isIntegerInput($event)"
+            @paste="isIntegerPaste($event)"
           />
         </VFlex>
       </VLayout>
@@ -188,6 +192,7 @@
               v => !!v || this.$tr('requiredValidationMessage'),
               v => v > 0 || this.$tr('mnValueValidationMessage'),
               v => v <= this.nValue || this.$tr('mValueValidationMessage'),
+              v => Number.isInteger(Number(v)) || this.$tr('mnIntegerValidationMessage'),
             ]
           : [];
       },
@@ -196,6 +201,7 @@
           ? [
               v => !!v || this.$tr('requiredValidationMessage'),
               v => v > 0 || this.$tr('mnValueValidationMessage'),
+              v => Number.isInteger(Number(v)) || this.$tr('mnIntegerValidationMessage'),
             ]
           : [];
       },
@@ -208,6 +214,29 @@
         };
         this.$emit('input', data);
       },
+      isIntegerInput(evt) {
+        evt = evt ? evt : window.event;
+        var charCode = evt.which ? evt.which : evt.keyCode;
+        if (charCode > 31 && (charCode < 48 || charCode > 57) && charCode === 46) {
+          evt.preventDefault();
+        } else {
+          return true;
+        }
+      },
+      isIntegerPaste(evt) {
+        try {
+          let num = Number(evt.clipboardData.getData('Text'));
+          if (Number.isInteger(num) && num >= 0) {
+            return true;
+          } else {
+            evt.preventDefault();
+            return false;
+          }
+        } catch (_) {
+          evt.preventDefault();
+          return false;
+        }
+      },
     },
     $trs: {
       labelText: 'Mastery Criteria',
@@ -219,6 +248,7 @@
         'Kolibri marks an exercise as "completed" when the mastery criteria is met. Here are the different types of mastery criteria for an exercise:',
       masteryValidationMessage: 'Mastery is required',
       mnValueValidationMessage: 'Must be at least 1',
+      mnIntegerValidationMessage: 'Must be a whole number',
       mValueValidationMessage: 'Must be lesser than or equal to N',
       requiredValidationMessage: 'Required',
       mHint: 'Correct answers needed',

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/masteryDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/masteryDropdown.spec.js
@@ -165,6 +165,24 @@ describe('masteryDropdown', () => {
           .exists()
       ).toBe(false);
     });
+    it('should flag if m is not a whole number', () => {
+      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 0.1231, n: 10 } });
+      formWrapper.vm.validate();
+      expect(
+        wrapper
+          .find({ ref: 'mValue' })
+          .find('.error--text')
+          .exists()
+      ).toBe(true);
+      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 1, n: 10 } });
+      formWrapper.vm.validate();
+      expect(
+        wrapper
+          .find({ ref: 'mValue' })
+          .find('.error--text')
+          .exists()
+      ).toBe(false);
+    });
     it('should flag if m < 1', () => {
       wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 0, n: 10 } });
       formWrapper.vm.validate();


### PR DESCRIPTION
## Description

Non-integer exercise success criteria will not be allowed.  If you are editing exercises:
- You will not paste non-integers into the M or N boxes
- You will not type decimals into the M or N boxes
- Even if you somehow manage to get them into the boxes, they won't be valid

#### Issue Addressed (if applicable)

https://github.com/learningequality/studio/issues/1774

## Steps to Test

- [ ] Edit an exercise with M of N success criteria
- [ ] Try typing decimals into the input boxes, and ensure that you cannot
- [ ] Try pasting a number with decimals into the input boxes, and ensure you cannot

## Implementation Notes 

#### At a high level, how did you implement this?

I used `@keypress` and `@paste` handlers, and additionally added a validation rule
#### Does this introduce any tech-debt items?

It could be useful to wrap this logic into a custom component if we ever need something like this again, since Vuetify 1.x doesn't have an integer input field.


## Checklist

- [x] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [x] Are there tests for this change?
- [x] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
