### PR TITLE
Sync endpoint robustifying and node creation bug fix

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1313,7 +1313,7 @@ class ContentNode(MPTTModel, models.Model):
     save.alters_data = True
 
     def delete(self, *args, **kwargs):
-        parent = self.parent or self._field_updates.changed('parent')
+        parent = self.parent or self._field_updates.changed().get('parent')
         if parent:
             parent.changed = True
             parent.save()

--- a/contentcuration/contentcuration/test_settings.py
+++ b/contentcuration/contentcuration/test_settings.py
@@ -5,3 +5,5 @@ DEBUG = True
 WEBPACK_LOADER["DEFAULT"][  # noqa
     "LOADER_CLASS"
 ] = "contentcuration.tests.webpack_loader.TestWebpackLoader"
+
+TEST_ENV = True

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -1,0 +1,318 @@
+from __future__ import absolute_import
+
+import uuid
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from le_utils.constants import content_kinds
+
+from contentcuration import models
+from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.tests import testdata
+from contentcuration.viewsets.sync.constants import CONTENTNODE
+from contentcuration.viewsets.sync.utils import generate_copy_event
+from contentcuration.viewsets.sync.utils import generate_create_event
+from contentcuration.viewsets.sync.utils import generate_update_event
+from contentcuration.viewsets.sync.utils import generate_delete_event
+
+
+class SyncTestCase(StudioAPITestCase):
+    @property
+    def sync_url(self):
+        return reverse("sync")
+
+    @property
+    def contentnode_metadata(self):
+        return {
+            "title": "Aron's cool contentnode",
+            "id": uuid.uuid4().hex,
+            "kind": content_kinds.VIDEO,
+            "description": "coolest contentnode this side of the Pacific",
+        }
+
+    @property
+    def contentnode_db_metadata(self):
+        return {
+            "title": "Aron's cool contentnode",
+            "id": uuid.uuid4().hex,
+            "kind_id": content_kinds.VIDEO,
+            "description": "coolest contentnode this side of the Pacific",
+            "parent_id": settings.ORPHANAGE_ROOT_ID,
+        }
+
+    def test_create_contentnode(self):
+        user = testdata.user()
+        self.client.force_authenticate(user=user)
+        contentnode = self.contentnode_metadata
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(contentnode["id"], CONTENTNODE, contentnode)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ContentNode.objects.get(id=contentnode["id"])
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode was not created")
+
+    def test_create_contentnodes(self):
+        user = testdata.user()
+        self.client.force_authenticate(user=user)
+        contentnode1 = self.contentnode_metadata
+        contentnode2 = self.contentnode_metadata
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_create_event(contentnode1["id"], CONTENTNODE, contentnode1),
+                generate_create_event(contentnode2["id"], CONTENTNODE, contentnode2),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ContentNode.objects.get(id=contentnode1["id"])
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode 1 was not created")
+
+        try:
+            models.ContentNode.objects.get(id=contentnode2["id"])
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode 2 was not created")
+
+    def test_update_contentnode(self):
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        new_title = "This is not the old title"
+
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {"title": new_title})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).title, new_title
+        )
+
+    def test_update_contentnodes(self):
+        user = testdata.user()
+        contentnode1 = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        contentnode2 = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        new_title = "This is not the old title"
+
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(
+                    contentnode1.id, CONTENTNODE, {"title": new_title}
+                ),
+                generate_update_event(
+                    contentnode2.id, CONTENTNODE, {"title": new_title}
+                ),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode1.id).title, new_title
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode2.id).title, new_title
+        )
+
+    def test_delete_contentnode(self):
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_delete_event(contentnode.id, CONTENTNODE)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ContentNode.objects.get(id=contentnode.id)
+            self.fail("ContentNode was not deleted")
+        except models.ContentNode.DoesNotExist:
+            pass
+
+    def test_delete_contentnodes(self):
+        user = testdata.user()
+        contentnode1 = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+
+        contentnode2 = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_delete_event(contentnode1.id, CONTENTNODE),
+                generate_delete_event(contentnode2.id, CONTENTNODE),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ContentNode.objects.get(id=contentnode1.id)
+            self.fail("ContentNode 1 was not deleted")
+        except models.ContentNode.DoesNotExist:
+            pass
+
+        try:
+            models.ContentNode.objects.get(id=contentnode2.id)
+            self.fail("ContentNode 2 was not deleted")
+        except models.ContentNode.DoesNotExist:
+            pass
+
+    def test_copy_contentnode(self):
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        new_node_id = uuid.uuid4().hex
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_copy_event(new_node_id, CONTENTNODE, contentnode.id, {})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        try:
+            new_node = models.ContentNode.objects.get(id=new_node_id)
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode was not copied")
+
+        self.assertEqual(new_node.parent_id, settings.ORPHANAGE_ROOT_ID)
+
+    def test_create_contentnode_moveable(self):
+        """
+        Regression test to ensure that nodes created here are able to be moved to
+        other MPTT trees without invalidating data.
+        """
+        user = testdata.user()
+        self.client.force_authenticate(user=user)
+        contentnode = self.contentnode_metadata
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(contentnode["id"], CONTENTNODE, contentnode)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            new_node = models.ContentNode.objects.get(id=contentnode["id"])
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode was not created")
+
+        new_root = models.ContentNode.objects.create(
+            title="Aron's cool contentnode",
+            kind_id=content_kinds.VIDEO,
+            description="coolest contentnode this side of the Pacific",
+        )
+
+        new_node.move_to(new_root, "last-child")
+
+        try:
+            new_node.get_root()
+        except models.ContentNode.MultipleObjectsReturned:
+            self.fail("Moving caused a breakdown of the tree structure")
+
+    def test_copy_contentnode_moveable(self):
+        """
+        Regression test to ensure that nodes created here are able to be moved to
+        other MPTT trees without invalidating data.
+        """
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        new_node_id = uuid.uuid4().hex
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_copy_event(new_node_id, CONTENTNODE, contentnode.id, {})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        try:
+            new_node = models.ContentNode.objects.get(id=new_node_id)
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode was not copied")
+
+        new_root = models.ContentNode.objects.create(
+            title="Aron's cool contentnode",
+            kind_id=content_kinds.VIDEO,
+            description="coolest contentnode this side of the Pacific",
+        )
+
+        new_node.move_to(new_root, "last-child")
+
+        try:
+            new_node.get_root()
+        except models.ContentNode.MultipleObjectsReturned:
+            self.fail("Moving caused a breakdown of the tree structure")
+
+
+class CRUDTestCase(StudioAPITestCase):
+    @property
+    def contentnode_metadata(self):
+        return {
+            "title": "Aron's cool contentnode",
+            "id": uuid.uuid4().hex,
+            "kind": content_kinds.VIDEO,
+            "description": "coolest contentnode this side of the Pacific",
+        }
+
+    @property
+    def contentnode_db_metadata(self):
+        return {
+            "title": "Aron's cool contentnode",
+            "id": uuid.uuid4().hex,
+            "kind_id": content_kinds.VIDEO,
+            "description": "coolest contentnode this side of the Pacific",
+            "parent_id": settings.ORPHANAGE_ROOT_ID,
+        }
+
+    def test_create_contentnode(self):
+        user = testdata.user()
+        self.client.force_authenticate(user=user)
+        contentnode = self.contentnode_metadata
+        response = self.client.post(
+            reverse("contentnode-list"), contentnode, format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        try:
+            models.ContentNode.objects.get(id=contentnode["id"])
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode was not created")
+
+    def test_update_contentnode(self):
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        new_title = "This is not the old title"
+
+        self.client.force_authenticate(user=user)
+        response = self.client.patch(
+            reverse("contentnode-detail", kwargs={"pk": contentnode.id}),
+            {"title": new_title},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).title, new_title
+        )
+
+    def test_delete_contentnode(self):
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+
+        self.client.force_authenticate(user=user)
+        response = self.client.delete(
+            reverse("contentnode-detail", kwargs={"pk": contentnode.id})
+        )
+        self.assertEqual(response.status_code, 204, response.content)
+        try:
+            models.ContentNode.objects.get(id=contentnode.id)
+            self.fail("ContentNode was not deleted")
+        except models.ContentNode.DoesNotExist:
+            pass

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -187,7 +187,7 @@ urlpatterns = [
     url(r'^api/set_channel_priority/$', views.set_channel_priority, name='set_channel_priority'),
     url(r'^api/download_channel_content_csv/(?P<channel_id>[^/]{32})$', views.download_channel_content_csv, name='download_channel_content_csv'),
     url(r'^api/probers/get_prober_channel', views.get_prober_channel, name='get_prober_channel'),
-    url(r'^^api/sync/$', sync, name="sync"),
+    url(r'^api/sync/$', sync, name="sync"),
     url(r'^api/get_clipboard_channels/$', views.get_clipboard_channels, name="get_clipboard_channels"),
 ]
 

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -170,7 +170,8 @@ for tree_name in channel_trees:
     )
 
 
-class AssessmentItemViewSet(ValuesViewset, CopyMixin, BulkCreateMixin, BulkUpdateMixin):
+# Apply mixin first to override ValuesViewset
+class AssessmentItemViewSet(BulkCreateMixin, BulkUpdateMixin, ValuesViewset, CopyMixin):
     queryset = AssessmentItem.objects.all()
     serializer_class = AssessmentItemSerializer
     permission_classes = [IsAuthenticated]

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -23,6 +23,9 @@ from contentcuration.models import generate_object_storage_name
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.base import BulkCreateMixin
+from contentcuration.viewsets.base import BulkUpdateMixin
+from contentcuration.viewsets.base import CopyMixin
 from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.common import NotNullArrayAgg
 from contentcuration.viewsets.common import UUIDInFilter
@@ -167,7 +170,7 @@ for tree_name in channel_trees:
     )
 
 
-class AssessmentItemViewSet(ValuesViewset):
+class AssessmentItemViewSet(ValuesViewset, CopyMixin, BulkCreateMixin, BulkUpdateMixin):
     queryset = AssessmentItem.objects.all()
     serializer_class = AssessmentItemSerializer
     permission_classes = [IsAuthenticated]
@@ -224,7 +227,7 @@ class AssessmentItemViewSet(ValuesViewset):
         queryset = queryset.annotate(file_ids=NotNullArrayAgg("files__id"))
         return queryset
 
-    def copy(self, pk, user=None, from_key=None, **mods):
+    def copy(self, pk, from_key=None, **mods):
         try:
             item = AssessmentItem.objects.get(assessment_id=from_key)
         except AssessmentItem.DoesNotExist:

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -17,7 +17,6 @@ from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.serializers import PrimaryKeyRelatedField
 
 from contentcuration.decorators import cache_no_user_data
 from contentcuration.models import Channel

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -239,6 +239,7 @@ class ChannelSerializer(BulkModelSerializer):
             "source_url",
             "demo_server_url",
         )
+        read_only_fields = ("version",)
         list_serializer_class = BulkListSerializer
         nested_writes = True
 

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -46,7 +46,7 @@ class ChannelSetSerializer(BulkModelSerializer):
         instance.secret_token.save()
         self.changes.append(
             generate_update_event(
-                instance.id, CHANNELSET, {"secret_token": instance.secret_token.token,},
+                instance.id, CHANNELSET, {"secret_token": instance.secret_token.token},
             )
         )
         return instance

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -30,6 +30,8 @@ from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.base import BulkUpdateMixin
+from contentcuration.viewsets.base import CopyMixin
 from contentcuration.viewsets.common import NotNullArrayAgg
 from contentcuration.viewsets.common import SQCount
 from contentcuration.viewsets.common import UUIDInFilter
@@ -243,7 +245,7 @@ for tree_name in channel_trees:
     )
 
 
-class ContentNodeViewSet(ValuesViewset):
+class ContentNodeViewSet(ValuesViewset, BulkUpdateMixin, CopyMixin):
     queryset = ContentNode.objects.all()
     serializer_class = ContentNodeSerializer
     permission_classes = [IsAuthenticated]
@@ -385,7 +387,7 @@ class ContentNodeViewSet(ValuesViewset):
             level=1,
         )
 
-    def copy(self, pk, user=None, from_key=None, **mods):
+    def copy(self, pk, from_key=None, **mods):
         delete_response = [
             dict(key=pk, table=CONTENTNODE, type=DELETED,),
         ]
@@ -410,7 +412,7 @@ class ContentNodeViewSet(ValuesViewset):
                 new_node.node_id = uuid.uuid4().hex
                 new_node.source_node_id = source.node_id
                 new_node.freeze_authoring_data = not Channel.objects.filter(
-                    pk=source.original_channel_id, editors=user
+                    pk=source.original_channel_id, editors=self.request.user
                 ).exists()
 
                 # Creating a new node, by default put it in the orphanage on initial creation.

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -224,7 +224,8 @@ for tree_name in channel_trees:
     )
 
 
-class ContentNodeViewSet(ValuesViewset, BulkUpdateMixin, CopyMixin):
+# Apply mixin first to override ValuesViewset
+class ContentNodeViewSet(BulkUpdateMixin, CopyMixin, ValuesViewset):
     queryset = ContentNode.objects.all()
     serializer_class = ContentNodeSerializer
     permission_classes = [IsAuthenticated]

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -339,7 +339,7 @@ class ContentNodeViewSet(BulkUpdateMixin, CopyMixin, ValuesViewset):
             | Q(tree_id=orphan_tree_id_subquery)
         )
 
-        return queryset
+        return queryset.exclude(pk=settings.ORPHANAGE_ROOT_ID)
 
     def get_edit_queryset(self):
         user_id = not self.request.user.is_anonymous() and self.request.user.id
@@ -351,7 +351,7 @@ class ContentNodeViewSet(BulkUpdateMixin, CopyMixin, ValuesViewset):
 
         queryset = queryset.filter(Q(edit=True) | Q(tree_id=orphan_tree_id_subquery))
 
-        return queryset
+        return queryset.exclude(pk=settings.ORPHANAGE_ROOT_ID)
 
     def annotate_queryset(self, queryset):
         queryset = queryset.annotate(total_count=(F("rght") - F("lft") - 1) / 2)

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -166,7 +166,7 @@ class ContentNodeSerializer(BulkModelSerializer):
         # Creating a new node, by default put it in the orphanage on initial creation.
         if "parent" not in validated_data:
             validated_data["parent_id"] = settings.ORPHANAGE_ROOT_ID
-        prerequisites = validated_data.pop("prerequisite")
+        prerequisites = validated_data.pop("prerequisite", [])
         self.prerequisite_ids = [prereq.id for prereq in prerequisites]
         return super(ContentNodeSerializer, self).create(validated_data)
 

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -45,13 +45,12 @@ ORPHAN_TREE_ID_CACHE_KEY = "orphan_tree_id_cache_key"
 
 def get_orphan_tree_id():
     if ORPHAN_TREE_ID_CACHE_KEY not in cache:
-        return (
-            ContentNode.objects.filter(id=settings.ORPHANAGE_ROOT_ID)
-            .values_list("tree_id", flat=True)
-            .get()
+        root, _new = ContentNode.objects.get_or_create(
+            id=settings.ORPHANAGE_ROOT_ID, kind_id=content_kinds.TOPIC
         )
         # No reason for this to change so can cache for a long time
-        cache.set(ORPHAN_TREE_ID_CACHE_KEY, 24 * 60 * 60)
+        cache.set(ORPHAN_TREE_ID_CACHE_KEY, root.tree_id, 24 * 60 * 60)
+        return root.tree_id
     else:
         return cache.get(ORPHAN_TREE_ID_CACHE_KEY)
 

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -3,7 +3,6 @@ import json
 import uuid
 
 from django.conf import settings
-from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Exists
 from django.db.models import F
@@ -23,15 +22,15 @@ from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 from contentcuration.models import ContentTag
 from contentcuration.models import File
-from contentcuration.models import User
 from contentcuration.models import generate_storage_url
 from contentcuration.models import PrerequisiteContentRelationship
+from contentcuration.models import User
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
-from contentcuration.viewsets.base import RequiredFilterSet
-from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.base import BulkUpdateMixin
 from contentcuration.viewsets.base import CopyMixin
+from contentcuration.viewsets.base import RequiredFilterSet
+from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.common import NotNullArrayAgg
 from contentcuration.viewsets.common import SQCount
 from contentcuration.viewsets.common import UUIDInFilter
@@ -40,23 +39,9 @@ from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.constants import UPDATED
 
 
-ORPHAN_TREE_ID_CACHE_KEY = "orphan_tree_id_cache_key"
-
 orphan_tree_id_subquery = ContentNode.objects.filter(
     pk=settings.ORPHANAGE_ROOT_ID
 ).values_list("tree_id", flat=True)[:1]
-
-
-def get_orphan_tree_id():
-    if ORPHAN_TREE_ID_CACHE_KEY not in cache:
-        root, _new = ContentNode.objects.get_or_create(
-            id=settings.ORPHANAGE_ROOT_ID, kind_id=content_kinds.TOPIC
-        )
-        # No reason for this to change so can cache for a long time
-        cache.set(ORPHAN_TREE_ID_CACHE_KEY, root.tree_id, 24 * 60 * 60)
-        return root.tree_id
-    else:
-        return cache.get(ORPHAN_TREE_ID_CACHE_KEY)
 
 
 class ContentNodeFilter(RequiredFilterSet):

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -17,6 +17,9 @@ from contentcuration.utils.files import duplicate_file
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.base import BulkCreateMixin
+from contentcuration.viewsets.base import BulkUpdateMixin
+from contentcuration.viewsets.base import CopyMixin
 from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.sync.constants import CREATED
@@ -110,7 +113,7 @@ for tree_name in channel_trees:
     )
 
 
-class FileViewSet(ValuesViewset):
+class FileViewSet(ValuesViewset, CopyMixin, BulkCreateMixin, BulkUpdateMixin):
     queryset = File.objects.all()
     serializer_class = FileSerializer
     permission_classes = [IsAuthenticated]
@@ -167,7 +170,7 @@ class FileViewSet(ValuesViewset):
 
         return queryset
 
-    def copy(self, pk, user=None, from_key=None, **mods):
+    def copy(self, pk, from_key=None, **mods):
         delete_response = [dict(key=pk, table=FILE, type=DELETED,)]
 
         try:

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -113,7 +113,8 @@ for tree_name in channel_trees:
     )
 
 
-class FileViewSet(ValuesViewset, CopyMixin, BulkCreateMixin, BulkUpdateMixin):
+# Apply mixin first to override ValuesViewset
+class FileViewSet(BulkCreateMixin, BulkUpdateMixin, CopyMixin, ValuesViewset):
     queryset = File.objects.all()
     serializer_class = FileSerializer
     permission_classes = [IsAuthenticated]

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -59,8 +59,7 @@ class InvitationSerializer(BulkModelSerializer):
                 )
                 add_event_for_user(user_id, event)
             instance.delete()
-        else:
-            return instance
+        return instance
 
 
 class InvitationFilter(FilterSet):

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -134,7 +134,10 @@ def handle_changes(request, viewset_class, change_type, changes):
                 # Capture exception and report, but allow sync
                 # to complete properly.
                 report_exception(e)
-                if getattr(settings, "DEBUG", False):
+
+                if getattr(settings, "DEBUG", False) or getattr(
+                    settings, "TEST_ENV", False
+                ):
                     raise
                 return changes, None
 

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -108,109 +108,35 @@ def get_change_order(obj):
     return change_order.index(change_type)
 
 
-def listify(thing):
-    return thing if isinstance(thing, list) else [thing]
-
-
-def create_handler(request, viewset, id_attr, changes_from_client):
-    new_data = list(
-        map(
-            lambda x: dict(
-                [(k, v) for k, v in x["obj"].items()] + [(id_attr, x["key"])]
-            ),
-            changes_from_client,
-        )
-    )
-    return viewset.bulk_create(request, data=new_data)
-
-
-def update_handler(request, viewset, id_attr, changes_from_client):
-    change_data = list(
-        map(
-            lambda x: dict(
-                [(k, v) for k, v in x["mods"].items()] + [(id_attr, x["key"])]
-            ),
-            changes_from_client,
-        )
-    )
-    return viewset.bulk_update(request, data=change_data)
-
-
-def delete_handler(request, viewset, id_attr, changes_from_client):
-    ids_to_delete = list(map(lambda x: x["key"], changes_from_client))
-    return viewset.bulk_delete(ids_to_delete)
-
-
-def move_handler(request, viewset, id_attr, changes_from_client):
-    errors = []
-    changes_to_return = []
-    for move in changes_from_client:
-        # Move change will have key, must also have target property
-        # optionally can include the desired position.
-        move_error, move_change = viewset.move(move["key"], **move["mods"])
-        if move_error:
-            move.update({"errors": [move_error]})
-            errors.append(move)
-        if move_change:
-            changes_to_return.extend(listify(move_change))
-    return errors, changes_to_return
-
-
-def copy_handler(request, viewset, id_attr, changes_from_client):
-    errors = []
-    changes_to_return = []
-    for copy in changes_from_client:
-        # Copy change will have key, must also have other attributes, defined in `copy`
-        copy_error, copy_change = viewset.copy(
-            copy["key"], user=request.user, from_key=copy["from_key"], **copy["mods"]
-        )
-        if copy_error:
-            copy.update({"errors": [copy_error]})
-            errors.append(copy)
-        if copy_change:
-            changes_to_return.extend(listify(copy_change))
-    return errors, changes_to_return
-
-
-def create_relation_handler(request, viewset, id_attr, changes_from_client):
-    errors = []
-    changes_to_return = []
-    for relation in changes_from_client:
-        # Create relation will have an object that at minimum has the keys
-        # for the two objects being related.
-        relation_error, relation_change = viewset.create_relation(request, relation)
-        if relation_error:
-            relation.update({"errors": [relation_error]})
-            errors.append(relation)
-        if relation_change:
-            changes_to_return.extend(listify(relation_change))
-    return errors, changes_to_return
-
-
-def delete_relation_handler(request, viewset, id_attr, changes_from_client):
-    errors = []
-    changes_to_return = []
-    for relation in changes_from_client:
-        # Delete relation will have an object that at minimum has the keys
-        # for the two objects whose relationship is being destroyed.
-        relation_error, relation_change = viewset.delete_relation(request, relation)
-        if relation_error:
-            relation.update({"errors": [relation_error]})
-            errors.append(relation)
-        if relation_change:
-            changes_to_return.extend(listify(relation_change))
-    return errors, changes_to_return
-
-
 event_handlers = {
-    CREATED: create_handler,
-    UPDATED: update_handler,
-    DELETED: delete_handler,
-    MOVED: move_handler,
-    COPIED: copy_handler,
-    CREATED_RELATION: create_relation_handler,
-    DELETED_RELATION: delete_relation_handler,
+    CREATED: "create_from_changes",
+    UPDATED: "update_from_changes",
+    DELETED: "delete_from_changes",
+    MOVED: "move_from_changes",
+    COPIED: "copy_from_changes",
+    CREATED_RELATION: "create_relation_from_changes",
+    DELETED_RELATION: "delete_relation_from_changes",
 }
+
+
+def handle_changes(request, viewset_class, change_type, changes):
+    try:
+        change_type = int(change_type)
+    except ValueError:
+        pass
+    else:
+        viewset = viewset_class(request=request)
+        viewset.initial(request)
+        if change_type in event_handlers:
+            try:
+                return getattr(viewset, event_handlers[change_type])(changes)
+            except Exception as e:
+                # Capture exception and report, but allow sync
+                # to complete properly.
+                report_exception(e)
+                if getattr(settings, "DEBUG", False):
+                    raise
+                return changes, None
 
 
 @authentication_classes((TokenAuthentication, SessionAuthentication))
@@ -228,30 +154,16 @@ def sync(request):
     for table_name, group in groupby(data, get_table):
         if table_name in viewset_mapping:
             viewset_class = viewset_mapping[table_name]
-            id_attr = viewset_class.id_attr()
             group = sorted(group, key=get_change_order)
             for change_type, changes in groupby(group, get_change_type):
-                try:
-                    change_type = int(change_type)
-                except ValueError:
-                    pass
-                else:
-                    viewset = viewset_class(request=request)
-                    viewset.initial(request)
-                    if change_type in event_handlers:
-                        try:
-                            es, cs = event_handlers[change_type](
-                                request, viewset, id_attr, changes
-                            )
-                            errors.extend(es)
-                            changes_to_return.extend(cs)
-                        except Exception as e:
-                            errors.extend(changes)
-                            # Capture exception and report, but allow sync
-                            # to complete properly.
-                            report_exception(e)
-                            if getattr(settings, "DEBUG", False):
-                                raise
+                # Coerce changes iterator to list so it can be read multiple times
+                es, cs = handle_changes(
+                    request, viewset_class, change_type, list(changes)
+                )
+                if es:
+                    errors.extend(es)
+                if cs:
+                    changes_to_return.extend(cs)
 
     # Add any changes that have been logged from elsewhere in our hacky redis
     # cache mechanism

--- a/contentcuration/contentcuration/viewsets/sync/utils.py
+++ b/contentcuration/contentcuration/viewsets/sync/utils.py
@@ -1,5 +1,6 @@
 from django.core.cache import cache
 
+from contentcuration.viewsets.sync.constants import COPIED
 from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import UPDATED
 from contentcuration.viewsets.sync.constants import DELETED
@@ -50,6 +51,17 @@ def generate_move_event(key, table, target, position):
         "position": position,
         "table": table,
         "type": MOVED,
+    }
+
+
+def generate_copy_event(key, table, from_key, mods):
+    validate_table(table)
+    return {
+        "key": key,
+        "from_key": from_key,
+        "mods": mods,
+        "table": table,
+        "type": COPIED,
     }
 
 


### PR DESCRIPTION
## Description

* Adds tests for Channel viewset
* Adds tests for ContentNode viewset
* Refactors sync endpoint to delegate change handling to viewsets
* Makes CRUD and sync handling parallel in viewsets
* Create mixins for opt-in bulk processing and change event handling
* Handles ContentNode creation in a way that does not mess up the orphanage tree
* Adds read/write permissions to orphanage tree for all authenticated users
* Adds regression test for bug for creation and copying events

## Steps to Test

- Create a topic or resource on a fresh DB
- Make sure the sync endpoint returns a 200
