### PR TITLE
Prevent modals from closing before unsaved changes confirmed/cancelled

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -1,8 +1,9 @@
 <template>
 
   <FullscreenModal
-    v-model="dialog"
+    :value="dialog"
     :header="headerText"
+    @input="onDialogInput"
   >
     <template v-if="step === 1 && !channelSet.isNew" #header>
       <span class="notranslate">{{ title }}</span>
@@ -215,13 +216,6 @@
         return this.channelSet.isNew ? this.$tr('createButton') : this.$tr('saveButton');
       },
     },
-    watch: {
-      dialog(newValue) {
-        if (!newValue) {
-          this.cancelChanges();
-        }
-      },
-    },
     beforeRouteEnter(to, from, next) {
       next(vm => {
         const channelSetId = to.params.channelSetId;
@@ -238,6 +232,13 @@
       ...mapActions('channel', ['loadChannelList']),
       ...mapActions('channelSet', ['updateChannelSet', 'loadChannelSet', 'deleteChannelSet']),
       ...mapMutations('channelSet', { setChannelSet: 'UPDATE_CHANNELSET' }),
+      onDialogInput(value) {
+        if (!value) {
+          this.cancelChanges();
+          return;
+        }
+        this.dialog = value;
+      },
       nameValid(name) {
         return name && name.length > 0 ? true : this.$tr('titleRequiredText');
       },

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -1,8 +1,9 @@
 <template>
 
   <FullscreenModal
-    v-model="dialog"
+    :value="dialog"
     :header="isNew? $tr('creatingHeader') : header"
+    @input="onDialogInput"
   >
     <template v-if="!isNew" #tabs>
       <VTab href="#edit" class="px-3" @click="currentTab = 'edit'">
@@ -214,13 +215,6 @@
         },
       },
     },
-    watch: {
-      dialog(newValue) {
-        if (!newValue) {
-          this.cancelChanges();
-        }
-      },
-    },
     beforeRouteEnter(to, from, next) {
       next(vm => {
         const channelId = to.params.channelId;
@@ -260,6 +254,13 @@
           // Go back to Details tab to show validation errors
           this.currentTab = false;
         }
+      },
+      onDialogInput(value) {
+        if (!value) {
+          this.cancelChanges();
+          return;
+        }
+        this.dialog = value;
       },
       setChannel(data) {
         for (let key in data) {


### PR DESCRIPTION
## Description

Fixes #2089
I've also opened a tech debt issue #2101

## Steps to Test

- [ ] *Open channel edit modal or collection edit modal*
- [ ] *Update values*
- [ ] *Close the modal*
- [ ] *Check that confirm/cancel dialog is displayed and the main modal is still displayed underneath*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

