### PR TITLE
Avoid duplicate calls in Channel Edit init w/ throttle and memoize

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -1,45 +1,11 @@
 import difference from 'lodash/difference';
 import union from 'lodash/union';
+import { memoizedThrottle } from './utils.js';
 import { NOVALUE } from 'shared/constants';
 import client from 'shared/client';
 import { RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
 import { ContentNode, Tree } from 'shared/data/resources';
 import { promiseChunk } from 'shared/utils';
-import throttle from 'lodash/throttle';
-import memoize from 'lodash/memoize';
-
-// lodash.memoize uses the first argument passed to the memoized fn
-// as its cache key. The first arg is always vuex context, so every call
-// may just use the same memoized results despite receiving different
-// parameters. We splice(1) to remove context altogether.
-const memoCacheResolver = (...args) => JSON.stringify(args.splice(1));
-
-// lodash.memoize a lodash.throttle function. Used to throttle any vuex
-// action we want so that the same parameters given to the function return
-// the same value no matter how many times it is called within `wait` ms.
-//
-// Usage: When multiple components may want the same vuex action but execute
-// the function conditionally based on whether the expected data exists, then 
-// we can ensure that this function is only called once every `wait` ms to avoid
-// duplicate API calls.
-//
-// We also clear the cache after `wait` number of seconds. We don't want to cache
-// longer than we're throttling for.
-//
-// Adapted with gratitude from @Galadirith's comment: 
-// https://github.com/lodash/lodash/issues/2403#issuecomment-290760787
-function memoizedThrottle(func, wait=0, opts={}) {
-  let memo = memoize(
-    function() {
-      return throttle(func, wait, opts);
-    }, 
-    memoCacheResolver
-  );
-  return function() { 
-    memo.apply(this, arguments).apply(this, arguments); 
-    setTimeout(memo.cache.clear, wait);
-  }
-}
 
 export const loadContentNodes = memoizedThrottle(
   function(context, params = {}) {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/utils.js
@@ -126,7 +126,7 @@ export function cacheKeyFromObject(...args) {
 export function memoizedThrottle(func, wait=0, opts={}) {
   // Adapted with gratitude from @Galadirith's comment: 
   // https://github.com/lodash/lodash/issues/2403#issuecomment-290760787
-  let memo = memoize(
+  const memo = memoize(
     function() {
       return throttle(func, wait, opts);
     }, 


### PR DESCRIPTION
## Description

There are several components where `loadChildren` is called. Many of those components call it in their `mounted` or `created` hooks conditionally - basically asking "Is the data I want in the store? No, then `loadChildren()`!" 

Since the components are checking for data before any other component has successfully retrieved the data - they all will call dispatch the `loadChildren` action within ms of each other.

---

I think we should reevaluate our use of the `created` and/or `mounted` hooks for Vuex store initialization across components. Ideally we would initialize things in one place and make everything else wait to render until it's done.

---

This solution that I worked out instead kind of gives us license to be reckless with our data initialization by using `lodash.throttle && lodash.memoize`.

Roughly speaking - we memoize (cache) the results of a throttled function for as long as it is throttled. This is done because `memoize` uses the first argument given as it's cache key and since it's throttling a vuex action, it gets `context` as the first arg. 

So - anyway - we cache it for `wait` ms and then clear the cache. This results in multiple dispatches to `loadChildren` and `loadContentNodes` _with the same paramters_ to only end up being called once every `wait` ms. After `wait` ms, subsequent calls with the same parameters will be called because the cache is cleared.

Frankly, this needs some tests and might be a sideways or unnecessarily complicated approach with only one real application. Whereas revising how/where we make our initialization call(s) may be a bit more of a refactor. I'll revisit this after getting some feedback and revise accordingly.

#### Issue Addressed (if applicable)

Fixes #1882 

## Steps to Test

- [ ] Before checking this out, go to a channel edit for a channel and watch the network tab in devtools. Watch for duplicate values.
- [ ] Check this PR out and start fresh (clear local cache to be sure)
- [ ] Go to that same channel and see that all of the calls were only made once.
- [ ] Navigate throughout the channel both using the tree view and the main view.

- Any performance issues between the two branches?
- Any errors or issues found while navigating between sections?

## Checklist


*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
