### PR TITLE
showInvalidText on report issue KTextbox

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/ReportIssueForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/ReportIssueForm.vue
@@ -18,18 +18,21 @@
       v-model="operating_system"
       :label="$tr('OSLabel')"
       :invalid="errors.operating_system"
+      :showInvalidText="errors.operating_system"
       :invalidText="$tr('fieldRequiredText')"
     />
     <KTextbox
       v-model="browser"
       :label="$tr('browserLabel')"
       :invalid="errors.browser"
+      :showInvalidText="errors.browser"
       :invalidText="$tr('fieldRequiredText')"
     />
     <KTextbox
       v-model="channel"
       :label="$tr('channelLabel')"
       :invalid="errors.channel"
+      :showInvalidText="errors.channel"
       :invalidText="$tr('fieldRequiredText')"
     />
     <KTextbox
@@ -37,6 +40,7 @@
       :label="$tr('descriptionLabel')"
       textArea
       :invalid="errors.description"
+      :showInvalidText="errors.description"
       :invalidText="$tr('fieldRequiredText')"
     />
   </KModal>


### PR DESCRIPTION
## Description

Include the `showInvalidText` prop on `KTextBox` because typically we only show validations on fields that have been focused and then blurred, but we can force it to show anyway if we also pass the `showInvalidText` prop.

#### Issue Addressed (if applicable)

Fixes #1947

## Steps to Test

- [ ] Go to settings -> using studio -> report issue and click "Submit" and see errors on the 3 fields that are required.