### PR TITLE
Enable back button when browsing the Content Library page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/mixins.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/mixins.js
@@ -97,7 +97,7 @@ export const catalogFilterMixin = {
       this.navigate({});
     },
     navigate(params) {
-      this.$router.replace({
+      this.$router.push({
         ...this.$route,
         query: {
           ...params,


### PR DESCRIPTION
## Description

The Content Library (a.k.a. Catalog) page was using vue-router's `router.replace`, which doesn't call `history.pushState`.  Switching to `router.push` will enable the back button while browsing the Content Library page, which could be useful if, for example, someone changes their filter but forgets exactly how and they just want to bail out and go back to the previous filter state.

The immediate issue this resolves is #2051.

## Steps to Test

- [ ] Navigate to the Content Library page
- [ ] Add a filter
- [ ] Press the back button
- [ ] Ensure that filter gets removed

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?

## Comments

My main uncertainty is around why we were using `router.replace` in the first place?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
