### PR TITLE
Fixed import modal styling

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -3,7 +3,7 @@
   <VCard @click="handleClick">
     <VCardTitle>
       <VLayout row wrap>
-        <VFlex sm2 xs12 class="pt-4">
+        <VFlex sm2 xs12 class="pt-4 px-4">
           <Thumbnail
             :src="node.thumbnail_src"
             :kind="node.kind"
@@ -35,36 +35,22 @@
               </template>
             </span>
           </VLayout>
-          <ActionLink
-            :text="node.title"
-            class="headline my-2 notranslate"
-            @click="$emit('preview')"
-          />
-          <div
+          <h3>
+            <ActionLink
+              :text="node.title"
+              class="headline my-2 notranslate"
+              @click="$emit('preview')"
+            />
+          </h3>
+          <ToggleText
             v-if="node.description"
-            class="notranslate"
-            :class="{'text-truncate': !showWholeDescription && descriptionIsLong}"
-          >
-            {{ node.description }}
-          </div>
+            :text="node.description"
+            notranslate
+          />
 
           <div v-if="tagsString">
             {{ $tr('tagsList', { tags: tagsString }) }}
           </div>
-          <VBtn
-            v-if="descriptionIsLong"
-            small
-            flat
-            class="show-more-btn"
-            @click.stop="showWholeDescription = !showWholeDescription"
-          >
-            <span>
-              {{ showWholeDescription ? $tr('showLessLabel') : $tr('showMoreLabel') }}
-              <Icon class="arrow-icon">
-                {{ showWholeDescription ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
-              </Icon>
-            </span>
-          </VBtn>
         </VFLex>
       </VLayout>
     </VCardTitle>
@@ -90,10 +76,10 @@
 
 <script>
 
-  import get from 'lodash/get';
   import IconButton from 'shared/views/IconButton';
   import Thumbnail from 'shared/views/files/Thumbnail';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
+  import ToggleText from 'shared/views/ToggleText';
   import { constantsTranslationMixin } from 'shared/mixins';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
@@ -104,6 +90,7 @@
       ContentNodeIcon,
       IconButton,
       Thumbnail,
+      ToggleText,
     },
     mixins: [constantsTranslationMixin],
     props: {
@@ -120,11 +107,6 @@
         type: Boolean,
         default: false,
       },
-    },
-    data() {
-      return {
-        showWholeDescription: false,
-      };
     },
     computed: {
       languageName() {
@@ -164,10 +146,6 @@
         }
         return this.$tr('resourcesCount', { count });
       },
-      descriptionIsLong() {
-        // "long" arbitrarily means it's longer than 120 characters
-        return get(this.node, ['description', 'length']) > 120;
-      },
       numLocations() {
         return this.node.location_ids.length;
       },
@@ -192,8 +170,6 @@
       },
     },
     $trs: {
-      showMoreLabel: 'Show more',
-      showLessLabel: 'Show less',
       tagsList: 'Tags: {tags}',
       goToSingleLocationAction: 'Go to location',
       goToPluralLocationsAction:

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -35,12 +35,10 @@
               </template>
             </span>
           </VLayout>
-          <h3>
-            <ActionLink
-              :text="node.title"
-              class="headline my-2 notranslate"
-              @click="$emit('preview')"
-            />
+          <h3 class="text-truncate my-2">
+            <a class="headline notranslate" @click="$emit('preview')">
+              {{ node.title }}
+            </a>
           </h3>
           <ToggleText
             v-if="node.description"
@@ -207,6 +205,14 @@
     cursor: pointer;
     &:hover {
       background-color: var(--v-greyBackground-base);
+    }
+  }
+  h3 {
+    // Hack to resolve card resizing when title is too long
+    width: 100px;
+    min-width: 100%;
+    a {
+      text-decoration: underline;
     }
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
@@ -2,13 +2,14 @@
 
   <VCard :to="channelRoute">
     <VCardTitle>
-      <VLayout row>
-        <VFlex sm2 xs12>
+      <VLayout row wrap>
+        <VFlex sm2 xs12 class="px-3">
           <VLayout align-center justify-center fill-height>
             <Thumbnail
               v-if="channel.thumbnail_url"
               :src="channel.thumbnail_url"
               :encoding="channel.thumbnail_encoding"
+              style="width: 100%;"
             />
             <Icon v-else size="80px" class="channel-icon">
               apps
@@ -30,28 +31,11 @@
             <h3 class="headline my-2 notranslate">
               {{ channel.name }}
             </h3>
-            <div
+            <ToggleText
               v-if="channel.description"
-              :class="{'text-truncate': !showWholeDescription && descriptionIsLong }"
-              class="notranslate"
-            >
-              {{ channel.description }}
-            </div>
-            <VBtn
-              v-if="descriptionIsLong"
-              small
-              flat
-              class="show-more-btn"
-              color="primary"
-              @click.stop.prevent="showWholeDescription = !showWholeDescription"
-            >
-              <span>
-                {{ showWholeDescription ? $tr('showLessLabel') : $tr('showMoreLabel') }}
-                <Icon class="arrow-icon">
-                  {{ showWholeDescription ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
-                </Icon>
-              </span>
-            </VBtn>
+              :text="channel.description"
+              notranslate
+            />
           </div>
         </VFLex>
       </VLayout>
@@ -65,11 +49,12 @@
 
   import { constantsTranslationMixin } from 'shared/mixins';
   import Thumbnail from 'shared/views/files/Thumbnail';
+  import ToggleText from 'shared/views/ToggleText';
 
   export default {
     name: 'ChannelInfoCard',
     inject: ['RouterNames'],
-    components: { Thumbnail },
+    components: { Thumbnail, ToggleText },
     mixins: [constantsTranslationMixin],
     props: {
       channel: {
@@ -77,18 +62,9 @@
         required: true,
       },
     },
-    data() {
-      return {
-        showWholeDescription: false,
-      };
-    },
     computed: {
       languageName() {
         return this.translateLanguage(this.channel.language);
-      },
-      descriptionIsLong() {
-        // "long" arbitrarily means it's longer than 120 characters
-        return this.channel.description.length > 120;
       },
       channelRoute() {
         return {
@@ -101,8 +77,6 @@
       },
     },
     $trs: {
-      showMoreLabel: 'Show more',
-      showLessLabel: 'Show less',
       resourceCount: '{count, number} {count, plural, one {resource} other {resources}}',
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -185,4 +185,4 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style scoped></style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -30,7 +30,7 @@
             @change="toggleSelected(node)"
           />
         </VFlex>
-        <VFlex class="pa-4" grow>
+        <VFlex class="pa-4">
           <BrowsingCard
             :ref="node.id"
             :node="node"

--- a/contentcuration/contentcuration/frontend/shared/views/ToggleText.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ToggleText.vue
@@ -10,9 +10,8 @@
         </span>
       </VSlideYTransition>
     </p>
-
     <p class="mt-2">
-      <a v-if="overflowText" class="toggler" @click.stop="toggle">
+      <a v-if="overflowText" class="toggler" @click.stop.prevent="toggle">
         {{ togglerText }}
         <Icon small>
           {{ expanded ? 'expand_less' : 'expand_more' }}


### PR DESCRIPTION
## Description

Fixes channel thumbnails not showing up (need to set width), text causing the cards to grow (removed grow attribute), and uses ToggleText component to fix the show more action link

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/1988

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?