### PR TITLE
Fixed styling around navigation drawer

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -1,6 +1,7 @@
 <template>
 
   <VLayout row wrap>
+    <LoadingText v-if="root && loading" absolute />
     <VFlex
       v-if="node && !root"
       tag="v-flex"
@@ -13,12 +14,12 @@
     >
       <ContextMenu :disabled="!allowEditing">
         <VLayout row align-center>
-          <VFlex shrink style="min-width: 40px;">
+          <VFlex shrink style="min-width: 40px;" class="text-xs-center">
             <VBtn
               v-if="showExpansion"
               icon
-              small
               data-test="expansionToggle"
+              class="ma-0"
               :style="{transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)'}"
               @click.stop="toggle"
             >
@@ -26,16 +27,16 @@
             </VBtn>
           </VFlex>
           <VFlex shrink>
-            <Icon class="ma-1">
+            <Icon class="mx-1">
               {{ hasContent ? "folder" : "folder_open" }}
             </Icon>
           </VFlex>
           <VFlex
             xs9
-            class="notranslate text-truncate px-1"
+            class="notranslate text-truncate px-1 caption"
             :style="{color: $vuetify.theme.darkGrey}"
           >
-            <VTooltip bottom open-delay="750">
+            <VTooltip bottom open-delay="500">
               <template #activator="{ on }">
                 <span v-on="on">{{ node.title }}</span>
               </template>
@@ -58,7 +59,6 @@
               <template #activator="{ on }">
                 <VBtn
                   class="topic-menu ma-0 mr-2"
-                  small
                   icon
                   flat
                   v-on="on"
@@ -105,12 +105,14 @@
   import ContentNodeOptions from '../ContentNodeOptions';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import ContextMenu from 'shared/views/ContextMenu';
+  import LoadingText from 'shared/views/LoadingText';
 
   export default {
     name: 'StudioTree',
     components: {
       ContextMenu,
       ContentNodeOptions,
+      LoadingText,
     },
     props: {
       treeId: {
@@ -217,6 +219,12 @@
 </script>
 
 <style scoped lang="less">
+
+  // size causes rows to shift
+  .v-btn {
+    width: 24px;
+    height: 24px;
+  }
 
   .topic-menu {
     display: none;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -32,7 +32,7 @@
           clipped
           localName="topic-tree"
           class="hidden-xs-only"
-          :maxWidth="400"
+          :maxWidth="500"
           :minWidth="200"
           style="height: unset"
           :style="{backgroundColor: $vuetify.theme.backgroundColor}"
@@ -64,9 +64,9 @@
             />
           </div>
         </ResizableNavigationDrawer>
-        <VContainer fluid class="pa-0 ma-0" style="height: calc(100vh - 64px);">
+        <VContent class="pa-0 ma-0" style="height: calc(100vh - 64px);">
           <CurrentTopicView :topicId="nodeId" :detailNodeId="detailNodeId" />
-        </VContainer>
+        </VContent>
       </VLayout>
     </VContainer>
   </TreeViewBase>


### PR DESCRIPTION
Fixes some of the styling reported at the QA session around the topic tree navigation drawer
* Smaller text
* Max width increased to 500px

![image](https://user-images.githubusercontent.com/7447496/91206687-63279500-e6bc-11ea-9b4e-b98db8eb4de7.png)
