### PR TITLE
no status message about the file if no errors or file

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -63,7 +63,7 @@ export const fileStatusMixin = {
         return errorMessage;
       }
       const file = this.getFileUpload(checksum);
-      if (file.total) {
+      if (file && file.total) {
         return statusStrings.$tr('uploadFileSize', {
           uploaded: bytesForHumans(file.loaded),
           total: bytesForHumans(file.total),


### PR DESCRIPTION
## Description

`statusMessage` method in `shared/mixins.js` tries to get a file and did not account for what to return if there is no file (which is nothing).

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2114

## Steps to Test

Read https://github.com/learningequality/studio/issues/2114 and replicate the error on `develop` - then check out this PR and see that the error message no longer shows.


