### PR TITLE
Added clipboard action to resource drawer

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -165,6 +165,7 @@
             small
             icon="content_copy"
             :text="$tr('copyToClipboardButton')"
+            @click="copyToClipboard([detailNodeId])"
           />
         </template>
       </ResourceDrawer>


### PR DESCRIPTION
Fixes [this issue](https://www.notion.so/learningequality/Clicking-copy-icon-in-resource-drawer-doesn-t-do-anything-a5497260b6bc470b854bb7218238b92f)