### PR TITLE
Load the clipboard tree before adding to it

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -379,7 +379,7 @@
           actionCallback: () => changeTracker.revert(),
         });
 
-        const copyPromise = this.copyAll({ id__in, deep: true }).then(() => {
+        this.copyAll({ id__in, deep: true }).then(() => {
           const nodes = id__in.map(id => this.getContentNode(id));
           const hasResource = nodes.find(n => n.kind !== 'topic');
           const hasTopic = nodes.find(n => n.kind === 'topic');
@@ -398,15 +398,6 @@
             actionCallback: () => changeTracker.revert(),
           });
         });
-
-        // If clipboardNode comes back undefined, the clipboard hasn't been
-        // loaded yet - so we must load it before returning the above Promise.
-        const clipboardNode = this.getContentNode(window.user.clipboard_root_id);
-        if (!clipboardNode) {
-          return this.loadClipboardTree().then(() => copyPromise);
-        } else {
-          return copyPromise;
-        }
       }),
       duplicateNodes: withChangeTracker(function(id__in, changeTracker) {
         const count = id__in.length;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -401,13 +401,12 @@
 
         // If clipboardNode comes back undefined, the clipboard hasn't been
         // loaded yet - so we must load it before returning the above Promise.
-        const clipboardNode = this.getContentNode(window.user.clipboard_root_id)
-        if(!clipboardNode) {
+        const clipboardNode = this.getContentNode(window.user.clipboard_root_id);
+        if (!clipboardNode) {
           return this.loadClipboardTree().then(() => copyPromise);
         } else {
           return copyPromise;
         }
-
       }),
       duplicateNodes: withChangeTracker(function(id__in, changeTracker) {
         const count = id__in.length;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -309,7 +309,6 @@
         'loadAncestors',
         'moveContentNodes',
         'copyContentNodes',
-        'loadClipboardTree',
       ]),
       ...mapActions('clipboard', ['copyAll']),
       ...mapMutations('contentNode', { setMoveNodes: 'SET_MOVE_NODES' }),

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -309,6 +309,7 @@
         'loadAncestors',
         'moveContentNodes',
         'copyContentNodes',
+        'loadClipboardTree',
       ]),
       ...mapActions('clipboard', ['copyAll']),
       ...mapMutations('contentNode', { setMoveNodes: 'SET_MOVE_NODES' }),
@@ -378,7 +379,7 @@
           actionCallback: () => changeTracker.revert(),
         });
 
-        return this.copyAll({ id__in, deep: true }).then(() => {
+        const copyPromise = this.copyAll({ id__in, deep: true }).then(() => {
           const nodes = id__in.map(id => this.getContentNode(id));
           const hasResource = nodes.find(n => n.kind !== 'topic');
           const hasTopic = nodes.find(n => n.kind === 'topic');
@@ -397,6 +398,16 @@
             actionCallback: () => changeTracker.revert(),
           });
         });
+
+        // If clipboardNode comes back undefined, the clipboard hasn't been
+        // loaded yet - so we must load it before returning the above Promise.
+        const clipboardNode = this.getContentNode(window.user.clipboard_root_id)
+        if(!clipboardNode) {
+          return this.loadClipboardTree().then(() => copyPromise);
+        } else {
+          return copyPromise;
+        }
+
       }),
       duplicateNodes: withChangeTracker(function(id__in, changeTracker) {
         const count = id__in.length;

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
@@ -167,9 +167,18 @@ export function copy(context, { id, target = null, deep = false, children = [] }
 }
 
 export function copyAll(context, { id__in, deep = false }) {
-  return promiseChunk(id__in, 20, idChunk => {
+  const clipboardNode = context.rootGetters['contentNode/getContentNode'](window.user.clipboard_root_id);
+  const copyPromise = promiseChunk(id__in, 20, idChunk => {
     return Promise.all(idChunk.map(id => context.dispatch('copy', { id, deep })));
   });
+
+  // We need to check if the clipboard tree is initialized before we try to copy.
+  if(!clipboardNode) {
+    return context.dispatch('contentNode/loadClipboardTree', null, { root: true })
+      .then(() => copyPromise);
+  } else {
+    return copyPromise;
+}
 }
 
 /**

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
@@ -167,18 +167,21 @@ export function copy(context, { id, target = null, deep = false, children = [] }
 }
 
 export function copyAll(context, { id__in, deep = false }) {
-  const clipboardNode = context.rootGetters['contentNode/getContentNode'](window.user.clipboard_root_id);
+  const clipboardNode = context.rootGetters['contentNode/getContentNode'](
+    window.user.clipboard_root_id
+  );
   const copyPromise = promiseChunk(id__in, 20, idChunk => {
     return Promise.all(idChunk.map(id => context.dispatch('copy', { id, deep })));
   });
 
   // We need to check if the clipboard tree is initialized before we try to copy.
-  if(!clipboardNode) {
-    return context.dispatch('contentNode/loadClipboardTree', null, { root: true })
+  if (!clipboardNode) {
+    return context
+      .dispatch('contentNode/loadClipboardTree', null, { root: true })
       .then(() => copyPromise);
   } else {
     return copyPromise;
-}
+  }
 }
 
 /**

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -49,15 +49,14 @@ export function loadTrashTree(context, tree_id) {
 export function loadClipboardTree(context) {
   const tree_id = context.rootGetters['clipboardRootId'];
   return client.get(window.Urls.get_clipboard_channels()).then(response => {
-    if(response.data && response.data.length) {
+    if (response.data && response.data.length) {
       return promiseChunk(response.data, 1, ids =>
         context.dispatch('loadTree', { tree_id, channel_id: ids[0] })
       );
     } else {
       // If response comes back as [] then we still want to load the tree,
       // but just don't have to worry about channels
-      return context.dispatch('loadTree', { tree_id })
-        .then(nodes => Promise.resolve(nodes));
+      return context.dispatch('loadTree', { tree_id }).then(nodes => Promise.resolve(nodes));
     }
   });
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -49,9 +49,16 @@ export function loadTrashTree(context, tree_id) {
 export function loadClipboardTree(context) {
   const tree_id = context.rootGetters['clipboardRootId'];
   return client.get(window.Urls.get_clipboard_channels()).then(response => {
-    return promiseChunk(response.data, 1, ids =>
-      context.dispatch('loadTree', { tree_id, channel_id: ids[0] })
-    );
+    if(response.data.length) {
+      return promiseChunk(response.data, 1, ids =>
+        context.dispatch('loadTree', { tree_id, channel_id: ids[0] })
+      );
+    } else {
+      // If response comes back as [] then we still want to load the tree,
+      // but just don't have to worry about channels
+      return context.dispatch('loadTree', { tree_id })
+        .then(nodes => Promise.resolve(nodes));
+    }
   });
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -49,7 +49,7 @@ export function loadTrashTree(context, tree_id) {
 export function loadClipboardTree(context) {
   const tree_id = context.rootGetters['clipboardRootId'];
   return client.get(window.Urls.get_clipboard_channels()).then(response => {
-    if(response.data.length) {
+    if(response.data && response.data.length) {
       return promiseChunk(response.data, 1, ids =>
         context.dispatch('loadTree', { tree_id, channel_id: ids[0] })
       );


### PR DESCRIPTION
## Description

Ensure that we've loaded the clipboard tree nodes prior to adding to it.

Additionally, the `contentNode/loadClipboardTree` action would not work properly if the clipboard is empty because `contentNode/loadTree` wasn't being called when there were no channels returned form `/api/get_clipboard_channels/`.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2122
Fixes https://github.com/learningequality/studio/issues/2118
Fixes https://github.com/learningequality/studio/issues/2108

## Steps to Test

In Channel Edit, can you select 1 or more nodes and "Copy to Clipboard" successfully?

Please review the three linked issues and see that they each are fixed by this.

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?