### PR TITLE
Fix issue going back from Channel Edit

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -45,6 +45,7 @@ const router = new VueRouter({
             params: {
               nodeId,
             },
+            replace: true,
           });
         });
       },


### PR DESCRIPTION
## Description

When we enter the root route `TREE_ROOT_VIEW` we init some Vuex then redirect to `TREE_VIEW`. This would `push` the new route - this PR ensures that we replace it so that there are no unnecessary history entries.

#### Issue Addressed (if applicable)

Fixes: https://github.com/learningequality/studio/issues/2069

## Steps to Test

Go to Channel Edit to edit a channel. Click your browser's back button. You should be returned to the previous page as expected. (ie, if you go to the Channel Edit from `/my-channels`, you should go back to it from the editor).

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Neat to note that the `next()` function in nav guards take a `replace` option that allows you to do a `router.replace` instead of the default `router.push`. *neat!*