### PR TITLE
Catalog filters fix

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/mixins.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/mixins.js
@@ -81,7 +81,7 @@ export const catalogFilterMixin = {
   },
   methods: {
     setQueryParam(field, value) {
-      let params = this.$route.query;
+      let params = Object.assign({}, { ...this.$route.query });
       if (isArray(value)) {
         value = uniq(value).join(',');
       }


### PR DESCRIPTION
## Description

Catalog filters were not working due to how we tried to update the route's query params.

Need to `Object.assign(...)` when borrowing `this.$route.*` so that we can modify a copy and replace the existing route.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2073

## Steps to Test

Go to the "Content Library" catalog view and mess w/ the filters. They ought to work as expected. The URL's query params should reflect your selections. You should be able to update your filter selections both by way of the form *and* by removing them using the little `x` icons in the chips/pillboxes that appear above the channel list.

