### PR TITLE
Make sure repr calls on Serializers don't evaluate querysets…

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -53,6 +53,22 @@ from contentcuration.statistics import record_node_addition_stats
 from contentcuration.utils.format import format_size
 
 
+def no_field_eval_repr(self):
+    """
+    DRF's default __repr__ implementation prints out all fields, and in the process
+    of that can evaluate querysets. If those querysets haven't yet had filters applied,
+    this will lead to full table scans, which are a big no-no if you like running servers.
+    """
+    return "{} object".format(self.__class__.__name__)
+
+
+# We have to monkey patch because DRF has some internal logic that returns a
+# ListSerializer object when a Serializer-derived object is requested if many=True.
+# Monkey-patching also means we don't have to worry about missing any serializers, tho. :)
+serializers.ListSerializer.__repr__ = no_field_eval_repr
+serializers.ModelSerializer.__repr__ = no_field_eval_repr
+
+
 class LicenseSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/contentcuration/contentcuration/tests/test_serializers.py
+++ b/contentcuration/contentcuration/tests/test_serializers.py
@@ -1,9 +1,5 @@
-import inspect
-import logging
-
-from django.db.models.query import QuerySet
-
 from base import BaseAPITestCase
+from django.db.models.query import QuerySet
 
 from contentcuration.models import ContentNode
 from contentcuration.serializers import ContentNodeSerializer
@@ -17,7 +13,7 @@ def ensure_no_querysets_in_serializer(object):
         assert not isinstance(object[field], QuerySet), '{} is not serialized'.format(field)
 
 
-class ContentNodeSErializerTestCase(BaseAPITestCase):
+class ContentNodeSerializerTestCase(BaseAPITestCase):
     def test_fields_are_json_serializable(self):
         """
         The serializer should return data that is ready for serialization, and not in 'object' form.
@@ -27,3 +23,25 @@ class ContentNodeSErializerTestCase(BaseAPITestCase):
         objects = ContentNodeSerializer(ContentNode.objects.filter(node_id__in=node_ids), many=True).data
         for object in objects:
             ensure_no_querysets_in_serializer(object)
+
+    def test_repr_doesnt_evaluate_querysets(self):
+        node_ids = [
+            "00000000000000000000000000000003",
+            "00000000000000000000000000000004",
+            "00000000000000000000000000000005",
+        ]
+        objects = ContentNodeSerializer(
+            ContentNode.objects.filter(node_id__in=node_ids), many=True
+        )
+
+        object = ContentNodeSerializer(
+            ContentNode.objects.get(node_id=node_ids[0])
+        )
+
+        # Ensure we don't evaluate querysets when repr is called on a Serializer. See docs for
+        # no_field_eval_repr in contentcuration/serializers.py for more info.
+        obj_string = repr(object)
+        assert "QuerySet" not in obj_string, "object __repr__ contains queryset: {}".format(obj_string)
+
+        objs_string = repr(objects)
+        assert "QuerySet" not in objs_string, "objects __repr__ contains queryset: {}".format(objs_string)


### PR DESCRIPTION
…potentially causing full table scans.

## Description

DRF's `__repr__` code for Serializer-based objects prints out all the fields and their properties. In the case of a queryset, this will cause it to evaluate. If the `repr` method is called before the queryset has had filters applied, it may return `Table.objects.all()`, in other words the entire table. Even with filtering, it's a waste of valuable resources for us to be making DB calls in response to a `repr` call on a Serializer, so this PR simply ensures this can no longer happen by overriding DRF's `__repr__` implementation. 

Note that this behavior could be part of the reason that we get a cascade of error reports when certain errors happen. The error report generation leads to full table scans on tables like ContentNode, which bogs down the db, and then users try the failed operation again, causing another table scan, and soon enough everything is timing out, which leads to more Sentry reports...

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
