### PR TITLE
Propagate the correct parent_id in tree generation.

### DIFF
--- a/contentcuration/contentcuration/utils/db_tools.py
+++ b/contentcuration/contentcuration/utils/db_tools.py
@@ -312,7 +312,7 @@ class TreeBuilder(object):
                     node = self.generate_leaf(parent_id)
                 else:
                     node = self.generate_topic(parent_id=parent_id)
-                    node["children"] = self.recurse_and_generate(parent_id, levels - 1)
+                    node["children"] = self.recurse_and_generate(node["id"], levels - 1)
                 children.append(node)
         return children
 


### PR DESCRIPTION
## Description

* Fixes a bug in the treebuilder implementation that incorrectly passed down the root parent_id to all descendants

