### PR TITLE
disable the channel VSelect while loading during import from channels

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -9,6 +9,7 @@
           :label="$tr('channelFilterLabel')"
           :items="channelFilterOptions"
           :menu-props="{offsetY: true}"
+          :disabled="loading"
           box
         />
       </VFlex>


### PR DESCRIPTION
## Description

During "Import from channels" process - the dropdown filtering which kind of channels previously allowed users to quickly switch between selections but did not handle the case of a user triggering another load causing issues.

This solution disables the dropdown while we're loading. We may opt later to optimize this so that people can change their selection without having to wait for the change to load.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2110

## Steps to Test

Go Edit Channel -> Add -> Import from channels and then try to change the selection of the "Channels" dropdown before it loads. This may be difficult to test locally if you don't have many channels. I set my Dev Tools -> Network -> "Online" to instead be "Fast 3G" once I had loaded the page to slow down the triggered requests enough that I could see the field be disabled as it ought to be.

