### PR TITLE
Channel creation bug fix - use diffTracker in commitChannel 

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -241,7 +241,7 @@
         if (this.$refs.detailsform.validate()) {
           this.changed = false;
           if (this.isNew) {
-            return this.commitChannel(this.channelId).then(() => {
+            return this.commitChannel({ id: this.channelId, ...this.diffTracker }).then(() => {
               // TODO: Make sure channel gets created before navigating to channel
               window.location = window.Urls.channel(this.channelId);
             });

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -55,11 +55,62 @@ export function createChannel(context) {
   return channel.id;
 }
 
-export function commitChannel(context, channelId) {
-  const channel = context.state.channelsMap[channelId];
-  if (channel) {
-    return Channel.createModel(channel).then(() => {
-      context.commit('SET_CHANNEL_NOT_NEW', channelId);
+export function commitChannel(
+  context,
+  {
+    id,
+    name = NOVALUE,
+    description = NOVALUE,
+    thumbnailData = NOVALUE,
+    language = NOVALUE,
+    contentDefaults = NOVALUE,
+    demo_server_url = NOVALUE,
+    source_url = NOVALUE,
+    deleted = NOVALUE,
+    isPublic = NOVALUE,
+  } = {}
+) {
+  if (context.state.channelsMap[id]) {
+    if (!id) {
+      throw ReferenceError('id must be defined to update a channel');
+    }
+    const channelData = { id };
+    if (name !== NOVALUE) {
+      channelData.name = name;
+    }
+    if (description !== NOVALUE) {
+      channelData.description = description;
+    }
+    if (thumbnailData !== NOVALUE) {
+      channelData.thumbnail = thumbnailData.thumbnail;
+      channelData.thumbnail_url = thumbnailData.thumbnail_url;
+      channelData.thumbnail_encoding = thumbnailData.thumbnail_encoding || {};
+    }
+    if (language !== NOVALUE) {
+      channelData.language = language;
+    }
+    if (demo_server_url !== NOVALUE) {
+      channelData.demo_server_url = demo_server_url;
+    }
+    if (source_url !== NOVALUE) {
+      channelData.source_url = source_url;
+    }
+    if (deleted !== NOVALUE) {
+      channelData.deleted = deleted;
+    }
+    if (isPublic !== NOVALUE) {
+      channelData.public = isPublic;
+    }
+    if (contentDefaults !== NOVALUE) {
+      const originalData = context.state.channelsMap[id].content_defaults;
+      // Pick out only content defaults that have been changed.
+      contentDefaults = pickBy(contentDefaults, (value, key) => value !== originalData[key]);
+      if (Object.keys(contentDefaults).length) {
+        channelData.content_defaults = contentDefaults;
+      }
+    }
+    return Channel.createModel(channelData).then(() => {
+      context.commit('SET_CHANNEL_NOT_NEW', channelData);
     });
   }
 }


### PR DESCRIPTION
## Description

The `commitChannel` action's signature matches `updateChannel` and works similarly until it doesn't.

#### Issue Addressed (if applicable)

No known reported issue addressed.

However, the issue was that creating a channel would not work because the newly implemented `diffTracker` pattern where a component (in this case ChannelModal) will locally track changes to fields and pass them to the `commit/updateChannel` actions depending on whether or not the Channel is `new` or not.

## Steps to Test

Make a new channel and you should be redirected to `channelEdit` for that new channel.

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*

I initially wanted to DRY the repeated field-specific logic a bit but decided that there's no need. Maybe someday we'll want the `commit*` and the `update*` to handle a certain field differently than the other, so it's a pretty inoffensive repetition of code.


