### PR TITLE
Formulas plugin and MathQuill documentation

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.css
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.css
@@ -1,5 +1,15 @@
 /* stylelint-disable */
 
+/* * * * * * * * * * * ATTENTION * * * * * * * * * * *
+ * This file contains some LEq customizations,
+ * so there's a need to be careful to reflect them
+ * if we upgrade MathQuill one day (or eventually
+ * create MathQuill fork if there's a need to upgrade
+ * often). For more information see the formulas plugin
+ * documentation docs/markdown_editor_viewer.md
+ * or commit 576b21d1f5664042dfe294b7e789829040e24c8e
+ * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 /*
  * MathQuill v0.10.1               http://mathquill.com
  * by Han, Jeanine, and Mary  maintainers@mathquill.com
@@ -9,13 +19,6 @@
  * was not distributed with this file, You can obtain
  * one at http://mozilla.org/MPL/2.0/.
  */
-@font-face {
-  font-family: Symbola;
-  src: url(font/Symbola.eot);
-  src: local('Symbola Regular'), local('Symbola'), url(font/Symbola.woff2) format('woff2'),
-    url(font/Symbola.woff) format('woff'), url(font/Symbola.ttf) format('truetype'),
-    url(font/Symbola.otf) format('opentype'), url(font/Symbola.svg#Symbola) format('svg');
-}
 .mq-editable-field {
   display: -moz-inline-box;
   display: inline-block;
@@ -109,7 +112,7 @@
 .mq-math-mode var,
 .mq-math-mode .mq-text-mode,
 .mq-math-mode .mq-nonSymbola {
-  font-family: 'Times New Roman', Symbola, serif;
+  font-family: MathJax, serif;
   line-height: 0.9;
 }
 .mq-math-mode * {
@@ -142,7 +145,7 @@
   box-shadow: inset darkgray 0 0.1em 0.2em;
 }
 .mq-math-mode .mq-font {
-  font: 1em 'Times New Roman', Symbola, serif;
+  font: 1em MathJax, serif;
 }
 .mq-math-mode .mq-font * {
   font-family: inherit;
@@ -191,10 +194,10 @@
   font-style: normal;
 }
 .mq-math-mode .mq-sans-serif {
-  font-family: sans-serif, Symbola, serif;
+  font-family: sans-serif, MathJax, serif;
 }
 .mq-math-mode .mq-monospace {
-  font-family: monospace, Symbola, serif;
+  font-family: monospace, MathJax, serif;
 }
 .mq-math-mode .mq-overline {
   margin-top: 1px;
@@ -265,7 +268,7 @@
   display: block;
 }
 .mq-math-mode .mq-operator-name {
-  font-family: Symbola, 'Times New Roman', serif;
+  font-family: MathJax, 'Times New Roman', serif;
   font-style: normal;
   line-height: 0.9;
 }
@@ -357,7 +360,7 @@
 }
 .mq-math-mode,
 .mq-math-mode .mq-editable-field {
-  font-family: Symbola, 'Times New Roman', serif;
+  font-family: MathJax, 'Times New Roman', serif;
   cursor: text;
 }
 .mq-math-mode .mq-overarrow {

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.css
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.css
@@ -9,6 +9,13 @@
  * was not distributed with this file, You can obtain
  * one at http://mozilla.org/MPL/2.0/.
  */
+@font-face {
+  font-family: Symbola;
+  src: url(font/Symbola.eot);
+  src: local('Symbola Regular'), local('Symbola'), url(font/Symbola.woff2) format('woff2'),
+    url(font/Symbola.woff) format('woff'), url(font/Symbola.ttf) format('truetype'),
+    url(font/Symbola.otf) format('opentype'), url(font/Symbola.svg#Symbola) format('svg');
+}
 .mq-editable-field {
   display: -moz-inline-box;
   display: inline-block;
@@ -102,7 +109,7 @@
 .mq-math-mode var,
 .mq-math-mode .mq-text-mode,
 .mq-math-mode .mq-nonSymbola {
-  font-family: MathJax, serif;
+  font-family: 'Times New Roman', Symbola, serif;
   line-height: 0.9;
 }
 .mq-math-mode * {
@@ -135,7 +142,7 @@
   box-shadow: inset darkgray 0 0.1em 0.2em;
 }
 .mq-math-mode .mq-font {
-  font: 1em MathJax, serif;
+  font: 1em 'Times New Roman', Symbola, serif;
 }
 .mq-math-mode .mq-font * {
   font-family: inherit;
@@ -184,10 +191,10 @@
   font-style: normal;
 }
 .mq-math-mode .mq-sans-serif {
-  font-family: sans-serif, MathJax, serif;
+  font-family: sans-serif, Symbola, serif;
 }
 .mq-math-mode .mq-monospace {
-  font-family: monospace, MathJax, serif;
+  font-family: monospace, Symbola, serif;
 }
 .mq-math-mode .mq-overline {
   margin-top: 1px;
@@ -258,7 +265,7 @@
   display: block;
 }
 .mq-math-mode .mq-operator-name {
-  font-family: MathJax, 'Times New Roman', serif;
+  font-family: Symbola, 'Times New Roman', serif;
   font-style: normal;
   line-height: 0.9;
 }
@@ -350,7 +357,7 @@
 }
 .mq-math-mode,
 .mq-math-mode .mq-editable-field {
-  font-family: MathJax, 'Times New Roman', serif;
+  font-family: Symbola, 'Times New Roman', serif;
   cursor: text;
 }
 .mq-math-mode .mq-overarrow {

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.css
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.css
@@ -7,7 +7,7 @@
  * create MathQuill fork if there's a need to upgrade
  * often). For more information see the formulas plugin
  * documentation docs/markdown_editor_viewer.md
- * or commit 576b21d1f5664042dfe294b7e789829040e24c8e
+ * or commit 9c85577761a75d1c3c216496f4e3373e57623699
  * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /*

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+
 /**
  * MathQuill v0.10.1               http://mathquill.com
  * by Han, Jeanine, and Mary  maintainers@mathquill.com
@@ -594,11 +595,11 @@
    *******************************************/
 
   /* The main thing that manipulates the Math DOM. Makes sure to manipulate the
-    HTML DOM to match. */
+HTML DOM to match. */
 
   /* Sort of singletons, since there should only be one per editable math
-    textbox, but any one HTML document can contain many such textboxes, so any one
-    JS environment could actually contain many instances. */
+textbox, but any one HTML document can contain many such textboxes, so any one
+JS environment could actually contain many instances. */
 
   //A fake cursor in the fake textbox that the math is rendered in.
   var Cursor = P(Point, function(_) {
@@ -1053,17 +1054,22 @@
           el = ctrlr.container;
         ctrlr.createTextarea();
 
-        el.attr('data-formula', el.text());
-
         var contents = el
           .addClass(classNames)
           .contents()
           .detach();
-
         root.jQ = $('<span class="mq-root-block"/>')
           .attr(mqBlockId, root.id)
           .appendTo(el);
         this.latex(contents.text());
+
+        this.revert = function() {
+          return el
+            .empty()
+            .unbind('.mathquill')
+            .removeClass('mq-editable-field mq-math-mode mq-text-mode')
+            .append(contents);
+        };
       };
       _.config = function(opts) {
         config(this.__options, opts);
@@ -1094,17 +1100,6 @@
       _.reflow = function() {
         this.__controller.root.postOrder('reflow');
         return this;
-      };
-      _.revert = function() {
-        const el = this.__controller.container;
-        const formula = el.attr('data-formula');
-
-        return el
-          .empty()
-          .unbind('.mathquill')
-          .removeClass('mq-editable-field mq-math-mode mq-text-mode mq-focused')
-          .removeAttr('data-formula')
-          .text(formula);
       };
     }));
     MQ.prototype = AbstractMathQuill.prototype;
@@ -2722,30 +2717,30 @@
 
     // methods involved in creating and cross-linking with HTML DOM nodes
     /*
-        They all expect an .htmlTemplate like
-          '<span>&0</span>'
-        or
-          '<span><span>&0</span><span>&1</span></span>'
+    They all expect an .htmlTemplate like
+      '<span>&0</span>'
+    or
+      '<span><span>&0</span><span>&1</span></span>'
 
-        See html.test.js for more examples.
+    See html.test.js for more examples.
 
-        Requirements:
-        - For each block of the command, there must be exactly one "block content
-          marker" of the form '&<number>' where <number> is the 0-based index of the
-          block. (Like the LaTeX \newcommand syntax, but with a 0-based rather than
-          1-based index, because JavaScript because C because Dijkstra.)
-        - The block content marker must be the sole contents of the containing
-          element, there can't even be surrounding whitespace, or else we can't
-          guarantee sticking to within the bounds of the block content marker when
-          mucking with the HTML DOM.
-        - The HTML not only must be well-formed HTML (of course), but also must
-          conform to the XHTML requirements on tags, specifically all tags must
-          either be self-closing (like '<br/>') or come in matching pairs.
-          Close tags are never optional.
+    Requirements:
+    - For each block of the command, there must be exactly one "block content
+      marker" of the form '&<number>' where <number> is the 0-based index of the
+      block. (Like the LaTeX \newcommand syntax, but with a 0-based rather than
+      1-based index, because JavaScript because C because Dijkstra.)
+    - The block content marker must be the sole contents of the containing
+      element, there can't even be surrounding whitespace, or else we can't
+      guarantee sticking to within the bounds of the block content marker when
+      mucking with the HTML DOM.
+    - The HTML not only must be well-formed HTML (of course), but also must
+      conform to the XHTML requirements on tags, specifically all tags must
+      either be self-closing (like '<br/>') or come in matching pairs.
+      Close tags are never optional.
 
-        Note that &<number> isn't well-formed HTML; if you wanted a literal '&123',
-        your HTML template would have to have '&amp;123'.
-      */
+    Note that &<number> isn't well-formed HTML; if you wanted a literal '&123',
+    your HTML template would have to have '&amp;123'.
+  */
     _.numBlocks = function() {
       var matches = this.htmlTemplate.match(/&\d+/g);
       return matches ? matches.length : 0;
@@ -3571,15 +3566,15 @@
   LatexCmds.quad = LatexCmds.emsp = bind(VanillaSymbol, '\\quad ', '    ');
   LatexCmds.qquad = bind(VanillaSymbol, '\\qquad ', '        ');
   /* spacing special characters, gonna have to implement this in LatexCommandInput::onText somehow
-    case ',':
-      return VanillaSymbol('\\, ',' ');
-    case ':':
-      return VanillaSymbol('\\: ','  ');
-    case ';':
-      return VanillaSymbol('\\; ','   ');
-    case '!':
-      return Symbol('\\! ','<span style="margin-right:-.2em"></span>');
-    */
+case ',':
+  return VanillaSymbol('\\, ',' ');
+case ':':
+  return VanillaSymbol('\\: ','  ');
+case ';':
+  return VanillaSymbol('\\; ','   ');
+case '!':
+  return Symbol('\\! ','<span style="margin-right:-.2em"></span>');
+*/
 
   //binary operators
   LatexCmds.diamond = bind(VanillaSymbol, '\\diamond ', '&#9671;');

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
@@ -7,7 +7,7 @@
  * create MathQuill fork if there's a need to upgrade
  * often). For more information see the formulas plugin
  * documentation docs/markdown_editor_viewer.md
- * or commit 576b21d1f5664042dfe294b7e789829040e24c8e
+ * or commit 9c85577761a75d1c3c216496f4e3373e57623699
  * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /**

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
@@ -1,5 +1,15 @@
 /* eslint-disable */
 
+/* * * * * * * * * * * ATTENTION * * * * * * * * * * *
+ * This file contains some LEq customizations,
+ * so there's a need to be careful to reflect them
+ * if we upgrade MathQuill one day (or eventually
+ * create MathQuill fork if there's a need to upgrade
+ * often). For more information see the formulas plugin
+ * documentation docs/markdown_editor_viewer.md
+ * or commit 576b21d1f5664042dfe294b7e789829040e24c8e
+ * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 /**
  * MathQuill v0.10.1               http://mathquill.com
  * by Han, Jeanine, and Mary  maintainers@mathquill.com
@@ -1054,6 +1064,8 @@ JS environment could actually contain many instances. */
           el = ctrlr.container;
         ctrlr.createTextarea();
 
+        el.attr('data-formula', el.text());
+
         var contents = el
           .addClass(classNames)
           .contents()
@@ -1068,6 +1080,7 @@ JS environment could actually contain many instances. */
             .empty()
             .unbind('.mathquill')
             .removeClass('mq-editable-field mq-math-mode mq-text-mode')
+            .removeAttr('data-formula')
             .append(contents);
         };
       };

--- a/docs/markdown_editor_viewer.md
+++ b/docs/markdown_editor_viewer.md
@@ -44,14 +44,44 @@ TUI editor uses the following 3rd party libraries and exposes their API for publ
 
 ## Custom plugins
 
-### Formulas editor
+Our custom plugins are located in [plugins directory](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins).
 
-TBD
+### [Formulas editor plugin](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas)
 
-#### HTML → Markdown
-#### Markdown → HTML
+#### Adding new formulas
+
+1. A new formula's LaTeX representation is inserted as a new HTML element using `getSquire().insertHTML()`. It is also assigned a special class to denote that it is a new math field so that later we know which fields should be initialized as MathQuill static math fields.
+
+2. HTML is converted to markdown (conversions logic will be described later)
+
+3. All new math fields are initialized as MathQuill static math fields
+
+#### Editing existing formulas
+
+The steps are the same as when adding a new formula, except that instead of inserting a new formula element with `getSquire().insertHTML()`, an active element being edited is replaced by a new HTML using `parentNode.replaceChild()`.
+
 #### MathQuill
 
-### Images upload
+We use [MathQuill's static math fields](http://docs.mathquill.com/en/latest/Getting_Started/#static-math-rendering) to render formulas in a list of all formulas in the formulas menu and in the editor. [Editable math fields](http://docs.mathquill.com/en/latest/Getting_Started/#editable-math-fields) are used in the edit part of the formulas menu.
+
+##### Customizations
+
+There is one customization in MathQuill code related to formulas logic: When initializing MathQuill fields (MathQuill replaces an element with its own HTML during that process), we add `data-formula` attribute to the root math element. Its value is the original formula's LaTeX representation. This attribute is used as a basis for conversion from HTML to markdown.
+
+*Important*
+All MathQuill customizations are saved in [this commit](https://github.com/learningequality/studio/commit/576b21d1f5664042dfe294b7e789829040e24c8e). There's a need to be careful to reflect them if we upgrade MathQuill one day (or create MathQuill fork for the sake of clarity if there's a need to upgrade more often or add more customizations).
+
+#### [HTML to Markdown conversion](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-html-to-md.js)
+
+All elements in the input HTML containing `data-formula` attribute are replaced by a value saved in that attribute and wrapped in double `$`.
+
+#### [Markdown to HTML conversion](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-md-to-html.js)
+
+All markdown substrings wrapped in double `$` are converted to `span` element and assigned `math-field` class. We use this class to know which elements should be initialized with MathQuill.
+
+This conversion is needed for rendering content in WYSIWYG after the first load (and eventually in the future if we allow users to switch to markdown mode on the fly) because we store markdown on our servers.
+
+
+### [Image upload plugin](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload)
 
 TBD

--- a/docs/markdown_editor_viewer.md
+++ b/docs/markdown_editor_viewer.md
@@ -68,7 +68,7 @@ We use [MathQuill's static math fields](http://docs.mathquill.com/en/latest/Gett
 
 There is one customization in MathQuill code related to formulas logic: When initializing MathQuill fields (MathQuill replaces an element with its own HTML during that process), we add `data-formula` attribute to the root math element. Its value is the original formula's LaTeX representation. This attribute is used as a basis for conversion from HTML to markdown.
 
-*Important*
+**Important**
 All MathQuill customizations are saved in [this commit](https://github.com/learningequality/studio/commit/9c85577761a75d1c3c216496f4e3373e57623699). There's a need to be careful to reflect them if we upgrade MathQuill one day (or create MathQuill fork for the sake of clarity if there's a need to upgrade more often or add more customizations).
 
 #### [HTML to Markdown conversion](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-html-to-md.js)

--- a/docs/markdown_editor_viewer.md
+++ b/docs/markdown_editor_viewer.md
@@ -69,7 +69,7 @@ We use [MathQuill's static math fields](http://docs.mathquill.com/en/latest/Gett
 There is one customization in MathQuill code related to formulas logic: When initializing MathQuill fields (MathQuill replaces an element with its own HTML during that process), we add `data-formula` attribute to the root math element. Its value is the original formula's LaTeX representation. This attribute is used as a basis for conversion from HTML to markdown.
 
 *Important*
-All MathQuill customizations are saved in [this commit](https://github.com/learningequality/studio/commit/576b21d1f5664042dfe294b7e789829040e24c8e). There's a need to be careful to reflect them if we upgrade MathQuill one day (or create MathQuill fork for the sake of clarity if there's a need to upgrade more often or add more customizations).
+All MathQuill customizations are saved in [this commit](https://github.com/learningequality/studio/commit/9c85577761a75d1c3c216496f4e3373e57623699). There's a need to be careful to reflect them if we upgrade MathQuill one day (or create MathQuill fork for the sake of clarity if there's a need to upgrade more often or add more customizations).
 
 #### [HTML to Markdown conversion](../contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-html-to-md.js)
 


### PR DESCRIPTION
## Description

Document markdown editor formulas plugin.
Make clear and document what's the original MathQuill code and what are our customizations (closes #1852). It will make more sense to review commit by commit.