### PR TITLE
Don't use delay_mptt_updates as only a single node should change tree…

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -242,42 +242,41 @@ class CustomListSerializer(serializers.ListSerializer):
             record_node_addition_stats(update_nodes, ContentNode.objects.get(id=update_nodes.itervalues().next()['id']),
                                        self.context['request'].user.id)
             with transaction.atomic():
-                with ContentNode.objects.delay_mptt_updates():
-                    for node_id, data in update_nodes.items():
-                        node, is_new = ContentNode.objects.get_or_create(pk=node_id)
+                for node_id, data in update_nodes.items():
+                    node, is_new = ContentNode.objects.get_or_create(pk=node_id)
 
-                        taglist = []
-                        for tag_data in tag_mapping.get(node_id, None):
-                            # when deleting nodes, tag_data is a dict, but when adding nodes, it's a unicode string
-                            if isinstance(tag_data, unicode):
-                                tag_data = json.loads(tag_data)
+                    taglist = []
+                    for tag_data in tag_mapping.get(node_id, None):
+                        # when deleting nodes, tag_data is a dict, but when adding nodes, it's a unicode string
+                        if isinstance(tag_data, unicode):
+                            tag_data = json.loads(tag_data)
 
-                            # this requires optimization
-                            for tag_itm in all_tags:
-                                if tag_itm.tag_name == tag_data['tag_name'] \
-                                        and tag_itm.channel_id == tag_data['channel']:
-                                    taglist.append(tag_itm)
+                        # this requires optimization
+                        for tag_itm in all_tags:
+                            if tag_itm.tag_name == tag_data['tag_name'] \
+                                    and tag_itm.channel_id == tag_data['channel']:
+                                taglist.append(tag_itm)
 
-                        # Detect if model has been moved to a different tree
-                        if node.pk is not None:
-                            original = ContentNode.objects.get(pk=node.pk)
-                            if original.parent_id and original.parent_id != node.parent_id:
-                                original_parent = ContentNode.objects.get(pk=original.parent_id)
-                                original_parent.changed = True
-                                original_parent.save()
+                    # Detect if model has been moved to a different tree
+                    if node.pk is not None:
+                        original = ContentNode.objects.get(pk=node.pk)
+                        if original.parent_id and original.parent_id != node.parent_id:
+                            original_parent = ContentNode.objects.get(pk=original.parent_id)
+                            original_parent.changed = True
+                            original_parent.save()
 
-                        # potential optimization opportunity
-                        for attr, value in data.items():
-                            setattr(node, attr, value)
-                        node.tags = taglist
+                    # potential optimization opportunity
+                    for attr, value in data.items():
+                        setattr(node, attr, value)
+                    node.tags = taglist
 
-                        node.save(request=self.context['request'])
+                    node.save(request=self.context['request'])
 
-                        PrerequisiteContentRelationship.objects.filter(target_node_id=node_id).delete()
-                        for prereq_node in prerequisite_mapping.get(node_id) or []:
-                            PrerequisiteContentRelationship.objects.get_or_create(target_node_id=node_id, prerequisite_id=prereq_node.id)
-                        node.save(request=self.context['request'])
-                        ret.append(node)
+                    PrerequisiteContentRelationship.objects.filter(target_node_id=node_id).delete()
+                    for prereq_node in prerequisite_mapping.get(node_id) or []:
+                        PrerequisiteContentRelationship.objects.get_or_create(target_node_id=node_id, prerequisite_id=prereq_node.id)
+                    node.save(request=self.context['request'])
+                    ret.append(node)
         return ret
 
     def to_representation(self, data):


### PR DESCRIPTION
…s each call.

## Description

When we use `delay_mptt_updates`, it ensures the entire tree will get re-indexed, which will be much slower than the more optimized node insertion / move logic that is triggered otherwise. As the only known case for `CustomListSerializer` having a `ContentNode` move operation is the move from garbage tree case, there should only be one insertion / move per endpoint call, making `delay_mptt_updates` slow us down rather than speed us up.

#### Issue Addressed (if applicable)

(Hopefully) Many of the hundreds of errors and deadlocks we've seen over the past week.

## Steps to Test

Ideally, use a large tree to perform these operations:

- [ ] Add a node
- [ ] Move / copy nodes
- [ ] Delete nodes

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
