### PR TITLE
Add some more error handling and logging to the image upload

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -159,6 +159,19 @@
           this.initImageFields();
         }
       },
+      'file.error'() {
+        // eslint-disable-next-line
+        console.error('The image could not be uploaded');
+      },
+      'file.progress'(progress) {
+        if (progress === 0) {
+          // eslint-disable-next-line
+          console.log('The image upload has started');
+        } else if (progress === 1) {
+          // eslint-disable-next-line
+          console.log('The image upload has finished');
+        }
+      },
       'file.file_on_disk'(src) {
         if (src) {
           this.insertImageToEditor({ src, alt: '' });

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -185,6 +185,17 @@ export function uploadFile(context, { file }) {
                 contentType: response.data['mimetype'],
               })
               .then(response => {
+                // This should ideally not happen when a successful
+                // response is returned but let's be careful to report
+                // it appropriately (e.g. we watch "file_on_disk" in our
+                // components so when an empty response was returned here,
+                // the file upload failed silently)
+                if (!response.data) {
+                  context.commit('ADD_FILEUPLOAD', {
+                    checksum,
+                    error: fileErrors.UPLOAD_FAILED,
+                  });
+                }
                 context.commit('ADD_FILEUPLOAD', { checksum, file_on_disk: response.data });
               })
               .catch(() => {


### PR DESCRIPTION
## Description

I've discovered several places where some more information would be useful for debugging purposes while documenting image uploading. I assume that we'll implement some UX to display errors and upload progress but for now I added at least some logging. I am going to open follow-up issues and link them here soon.
