### PR TITLE
Allow adding text before a formula field when formula is a first entity in the markdown editor

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -587,10 +587,8 @@
         if (activeMathFieldEl !== null) {
           activeMathFieldEl.parentNode.replaceChild(formulaEl, activeMathFieldEl);
         } else {
-          // if creating a new element, insert a non-breaking space to allow users
-          // continue writing a text (otherwise cursor would stay stuck in a formula
-          // field)
-          this.editor.getSquire().insertHTML(formulaEl.outerHTML + '&nbsp;');
+          // insert non-breaking spaces to allow users to write text before and after
+          this.editor.getSquire().insertHTML('&nbsp;' + formulaEl.outerHTML + '&nbsp;');
         }
 
         this.initStaticMathFields({ newOnly: true });
@@ -686,7 +684,10 @@
           imageEl.classList.add(CLASS_IMG_FIELD_NEW);
           imageEl.src = imageData.src;
           imageEl.alt = imageData.alt;
+
+          // insert non-breaking spaces to allow users to write text before and after
           this.editor.getSquire().insertHTML('&nbsp;' + imageEl.outerHTML + '&nbsp;');
+
           this.initImageFields({ newOnly: true });
         }
         this.resetImagesMenu();

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/__tests__/plugins/formulas/formula-html-to-md.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/__tests__/plugins/formulas/formula-html-to-md.spec.js
@@ -48,11 +48,5 @@ describe('MarkdownEditor - extensions - formulas', () => {
 
       expect(formulaHtmlToMd(input)).toBe('$${a}^{b}$$ Have fun!');
     });
-
-    it('replaces non-breakable space character with an empty character', () => {
-      const input = 'Please solve: <span data-formula="3+5y=2"></span>&nbsp;';
-
-      expect(formulaHtmlToMd(input)).toBe('Please solve: $$3+5y=2$$ ');
-    });
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-html-to-md.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-html-to-md.js
@@ -40,11 +40,5 @@ export default html => {
   }
 
   let newHtml = doc.body.innerHTML;
-
-  // when inserting a new formula to editor, a non-breakable space
-  // is inserted after the formula HTML - they should be replaced
-  // with an empty character in markdown
-  newHtml = newHtml.replace(/&nbsp;/g, ' ');
-
   return newHtml;
 };


### PR DESCRIPTION
## Description

I've noticed that I can't add a text before a formula if it's the first entity in the markdown editor.

- Add non-breakable space before the formula
- Remove duplicate logic for the conversion of non-breakable spaces to markdown

## Steps to Test

- [ ] *Open an assessment item and open a markdown editor for a question*
- [ ] *Clear its content completely*
- [ ] *Insert a new formula*
- [ ] *Check that you can add a text before the formula*