### PR TITLE
Ensure we can exit from the new channel modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -117,6 +117,7 @@
           this.$router.push({
             name: RouterNames.CHANNEL_EDIT,
             params: { channelId: id },
+            query: { last: this.$route.name },
           });
         });
       },


### PR DESCRIPTION
## Description
Fixes an issue where it wasn't possible to exit the `ChannelModal` right after creating a new channel.

#### Issue Addressed

Addresses #2154 

## Steps to Test

- [ ] Starting from `/channels/`, make a new channel 
- [ ] Click the close button ("x") in the upper left corner
- [ ] Ensure that the Channel edit modal is closed and you're back where you started from.

## Implementation Notes

I made sure that `$route.query.last` was passed in.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
