### PR TITLE
Load staged channel in created() not route hook to show loader

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VLayout row wrap>
-    <LoadingText v-if="root && loading" absolute />
+    <LoadingText v-if="root && loading" class="loading-text" absolute />
     <VFlex
       v-if="node && !root"
       tag="v-flex"
@@ -240,6 +240,13 @@
   .slide-y-transition-enter-active,
   .slide-y-transition-leave-active {
     transition-duration: 0.25s;
+  }
+
+  .loading-text {
+    /* Centers the loading spinner in the tree view vertically */
+
+    /* 56px is the height of appbar in this context */
+    max-height: calc(100vh - 56px);
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -44,10 +44,12 @@ const ACTIONS = {
     loadChannel: jest.fn(),
   },
   currentChannel: {
+    loadChannel: jest.fn(),
     loadCurrentChannelStagingDiff: jest.fn(),
     deployCurrentChannel: jest.fn(),
   },
   contentNode: {
+    loadTree: jest.fn(),
     loadAncestors: jest.fn(),
     loadChildren: jest.fn(),
     loadContentNode: jest.fn(),

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -423,7 +423,7 @@
       },
     },
     created() {
-      return this.loadCurrentChannel({staging: true})
+      return this.loadCurrentChannel({ staging: true })
         .then(channel => {
           if (channel.staging_root_id) {
             return this.loadTree({ tree_id: channel.staging_root_id });
@@ -437,7 +437,7 @@
             this.loadAncestors({ id: this.nodeId, includeSelf: true }),
             this.loadChildren({ parent: this.nodeId, tree_id: this.stagingId }),
           ]).then(() => {
-            this.isLoading = false
+            this.isLoading = false;
             this.loadCurrentChannelStagingDiff();
           });
         })

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -73,19 +73,6 @@ const router = new VueRouter({
       path: '/staging/:nodeId/:detailNodeId?',
       props: true,
       component: StagingTreePage,
-      beforeEnter: (to, from, next) => {
-        return store
-          .dispatch('currentChannel/loadChannel', { staging: true })
-          .then(channel => {
-            if (channel.staging_root_id) {
-              return store.dispatch('contentNode/loadTree', { tree_id: channel.staging_root_id });
-            }
-          })
-          .catch(error => {
-            throw new Error(error);
-          })
-          .then(() => next());
-      },
     },
     {
       name: RouterNames.ADD_PREVIOUS_STEPS,


### PR DESCRIPTION
## Description

- Remove `beforeRouteEnter` hook from `StagingTreePage` route. 
- Implement the data init logic from that hook in `StagingTreePage.created()`
- Apply styling to `StudioTree` so that the `<LoadingText.../>` component cannot be so tall that its loader isn't visible unless you scroll down the page. This was very obvious because `StudioTree` would take longer to load than the channel I was testing on that had 200 topics in its root.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2106

## Steps to Test

1. Find a ricecooker channel that you want to use - such as the one created by the `devsetup` command. Go to that channel and extract its ID from the URL (which will be the `<ID>` in `/channels/<ID>`).
2. Create a file `contentcuration/make_staged.py` with the following code (replace the `<ID>` on line 2 with your own`<ID>` that you extracted above)

```
from contentcuration.models import Channel, ContentNode
c = Channel.objects.get(pk='<ID>')
c.staging_tree = ContentNode.objects.create(kind_id="topic", title="Test title")
print(c.__dict__)
c.save()
for i in range(0, 200):
  ContentNode.objects.create(kind_id="topic", title="Test topic {}".format(i), parent_id=c.staging_tree.id)
```

3. Run `python contentcuration/generate_staged.py`
4. Go to the channel that you got the ID from and you should now see a link at the top: "Updated resources are ready for review..." - click that link.

BEFORE: You would see a blank screen for a while and then it would load.
AFTER: You see loader(s) for a while, and then it loads. The StudioTree on the left sidebar ought to also show its loader visibly and roughly centered vertically as well as horizontally.

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

RE: https://github.com/learningequality/studio/issues/2106#issuecomment-678906547 (A general concern about data init in `created/mounted` hooks)

This ought not be an issue and if we were to load data in any of the hooks, this is the component to do it in because it is the root of the component tree. This does mean we will not need to load this stuff in child components. It does seem that StudioTree is doing some additional work after the initial load and I'm not sure what that is or if it is necessary, but there are `UPDATE_CONTENTNODE` mutations occurring for every node before the StudioTree is rendered.

