### PR TITLE
Only use delay_mptt_updates() when it is really needed for move operations

### DIFF
--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -339,20 +339,19 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
     # use delay_mptt_updates(). However, in some cases, like moving 10 items to
     # the first subtopic of a large tree, we could end up reindexing most of the tree
     # many times over, once per move. Here we calculate if the total number of reindexed
-    # nodes is likely to be much higher than the number of total nodes in the tree. If so,
+    # nodes is likely to be large and higher than the number of total nodes in the tree. If so,
     # we utilize delay_mptt_updates(), otherwise we use the default reindexing logic.
     should_delay = False
     if len(nodes) > 2:
         root = target_parent.get_root()
         num_tree_nodes = root.get_descendant_count()
-        # This is a tree size threshold around which reindexing multiple times
-        # could cause considerable delays.
-        if num_tree_nodes > 1000:
-            reindexed_nodes_per_move = num_tree_nodes - target_parent.lft
-            total_reindexed = len(nodes) * reindexed_nodes_per_move
-            # Since both the source and target trees will be reindexed after move,
-            # delay_mptt_updates will fully reindex both. So only use it
-            # if we're indexing the target tree at least twice over.
+        reindexed_nodes_per_move = num_tree_nodes - target_parent.lft
+        total_reindexed = len(nodes) * reindexed_nodes_per_move
+        # Since both the source and target trees will be reindexed after move,
+        # delay_mptt_updates will fully reindex both. So only use it
+        # if we're reindexing a lot of nodes and reindexing the target tree
+        # at least twice over.
+        if total_reindexed > 1000:
             should_delay = total_reindexed > (num_tree_nodes * 2)
 
     @contextlib.contextmanager


### PR DESCRIPTION
## Description

Most of our remaining deadlock errors are coming from `move_nodes_task`, and are caused by small moves triggering full tree re-indexing on both the source and target trees.

This PR changes move behavior to not use `delay_mptt_updates` by default, but will use it in cases where a large number of nodes are reindexed and the number is higher than 2X the total target tree size.

In terms of code review, please check it with an eye on if any scenario could end up worse than before. I know this is some fuzzy logic, and it may trigger in cases where `delay_mptt_updates` could be slightly slower.  I tried to keep the logic simple and easy to read / predict to keep overall risk down. 

I considered simply removing `delay_mptt_updates`, but I know this is being used on trees with thousands of nodes, so I felt it was important to try to avoid risking major performance regressions for big moves on large trees.

## Steps to Test

- [ ] Move nodes, both in a normal scenario and to the first subtopic of a large tree (I can test this on hotfixes)

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
