### PR TITLE
Turn `ChannelItem` cards into real links

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -5,8 +5,8 @@
     :class="{hideHighlight}"
     data-test="channel-card"
     tabindex="0"
-    @click="openChannelLink"
-    @keyup.enter="openChannelLink"
+    :to="channelRoute"
+    :href="channelHref"
   >
     <VLayout row wrap>
       <VFlex :class="{xs12: fullWidth, sm12: !fullWidth, sm3: fullWidth}" md3 class="pa-3">
@@ -293,6 +293,23 @@
           (this.channel.published && this.allowEdit)
         );
       },
+      linkToChannelTree() {
+        return this.loggedIn && !this.libraryMode;
+      },
+      channelHref() {
+        if (this.linkToChannelTree) {
+          return window.Urls.channel(this.channelId);
+        } else {
+          return false;
+        }
+      },
+      channelRoute() {
+        if (!this.linkToChannelTree) {
+          return this.channelDetailsLink;
+        } else {
+          return false;
+        }
+      },
     },
     methods: {
       ...mapActions('channel', ['deleteChannel']),
@@ -300,16 +317,6 @@
         this.deleteChannel(this.channelId).then(() => {
           this.deleteDialog = false;
         });
-      },
-      openChannelLink() {
-        // TODO: if we decide to make channel edit page accessible
-        // without an account, update this to be a :to computed property
-        // to take advantage of the router more
-        if (this.loggedIn && !this.libraryMode) {
-          window.location = window.Urls.channel(this.channelId);
-        } else {
-          this.$router.push(this.channelDetailsLink);
-        }
       },
     },
     $trs: {


### PR DESCRIPTION
## Description

Makes ChannelItem cards into actual links, for accessibility benefits, the ability to open in a new window or tab, etc.

#### Issue Addressed (if applicable)
Fixes #2156

## Steps to Test

- [ ] While logged in, try right-clicking a channel card and opening it in a new tab.  Ensure that the tree editor opens.
- [ ] While logged out, try right-clicking a channel card and opening in a new tab.  Ensure that the channel details modal opens.

## Implementation Notes (optional)

#### At a high level, how did you implement this?
I used the `v-card` component's `to` and `href` properties.  The `href` property was necessary because the channel tree view is in a different single page application, but in order to navigate to the channel details modal, it's necessary to use the `to` property.
 
#### Does this introduce any tech-debt items?

If we ever consolidate everything into one single page application, we can simplify this a lot.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
