### PR TITLE
Card layout cleanup

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -23,19 +23,13 @@
             </h3>
           </VFlex>
           <VFlex xs12>
-            <VLayout class="grey--text metadata" justify-space-between>
-              <VFlex sm6 md4>
-                <span v-if="language">
-                  {{ language.native_name }}
-                </span>
-                <span v-else>
-                  {{ $tr('channelLanguageNotSetIndicator') }}
-                </span>
-              </VFlex>
-              <VFlex sm6 md4>
+            <VLayout class="grey--text metadata-section">
+              <span class="metadata-field">
+                {{ language }}
+              </span>
+              <span class="metadata-field">
                 {{ $tr('resourceCount', {'count': channel.count || 0}) }}
-              </VFlex>
-              <VFlex v-if="$vuetify.breakpoint.smAndUp" sm4 />
+              </span>
             </VLayout>
           </VFlex>
           <VFlex xs12 class="notranslate">
@@ -249,7 +243,11 @@
         return this.getChannel(this.channelId) || {};
       },
       language() {
-        return Languages.get(this.channel.language);
+        const lang = Languages.get(this.channel.language);
+        if (lang) {
+          return lang.native_name;
+        }
+        return this.$tr('channelLanguageNotSetIndicator');
       },
       channelEditLink() {
         return {
@@ -341,9 +339,17 @@
     }
   }
 
-  .metadata {
+  .metadata-section {
     // Double space metadata section
     line-height: 3;
+  }
+
+  .metadata-field {
+    display: inline-block;
+    &:not(:last-child)::after {
+      margin-right: 8px;
+      content: '•';
+    }
   }
 
   /deep/ .thumbnail {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -25,10 +25,10 @@
           <VFlex xs12>
             <VLayout class="grey--text metadata-section">
               <span class="metadata-field">
-                {{ language }}
+                {{ $tr('resourceCount', {'count': channel.count || 0}) }}
               </span>
               <span class="metadata-field">
-                {{ $tr('resourceCount', {'count': channel.count || 0}) }}
+                {{ language }}
               </span>
             </VLayout>
           </VFlex>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -18,7 +18,7 @@
       <VFlex :class="{xs12: fullWidth, sm12: !fullWidth, sm9: fullWidth}" md9>
         <VCardTitle>
           <VFlex xs12>
-            <h3 class="headline notranslate font-weight-bold" dir="auto">
+            <h3 class="card-header notranslate font-weight-bold" dir="auto">
               {{ channel.name }}
             </h3>
           </VFlex>
@@ -339,6 +339,9 @@
     }
   }
 
+  .card-header {
+    font-size: 18px;
+  }
   .metadata-section {
     // Double space metadata section
     line-height: 3;

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -342,6 +342,7 @@
   }
 
   .metadata {
+    // Double space metadata section
     line-height: 3;
   }
 

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -57,7 +57,7 @@
               }}
             </span>
           </VCardText>
-          <VCardText v-else class="font-italic grey--text">
+          <VCardText v-else class="grey--text">
             {{ $tr('unpublishedText') }}
           </VCardText>
         </VFlex>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -18,7 +18,12 @@
       <VFlex :class="{xs12: fullWidth, sm12: !fullWidth, sm9: fullWidth}" md9>
         <VCardTitle>
           <VFlex xs12>
-            <VLayout class="grey--text" justify-space-between>
+            <h3 class="headline notranslate font-weight-bold" dir="auto">
+              {{ channel.name }}
+            </h3>
+          </VFlex>
+          <VFlex xs12>
+            <VLayout class="grey--text metadata" justify-space-between>
               <VFlex sm6 md4>
                 <span v-if="language">
                   {{ language.native_name }}
@@ -32,11 +37,6 @@
               </VFlex>
               <VFlex v-if="$vuetify.breakpoint.smAndUp" sm4 />
             </VLayout>
-          </VFlex>
-          <VFlex xs12>
-            <h3 class="headline notranslate font-weight-bold" dir="auto">
-              {{ channel.name }}
-            </h3>
           </VFlex>
           <VFlex xs12 class="notranslate">
             <p dir="auto">

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -29,7 +29,7 @@
                   {{ language.native_name }}
                 </span>
                 <span v-else>
-                  &nbsp;
+                  {{ $tr('channelLanguageNotSetIndicator') }}
                 </span>
               </VFlex>
               <VFlex sm6 md4>
@@ -324,6 +324,7 @@
       deleteChannel: 'Delete channel',
       deleteTitle: 'Delete this channel',
       deletePrompt: 'This channel will be permanently deleted. This cannot be undone.',
+      channelLanguageNotSetIndicator: 'No language set',
       cancel: 'Cancel',
     },
   };

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -340,6 +340,10 @@
     }
   }
 
+  .metadata {
+    line-height: 3;
+  }
+
   /deep/ .thumbnail {
     width: 100%;
   }


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Adjusts channel card according to specifications in [this doc](https://www.notion.so/learningequality/card-layout-cleanup-9b33f256f93b47678288b9e83d2e4b27).

Only thing missing is title reduction - need some guidance.

#### Before/After Screenshots (if applicable)

*Insert images here*
![before](https://user-images.githubusercontent.com/9877852/92099186-12d0c700-ed8f-11ea-84d7-589fd3c0d400.png)
![after](https://user-images.githubusercontent.com/9877852/92099132-fe8cca00-ed8e-11ea-917b-ada63cbd464e.png)


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

- Shifting HTML
- Tweaking line height to achieve double-spacing.

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [x] Are all user-facing strings translated properly (if applicable)?

## Comments

Really missed the immediate gratification of styling work.