### PR TITLE
Fix copy to clipboard (again)

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -387,7 +387,7 @@
           actionCallback: () => changeTracker.revert(),
         });
 
-        this.copyAll({ id__in, deep: true }).then(() => {
+        return this.copyAll({ id__in, deep: true }).then(() => {
           this.selectAll = false;
           return this.showSnackbar({
             text: this.$tr('copiedItemsToClipboard'),


### PR DESCRIPTION
## Description

I removed the `return` here https://github.com/learningequality/studio/pull/2143 for some reason - replacing it fixed the copying issue reported in today's bug hunt.

#### Issue Addressed (if applicable)

https://www.notion.so/learningequality/TypeError-Cannot-read-property-tree_id-of-undefined-when-adding-to-clipboard-this-ought-to-hav-ee495afe152643de83a262415a345e1e

