### PR TITLE
Move tweak

### DIFF
--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -364,6 +364,10 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
         move_context = ContentNode.objects.delay_mptt_updates()
 
     with transaction.atomic():
+        # if it requires time to reindex the first node, the user won't see any progress until after
+        # that completes, so make sure we always show some progress before we start.
+        if task_object:
+            task_object.update_state(state='STARTED', meta={'progress': percent_done})
         with move_context:
             step = float(max_order - min_order) / (2 * len(nodes))
             for n in nodes:

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -329,10 +329,10 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
     all_ids = []
 
     target_parent = ContentNode.objects.get(pk=target_parent_id)
-    # last 20% is MPTT tree updates
-    total_percent = 100.0
+    # we do 10% at start, then the last 10% is MPTT tree updates, if processed in bulk
+    total_percent = 80.0
     percent_per_node = math.ceil(total_percent / len(nodes))
-    percent_done = 0.0
+    percent_done = 10.0
 
     # The best way to handle reindexing during a move depends a lot on the context.
     # Moving one node will always be faster, often much faster, if we don't
@@ -362,11 +362,6 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
     move_context = nullcontext()
     if should_delay:
         move_context = ContentNode.objects.delay_mptt_updates()
-        # the last twenty percent of the task will be reindexing
-        # TODO: Find a better way to calculate this, or just use
-        # indeterminate progress bars here, as the moves themselves
-        # are almost instant.
-        percent_per_node *= 0.8
 
     with transaction.atomic():
         with move_context:
@@ -381,7 +376,7 @@ def move_nodes(channel_id, target_parent_id, nodes, min_order, max_order, task_o
                 all_ids.append(n['id'])
 
     # This will fire after all reindexing has occurred.
-    if task_object and should_delay:
+    if task_object:
         task_object.update_state(state='STARTED', meta={'progress': 100})
 
     return all_ids


### PR DESCRIPTION
## Description

Fixes issues where progress will stay at 0% until the first move (and any subsequent reindexing) has completed, giving a sense that the task hasn't started. Also makes the percent calculation the same for both slow and fast reindexing paths.

This is not fixing an actual bug in the move handling, just improving the UX.

## Steps to Test

- [ ] Move nodes... :)

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
