### PR TITLE
Channel thumbnails upload fix

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -169,10 +169,17 @@
       thumbnail: {
         get() {
           return {
-            thumbnail: this.diffTracker.thumbnail || this.channel.thumbnail,
-            thumbnail_url: this.diffTracker.thumbnail_url || this.channel.thumbnail_url,
-            thumbnail_encoding:
-              this.diffTracker.thumbnail_encoding || this.channel.thumbnail_encoding,
+            // If we have thumbnail values in diffTracker, we put them there for a reason
+            // so we check if the property is defined on diffTracker and use it (even if it's falsy)
+            thumbnail: this.diffTracker.hasOwnProperty('thumbnail')
+              ? this.diffTracker.thumbnail
+              : this.channel.thumbnail,
+            thumbnail_url: this.diffTracker.hasOwnProperty('thumbnail_url')
+              ? this.diffTracker.thumbnail_url
+              : this.channel.thumbnail_url,
+            thumbnail_encoding: this.diffTracker.hasOwnProperty('thumbnail_encoding')
+              ? this.diffTracker.thumbnail_encoding
+              : this.channel.thumbnail_encoding,
           };
         },
         set(thumbnailData) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -176,7 +176,7 @@
           };
         },
         set(thumbnailData) {
-          this.setChannel({ thumbnailData });
+          this.setChannel({ ...thumbnailData });
         },
       },
       name: {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -226,10 +226,7 @@
     },
     methods: {
       updateThumbnail(data) {
-        let thumbnailData = {
-          ...this.value,
-          ...data,
-        };
+        const thumbnailData = Object.assign({ ...this.value }, { ...data });
         this.$emit('input', thumbnailData);
       },
       handleUploading(fileUpload) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -142,6 +142,7 @@
   import { mapGetters } from 'vuex';
   import IconButton from '../IconButton';
   import Uploader from 'shared/views/files/Uploader';
+  import FileStatus from 'shared/views/files/FileStatus';
   import FileStatusText from 'shared/views/files/FileStatusText';
   import Thumbnail from 'shared/views/files/Thumbnail';
   import FileDropzone from 'shared/views/files/FileDropzone';
@@ -156,11 +157,12 @@
   export default {
     name: 'ChannelThumbnail',
     components: {
-      Uploader,
+      FileDropzone,
+      FileStatus,
       FileStatusText,
       IconButton,
       Thumbnail,
-      FileDropzone,
+      Uploader,
     },
     props: {
       value: {

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -68,6 +68,9 @@ export function commitChannel(
     source_url = NOVALUE,
     deleted = NOVALUE,
     isPublic = NOVALUE,
+    thumbnail = NOVALUE,
+    thumbnail_encoding = NOVALUE,
+    thumbnail_url = NOVALUE,
   } = {}
 ) {
   if (context.state.channelsMap[id]) {
@@ -101,6 +104,15 @@ export function commitChannel(
     if (isPublic !== NOVALUE) {
       channelData.public = isPublic;
     }
+    if (thumbnail !== NOVALUE) {
+      channelData.thumbnail = thumbnail;
+    }
+    if (thumbnail_encoding !== NOVALUE) {
+      channelData.thumbnail_encoding = thumbnail_encoding;
+    }
+    if (thumbnail_url !== NOVALUE) {
+      channelData.thumbnail_url = thumbnail_url;
+    }
     if (contentDefaults !== NOVALUE) {
       const originalData = context.state.channelsMap[id].content_defaults;
       // Pick out only content defaults that have been changed.
@@ -128,6 +140,9 @@ export function updateChannel(
     source_url = NOVALUE,
     deleted = NOVALUE,
     isPublic = NOVALUE,
+    thumbnail = NOVALUE,
+    thumbnail_encoding = NOVALUE,
+    thumbnail_url = NOVALUE,
   } = {}
 ) {
   if (context.state.channelsMap[id]) {
@@ -160,6 +175,15 @@ export function updateChannel(
     }
     if (isPublic !== NOVALUE) {
       channelData.public = isPublic;
+    }
+    if (thumbnail !== NOVALUE) {
+      channelData.thumbnail = thumbnail;
+    }
+    if (thumbnail_encoding !== NOVALUE) {
+      channelData.thumbnail_encoding = thumbnail_encoding;
+    }
+    if (thumbnail_url !== NOVALUE) {
+      channelData.thumbnail_url = thumbnail_url;
     }
     if (contentDefaults !== NOVALUE) {
       const originalData = context.state.channelsMap[id].content_defaults;


### PR DESCRIPTION
## Description

Channel edit was not saving thumbnails, now it is.

![screenshot-localhost_8080-2020 09 03-15_29_39](https://user-images.githubusercontent.com/6356129/92179975-c02cf480-edfa-11ea-97f9-aa1210aff097.png)

I also found that the X "Remove" button in the image above wasn't doing anything and fixed that as well. Now we can add during create, edit and remove a channel thumbnail altogether.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2155

## Steps to Test

- Create a new channel and upload an image when you do it. 
- Go to channels list and see the image.
- Go to that channel, edit it, then change the thumbnail (you have to click the image) and save your changes
- Go to channels list and see the new image.