### PR TITLE
First pass vue component cleanup Resolves #2079

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -163,7 +163,6 @@
         }
       },
       imageEls() {
-        console.log("els changed");
         this.initImageFields();
         this.cleanUpImageFields();
       },
@@ -291,12 +290,12 @@
 
       this.editor.on('change', () => {
         this.$emit('update', this.editor.getMarkdown());
-        this.$set(this.imageEls,this.$el.getElementsByTagName('img'))
+        this.$set(this.imageEls, this.$el.getElementsByTagName('img'));
       });
 
       this.initStaticMathFields();
 
-      this.$set(this.imageEls,this.$el.getElementsByTagName('img'))
+      this.$set(this.imageEls, this.$el.getElementsByTagName('img'));
 
       this.editor.getSquire().addEventListener('willPaste', this.onPaste);
       this.keyDownEventListener = this.$el.addEventListener('keydown', this.onKeyDown, true);
@@ -663,15 +662,15 @@
             imageEl.replaceWith(ImageComponent.$el);
             imageEl.classList.remove(CLASS_IMG_FIELD_NEW);
             // add to tracking array.
-            this.imageFields.push(ImageComponent)
+            this.imageFields.push(ImageComponent);
           }
         }
       },
-      cleanUpImageFields(){
+      cleanUpImageFields() {
         this.imageFields.forEach((imageField, index) => {
           // Editor only removes <img> reliably - div and other elements remain
           const imageFieldImg = imageField.$el.getElementsByTagName('img')[0];
-          const imageHasBeenDeleted = !(this.imageEls.includes(imageFieldImg));
+          const imageHasBeenDeleted = !this.imageEls.includes(imageFieldImg);
 
           if (imageHasBeenDeleted) {
             // Unmount and remove all listeners

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -116,6 +116,8 @@
       return {
         editor: null,
         highlight: false,
+        // will be an HTMLCollection, set in mounted()
+        imageEls: {},
         imageFields: [],
         formulasMenu: {
           isOpen: false,
@@ -159,6 +161,11 @@
           this.initStaticMathFields();
           this.initImageFields();
         }
+      },
+      imageEls() {
+        console.log("els changed");
+        this.initImageFields();
+        this.cleanUpImageFields();
       },
       'file.error'() {
         // eslint-disable-next-line
@@ -284,11 +291,12 @@
 
       this.editor.on('change', () => {
         this.$emit('update', this.editor.getMarkdown());
-        this.cleanUpImageFields();
+        this.$set(this.imageEls,this.$el.getElementsByTagName('img'))
       });
 
       this.initStaticMathFields();
-      this.initImageFields();
+
+      this.$set(this.imageEls,this.$el.getElementsByTagName('img'))
 
       this.editor.getSquire().addEventListener('willPaste', this.onPaste);
       this.keyDownEventListener = this.$el.addEventListener('keydown', this.onKeyDown, true);
@@ -628,8 +636,7 @@
        * Initialize elements with image field class with ImageField component
        */
       initImageFields({ newOnly = false } = {}) {
-        const imageFieldEls = this.$el.getElementsByTagName('img');
-        for (let imageEl of imageFieldEls) {
+        for (let imageEl of this.imageEls) {
           if (!newOnly || imageEl.classList.contains(CLASS_IMG_FIELD_NEW)) {
             const ImageComponent = new ImageFieldClass({
               propsData: {
@@ -661,11 +668,11 @@
         }
       },
       cleanUpImageFields(){
-        const editorNode = this.editor.getSquire().getBody();
         this.imageFields.forEach((imageField, index) => {
           // Editor only removes <img> reliably - div and other elements remain
           const imageFieldImg = imageField.$el.getElementsByTagName('img')[0];
-          const imageHasBeenDeleted = !(editorNode.contains(imageFieldImg))
+          const imageHasBeenDeleted = !(this.imageEls.includes(imageFieldImg));
+
           if (imageHasBeenDeleted) {
             // Unmount and remove all listeners
             imageField.$destroy();


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Absolute lightest touch way I could think of to allow for destruction of Vue components without messing with the rest of the code. Have some ideas for iteration, but will wait and see what the original devs think of this solution.

Surely, there are more elegant ways to do this. But it's not the right time for a refactor :upside_down_face: 

#### Issue Addressed (if applicable)

Addresses #2079

## Steps to Test

- [ ] Add a photo in the question creator
- [ ] Remove a photo from the question creator
- [ ] check and see if the photo's vue component is still bound and listening.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Track the Vue components created, delete them when their associated elements have been deleted by a user's markdown edits.

*Briefly describe how this works*

Rather than manually binding HTMLElements to DOM, add them to a tracker Array `imageFields`.

Continuously scan the DOM (in the case, listening for the `change` event on the Squire body element), for `<img>` tags - if the `<img>` belonging to one of the tracked components, `$destroy` the component and stop tracking. 


#### Does this introduce any tech-debt items?

Not introduced here, but noticed that the editor does not clean up the entire element injected by `insertImageToEditor`, then `initImageFields`. The editor's default behavior seems to delete the HTML tags (closing tags first, I think), then the image, then the remaining HTML tags. 

This has changed a bit in this PR - because the component is `$destroyed`, I think it automatically dismounts the `$el` it's claimed. So the user only goes through the first set of tags and the image before being rid of the image altogether.


Otherwise, I am a bit concerned by how often this cleanup process occurs (on every edit, for every image). I have a rough optimization in the works where the vue component continuously maintains a list of `<img>` elements - changes to _that_ could be what trigger `initImageFields` and `cleanUpImageFields`. There are some reactivity considerations, but it sounds like the only way to reduce how often this runs without debouncing the edit events or a magical native `removed`/`unmounted` event for HTMLElements.


## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
    As clean as I saw fit, at least.
~[ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?~
~[ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time~
- [ ] Are there tests for this change?
    No, but there probably should be? Are we doing frontend tests?
~[ ] Are all user-facing strings translated properly (if applicable)?~
~[ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?~
~[ ] Are all UI components LTR and RTL compliant (if applicable)?~
~[ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)~
~[ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?~
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
    I get the feeling this might be a good candidate? But there's no real user facing way to test it.
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
    Might be worth seeing how often people are removing photos after adding them? Or how many photos there are on average? :man_shrugging: 
~[ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?~
~[ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?~

## Comments

Added many below checkmarks above

Not sure if I applied the right labels, please correct if necessary.

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
