### PR TITLE
Fixed related tab issues

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/NodeTreeNavigation.vue
@@ -1,25 +1,23 @@
 <template>
 
   <div>
-    <VBreadcrumbs
-      :items="breadcrumbsItems"
-      divider=">"
-    >
-      <template v-slot:item="props">
+    <Breadcrumbs :items="breadcrumbsItems">
+      <template #item="{item}">
         <span
           class="notranslate"
-          :class="breadcrumbsItemClasses(props.item)"
-          @click="onBreadcrumbsItemClick(props.item)"
+          :class="breadcrumbsItemClasses(item)"
+          @click="onBreadcrumbsItemClick(item)"
         >
-          {{ props.item.title }}
+          {{ item.title }}
         </span>
       </template>
-    </VBreadcrumbs>
-
-    <VList>
+    </Breadcrumbs>
+    <VContainer v-if="loading">
+      <LoadingText />
+    </VContainer>
+    <VList v-else>
       <template v-for="child in selectedNodeChildren">
         <VDivider :key="`divider-${child.id}`" />
-
         <slot
           name="child"
           :childNode="child"
@@ -33,9 +31,15 @@
 <script>
 
   import { mapGetters, mapActions } from 'vuex';
+  import Breadcrumbs from 'shared/views/Breadcrumbs';
+  import LoadingText from 'shared/views/LoadingText';
 
   export default {
     name: 'NodeTreeNavigation',
+    components: {
+      Breadcrumbs,
+      LoadingText,
+    },
     model: {
       prop: 'selectedNodeId',
       event: 'updateSelectedNodeId',
@@ -49,6 +53,11 @@
         type: String,
         required: true,
       },
+    },
+    data() {
+      return {
+        loading: false,
+      };
     },
     computed: {
       ...mapGetters('contentNode', [
@@ -93,19 +102,24 @@
     methods: {
       ...mapActions('contentNode', ['loadContentNode', 'loadAncestors', 'loadChildren']),
       onSelectionUpdate(nodeId) {
-        this.loadContentNode(nodeId);
+        this.loading = true;
+        const promises = [
+          this.loadContentNode(nodeId),
+          this.loadAncestors({
+            id: nodeId,
+            includeSelf: true,
+          }),
+        ];
 
         if (this.selectedNode.has_children) {
-          this.loadChildren({
-            parent: nodeId,
-            tree_id: this.treeId,
-          });
+          promises.push(
+            this.loadChildren({
+              parent: nodeId,
+              tree_id: this.treeId,
+            })
+          );
         }
-
-        this.loadAncestors({
-          id: nodeId,
-          includeSelf: true,
-        });
+        Promise.all(promises).then(() => (this.loading = false));
       },
       breadcrumbsItemClasses(item) {
         const classes = ['breadcrumbs-item'];

--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
@@ -70,13 +70,13 @@
       </VCard>
     </VDialog>
 
-    <VLayout justify-start mt-3 wrap>
+    <VLayout justify-start wrap>
       <VFlex
         xs12
         md5
         data-test="previousSteps"
       >
-        <h3 class="title font-weight-bold mt-4">
+        <h3 class="title font-weight-bold mt-5">
           {{ $tr('previousStepsTitle') }}
         </h3>
         <p>{{ $tr('previousStepsExplanation') }}</p>
@@ -110,7 +110,7 @@
         offset-md1
         data-test="nextSteps"
       >
-        <h3 class="title font-weight-bold mt-4">
+        <h3 class="title font-weight-bold mt-5">
           {{ $tr('nextStepsTitle') }}
         </h3>
         <p>{{ $tr('nextStepsExplanation') }}</p>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
@@ -190,8 +190,7 @@
         const route = this.$router.resolve({
           name: RouterNames.CONTENTNODE_DETAILS,
           params: {
-            ...this.$route.params,
-            targetNodeId: nodeId,
+            detailNodeIds: nodeId,
           },
         });
         window.open(route.href, '_blank');

--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
@@ -9,7 +9,7 @@
       />
       <h2
         v-if="node && node.title"
-        class="notranslate headline"
+        class="notranslate headline mx-2"
         data-test="title"
       >
         {{ node.title }}
@@ -76,7 +76,7 @@
         md5
         data-test="previousSteps"
       >
-        <h3 class="title font-weight-bold">
+        <h3 class="title font-weight-bold mt-4">
           {{ $tr('previousStepsTitle') }}
         </h3>
         <p>{{ $tr('previousStepsExplanation') }}</p>
@@ -110,7 +110,7 @@
         offset-md1
         data-test="nextSteps"
       >
-        <h3 class="title font-weight-bold">
+        <h3 class="title font-weight-bold mt-4">
           {{ $tr('nextStepsTitle') }}
         </h3>
         <p>{{ $tr('nextStepsExplanation') }}</p>
@@ -190,22 +190,28 @@
         const route = this.$router.resolve({
           name: RouterNames.CONTENTNODE_DETAILS,
           params: {
-            detailNodeIds: nodeId,
+            ...this.$route.params,
+            targetNodeId: nodeId,
           },
         });
         window.open(route.href, '_blank');
       },
       onRemovePreviousStepClick(previousStepId) {
-        this.removePreviousStepFromNode({ targetId: this.nodeId, previousStepId });
+        this.removePreviousStepFromNode({ targetId: this.nodeId, previousStepId }).then(() => {
+          this.$store.dispatch('showSnackbarSimple', this.$tr('removedPreviousStepSnackbar'));
+        });
       },
       onRemoveNextStepClick(nextStepId) {
-        this.removeNextStepFromNode({ targetId: this.nodeId, nextStepId });
+        this.removeNextStepFromNode({ targetId: this.nodeId, nextStepId }).then(() => {
+          this.$store.dispatch('showSnackbarSimple', this.$tr('removedNextStepSnackbar'));
+        });
       },
       onAddPreviousStepClick() {
         this.$router.push({
           name: RouterNames.ADD_PREVIOUS_STEPS,
           params: {
-            nodeId: this.nodeId,
+            ...this.$route.params,
+            targetNodeId: this.nodeId,
           },
           query: {
             last: this.$route.name,
@@ -216,7 +222,8 @@
         this.$router.push({
           name: RouterNames.ADD_NEXT_STEPS,
           params: {
-            nodeId: this.nodeId,
+            ...this.$route.params,
+            targetNodeId: this.nodeId,
           },
           query: {
             last: this.$route.name,
@@ -246,6 +253,8 @@
         a more guided learning experience`,
       tooManyNextStepsWarning: `Limit the number of next steps to create
         a more guided learning experience`,
+      removedNextStepSnackbar: 'Removed next step',
+      removedPreviousStepSnackbar: 'Removed previous step',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -91,6 +91,7 @@
         </Uploader>
       </VCard>
     </VDialog>
+    <GlobalSnackbar />
 
     <!-- Dialog for catching unsaved changes -->
     <MessageDialog
@@ -159,6 +160,7 @@
   import FormatPresets from 'shared/leUtils/FormatPresets';
   import OfflineText from 'shared/views/OfflineText';
   import FileDropzone from 'shared/views/files/FileDropzone';
+  import GlobalSnackbar from 'shared/views/GlobalSnackbar';
 
   export default {
     name: 'EditModal',
@@ -173,6 +175,7 @@
       MessageDialog,
       OfflineText,
       FileDropzone,
+      GlobalSnackbar,
     },
     mixins: [fileSizeMixin],
     props: {
@@ -183,6 +186,12 @@
       tab: {
         type: String,
         default: TabNames.DETAILS,
+      },
+      // Catch cases where user is navigating back from another view
+      // (e.g. selecting related resources)
+      targetNodeId: {
+        type: String,
+        required: false,
       },
     },
     data() {
@@ -274,7 +283,7 @@
     },
     mounted() {
       this.hideHTMLScroll(true);
-      this.selected = this.nodeIds;
+      this.selected = this.targetNodeId ? [this.targetNodeId] : this.nodeIds;
     },
     methods: {
       ...mapActions('contentNode', [

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -179,8 +179,14 @@
       },
     },
     watch: {
-      nodeIds() {
+      nodeIds(newValue, oldValue) {
         this.$refs.editview.scrollTop = 0;
+        // If oldValue is empty, user might be navigating in from another page
+        // (if they hadn't had anything selected before, tab should have been changed
+        // back to details on deselect all anyways)
+        if (oldValue.length) {
+          this.currentTab = TabNames.DETAILS;
+        }
       },
       currentTab(newValue, oldValue) {
         if (newValue === oldValue) {

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <AddRelatedResourcesModal
-    :nodeId="nodeId"
+    :nodeId="targetNodeId"
     :toolbarTitle="$tr('toolbarTitle')"
     :selectedAsPreviousStepTooltip="$tr('selectedAsPreviousStep')"
     :selectedAsNextStepTooltip="$tr('selectedAsNextStep')"
@@ -24,7 +24,7 @@
       AddRelatedResourcesModal,
     },
     props: {
-      nodeId: {
+      targetNodeId: {
         type: String,
         required: true,
       },
@@ -33,8 +33,11 @@
       ...mapActions('contentNode', ['addNextStepToNode']),
       onAddStepClick(nodeId) {
         this.addNextStepToNode({
-          targetId: this.nodeId,
+          targetId: this.targetNodeId,
           nextStepId: nodeId,
+        }).then(() => {
+          this.onCancelClick();
+          this.$store.dispatch('showSnackbarSimple', this.$tr('addedNextStepSnackbar'));
         });
       },
       onCancelClick() {
@@ -46,7 +49,7 @@
         this.$router.push({
           name: routeName,
           params: {
-            detailNodeIds: this.nodeId,
+            ...this.$route.params,
             tab: TabNames.RELATED,
           },
         });
@@ -57,6 +60,7 @@
       selectedAsPreviousStep:
         'Cannot select resources that are previous steps for the current resource',
       selectedAsNextStep: 'Already selected as a next step',
+      addedNextStepSnackbar: 'Added next step',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
@@ -1,7 +1,7 @@
 <template>
 
   <AddRelatedResourcesModal
-    :nodeId="nodeId"
+    :nodeId="targetNodeId"
     :toolbarTitle="$tr('toolbarTitle')"
     :selectedAsPreviousStepTooltip="$tr('selectedAsPreviousStep')"
     :selectedAsNextStepTooltip="$tr('selectedAsNextStep')"
@@ -24,7 +24,7 @@
       AddRelatedResourcesModal,
     },
     props: {
-      nodeId: {
+      targetNodeId: {
         type: String,
         required: true,
       },
@@ -33,8 +33,11 @@
       ...mapActions('contentNode', ['addPreviousStepToNode']),
       onAddStepClick(nodeId) {
         this.addPreviousStepToNode({
-          targetId: this.nodeId,
+          targetId: this.targetNodeId,
           previousStepId: nodeId,
+        }).then(() => {
+          this.onCancelClick();
+          this.$store.dispatch('showSnackbarSimple', this.$tr('addedPreviousStepSnackbar'));
         });
       },
       onCancelClick() {
@@ -46,7 +49,7 @@
         this.$router.push({
           name: routeName,
           params: {
-            detailNodeIds: this.nodeId,
+            ...this.$route.params,
             tab: TabNames.RELATED,
           },
         });
@@ -56,6 +59,7 @@
       toolbarTitle: 'Add previous step',
       selectedAsPreviousStep: 'Already selected as a previous step',
       selectedAsNextStep: 'Cannot select resources that are next steps for the current resource',
+      addedPreviousStepSnackbar: 'Added previous step',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -89,15 +89,15 @@ const router = new VueRouter({
     },
     {
       name: RouterNames.ADD_PREVIOUS_STEPS,
-      path: '/previous-steps/:nodeId',
+      path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/previous-steps/:targetNodeId',
       props: true,
       component: AddPreviousStepsPage,
       beforeEnter: (to, from, next) => {
         const { currentChannelId } = store.state.currentChannel;
-        const { nodeId } = to.params;
+        const { targetNodeId } = to.params;
         const promises = [
           store.dispatch('channel/loadChannel', currentChannelId),
-          store.dispatch('contentNode/loadRelatedResources', nodeId),
+          store.dispatch('contentNode/loadRelatedResources', targetNodeId),
         ];
 
         return Promise.all(promises)
@@ -109,15 +109,15 @@ const router = new VueRouter({
     },
     {
       name: RouterNames.ADD_NEXT_STEPS,
-      path: '/next-steps/:nodeId',
+      path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/next-steps/:targetNodeId',
       props: true,
       component: AddNextStepsPage,
       beforeEnter: (to, from, next) => {
         const { currentChannelId } = store.state.currentChannel;
-        const { nodeId } = to.params;
+        const { targetNodeId } = to.params;
         const promises = [
           store.dispatch('channel/loadChannel', currentChannelId),
-          store.dispatch('contentNode/loadRelatedResources', nodeId),
+          store.dispatch('contentNode/loadRelatedResources', targetNodeId),
         ];
 
         return Promise.all(promises)
@@ -171,7 +171,7 @@ const router = new VueRouter({
     },
     {
       name: RouterNames.CONTENTNODE_DETAILS,
-      path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/:tab?',
+      path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/:tab?/:targetNodeId?',
       props: true,
       component: EditModal,
       beforeEnter: (to, from, next) => {


### PR DESCRIPTION
## Description

Fixed issues on related resource navigation and added snackbars + breadcrumb components

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/1847
Fixes https://github.com/learningequality/studio/issues/2208
Fixes https://github.com/learningequality/studio/issues/2209
Fixes https://github.com/learningequality/studio/issues/1814

#### Other issues
- [After entering and exiting the selection screen for related content, and then exiting an exercise edit modal, somehow I'm inside of the exercise like a topic in the topic tree](https://www.notion.so/learningequality/After-entering-and-exiting-the-selection-screen-for-related-content-and-then-exiting-an-exercise-ed-cf6c8408c7b24d3da2fb8400b4d24a97)
- [Seeing previous steps in previewer but not in the related tab](https://www.notion.so/learningequality/Seeing-previous-steps-in-previewer-but-not-in-the-related-tab-0fae526dd0fc420aaac513b74bdf1456)
- [Selecting related resources doesn't show snackbars](https://www.notion.so/learningequality/Selecting-related-resources-doesn-t-show-snackbars-5aca1684f87242fc8ffc238a6be45fd7)
- [Navigating through related tab also navigates me on the main tree](https://www.notion.so/learningequality/Navigating-through-related-tab-also-navigates-me-on-the-main-tree-01260ccdb1b84fec91c15e069e06c452)
- [Resources aren't loading when I navigate through the related tab](https://www.notion.so/learningequality/Resources-aren-t-loading-when-I-navigate-through-the-related-tab-47686c9cc51b4fca91b3e75540b0804b)
- [The only way to exit "previous steps" is to cancel. wasn't sure what was being saved. Intended design is to go back to main "related" list after the user clicks "add" on a resource](https://www.notion.so/learningequality/The-only-way-to-exit-previous-steps-is-to-cancel-wasn-t-sure-what-was-being-saved-Intended-desig-bac78b0377734598a25b6aeedeb1a44a)
- [Going back from the related tab doesn't maintain all my selected resources in the edit modal list](https://www.notion.so/learningequality/Going-back-from-the-related-tab-doesn-t-maintain-all-my-selected-resources-in-the-edit-modal-list-1160e6fd264d4ab9aa06bbba99983044)
- [Related tab should say "FINISH" as cancelling implies undoing any actions](https://www.notion.so/learningequality/Related-tab-should-say-FINISH-as-cancelling-implies-undoing-any-actions-db434dfb89d84cc9bb78f31187e3fc36)
- [Improve layout for smaller resolutions on related resources tab](https://www.notion.so/learningequality/Improve-layout-for-smaller-resolutions-on-related-resources-tab-0fe627036f144cd5b2b3437838fa78d1)


## Steps to Test

- [ ] Select multiple items and open the edit modal
- [ ] Navigate through topics under the related tab for one of the items
- [ ] Select an item (snackbar should appear,navigate back to edit modal, and retain the selected items)
- [ ] Remove item (snackbar should appear)
- [ ] Exit edit modal (location should be the same topic from which you entered the edit modal)


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
