### PR TITLE
Formulas fields reset experiment

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -319,6 +319,18 @@
           keyHandlers[event.key](squire);
         }
 
+        if (event.key === 'Enter') {
+          // Prevent formulas style glitches
+          // MathQuill's reflow doesn't seem to work
+          // http://docs.mathquill.com/en/latest/Api_Methods/#reflow
+          // So revert and initialize again for math fields
+          // dynamic styles to be recomputed
+          // (not sure why delay is needed for reset to work,
+          // maybe there's something going in TUI that
+          // we need to wait for)
+          this.resetStaticMathFields(200);
+        }
+
         // ESC should close menus if any are open
         // or close the editor if none are open
         if (event.key === 'Escape') {
@@ -537,11 +549,19 @@
         const mathFieldEls = this.$el.getElementsByClassName(className);
         for (let mathFieldEl of mathFieldEls) {
           this.mathQuill.StaticMath(mathFieldEl);
-
           if (newOnly) {
             mathFieldEl.classList.remove(CLASS_MATH_FIELD_NEW);
           }
         }
+      },
+      resetStaticMathFields(delay = 0) {
+        setTimeout(() => {
+          const mathFieldEls = this.$el.getElementsByClassName(CLASS_MATH_FIELD);
+          for (let mathFieldEl of mathFieldEls) {
+            this.mathQuill(mathFieldEl).revert();
+            this.mathQuill.StaticMath(mathFieldEl);
+          }
+        }, delay);
       },
       findActiveMathField() {
         return this.$el.getElementsByClassName(CLASS_MATH_FIELD_ACTIVE)[0] || null;

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/mathquill/mathquill.js
@@ -1074,15 +1074,17 @@ JS environment could actually contain many instances. */
           .attr(mqBlockId, root.id)
           .appendTo(el);
         this.latex(contents.text());
+      };
+      _.revert = function() {
+        const el = this.__controller.container;
+        const formula = el.attr('data-formula');
 
-        this.revert = function() {
-          return el
-            .empty()
-            .unbind('.mathquill')
-            .removeClass('mq-editable-field mq-math-mode mq-text-mode')
-            .removeAttr('data-formula')
-            .append(contents);
-        };
+        return el
+          .empty()
+          .unbind('.mathquill')
+          .removeClass('mq-editable-field mq-math-mode mq-text-mode mq-focused')
+          .removeAttr('data-formula')
+          .text(formula);
       };
       _.config = function(opts) {
         config(this.__options, opts);


### PR DESCRIPTION
## Description

See explanation in commit messages and code comments.

Can be tested with binomial coefficient and Enter:
1. Insert binomial coefficient
2. Press Enter
3. After a while, the height of the formula will be fixed

This is still not sufficient. If we don't find CSS only solution or solve it in another way, we will need to reset formulas for some other keys, too  (for example, press Enter and then Backspace).

I thought that I could use [reflow](http://docs.mathquill.com/en/latest/Api_Methods/#reflow) instead of reverting a field and initializing again. For some reason, it doesn't work - linking it in case someone else would like to give it a try.