### PR TITLE
Update mastery model to use extra_fields.type

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -122,7 +122,7 @@ describe('channelEdit utils', () => {
           kind: 'exercise',
           license: 8,
           extra_fields: {
-            mastery_model: 'do_all',
+            type: 'do_all',
           },
         },
         [],
@@ -133,7 +133,7 @@ describe('channelEdit utils', () => {
           kind: 'exercise',
           license: 8,
           extra_fields: {
-            mastery_model: 'm_of_n',
+            type: 'm_of_n',
             m: 3,
           },
         },
@@ -145,7 +145,7 @@ describe('channelEdit utils', () => {
           kind: 'exercise',
           license: 8,
           extra_fields: {
-            mastery_model: 'm_of_n',
+            type: 'm_of_n',
             m: 3,
             n: 2,
           },
@@ -158,7 +158,7 @@ describe('channelEdit utils', () => {
           kind: 'exercise',
           license: 8,
           extra_fields: {
-            mastery_model: 'm_of_n',
+            type: 'm_of_n',
             m: 2,
             n: 3,
           },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -395,7 +395,7 @@
         },
       },
       mastery_model() {
-        return this.getExtraFieldsValueFromNodes('mastery_model');
+        return this.getExtraFieldsValueFromNodes('type');
       },
       m() {
         return this.getExtraFieldsValueFromNodes('m');
@@ -406,7 +406,7 @@
       masteryModelItem: {
         get() {
           return {
-            mastery_model: this.mastery_model,
+            type: this.mastery_model,
             m: this.m,
             n: this.n,
           };
@@ -520,8 +520,8 @@
       update(payload) {
         this.updateContentNodes({ ids: this.nodeIds, ...payload });
       },
-      updateExtraFields(payload) {
-        this.updateContentNodes({ ids: this.nodeIds, extra_fields: payload });
+      updateExtraFields(extra_fields) {
+        this.updateContentNodes({ ids: this.nodeIds, extra_fields });
       },
       addTags(tags) {
         this.addTags({ ids: this.nodeIds, tags });
@@ -595,10 +595,6 @@
   /deep/ a:hover {
     color: inherit;
     text-decoration: none;
-  }
-
-  /deep/ .error--text {
-    font-weight: bold;
   }
 
   .details-edit-view {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/data.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/data.js
@@ -28,7 +28,7 @@ export function generateNode(props = {}) {
   });
 
   let extra_fields = {
-    mastery_model: 'do_all',
+    type: 'do_all',
     randomize: false,
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/detailsTabView.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/detailsTabView.spec.js
@@ -82,7 +82,7 @@ describe.skip('detailsTabView', () => {
         role: DEFAULT_EXERCISE.role_visibility,
         randomizeOrder: DEFAULT_EXERCISE.extra_fields.randomize,
         masteryModel: {
-          mastery_model: DEFAULT_EXERCISE.extra_fields.mastery_model,
+          type: DEFAULT_EXERCISE.extra_fields.type,
         },
         copyrightHolder: DEFAULT_EXERCISE.copyright_holder,
       });
@@ -144,8 +144,8 @@ describe.skip('detailsTabView', () => {
       expect(wrapper.vm.title).toEqual('New Title');
     });
     it('exercise fields should set selected node data extra_fields', () => {
-      wrapper.find({ ref: 'mastery_model' }).vm.$emit('input', { mastery_model: 'm_of_n' });
-      expect(wrapper.vm.masteryModel.mastery_model).toEqual('m_of_n');
+      wrapper.find({ ref: 'mastery_model' }).vm.$emit('input', { type: 'm_of_n' });
+      expect(wrapper.vm.masteryModel.type).toEqual('m_of_n');
     });
   });
   describe('on validation', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -25,14 +25,14 @@ export function validateLicenseDescription(node) {
 
 export function validateMasteryModel(node) {
   const mastery = node.extra_fields;
-  return mastery && mastery.mastery_model;
+  return mastery && mastery.type;
 }
 
 export function validateMasteryModelMofN(node) {
   const mastery = node.extra_fields;
   return (
     !mastery ||
-    mastery.mastery_model !== MasteryModelsNames.M_OF_N ||
+    mastery.type !== MasteryModelsNames.M_OF_N ||
     (mastery.m && mastery.n && mastery.m <= mastery.n)
   );
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -411,7 +411,7 @@
           return '';
         }
 
-        const masteryModel = this.node.extra_fields.type || this.node.extra_fields.mastery_model;
+        const masteryModel = this.node.extra_fields.type;
         if (!masteryModel) {
           return this.defaultText;
         } else if (masteryModel === MasteryModelsNames.M_OF_N) {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -318,8 +318,9 @@ function generateContentNodeData({
     contentNodeData.provider = provider;
   }
   if (extra_fields !== NOVALUE) {
-    if (extra_fields.mastery_model) {
-      contentNodeData.extra_fields.mastery_model = extra_fields.mastery_model;
+    contentNodeData.extra_fields = contentNodeData.extra_fields || {};
+    if (extra_fields.type) {
+      contentNodeData.extra_fields.type = extra_fields.type;
     }
     if (extra_fields.m) {
       contentNodeData.extra_fields.m = extra_fields.m;

--- a/contentcuration/contentcuration/frontend/shared/views/MasteryDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MasteryDropdown.vue
@@ -97,7 +97,10 @@
 
 <script>
 
-  import MasteryModels, { MasteryModelsList } from 'shared/leUtils/MasteryModels';
+  import MasteryModels, {
+    MasteryModelsList,
+    MasteryModelsNames,
+  } from 'shared/leUtils/MasteryModels';
   import InfoModal from 'shared/views/InfoModal.vue';
   import { constantsTranslationMixin } from 'shared/mixins';
 
@@ -112,7 +115,7 @@
         type: Object,
         required: false,
         validator: function(value) {
-          return !value || !value.mastery_model || MasteryModels.has(value.mastery_model);
+          return !value || !value.type || MasteryModels.has(value.type);
         },
       },
       placeholder: {
@@ -148,10 +151,10 @@
     computed: {
       masteryModel: {
         get() {
-          return this.value && this.value.mastery_model;
+          return this.value && this.value.type;
         },
-        set(value) {
-          this.handleInput({ mastery_model: value });
+        set(type) {
+          this.handleInput({ type });
         },
       },
       mValue: {
@@ -181,7 +184,7 @@
         }));
       },
       showMofN() {
-        return this.masteryModel === 'm_of_n';
+        return this.masteryModel === MasteryModelsNames.M_OF_N;
       },
       masteryRules() {
         return this.required ? [v => !!v || this.$tr('masteryValidationMessage')] : [];

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/masteryDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/masteryDropdown.spec.js
@@ -25,7 +25,7 @@ describe('masteryDropdown', () => {
   beforeEach(() => {
     formWrapper = makeWrapper();
     wrapper = formWrapper.find(MasteryDropdown);
-    wrapper.setProps({ value: { mastery_model: 'm_of_n' } });
+    wrapper.setProps({ value: { type: 'm_of_n' } });
     modelInput = wrapper.find({ ref: 'masteryModel' }).find('input');
     wrapper.vm.$nextTick(() => {
       mInput = wrapper.find({ ref: 'mValue' }).find('input');
@@ -41,7 +41,7 @@ describe('masteryDropdown', () => {
     });
     it('should render according to masteryModel prop', () => {
       function test(model) {
-        wrapper.setProps({ value: { mastery_model: model } });
+        wrapper.setProps({ value: { type: model } });
         expect(wrapper.vm.$refs.masteryModel.value).toEqual(model);
         expect(wrapper.find({ ref: 'mValue' }).exists()).toBe(model === 'm_of_n');
         expect(wrapper.find({ ref: 'nValue' }).exists()).toBe(model === 'm_of_n');
@@ -49,7 +49,7 @@ describe('masteryDropdown', () => {
       MasteryModels.forEach(test);
     });
     it('should render correct mValue and nValue props', () => {
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 10, n: 20 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 10, n: 20 } });
       expect(wrapper.vm.$refs.mValue.value).toEqual(10);
       expect(wrapper.vm.$refs.nValue.value).toEqual(20);
     });
@@ -102,7 +102,7 @@ describe('masteryDropdown', () => {
       expect(wrapper.emitted('input')).toBeFalsy();
       modelInput.setValue('do_all');
       expect(wrapper.emitted('input')).toBeTruthy();
-      expect(wrapper.emitted('input')[0][0].mastery_model).toEqual('do_all');
+      expect(wrapper.emitted('input')[0][0].type).toEqual('do_all');
     });
     it('input should be emitted when mValue is updated', () => {
       expect(wrapper.emitted('input')).toBeFalsy();
@@ -119,7 +119,7 @@ describe('masteryDropdown', () => {
   });
   describe('validation', () => {
     it('should flag empty required mastery models', () => {
-      wrapper.setProps({ value: { mastery_model: null } });
+      wrapper.setProps({ value: { type: null } });
       formWrapper.vm.validate();
       expect(
         wrapper
@@ -166,7 +166,7 @@ describe('masteryDropdown', () => {
       ).toBe(false);
     });
     it('should flag if m is not a whole number', () => {
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 0.1231, n: 10 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 0.1231, n: 10 } });
       formWrapper.vm.validate();
       expect(
         wrapper
@@ -174,7 +174,7 @@ describe('masteryDropdown', () => {
           .find('.error--text')
           .exists()
       ).toBe(true);
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 1, n: 10 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 1, n: 10 } });
       formWrapper.vm.validate();
       expect(
         wrapper
@@ -184,7 +184,7 @@ describe('masteryDropdown', () => {
       ).toBe(false);
     });
     it('should flag if m < 1', () => {
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 0, n: 10 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 0, n: 10 } });
       formWrapper.vm.validate();
       expect(
         wrapper
@@ -192,7 +192,7 @@ describe('masteryDropdown', () => {
           .find('.error--text')
           .exists()
       ).toBe(true);
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 1, n: 10 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 1, n: 10 } });
       formWrapper.vm.validate();
       expect(
         wrapper
@@ -202,7 +202,7 @@ describe('masteryDropdown', () => {
       ).toBe(false);
     });
     it('should flag if m > n', () => {
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 2, n: 1 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 2, n: 1 } });
       formWrapper.vm.validate();
       expect(
         wrapper
@@ -210,7 +210,7 @@ describe('masteryDropdown', () => {
           .find('.error--text')
           .exists()
       ).toBe(true);
-      wrapper.setProps({ value: { mastery_model: 'm_of_n', m: 2, n: 2 } });
+      wrapper.setProps({ value: { type: 'm_of_n', m: 2, n: 2 } });
       formWrapper.vm.validate();
       expect(
         wrapper

--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             Q(kind_id=content_kinds.EXERCISE) & (
                 Q(has_questions=False) |
                 Q(invalid_exercise=True) |
-                Q(extra_fields__has_key='mastery_model') |
+                Q(extra_fields__has_key='type') |
                 Q(extra_fields__mastery_model=exercises.M_OF_N) & (
                     ~Q(extra_fields__has_key='m') | ~Q(extra_fields__has_key='n')
                 )

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1011,6 +1011,12 @@ class ContentNode(MPTTModel, models.Model):
     complete = models.BooleanField(default=False)
 
     changed = models.BooleanField(default=True)
+    """
+        Extra fields for exercises:
+        - type: mastery model to use to determine completion
+        - m: m value for M out of N mastery criteria
+        - n: n value for M out of N mastery criteria
+    """
     extra_fields = JSONField(default=dict, blank=True, null=True)
     author = models.CharField(max_length=200, blank=True, default="", help_text="Who created this content?",
                               null=True)


### PR DESCRIPTION
## Description

Fixes saving on mastery model by using the correct extra_fields field

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2195

## Steps to Test

- [ ] Edit an exercise 
- [ ] Update the mastery model (make sure switching between M of N toggles the M and N fields)
- [ ] Exit and check exercise details

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

Eventually, we'll want to update exercises to use extra_fields.mastery model ([issue filed here](https://github.com/learningequality/studio/issues/2233))


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
