### PR TITLE
Changes in requirements to run Studio on Python 3.8

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ django-filter==1.0.4
 django-pg-utils==0.1.5
 djangorestframework==3.9.1
 pdfkit==0.6.1
-psycopg2-binary==2.7.4
+psycopg2-binary==2.8.4
 django-js-reverse==0.9.1
 django-registration==2.1.2
 django-hashedfilenamestorage==1.0.0
@@ -20,8 +20,8 @@ porter2stemmer==1.0
 django-postmark==0.1.6
 jsonfield==2.0.2
 newrelic>=2.86.3.70
-celery==4.1.1
-redis==2.10.5
+celery==4.3.0
+redis==3.2.0
 reportlab==3.4.0
 python-resize-image==1.1.11
 pycountry==17.5.14
@@ -54,12 +54,12 @@ python-pptx
 google-cloud-kms==0.2.1
 backoff
 flower
-kombu==4.3
+kombu==4.6.11
 singledispatch==3.4.0.3
 backports-abc==0.5
 whitenoise==4.1.4
 django-model-utils==3.2.0
-django-redis
+django-redis==4.11.0
 django-prometheus
 future
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,17 @@
 #    pip-compile requirements.in
 #
 alabaster==0.7.12         # via sphinx
-amqp==2.5.2               # via kombu
+amqp==2.6.1               # via kombu
 argh==0.26.2              # via sphinx-autobuild
 babel==2.8.0              # via flower, sphinx, sphinx-intl
 backoff==1.10.0           # via -r requirements.in
 backports-abc==0.5        # via -r requirements.in
 beautifulsoup4==4.8.2     # via le-pycaption, pressurecooker
-billiard==3.5.0.5         # via celery
+billiard==3.6.3.0         # via celery
 boto3==1.12.1             # via django-s3-storage
 botocore==1.15.1          # via boto3, s3transfer
 cachetools==4.0.0         # via -r requirements.in, google-auth
-celery==4.1.1             # via -r requirements.in, flower
+celery==4.3.0             # via -r requirements.in, flower
 certifi==2019.11.28       # via minio, requests, sentry-sdk
 chardet==3.0.4            # via requests
 click==7.0                # via sphinx-intl
@@ -73,7 +73,7 @@ jmespath==0.9.4           # via boto3, botocore
 jsonfield==2.0.2          # via -r requirements.in
 kiwisolver==1.1.0         # via -r requirements.in, matplotlib
 kolibri==0.7.0            # via -r requirements.in
-kombu==4.3.0              # via -r requirements.in, celery
+kombu==4.6.11             # via -r requirements.in, celery
 le-pycaption==2.1.0a1     # via pressurecooker
 le-utils==0.1.24          # via -r requirements.in, pressurecooker
 livereload==2.6.1         # via sphinx-autobuild
@@ -97,7 +97,7 @@ pressurecooker==0.0.26    # via -r requirements.in
 progressbar2==3.38.0      # via -r requirements.in
 prometheus-client==0.7.1  # via django-prometheus
 protobuf==3.11.3          # via google-api-core, googleapis-common-protos
-psycopg2-binary==2.7.4    # via -r requirements.in
+psycopg2-binary==2.8.4    # via -r requirements.in
 pyasn1-modules==0.2.8     # via google-auth, oauth2client
 pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
 pycountry==17.5.14        # via -r requirements.in, le-utils
@@ -113,7 +113,7 @@ python-utils==2.3.0       # via progressbar2
 pytz==2019.3              # via babel, celery, django, django-postmark, flower, google-api-core, matplotlib, minio
 pyyaml==5.3               # via sphinx-autobuild
 raven==6.10.0             # via -r requirements.in
-redis==2.10.5             # via -r requirements.in, django-redis
+redis==3.2.0              # via -r requirements.in, django-redis
 reportlab==3.4.0          # via -r requirements.in, xhtml2pdf
 requests==2.22.0          # via -r requirements.in, django-mailgun, google-api-core, gspread, python-resize-image, sphinx
 rsa==4.0                  # via google-auth, oauth2client


### PR DESCRIPTION
## Description

Upgrade some python packages to be able to run Studio on python 3.8


## Steps to Test

- Using different versions of Python:
  `pip install -r requirements.txt`
  `make prodceleryworkers`

- Do current tests pass?


## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
