### PR TITLE
Profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ make stop_slaves  # mac: killall python
 
 #### Profiling
 
-In case you need to profile different the application to know which part of the code are more time consuming, there are two different profilers available. Both will store the profiling output in a directory that's determined by the `PROFILE_DIR` env variable. If  this variable is not set, the output files will be store in a folder called profiler inside the OS temp folder (`/tmp/profile` usually)
+In case you need to profile the application to know which part of the code are more time consuming, there are two different profilers available to work in two different modes. Both will store the profiling output in a directory that's determined by the `PROFILE_DIR` env variable. If  this variable is not set, the output files will be store in a folder called profiler inside the OS temp folder (`/tmp/profile` usually)
+Note that both profiling modes are incompatible: you can either use one or the other, but not both at the same time. In case the env variables are set for both modes, _All request profiling mode_ will be used.
 
 ##### All requests profiling mode
 
@@ -192,6 +193,8 @@ To activate it an env variable called `PROFILE_STUDIO_FULL` must be set.
 Example of use:
 
 `PROFILE_STUDIO_FULL=y yarn runserver`
+
+Afterwards no further treatment of the generated files is needed. You can open directly the html files in your browser.
 
 ##### Endpoint profiling mode
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ make stop_slaves  # mac: killall python
 
 #### Profiling
 
-In case you need to profile different the application to know which part of the code are more time consuming, there are two different profilers available. Both will store the profiling output in a directory that's determined by the `PROFILE_DIR` env variable. If  this variable is not set, the output files will be store in a folder called profiler inside the OS temp folder (`/tmp/profiler` usually)
+In case you need to profile different the application to know which part of the code are more time consuming, there are two different profilers available. Both will store the profiling output in a directory that's determined by the `PROFILE_DIR` env variable. If  this variable is not set, the output files will be store in a folder called profiler inside the OS temp folder (`/tmp/profile` usually)
 
 ##### All requests profiling mode
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Example of use:
 
 `PROFILE_STUDIO_FILTER=edit yarn localprodserver`
 
-For this case, only html requests having the word edit in his request path will be profiled. The profile folder will not have html files, but binary dump files (with the timestamp as filename) of the profiler information that can be later seen by different profiling tools (`snakeviz` that can be installed using pip is recommended). Also while the server is running,  the ten most time consuming lines of code of the filtered request will be shown in the console where Studio has been launched.
+For this case, only html requests having the text _edit_ in their request path will be profiled. The profile folder will not have html files, but binary dump files (with the timestamp as filename) of the profiler information that can be later seen by different profiling tools (`snakeviz` that can be installed using pip is recommended). Also while the server is running,  the ten most time consuming lines of code of the filtered request will be shown in the console where Studio has been launched.
 
 Example of snakeviz use:
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,38 @@ make timed_run
 make stop_slaves  # mac: killall python
 ```
 
+#### Profiling
+
+In case you need to profile different the application to know which part of the code are more time consuming, there are two different profilers available. Both will store the profiling output in a directory that's determined by the `PROFILE_DIR` env variable. If  this variable is not set, the output files will be store in a folder called profiler inside the OS temp folder (`/tmp/profiler` usually)
+
+##### All requests profiling mode
+
+This mode will create interactive html files with all the profiling information for every request the Studio server receives. The name of the files will contain the total execution time, the endpoint  name and a timestamp.
+
+To activate it an env variable called `PROFILE_STUDIO_FULL` must be set.
+
+Example of use:
+
+`PROFILE_STUDIO_FULL=y yarn runserver`
+
+##### Endpoint profiling mode
+
+When using the all requests mode it's usual that the profile folder is soon full of information for requests that are not interesting for the developer and it's hard to find the files for some specific endpoints.
+
+If an env variable called `PROFILE_STUDIO_FILTER` is used, the profiler will be executed only on the http requests containing the text stated by the variable.
+
+Example of use:
+
+`PROFILE_STUDIO_FILTER=edit yarn localprodserver`
+
+For this case, only html requests having the word edit in his request path will be profiled. The profile folder will not have html files, but binary dump files (with the timestamp as filename) of the profiler information that can be later seen by different profiling tools (`snakeviz` that can be installed using pip is recommended). Also while the server is running,  the ten most time consuming lines of code of the filtered request will be shown in the console where Studio has been launched.
+
+Example of snakeviz use:
+
+`snakeviz /tmp/profile/studio\:20200909161405011678.prof`
+
+will open the browser with an interactive diagram with all the profiling information
+
 ### Linting
 
 Front-end linting is run using:

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -16,6 +16,7 @@ import re
 import sys
 from datetime import datetime
 from datetime import timedelta
+from tempfile import gettempdir
 
 import pycountry
 
@@ -134,6 +135,22 @@ MIDDLEWARE = (
     'contentcuration.middleware.db_readonly.DatabaseReadOnlyMiddleware',
     # 'django.middleware.cache.FetchFromCacheMiddleware',
 )
+
+if os.getenv("PROFILE_STUDIO_FULL"):
+    MIDDLEWARE = MIDDLEWARE + ("pyinstrument.middleware.ProfilerMiddleware",)
+    PYINSTRUMENT_PROFILE_DIR = os.getenv("PROFILE_DIR") or "{}/profile".format(
+        gettempdir()
+    )
+elif os.getenv("PROFILE_STUDIO_FILTER"):
+    MIDDLEWARE = MIDDLEWARE + ("customizable_django_profiler.cProfileMiddleware",)
+    PROFILER = {
+        "activate": True,
+        "output": ["dump", "console"],
+        "count": "10",
+        "file_location": os.getenv("PROFILE_DIR")
+        or "{}/profile/studio".format(gettempdir()),
+        "trigger": "query_param:{}".format(os.getenv("PROFILE_STUDIO_FILTER")),
+    }
 
 if os.getenv("GCLOUD_ERROR_REPORTING"):
     MIDDLEWARE = (

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -32,3 +32,6 @@ nodeenv
 pip-tools
 locust
 drf-yasg
+pyinstrument
+pypandoc
+git+https://github.com/someshchaturvedi/customizable-django-profiler.git#customizable-django-profiler

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@
 #    pip-compile requirements-dev.in
 #
 appdirs==1.4.3            # via virtualenv
-appnope==0.1.0            # via ipython
 aspy.yaml==1.3.0          # via pre-commit
 astroid==2.3.3            # via pylint
 attrs==19.3.0             # via pytest
@@ -22,6 +21,7 @@ configargparse==1.2.3     # via locust
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==5.0.3           # via -r requirements-dev.in, codecov, pytest-cov
+git+https://github.com/someshchaturvedi/customizable-django-profiler.git#customizable-django-profiler  # via -r requirements-dev.in
 decorator==4.4.1          # via -c requirements.txt, ipython, traitlets
 distlib==0.3.0            # via virtualenv
 django-debug-panel==0.8.3  # via -r requirements-dev.in
@@ -40,8 +40,7 @@ geventhttpclient==1.4.4   # via locust
 greenlet==0.4.16          # via gevent
 identify==1.4.11          # via pre-commit
 idna==2.8                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via pluggy, pre-commit, pytest, virtualenv
-importlib-resources==1.0.2  # via pre-commit, virtualenv
+importlib-metadata==1.5.0  # via pre-commit
 importmagic==0.1.7        # via -r requirements-dev.in
 inflection==0.5.0         # via drf-yasg
 ipdb==0.12.3              # via -r requirements-dev.in
@@ -77,9 +76,12 @@ py==1.8.1                 # via pytest
 pycodestyle==2.3.1        # via autopep8, flake8
 pyflakes==1.5.0           # via autoflake, flake8
 pygments==2.5.2           # via -c requirements.txt, ipython
+pyinstrument-cext==0.2.2  # via pyinstrument
+pyinstrument==3.1.4       # via -r requirements-dev.in
 pylint==2.4.4             # via -r requirements-dev.in
 pyls-isort==0.1.1         # via -r requirements-dev.in
 pympler==0.8              # via -r requirements-dev.in
+pypandoc==1.5             # via -r requirements-dev.in
 pyparsing==2.4.6          # via -c requirements.txt, packaging
 pytest-cov==2.8.1         # via -r requirements-dev.in
 pytest-django==3.8.0      # via -r requirements-dev.in
@@ -102,7 +104,6 @@ six==1.14.0               # via -c requirements.txt, astroid, drf-yasg, faker, g
 sqlparse==0.3.0           # via django-debug-toolbar
 toml==0.10.0              # via pre-commit
 traitlets==4.3.3          # via ipython
-typed-ast==1.4.1          # via astroid
 ujson==1.35               # via python-jsonrpc-server, python-language-server
 uritemplate==3.0.1        # via -c requirements.txt, coreapi, drf-yasg
 urllib3==1.25.8           # via -c requirements.txt, requests
@@ -110,6 +111,7 @@ virtualenv==20.0.3        # via pre-commit
 watchdog==0.10.2          # via -c requirements.txt, pytest-watch
 wcwidth==0.1.8            # via prompt-toolkit, pytest
 werkzeug==1.0.1           # via flask
+wheel==0.35.1             # via pypandoc
 wrapt==1.11.2             # via astroid
 yapf==0.29.0              # via -r requirements-dev.in
 zipp==2.2.0               # via importlib-metadata


### PR DESCRIPTION

## Description

Adds an easy setup to profile to Studio and documents how to use it


## Steps to Test

`pip install -r requirements-dev.txt` is needed before being able to do the profiling

- Read the profiling section of the README.md file
- Try to undersand it and test the two different profiling modes

## Implementation Notes (optional)

There are not many profilers for Django < 2.0 and among the available ones there's not a perfect profiler. For this reason the implementation uses two different profiling libraries depending on the needs of the developer:
- Every request is profiled and the info is written in the form of an interactive html folder  (it produces a lot of html files in the profile folder)
OR
- Only one endpoint is profiled, but the result is given in a dump format that  needs a third tool (`snakeviz` recommended) to visualize it

The changes in the README.md file should explain how to use both methods


## Checklist



- [ ] Is the code clean and well-commented?

## Comments

Please check the English grammar of the documentation 

