### PR TITLE
Annotate assessment item count directly to contentnode viewset

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.spec.js
@@ -15,10 +15,7 @@ const EXERCISE_NODE = {
   kind: ContentKindsNames.EXERCISE,
   title: 'Exercise title',
   description: 'This is an exercise',
-  assessment_items: [
-    { assessment_id: 'assessment-item-1' },
-    { assessment_id: 'assessment-item-2' },
-  ],
+  assessment_item_count: 5,
 };
 
 const TOPIC_NODE = {
@@ -88,7 +85,7 @@ describe('ContentNodeListItem', () => {
     it('renders assessment items count in a subtitle', () => {
       expect(wrapper.contains('[data-test="subtitle"]')).toBe(true);
       expect(wrapper.find('[data-test="subtitle"]').html()).toContain(
-        EXERCISE_NODE.assessment_items.length
+        EXERCISE_NODE.assessment_item_count
       );
     });
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -133,7 +133,7 @@
             });
           case ContentKindsNames.EXERCISE:
             return this.$tr('questions', {
-              value: this.node.assessment_items ? this.node.assessment_items.length : 0,
+              value: this.node.assessment_item_count || 0,
             });
         }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
@@ -130,7 +130,7 @@
       },
       subtitleText() {
         if (this.node.kind === 'exercise') {
-          return this.$tr('questionCount', { count: this.node.assessment_items.length });
+          return this.$tr('questionCount', { count: this.node.assessment_item_count });
         }
         return this.statusMessage(this.node.files);
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/data.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/data.js
@@ -41,7 +41,6 @@ export function generateNode(props = {}) {
     is_prerequisite_of: [],
     files: [{ id: 'file', preset: { id: 'preset' } }],
     metadata: { resource_size: 0 },
-    assessment_items: [],
     extra_fields: extra_fields,
     tags: [],
     ancestors: [],

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -121,7 +121,7 @@
               <span class="mx-1">{{ $tr('noQuestionsError') }}</span>
             </span>
             <span v-else>
-              {{ $formatNumber(node.assessment_items.length) }}
+              {{ $formatNumber(assessmentItems.length) }}
             </span>
           </DetailsRow>
           <DetailsRow

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -181,7 +181,6 @@ export function createContentNode(context, { parent, kind = 'topic', ...payload 
     kind,
     files: [],
     prerequisite: [],
-    assessment_items: [],
     extra_fields: {},
     isNew: true,
     language: session.preferences ? session.preferences.language : session.currentLanguage,


### PR DESCRIPTION
## Description

Annotate the assessment item count directly to the contentnode viewset to get a more accurate question count

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2127

## Steps to Test

- [ ] Open the resource panel for an exercise with questions
- [ ] Check that the question count matches the number of questions listed

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
