### PR TITLE
Updated the styling on info modals

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
@@ -2,15 +2,18 @@
 
   <VBtn
     :style="{color: $vuetify.theme.primary}"
+    :target="target"
     v-bind="$attrs"
     flat
     exact
-    class="action-link"
     @keyup.enter.stop="$emit('click')"
     @click.stop="$emit('click')"
   >
     <slot>
-      {{ text }}
+      <span style="text-decoration: underline;">
+        {{ text }}
+        <Icon v-if="target === '_blank'" size="12">open_in_new</Icon>
+      </span>
     </slot>
   </VBtn>
 
@@ -22,6 +25,10 @@
     props: {
       text: {
         type: String,
+      },
+      target: {
+        type: String,
+        required: false,
       },
     },
   };
@@ -36,8 +43,11 @@
     padding: 0;
     margin: 0;
     font-weight: normal;
-    text-decoration: underline !important;
     text-transform: none;
+  }
+
+  .v-icon {
+    vertical-align: baseline;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
@@ -1,24 +1,30 @@
 <template>
 
-  <VDialog v-model="dialog" width="550">
-    <template v-slot:activator="{ on }">
+  <VDialog v-model="dialog" v-resize="handleWindowResize" width="550">
+    <template #activator="{ on }">
       <Icon color="primary" v-on="on">
         help
       </Icon>
     </template>
 
     <VCard>
-      <VCardTitle class="headline">
+      <VCardTitle class="title font-weight-bold pa-4" :class="{overflow}">
         {{ header }}
       </VCardTitle>
-
-      <VCardText>
-        <slot name="content"></slot>
+      <VCardText ref="content" class="content px-4" :class="overflow? 'py-3' : 'py-0'">
+        <slot></slot>
+        <div v-for="(item, index) in items" :key="`info-${index}`" class="mb-4">
+          <h1 class="subheading font-weight-bold mb-1">
+            <slot name="header" :item="item"></slot>
+          </h1>
+          <p class="body-1 grey--text">
+            <slot name="description" :item="item"></slot>
+          </p>
+        </div>
       </VCardText>
-      <VCardActions>
-        <slot name="extra-button" class="extra-button"></slot>
+      <VCardActions class="px-4 py-3" :class="{overflow}">
         <VSpacer />
-        <VBtn color="primary" depressed autofocus @click="dialog = false">
+        <VBtn color="greyBackground" autofocus @click="dialog = false">
           <b>{{ $tr('closeButtonLabel') }}</b>
         </VBtn>
       </VCardActions>
@@ -36,11 +42,33 @@
         type: String,
         required: true,
       },
+      items: {
+        type: Array,
+        default() {
+          return [];
+        },
+      },
     },
     data() {
       return {
         dialog: false,
+        overflow: false,
       };
+    },
+    watch: {
+      dialog(open) {
+        if (open) {
+          this.$nextTick(this.handleWindowResize);
+        }
+      },
+    },
+    methods: {
+      handleWindowResize() {
+        if (this.dialog) {
+          const contentElement = this.$refs.content;
+          this.overflow = contentElement.clientHeight < contentElement.scrollHeight;
+        }
+      },
     },
     $trs: {
       closeButtonLabel: 'Close',
@@ -51,18 +79,22 @@
 
 <style lang="less" scoped>
 
-  .v-card__title {
-    padding-bottom: 0;
-  }
-
-  .headline,
-  /deep/ .headline {
-    font-family: 'Noto Sans' !important;
-  }
-
   /deep/ p {
     font-size: 12pt;
     color: var(--v-grey-darken3);
+  }
+
+  .content {
+    max-height: calc(90vh - 190px);
+    overflow-y: auto;
+  }
+
+  // Show borders if there's overflow
+  .v-card__title.overflow {
+    border-bottom: 1px solid var(--v-greyBorder-lighten1);
+  }
+  .v-card__actions.overflow {
+    border-top: 1px solid var(--v-greyBorder-lighten1);
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -19,23 +19,20 @@
         class="ma-0"
         box
       >
-        <template v-slot:append-outer>
-          <InfoModal v-if="selectedLicense" :header="translate(selectedLicense)">
-            <template v-slot:content>
-              <p class="license-info">
-                {{ translateDescription(selectedLicense) }}
-              </p>
+        <template #append-outer>
+          <InfoModal :header="$tr('licenseInfoHeader')" :items="licenses">
+            <template #header="{item}">
+              {{ translate(item) }}
             </template>
-            <template v-if="selectedLicense.license_url" v-slot:extra-button>
-              <VBtn
-                flat
-                color="primary"
-                :href="licenseUrl"
-                target="_blank"
-                class="action-text"
-              >
-                {{ $tr('learnMoreButton') }}
-              </VBtn>
+            <template #description="{item}">
+              {{ translateDescription(item) }}
+              <p v-if="item.license_url" class="mt-1">
+                <ActionLink
+                  :href="getLicenseUrl(item)"
+                  target="_blank"
+                  :text="$tr('learnMoreButton')"
+                />
+              </p>
             </template>
           </InfoModal>
         </template>
@@ -137,11 +134,6 @@
       licenses() {
         return LicensesList;
       },
-      licenseUrl() {
-        let licenseUrl = this.selectedLicense.license_url;
-        let isCC = licenseUrl.includes('creativecommons.org');
-        return isCC ? licenseUrl + 'deed.' + (window.languageCode || 'en') : licenseUrl;
-      },
       licenseRules() {
         return this.required ? [v => !!v || this.$tr('licenseValidationMessage')] : [];
       },
@@ -160,6 +152,11 @@
           (item.toString() && this.translateConstant(item.license_name + '_description')) || ''
         );
       },
+      getLicenseUrl(item) {
+        const isCC = item.license_url.includes('creativecommons.org');
+        const language = window.languageCode || 'en';
+        return isCC ? `${item.license_url}deed.${language}` : item.license_url;
+      },
     },
     $trs: {
       licenseLabel: 'License',
@@ -167,6 +164,7 @@
       licenseDescriptionLabel: 'Description of License',
       descriptionValidationMessage: 'Special permissions license must have a description',
       learnMoreButton: 'Learn More',
+      licenseInfoHeader: 'About licenses',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/views/MasteryDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MasteryDropdown.vue
@@ -16,30 +16,15 @@
         :rules="masteryRules"
         menu-props="offsetY"
       >
-        <template v-slot:append-outer>
-          <InfoModal :header="$tr('exerciseHeader')">
-            <template v-slot:content>
-              <p>{{ $tr('exerciseDescripiton') }}</p>
-              <VDivider />
-              <h3 class="headline my-3">
-                {{ $tr('masterySubheader') }}
-              </h3>
-              <p>{{ $tr('masteryDescripiton') }}</p>
-              <div class="mastery-table">
-                <VLayout
-                  v-for="criteria in masteryCriteria"
-                  :key="criteria.value"
-                  row
-                  class="mastery-row"
-                >
-                  <VFlex xs3 class="mastery-label text-right">
-                    {{ translateConstant(criteria.value) }}
-                  </VFlex>
-                  <VFlex xs9>
-                    {{ translateConstant(criteria.value + '_description') }}
-                  </VFlex>
-                </VLayout>
-              </div>
+        <template #append-outer>
+          <InfoModal :header="$tr('exerciseHeader')" :items="masteryCriteria">
+            <p>{{ $tr('exerciseDescripiton') }}</p>
+            <p>{{ $tr('masteryDescripiton') }}</p>
+            <template #header="{item}">
+              {{ translateConstant(item.value) }}
+            </template>
+            <template #description="{item}">
+              {{ translateConstant(item.value + '_description') }}
             </template>
           </InfoModal>
         </template>
@@ -243,10 +228,9 @@
     },
     $trs: {
       labelText: 'Mastery Criteria',
-      exerciseHeader: 'What is an Exercise?',
+      exerciseHeader: 'About mastery criteria',
       exerciseDescripiton:
         'An exercise contains a set of interactive questions that a learner can engage with in Kolibri. They will receive instant feedback on whether they answer each question correctly or incorrectly. Kolibri will cycle through the available questions in an exercise until the learner achieves mastery.',
-      masterySubheader: 'Achieving Mastery',
       masteryDescripiton:
         'Kolibri marks an exercise as "completed" when the mastery criteria is met. Here are the different types of mastery criteria for an exercise:',
       masteryValidationMessage: 'Mastery is required',

--- a/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
@@ -16,23 +16,18 @@
       box
     >
       <template v-slot:append-outer>
-        <InfoModal :header="$tr('visibilityHeader')">
-          <template #content>
-            <p>{{ $tr('visibilityDescription') }}</p>
-            <VDivider />
-            <div class="role-table">
-              <VLayout v-for="roleOption in roles" :key="roleOption.value" row>
-                <VFlex xs3 text-right class="role-label">
-                  {{ roleOption.text }}
-                  <Icon v-if="roleIcon(roleOption.value)" color="primary">
-                    {{ roleIcon(roleOption.value) }}
-                  </Icon>
-                </VFlex>
-                <VFlex xs9>
-                  {{ $tr(roleOption.value) }}
-                </VFlex>
-              </VLayout>
-            </div>
+        <InfoModal :header="$tr('visibilityHeader')" :items="roles">
+          <p>{{ $tr('visibilityDescription') }}</p>
+          <template #header="{item}">
+            <span>
+              {{ item.text }}
+              <Icon v-if="roleIcon(item.value)" color="primary">
+                {{ roleIcon(item.value) }}
+              </Icon>
+            </span>
+          </template>
+          <template #description="{item}">
+            {{ $tr(item.value) }}
           </template>
         </InfoModal>
       </template>
@@ -136,24 +131,6 @@
     margin-left: 5px;
     font-size: 12pt;
     vertical-align: text-top;
-  }
-
-  .role-table {
-    padding: 15px;
-    .row {
-      padding: 5px;
-      .role-label {
-        padding-right: 15px;
-        font-weight: bold;
-      }
-    }
-  }
-
-  /deep/ a {
-    text-decoration: none !important;
-    &:hover {
-      color: var(--v-blue-darken-1);
-    }
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/infoModal.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/infoModal.spec.js
@@ -22,10 +22,6 @@ describe('infoModal', () => {
   beforeEach(() => {
     wrapper = makeWrapper({ header: 'testHeader' });
   });
-  it('header and content should be displayed on the dialog', () => {
-    expect(wrapper.find('.v-dialog').text()).toContain('testHeader');
-    expect(wrapper.find('.v-dialog').text()).toContain('Test Content');
-  });
   it('clicking the info button should open the dialog', () => {
     expect(wrapper.find('.v-dialog').isVisible()).toBe(false);
     let button = wrapper.find('.v-icon');

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/licenseDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/licenseDropdown.spec.js
@@ -3,7 +3,6 @@ import Vue from 'vue';
 import Vuetify from 'vuetify';
 import { mount } from '@vue/test-utils';
 import LicenseDropdown from '../LicenseDropdown.vue';
-import InfoModal from '../InfoModal.vue';
 import TestForm from './TestForm.vue';
 import { LicensesList } from 'shared/leUtils/Licenses';
 
@@ -67,32 +66,6 @@ describe('licenseDropdown', () => {
       wrapper.setProps({ disabled: true, value: { license: specialPermissions.id } });
       expect(wrapper.find('input:disabled').exists()).toBe(true);
       expect(wrapper.find('textarea:disabled').exists()).toBe(true);
-    });
-  });
-  describe('license info modal', () => {
-    it('should open the info modal when button is clicked', () => {
-      wrapper.setProps({ value: { license: specialPermissions.id } });
-      expect(wrapper.find('.v-dialog').isVisible()).toBe(false);
-      let button = wrapper.find(InfoModal).find('.v-icon');
-      button.trigger('click');
-      expect(wrapper.find('.v-dialog').isVisible()).toBe(true);
-    });
-    it('should render the correct license description', () => {
-      function test(license) {
-        wrapper.setProps({ value: { license: license.id } });
-        expect(wrapper.find('.v-dialog').text()).toContain(license.license_name);
-        expect(wrapper.find('.v-dialog').text()).toContain(license.license_description);
-      }
-      _.each(LicensesList, test);
-    });
-    it('should render a LEARN MORE link to the license information page', () => {
-      function test(license) {
-        wrapper.setProps({ value: { license: license.id } });
-        if (license.license_url)
-          expect(wrapper.find('.v-dialog a').attributes('href')).toContain(license.license_url);
-        else expect(wrapper.find('.v-dialog a').exists()).toBe(false);
-      }
-      _.each(LicensesList, test);
     });
   });
   describe('change events', () => {


### PR DESCRIPTION
## Description

Standardizes the styling for info modals

# Before/After Screenshots
## Visibility modal
### Before
![image](https://user-images.githubusercontent.com/7447496/92686395-6a6eb580-f2ee-11ea-9761-0bfb52cc6786.png)

### After
![image](https://user-images.githubusercontent.com/7447496/92686179-00eea700-f2ee-11ea-8142-ef49ae93c070.png)

## License modal
### Before
![image](https://user-images.githubusercontent.com/7447496/92686366-57f47c00-f2ee-11ea-86fa-bda55bdaf5f5.png)

### After
![image](https://user-images.githubusercontent.com/7447496/92686230-1794fe00-f2ee-11ea-94f6-66cc302c8f1b.png)

## Mastery modal
### Before
![image](https://user-images.githubusercontent.com/7447496/92686313-44491580-f2ee-11ea-916b-a11915567c0f.png)

### After
![image](https://user-images.githubusercontent.com/7447496/92686253-267bb080-f2ee-11ea-89e1-26074d33df08.png)
