### PR TITLE
Use native input and debounce it for text fields in content edit

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -520,7 +520,7 @@
         this.updateContentNodes({ ids: this.nodeIds, ...payload });
       },
       handleTextFieldInput: debounce(function(key, nativeInputEvent) {
-        this.update({ [key] : nativeInputEvent.srcElement.value });
+        this.update({ [key]: nativeInputEvent.srcElement.value });
       }, 300),
       updateExtraFields(extra_fields) {
         this.updateContentNodes({ ids: this.nodeIds, extra_fields });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -130,7 +130,7 @@
               box
               :placeholder="getPlaceholder('author')"
               :value="author && author.toString()"
-              @input="v => author = v"
+              @input.native="handleTextFieldInput('author', $event)"
             >
               <template v-slot:append-outer>
                 <HelpTooltip :text="$tr('authorToolTip')" top />
@@ -148,7 +148,7 @@
               autoSelectFirst
               box
               :value="provider && provider.toString()"
-              @input="v => provider = v"
+              @input.native="handleTextFieldInput('provider', $event)"
             >
               <template v-slot:append-outer>
                 <HelpTooltip :text="$tr('providerToolTip')" top />
@@ -166,7 +166,7 @@
               :placeholder="getPlaceholder('aggregator')"
               box
               :value="aggregator && aggregator.toString()"
-              @input="v => aggregator = v"
+              @input.native="handleTextFieldInput('aggregator', $event)"
             >
               <template v-slot:append-outer>
                 <HelpTooltip :text="$tr('aggregatorToolTip')" top />
@@ -197,7 +197,7 @@
               :readonly="disableAuthEdits"
               box
               :value="copyright_holder && copyright_holder.toString()"
-              @input="v => copyright_holder = v"
+              @input.native="handleTextFieldInput('copyright_holder', $event)"
             />
           </VFlex>
           <VSpacer />
@@ -271,6 +271,7 @@
   import difference from 'lodash/difference';
   import intersection from 'lodash/intersection';
   import uniq from 'lodash/uniq';
+  import debounce from 'lodash/debounce';
   import { mapGetters, mapActions } from 'vuex';
   import ContentNodeThumbnail from '../../views/files/thumbnails/ContentNodeThumbnail';
   import FileUpload from '../../views/files/FileUpload';
@@ -518,6 +519,9 @@
       update(payload) {
         this.updateContentNodes({ ids: this.nodeIds, ...payload });
       },
+      handleTextFieldInput: debounce(function(key, nativeInputEvent) {
+        this.update({ [key] : nativeInputEvent.srcElement.value });
+      }, 300),
       updateExtraFields(extra_fields) {
         this.updateContentNodes({ ids: this.nodeIds, extra_fields });
       },


### PR DESCRIPTION
## Description

When editing multiple content nodes, text was not saving properly or as expected.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2235

Applies to other fields in addition to `author`.

## Steps to Test

1. Select multiple items to edit
2. Edit one item's author field
3. Click directly onto a different node in the left panel without clicking anything else (don't blur the text field)
4. Author field stays around, depsite having switched to a different node

Previously, changes would not be persisted if you clicked away without blurring the edited field.

Do the same with Provider, Aggregator, etc in that section.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

The Vuetify `@input` and `@change` event listeners were not being triggered _on input_ but rather on blur. So if we don't blur the field, the value of the data isn't saved and that's annoying.

Since they events aren't triggered in a way that suits our use case of constantly saving the data (ie, we don't have a "Save Changes" button - rather, all changes are expected to save as you go in this context) --- I had to use the native input event and write a function that takes the `key` to be updated (eg, `author`, `provider`, etc) and takes a native event.

Debouncing it 300ms feels super smooth on my end and I couldn't click away fast enough after typing to ever beat debounce to firing the function.

#### Does this introduce any tech-debt items?

I think that we may need to retain this if/when we move to KDS - but in that case we have the option of updating our component to suit our needs (eg, add a prop to force KTextBox to emit its value `onchange` and not only `onblur`).

