### PR TITLE
Input question on AnswerEdit is now a type=number field

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -1,4 +1,9 @@
-import { floatOrIntRegex, getCorrectAnswersIndices, mapCorrectAnswers, updateAnswersToQuestionType } from '../utils';
+import {
+  floatOrIntRegex,
+  getCorrectAnswersIndices,
+  mapCorrectAnswers,
+  updateAnswersToQuestionType,
+} from '../utils';
 import { AssessmentItemTypes } from 'shared/constants';
 
 describe('channelEdit utils', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -1,4 +1,4 @@
-import { getCorrectAnswersIndices, mapCorrectAnswers, updateAnswersToQuestionType } from '../utils';
+import { floatOrIntRegex, getCorrectAnswersIndices, mapCorrectAnswers, updateAnswersToQuestionType } from '../utils';
 import { AssessmentItemTypes } from 'shared/constants';
 
 describe('channelEdit utils', () => {
@@ -386,6 +386,29 @@ describe('channelEdit utils', () => {
           ]);
         });
       });
+    });
+  });
+
+  // At least we know that these will work
+  describe('floatOrIntRegex', () => {
+    it('tests true for valid values', () => {
+      [
+        '1.5', // Float
+        '-4.5', // Signed Float
+        '+1', // Signed Int
+        '10e5', // Exponentiation
+        '-15.3e5', // Combo
+        '-12345.67890e98', // Combo 2
+      ].forEach(v => expect(floatOrIntRegex.test(v)).toBe(true));
+    });
+
+    it('tests false for invalid values', () => {
+      [
+        'i * 1.5', // Math
+        'one.point.five', // Text
+        '10 5 0 100', // Spaces
+        '1.2.3.4', // IP
+      ].forEach(v => expect(floatOrIntRegex.test(v)).toBe(false));
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -184,11 +184,21 @@ describe('channelEdit utils', () => {
       });
 
       describe('conversion to input question', () => {
-        it('makes all answers correct', () => {
+        beforeEach(() => {
+          answers = [
+            { answer: '1500', correct: false, order: 1 },
+            { answer: '1500.00', correct: false, order: 2 },
+            { answer: '-1500.00', correct: true, order: 3 },
+            { answer: '1500 with alphabetical', correct: false, order: 4 },
+            { answer: '$1500.00', correct: false, order: 5 },
+          ];
+        });
+
+        it('makes all answers correct and removes any answers with non-numeric characters', () => {
           expect(updateAnswersToQuestionType(AssessmentItemTypes.INPUT_QUESTION, answers)).toEqual([
-            { answer: 'Mayonnaise (I mean you can, but...)', correct: true, order: 1 },
-            { answer: 'Peanut butter', correct: true, order: 2 },
-            { answer: 'Jelly', correct: true, order: 3 },
+            { answer: '1500', correct: true, order: 1 },
+            { answer: '1500.00', correct: true, order: 2 },
+            { answer: '-1500.00', correct: true, order: 3 },
           ]);
         });
       });
@@ -208,6 +218,8 @@ describe('channelEdit utils', () => {
         answers = [
           { answer: '8', correct: true, order: 1 },
           { answer: '8.0', correct: true, order: 2 },
+          { answer: '-400.19090', correct: true, order: 3 },
+          { answer: '-140140104', correct: true, order: 4 },
         ];
       });
 
@@ -234,6 +246,8 @@ describe('channelEdit utils', () => {
           ).toEqual([
             { answer: '8', correct: true, order: 1 },
             { answer: '8.0', correct: false, order: 2 },
+            { answer: '-400.19090', correct: false, order: 3 },
+            { answer: '-140140104', correct: false, order: 4 },
           ]);
         });
       });
@@ -281,11 +295,10 @@ describe('channelEdit utils', () => {
       });
 
       describe('conversion to input question', () => {
-        it('makes all answers correct', () => {
-          expect(updateAnswersToQuestionType(AssessmentItemTypes.INPUT_QUESTION, answers)).toEqual([
-            { answer: 'True', correct: true, order: 1 },
-            { answer: 'False', correct: true, order: 2 },
-          ]);
+        it('remove all answers', () => {
+          expect(updateAnswersToQuestionType(AssessmentItemTypes.INPUT_QUESTION, answers)).toEqual(
+            []
+          );
         });
       });
     });
@@ -344,17 +357,15 @@ describe('channelEdit utils', () => {
       describe('conversion to input question', () => {
         beforeEach(() => {
           answers = [
-            { answer: 'Mayonnaise (I mean you can, but...)', correct: true, order: 1 },
-            { answer: 'Peanut butter', correct: false, order: 2 },
-            { answer: 'Jelly', correct: true, order: 3 },
+            { answer: '1500', correct: false, order: 1 },
+            { answer: '1500 00', correct: false, order: 2 },
+            { answer: '1500 with alphabetical', correct: false, order: 3 },
           ];
         });
 
-        it('marks all answers to be correct', () => {
+        it('makes all answers correct and removes any answers with non-numeric characters', () => {
           expect(updateAnswersToQuestionType(AssessmentItemTypes.INPUT_QUESTION, answers)).toEqual([
-            { answer: 'Mayonnaise (I mean you can, but...)', correct: true, order: 1 },
-            { answer: 'Peanut butter', correct: true, order: 2 },
-            { answer: 'Jelly', correct: true, order: 3 },
+            { answer: '1500', correct: true, order: 1 },
           ]);
         });
       });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.spec.js
@@ -216,6 +216,17 @@ describe('AnswersEditor', () => {
     });
 
     it('renders all possible answers', () => {
+      // The answer text won't render when `mount()` is used so we override
+      // and use shallowMount here
+      wrapper = shallowMount(AnswersEditor, {
+        propsData: {
+          questionKind: AssessmentItemTypes.INPUT_QUESTION,
+          answers: [
+            { answer: 'Mayonnaise (I mean you can, but...)', correct: true, order: 1 },
+            { answer: 'Peanut butter', correct: true, order: 2 },
+          ],
+        },
+      });
       expect(wrapper.html()).toContain('Mayonnaise (I mean you can, but...)');
       expect(wrapper.html()).toContain('Peanut butter');
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -72,37 +72,37 @@
               </VFlex>
 
               <VSpacer />
-            <VFlex xs7>
-              <keep-alive :max="5">
-                <!-- Input question shows a text field with type of `number` -->
-                <div v-if="isInputQuestion">
-                  <VTextField 
-                    v-if="isAnswerOpen(answerIdx)" 
-                    v-model="answer.answer" 
-                    class="answer-number" 
-                    type="number" 
-                  />
-                  <VTextField v-else :value="answer.answer" class="no-border" type="number" />
-                </div>
+              <VFlex xs7>
+                <keep-alive :max="5">
+                  <!-- Input question shows a text field with type of `number` -->
+                  <div v-if="isInputQuestion">
+                    <VTextField 
+                      v-if="isAnswerOpen(answerIdx)" 
+                      v-model="answer.answer" 
+                      class="answer-number" 
+                      type="number" 
+                    />
+                    <VTextField v-else :value="answer.answer" class="no-border" type="number" />
+                  </div>
 
-                <div v-else>
-                  <MarkdownEditor
-                    v-if="isAnswerOpen(answerIdx)"
-                    class="editor"
-                    :markdown="answer.answer"
-                    :handleFileUpload="handleFileUpload"
-                    :getFileUpload="getFileUpload"
-                    :imagePreset="imagePreset"
-                    @update="updateAnswerText($event, answerIdx)"
-                    @minimize="emitClose"
-                  />
-                  <MarkdownViewer
-                    v-else
-                    :markdown="answer.answer"
-                  />
-                </div>
-              </keep-alive>
-            </VFlex>
+                  <div v-else>
+                    <MarkdownEditor
+                      v-if="isAnswerOpen(answerIdx)"
+                      class="editor"
+                      :markdown="answer.answer"
+                      :handleFileUpload="handleFileUpload"
+                      :getFileUpload="getFileUpload"
+                      :imagePreset="imagePreset"
+                      @update="updateAnswerText($event, answerIdx)"
+                      @minimize="emitClose"
+                    />
+                    <MarkdownViewer
+                      v-else
+                      :markdown="answer.answer"
+                    />
+                  </div>
+                </keep-alive>
+              </VFlex>
 
               <VFlex>
                 <AssessmentItemToolbar

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -72,6 +72,36 @@
               </VFlex>
 
               <VSpacer />
+            <VFlex xs7>
+              <keep-alive :max="5">
+                <div v-if="isInputQuestion">
+                  <VTextField 
+                    v-if="isAnswerOpen(answerIdx)" 
+                    v-model="answer.answer" 
+                    class="answer-number" 
+                    type="number" 
+                  />
+                  <VTextField v-else v-model="answer.answer" class="no-border" type="number" />
+                </div>
+
+                <div v-else>
+                  <MarkdownEditor
+                    v-if="isAnswerOpen(answerIdx)"
+                    class="editor"
+                    :markdown="answer.answer"
+                    :handleFileUpload="handleFileUpload"
+                    :getFileUpload="getFileUpload"
+                    :imagePreset="imagePreset"
+                    @update="updateAnswerText($event, answerIdx)"
+                    @minimize="emitClose"
+                  />
+                  <MarkdownViewer
+                    v-else
+                    :markdown="answer.answer"
+                  />
+                </div>
+              </keep-alive>
+            </VFlex>
 
               <VFlex>
                 <AssessmentItemToolbar
@@ -440,6 +470,29 @@
 
   .v-input--selection-controls {
     margin-top: 6px;
+  }
+
+  /* 
+  Ensure that the up/down arrows for type=number input
+  are hidden from view. We want a text field that only
+  accepts numbers 
+  */
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type=number] {
+    -moz-appearance: textfield;
+  }
+  
+  /* Remove the underline on text fields that are not focused */
+  /deep/.no-border.v-text-field>.v-input__control>.v-input__slot:before,
+  /deep/.no-border.v-text-field>.v-input__control>.v-input__slot:after {
+    border-style: none;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -82,7 +82,7 @@
                     class="answer-number" 
                     type="number" 
                   />
-                  <VTextField v-else v-model="answer.answer" class="no-border" type="number" />
+                  <VTextField v-else :value="answer.answer" class="no-border" type="number" />
                 </div>
 
                 <div v-else>
@@ -471,24 +471,6 @@
 
   .v-input--selection-controls {
     margin-top: 6px;
-  }
-
-  /* 
-  Ensure that the up/down arrows for type=number input
-  are hidden from view. We want a text field that only
-  accepts numbers 
-  */
-
-  /* Chrome, Safari, Edge, Opera */
-  input::-webkit-outer-spin-button,
-  input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-
-  /* Firefox */
-  input[type='number'] {
-    -moz-appearance: textfield;
   }
 
   /* Remove the underline on text fields that are not focused */

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -74,6 +74,7 @@
               <VSpacer />
             <VFlex xs7>
               <keep-alive :max="5">
+                <!-- Input question shows a text field with type of `number` -->
                 <div v-if="isInputQuestion">
                   <VTextField 
                     v-if="isAnswerOpen(answerIdx)" 
@@ -477,6 +478,7 @@
   are hidden from view. We want a text field that only
   accepts numbers 
   */
+
   /* Chrome, Safari, Edge, Opera */
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
@@ -485,13 +487,13 @@
   }
 
   /* Firefox */
-  input[type=number] {
+  input[type='number'] {
     -moz-appearance: textfield;
   }
-  
+
   /* Remove the underline on text fields that are not focused */
-  /deep/.no-border.v-text-field>.v-input__control>.v-input__slot:before,
-  /deep/.no-border.v-text-field>.v-input__control>.v-input__slot:after {
+  /deep/.no-border.v-text-field > .v-input__control > .v-input__slot::before,
+  /deep/.no-border.v-text-field > .v-input__control > .v-input__slot::after {
     border-style: none;
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -52,26 +52,7 @@
                 />
               </VFlex>
 
-              <VFlex xs7>
-                <keep-alive :max="5">
-                  <MarkdownEditor
-                    v-if="isAnswerOpen(answerIdx)"
-                    class="editor"
-                    :markdown="answer.answer"
-                    :handleFileUpload="handleFileUpload"
-                    :getFileUpload="getFileUpload"
-                    :imagePreset="imagePreset"
-                    @update="updateAnswerText($event, answerIdx)"
-                    @minimize="emitClose"
-                  />
-                  <MarkdownViewer
-                    v-else
-                    :markdown="answer.answer"
-                  />
-                </keep-alive>
-              </VFlex>
 
-              <VSpacer />
               <VFlex xs7>
                 <keep-alive :max="5">
                   <!-- Input question shows a text field with type of `number` -->
@@ -103,6 +84,8 @@
                   </div>
                 </keep-alive>
               </VFlex>
+
+              <VSpacer />
 
               <VFlex>
                 <AssessmentItemToolbar

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -62,6 +62,7 @@
                       v-model="answer.answer" 
                       class="answer-number" 
                       type="number" 
+                      :rules="[numericRule]"
                     />
                     <VTextField v-else :value="answer.answer" class="no-border" type="number" />
                   </div>
@@ -118,8 +119,8 @@
 
 <script>
 
+  import { floatOrIntRegex, getCorrectAnswersIndices, mapCorrectAnswers } from '../../utils';
   import { AssessmentItemToolbarActions } from '../../constants';
-  import { getCorrectAnswersIndices, mapCorrectAnswers } from '../../utils';
   import AssessmentItemToolbar from '../AssessmentItemToolbar';
   import { AssessmentItemTypes } from 'shared/constants';
   import { swapElements } from 'shared/utils/helpers';
@@ -178,6 +179,7 @@
     data() {
       return {
         correctAnswersIndices: getCorrectAnswersIndices(this.questionKind, this.answers),
+        numericRule: val => floatOrIntRegex.test(val) || this.$tr('numberFieldErrorLabel'),
       };
     },
     computed: {
@@ -404,6 +406,7 @@
       answersLabel: 'Answers',
       noAnswersPlaceholder: 'Question has no answer options',
       newAnswerBtnLabel: 'New answer',
+      numberFieldErrorLabel: 'Only numbers are permitted',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.spec.js
@@ -197,8 +197,10 @@ describe('AssessmentItemEditor', () => {
           ...ITEM,
           type: AssessmentItemTypes.SINGLE_SELECTION,
           answers: [
-            { answer: 'Mayonnaise (I mean you can, but...)', correct: true, order: 1 },
-            { answer: 'Peanut butter', correct: false, order: 2 },
+            { answer: '8', correct: true, order: 1 },
+            { answer: '8.0', correct: false, order: 2 },
+            { answer: '-400.19090', correct: false, order: 3 },
+            { answer: '-140140104', correct: false, order: 4 },
           ],
         };
 
@@ -215,14 +217,17 @@ describe('AssessmentItemEditor', () => {
       it('emits update event with item containing updated answers and type', () => {
         expect(wrapper.emitted().update).toBeTruthy();
         expect(wrapper.emitted().update.length).toBe(1);
-        expect(wrapper.emitted().update[0][0]).toEqual({
-          ...ITEM,
-          answers: [
-            { answer: 'Mayonnaise (I mean you can, but...)', correct: true, order: 1 },
-            { answer: 'Peanut butter', correct: true, order: 2 },
-          ],
-          type: AssessmentItemTypes.INPUT_QUESTION,
-        });
+        expect(wrapper.emitted().update[0][0]).toEqual(
+          Object.assign({}, ITEM, {
+            answers: [
+              { answer: '8', correct: true, order: 1 },
+              { answer: '8.0', correct: true, order: 2 },
+              { answer: '-400.19090', correct: true, order: 3 },
+              { answer: '-140140104', correct: true, order: 4 },
+            ],
+            type: AssessmentItemTypes.INPUT_QUESTION,
+          })
+        );
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -53,6 +53,10 @@ export function mapCorrectAnswers(answers, correctAnswersIndices) {
   });
 }
 
+// RegEx to test for signed floats or ints. Also allows the letter e
+// to comply with what Chrome permits in their type="number" fields
+export const floatOrIntRegex = /^(?=.)([+-]?([0-9e]*)(\.([0-9e]+))?)$/;
+
 /**
  * Update answers to correspond to a question type:
  * - multiple selection: No answers updates needed.
@@ -86,7 +90,6 @@ export function updateAnswersToQuestionType(questionType, answers) {
 
     case AssessmentItemTypes.INPUT_QUESTION:
       return answersCopy.reduce((obj, answer) => {
-        const floatOrIntRegex = /^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$/;
         // If there is anything other than a number in the answer
         // we'll just skip it - removing non-numeric answers
         if (floatOrIntRegex.test(answer.answer) === false) {

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -88,7 +88,9 @@ export function updateAnswersToQuestionType(questionType, answers) {
       return answersCopy.reduce((obj, answer) => {
         // If there is anything other than a number in the answer
         // we'll just skip it - removing non-numeric answers
-        if(/^[0-9]+$/.test(answer.answer) === false) { return obj };
+        if (/^[0-9]+$/.test(answer.answer) === false) {
+          return obj;
+        }
 
         // Otherwise, set the answer to correct and push it to our obj
         answer.correct = true;

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -56,7 +56,7 @@ export function mapCorrectAnswers(answers, correctAnswersIndices) {
 /**
  * Update answers to correspond to a question type:
  * - multiple selection: No answers updates needed.
- * - input question: Make all answers correct.
+ * - input question: Make all answers correct and remove non-numerics altogether
  * - true/false: Remove answers in favour of new true/false values.
  * - single selection: Keep first correct choice only if there is any.
  *                     Otherwise mark first choice as correct.
@@ -85,10 +85,16 @@ export function updateAnswersToQuestionType(questionType, answers) {
       return answersCopy;
 
     case AssessmentItemTypes.INPUT_QUESTION:
-      return answersCopy.map(answer => {
+      return answersCopy.reduce((obj, answer) => {
+        // If there is anything other than a number in the answer
+        // we'll just skip it - removing non-numeric answers
+        if(/^[0-9]+$/.test(answer.answer) === false) { return obj };
+
+        // Otherwise, set the answer to correct and push it to our obj
         answer.correct = true;
-        return answer;
-      });
+        obj.push(answer);
+        return obj;
+      }, []);
 
     case AssessmentItemTypes.TRUE_FALSE:
       return NEW_TRUE_FALSE_ANSWERS;

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -86,9 +86,10 @@ export function updateAnswersToQuestionType(questionType, answers) {
 
     case AssessmentItemTypes.INPUT_QUESTION:
       return answersCopy.reduce((obj, answer) => {
+        const floatOrIntRegex = /^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$/;
         // If there is anything other than a number in the answer
         // we'll just skip it - removing non-numeric answers
-        if (/^[0-9]+$/.test(answer.answer) === false) {
+        if (floatOrIntRegex.test(answer.answer) === false) {
           return obj;
         }
 


### PR DESCRIPTION
## Description

When editing an answer, Input fields can only accept numeric values.

Also - if you change from one question type to the Input question type any answers you've added to the previous question type will be removed if they include anything other than numbers.

The modal confirmation already says something along the lines of "if you change you will lose non-numeric answers".

Adds a validation string for non-numeric values: 

![new-string-numeric-validation](https://user-images.githubusercontent.com/6356129/94187889-7a91a380-fe5d-11ea-866a-1fdb5a597299.png)


#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2199

## Steps to Test

NEW TO TEST:

In Chrome and Firefox, enter valid and invalid values. If you ever blur away from an invalid field, you should see the validation error. Note that `e` is allowed in an exponentiation context, `+ and -` are allowed to sign the values and floats are valid as well.

Old instructions for testing below:
 
1. Create a new exercise
2. Create a "Single Select" question and add answers. Some of your questions should be `number` type (ie, `123123123` is what I mean but `1f2f` or `123 456` are not - but you *should* test the latter examples too)
3. Change the question to a "Input question" and confirm the modal
4. You should now see all answers are `correct` (green) and the "valid" number type questions remain.
5. Go to edit one of the remaining answers and try to type non-numerics and you should see nothing happen. Typing numbers, however, will work.

Please review the styling as well.

- Unfocused number-type inputs have no underline
- ~I removed the browser-native up/down number arrows~ harder to do than expected cross-browser while keeping the `type="number"` 

Also test anything and everything related to creating questions with Input question type.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

1. Revises the `updateAnswersToQuestionType` util to better handle changing to the Input question type so that it removes all non-numeric answers. Tested with regex `/^[0-9]+$/`
2. Updates the template for the answer editor to show number type rather than markdown editor and applied the styling noted above.
