### PR TITLE
Resource panel minor UI fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -76,6 +76,10 @@
         type: Boolean,
         default: false,
       },
+      previewing: {
+        type: Boolean,
+        default: false,
+      },
       compact: {
         type: Boolean,
         default: false,
@@ -102,7 +106,7 @@
         },
       },
       active() {
-        return this.selected || this.activated;
+        return this.selected || this.activated || this.previewing;
       },
       contentNode() {
         return this.getContentNode(this.nodeId);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -26,19 +26,14 @@
       </template>
 
       <template #actions-end>
-        <VListTileAction :aria-hidden="!active">
+        <VListTileAction :aria-hidden="!active" class="px-1">
           <VMenu v-model="activated" offset-y left>
             <template #activator="{ on }">
-              <VBtn
-                small
-                icon
-                flat
-                class="ma-0"
+              <IconButton
+                icon="more_horiz"
+                :text="$tr('optionsTooltip')"
                 v-on="on"
-                @click.stop
-              >
-                <Icon>more_horiz</Icon>
-              </VBtn>
+              />
             </template>
             <ContentNodeOptions :nodeId="nodeId" />
           </VMenu>
@@ -61,6 +56,7 @@
   import ContentNodeOptions from './ContentNodeOptions';
   import Checkbox from 'shared/views/form/Checkbox';
   import ContextMenu from 'shared/views/ContextMenu';
+  import IconButton from 'shared/views/IconButton';
 
   export default {
     name: 'ContentNodeEditListItem',
@@ -69,6 +65,7 @@
       ContentNodeOptions,
       Checkbox,
       ContextMenu,
+      IconButton,
     },
     props: {
       nodeId: {
@@ -110,6 +107,9 @@
       contentNode() {
         return this.getContentNode(this.nodeId);
       },
+    },
+    $trs: {
+      optionsTooltip: 'Options',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -50,25 +50,22 @@
               size="15"
               width="2"
             />
-            <VMenu
-              v-if="allowEditing && !loading"
-              offset-y
-              right
-              data-test="editMenu"
-            >
-              <template #activator="{ on }">
-                <VBtn
-                  class="topic-menu ma-0 mr-2"
-                  icon
-                  flat
-                  v-on="on"
-                  @click.stop
-                >
-                  <Icon>more_horiz</Icon>
-                </VBtn>
-              </template>
-              <ContentNodeOptions :nodeId="nodeId" />
-            </VMenu>
+            <div v-if="allowEditing && !loading" class="topic-menu mr-2">
+              <VMenu
+                offset-y
+                right
+                data-test="editMenu"
+              >
+                <template #activator="{ on }">
+                  <IconButton
+                    icon="more_horiz"
+                    :text="$tr('optionsTooltip')"
+                    v-on="on"
+                  />
+                </template>
+                <ContentNodeOptions :nodeId="nodeId" />
+              </VMenu>
+            </div>
           </VFlex>
         </VLayout>
         <template #menu>
@@ -105,6 +102,7 @@
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import ContextMenu from 'shared/views/ContextMenu';
   import LoadingText from 'shared/views/LoadingText';
+  import IconButton from 'shared/views/IconButton';
 
   export default {
     name: 'StudioTree',
@@ -112,6 +110,7 @@
       ContextMenu,
       ContentNodeOptions,
       LoadingText,
+      IconButton,
     },
     props: {
       nodeId: {
@@ -210,7 +209,9 @@
         }
       },
     },
-    $trs: {},
+    $trs: {
+      optionsTooltip: 'Options',
+    },
   };
 
 </script>
@@ -218,9 +219,10 @@
 <style scoped lang="less">
 
   // size causes rows to shift
-  .v-btn {
+  /deep/ .v-btn {
     width: 24px;
     height: 24px;
+    margin: 0;
   }
 
   .topic-menu {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -13,9 +13,11 @@
             </VFlex>
             <VMenu v-if="item.displayNodeOptions" offset-y right>
               <template #activator="{ on }">
-                <VBtn icon flat small v-on="on">
-                  <Icon>arrow_drop_down</Icon>
-                </VBtn>
+                <IconButton
+                  icon="arrow_drop_down"
+                  :text="$tr('optionsButton')"
+                  v-on="on"
+                />
               </template>
               <ContentNodeOptions v-if="node" :nodeId="topicId" />
             </VMenu>
@@ -159,9 +161,12 @@
           />
           <VMenu offset-y left>
             <template #activator="{ on }">
-              <VBtn small icon flat v-on="on">
-                <Icon>more_horiz</Icon>
-              </VBtn>
+              <IconButton
+                small
+                icon="more_horiz"
+                :text="$tr('optionsButton')"
+                v-on="on"
+              />
             </template>
             <ContentNodeOptions
               :nodeId="detailNodeId"
@@ -230,7 +235,13 @@
     },
     computed: {
       ...mapState(['viewMode']),
-      ...mapGetters('currentChannel', ['canEdit', 'currentChannel', 'trashId', 'hasStagingTree']),
+      ...mapGetters('currentChannel', [
+        'canEdit',
+        'currentChannel',
+        'trashId',
+        'hasStagingTree',
+        'rootId',
+      ]),
       ...mapGetters('contentNode', [
         'getContentNode',
         'getContentNodes',
@@ -262,7 +273,7 @@
             id: ancestor.id,
             to: this.treeLink({ nodeId: ancestor.id }),
             title: ancestor.title,
-            displayNodeOptions: Boolean(ancestor.parent_id),
+            displayNodeOptions: this.rootId !== ancestor.id,
           };
         });
       },
@@ -439,6 +450,7 @@
       importFromChannels: 'Import from channels',
       addButton: 'Add',
       editButton: 'Edit',
+      optionsButton: 'Options',
       copyToClipboardButton: 'Copy to clipboard',
       [viewModes.DEFAULT]: 'Default view',
       [viewModes.COMFORTABLE]: 'Comfortable view',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -37,6 +37,7 @@
         :compact="isCompactViewMode"
         :comfortable="isComfortableViewMode"
         :select="selected.indexOf(child.id) >= 0"
+        :previewing="$route.params.detailNodeId === child.id"
         @select="$emit('select', child.id)"
         @deselect="$emit('deselect', child.id)"
         @infoClick="goToNodeDetail(child.id)"

--- a/contentcuration/contentcuration/frontend/shared/views/ExpandableList.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ExpandableList.vue
@@ -147,9 +147,9 @@
     padding: 0;
     li {
       display: inline;
-      &.delimit:not(:last-child)::after {
-        content: ' • ';
-      }
+    }
+    &.delimit li:not(:last-child)::after {
+      content: ' • ';
     }
   }
 

--- a/contentcuration/contentcuration/frontend/shared/views/IconButton.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/IconButton.vue
@@ -8,7 +8,7 @@
         :small="small"
         v-bind="$attrs"
         v-on="on"
-        @click.stop="$emit('click')"
+        @click.stop="$event => $emit('click', $event)"
         @keydown.enter="$emit('mousedown')"
         @keyup.enter="$emit('mouseup')"
         @mousedown="$emit('mousedown')"

--- a/contentcuration/contentcuration/frontend/shared/views/details/DetailsRow.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/DetailsRow.vue
@@ -45,6 +45,9 @@
 
 <style lang="less" scoped>
 
+  .flex {
+    word-break: break-word;
+  }
   .flex:last-child {
     padding-left: 10px;
   }


### PR DESCRIPTION
## Description

I broke down the changes by commit, but in summary, this PR fixes some of the minor styling issues on the resource panel and main channel editor page.

#### Issue Addressed (if applicable)

Fixes [this issue](https://www.notion.so/learningequality/On-content-items-in-list-the-Show-topic-icon-button-is-bigger-than-the-context-menu-icon-button-n-8ced304710474bf59447da1dc1cc8d14) from the QA session
Fixes https://github.com/learningequality/studio/issues/2250

## Steps to Test

- [ ] Navigate to the channel editor page
- [ ] Hover over options on topic (should be same size as open topic button and have a tooltip)
- [ ] Preview a resource (resource list item should have a grey background)
- [ ] Update a description to be one long string of letters (text should wrap)

## Checklist

- [ ] Is the code clean and well-commented?
