### PR TITLE
Fix issues with license being passed as a string rather than id.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -276,7 +276,7 @@
   import ContentNodeThumbnail from '../../views/files/thumbnails/ContentNodeThumbnail';
   import FileUpload from '../../views/files/FileUpload';
   import SubtitlesList from '../../views/files/supplementaryLists/SubtitlesList';
-  import Licenses from 'shared/leUtils/Licenses';
+  import { findLicense } from 'shared/utils';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
   import HelpTooltip from 'shared/views/HelpTooltip';
   import LicenseDropdown from 'shared/views/LicenseDropdown';
@@ -464,7 +464,9 @@
       copyrightHolderRequired() {
         // Needs to appear when any of the selected licenses require a copyright holder
         return this.nodes.some(
-          node => Licenses.has(node.license) && Licenses.get(node.license).copyright_holder_required
+          node =>
+            findLicense(node.license, { copyright_holder_required: false })
+              .copyright_holder_required
         );
       },
       importUrl() {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -5,7 +5,7 @@ import { NOVALUE } from 'shared/constants';
 import client from 'shared/client';
 import { RELATIVE_TREE_POSITIONS, CHANGES_TABLE, TABLE_NAMES } from 'shared/data/constants';
 import { ContentNode } from 'shared/data/resources';
-import { promiseChunk } from 'shared/utils';
+import { findLicense, promiseChunk } from 'shared/utils';
 
 import db from 'shared/data/db';
 
@@ -178,6 +178,20 @@ export function addNextStepToNode(context, { targetId, nextStepId }) {
 /* CONTENTNODE EDITOR ACTIONS */
 export function createContentNode(context, { parent, kind = 'topic', ...payload }) {
   const session = context.rootState.session;
+
+  const channel = context.rootGetters['currentChannel/currentChannel'];
+  let contentDefaults = Object.assign({}, channel.content_defaults);
+
+  // content_defaults for historical reason has stored the license as a string constant,
+  // but the serializers and frontend now use the license ID. So make sure that we pass
+  // a license ID when we create the content node.
+  if (kind === 'topic') {
+    // Don't assign a license to topics, even if one is set in content_defaults
+    contentDefaults.license = null;
+  } else {
+    contentDefaults.license = findLicense(contentDefaults.license, { id: null }).id;
+  }
+
   const contentNodeData = {
     title: '',
     description: '',
@@ -188,7 +202,7 @@ export function createContentNode(context, { parent, kind = 'topic', ...payload 
     isNew: true,
     language: session.preferences ? session.preferences.language : session.currentLanguage,
     parent,
-    ...context.rootGetters['currentChannel/currentChannel'].content_defaults,
+    ...contentDefaults,
     ...payload,
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -5,6 +5,7 @@ import { NOVALUE } from 'shared/constants';
 import client from 'shared/client';
 import { RELATIVE_TREE_POSITIONS, CHANGES_TABLE, TABLE_NAMES } from 'shared/data/constants';
 import { ContentNode } from 'shared/data/resources';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import { findLicense, promiseChunk } from 'shared/utils';
 
 import db from 'shared/data/db';
@@ -176,19 +177,19 @@ export function addNextStepToNode(context, { targetId, nextStepId }) {
 }
 
 /* CONTENTNODE EDITOR ACTIONS */
-export function createContentNode(context, { parent, kind = 'topic', ...payload }) {
+export function createContentNode(context, { parent, kind = ContentKindsNames.TOPIC, ...payload }) {
   const session = context.rootState.session;
 
   const channel = context.rootGetters['currentChannel/currentChannel'];
   let contentDefaults = Object.assign({}, channel.content_defaults);
 
-  // content_defaults for historical reason has stored the license as a string constant,
-  // but the serializers and frontend now use the license ID. So make sure that we pass
-  // a license ID when we create the content node.
-  if (kind === 'topic') {
-    // Don't assign a license to topics, even if one is set in content_defaults
-    contentDefaults.license = null;
+  if (kind === ContentKindsNames.TOPIC) {
+    // Topics shouldn't have license, language or copyright info assigned.
+    contentDefaults = {};
   } else {
+    // content_defaults for historical reason has stored the license as a string constant,
+    // but the serializers and frontend now use the license ID. So make sure that we pass
+    // a license ID when we create the content node.
     contentDefaults.license = findLicense(contentDefaults.license, { id: null }).id;
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -127,7 +127,7 @@ export function getContentNodeDetailsAreValid(state) {
 export function getContentNodeFilesAreValid(state, getters, rootState, rootGetters) {
   return function(contentNodeId) {
     const contentNode = state.contentNodesMap[contentNodeId];
-    if (contentNode && contentNode.kind !== 'topic') {
+    if (contentNode && contentNode.kind !== ContentKindsNames.TOPIC) {
       let files = rootGetters['file/getContentNodeFiles'](contentNode.id);
       if (files.length) {
         // Don't count errors before files have loaded

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -127,7 +127,7 @@ export function getContentNodeDetailsAreValid(state) {
 export function getContentNodeFilesAreValid(state, getters, rootState, rootGetters) {
   return function(contentNodeId) {
     const contentNode = state.contentNodesMap[contentNodeId];
-    if (contentNode) {
+    if (contentNode && contentNode.kind !== 'topic') {
       let files = rootGetters['file/getContentNodeFiles'](contentNode.id);
       if (files.length) {
         // Don't count errors before files have loaded

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -17,6 +17,11 @@ import ActionLink from 'shared/views/ActionLink';
 
 import { initializeDB } from 'shared/data';
 
+// just say yes to devtools (in debug mode)
+if (process.env.NODE_ENV !== 'production') {
+  Vue.config.devtools = true;
+}
+
 Vue.use(Croppa);
 Vue.use(VueIntl);
 Vue.use(VueRouter);

--- a/contentcuration/contentcuration/frontend/shared/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/utils.js
@@ -1,5 +1,7 @@
 import chunk from 'lodash/chunk';
 
+import { LicensesList } from 'shared/leUtils/Licenses';
+
 /**
  * Insert an item into an array before another item.
  * @param {Array} arr
@@ -407,4 +409,17 @@ export async function generatePdf(
       return doc;
     });
   });
+}
+
+/**
+ * Given an ID or string constant identifier, return the license info
+
+ * @param {Number | String} key A license identifier
+ */
+export function findLicense(key, defaultValue = {}) {
+  let license = LicensesList.find(
+    license => license.license_name === key || license.id === parseInt(key, 10)
+  );
+
+  return license || defaultValue;
 }

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -61,8 +61,9 @@
 <script>
 
   import InfoModal from './InfoModal.vue';
-  import Licenses, { LicensesList } from 'shared/leUtils/Licenses';
+  import { LicensesList } from 'shared/leUtils/Licenses';
   import { constantsTranslationMixin } from 'shared/mixins';
+  import { findLicense } from 'shared/utils';
 
   export default {
     name: 'LicenseDropdown',
@@ -76,9 +77,7 @@
         type: Object,
         required: false,
         validator: value => {
-          return (
-            !value || !value.license || !value.license.toString() || Licenses.has(value.license)
-          );
+          return value && value.license && findLicense(value.license, { id: null }).id !== null;
         },
       },
       required: {
@@ -105,11 +104,11 @@
     computed: {
       license: {
         get() {
-          return this.value && this.value.license;
+          return this.value && findLicense(this.value.license).id;
         },
         set(value) {
           this.$emit('input', {
-            license: value,
+            license: findLicense(value).id,
             license_description: this.isCustom ? this.description : '',
           });
         },
@@ -126,7 +125,7 @@
         },
       },
       selectedLicense() {
-        return this.value && Licenses.get(this.value.license);
+        return this.value && findLicense(this.value.license);
       },
       isCustom() {
         return this.selectedLicense && this.selectedLicense.is_custom;
@@ -145,11 +144,14 @@
     },
     methods: {
       translate(item) {
-        return (item.toString() && this.translateConstant(item.license_name)) || '';
+        return (item.id && item.id !== '' && this.translateConstant(item.license_name)) || '';
       },
       translateDescription(item) {
         return (
-          (item.toString() && this.translateConstant(item.license_name + '_description')) || ''
+          (item.id &&
+            item.id !== '' &&
+            this.translateConstant(item.license_name + '_description')) ||
+          ''
         );
       },
       getLicenseUrl(item) {

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/licenseDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/licenseDropdown.spec.js
@@ -33,9 +33,17 @@ describe('licenseDropdown', () => {
         expect(wrapper.find('.v-list').text()).toContain(license.license_name);
       });
     });
-    it('should render according to license prop', () => {
+    it('should render a license when value is set to a license id', () => {
       function test(license) {
         wrapper.setProps({ value: { license: license.id } });
+        expect(wrapper.vm.$refs.license.value).toEqual(license.id);
+        expect(wrapper.find('.v-textarea').exists()).toBe(license.is_custom);
+      }
+      _.each(LicensesList, test);
+    });
+    it('should render a license when value is set to a license name', () => {
+      function test(license) {
+        wrapper.setProps({ value: { license: license.license_name } });
         expect(wrapper.vm.$refs.license.value).toEqual(license.id);
         expect(wrapper.find('.v-textarea').exists()).toBe(license.is_custom);
       }
@@ -73,7 +81,7 @@ describe('licenseDropdown', () => {
       expect(wrapper.emitted('input')).toBeFalsy();
       wrapper.find('input').setValue(specialPermissions.id);
       expect(wrapper.emitted('input')).toBeTruthy();
-      expect(wrapper.emitted('input')[0][0].license).toEqual(specialPermissions.id.toString());
+      expect(wrapper.emitted('input')[0][0].license).toEqual(specialPermissions.id);
     });
     it('input should be emitted when description is changed', () => {
       wrapper.setProps({ value: { license: specialPermissions.id } });

--- a/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
@@ -103,10 +103,7 @@
   import Checkbox from './Checkbox';
   import { LicensesList } from 'shared/leUtils/Licenses';
   import { ContentDefaults, ContentDefaultsDefaults } from 'shared/constants';
-
-  function findLicense(name, defaultValue = {}) {
-    return LicensesList.find(license => license.license_name === name) || defaultValue;
-  }
+  import { findLicense } from 'shared/utils';
 
   function normalizeContentDefaults(contentDefaults) {
     return Object.entries(ContentDefaultsDefaults).reduce((normalized, [key, defaultValue]) => {


### PR DESCRIPTION

## Description

When getting licenses, search by both name and id so that `content_defaults` string keys can be found. When setting license on a node, always use id to be consistent with frontend and serializer behavior.

## Steps to Test

- [ ] Set a license in the channel's content defaults
- [ ] Create an exercise or upload a file

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

I tried to get the `ContentDefaults` view using `LicenseDropdown`, and functionally it seemed to work, but it broke some conventions because it was a composite field but ContentDefaults treated license and description as two separate fields. My Vue-Fu was not strong enough to figure out the right fix for this and didn't want to start refactoring enough that I may break other things, so after fighting with it for a while, I realized that this was one battle best saved for another day!



## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
