### PR TITLE
Fix iteration over empty `imageEls` for exercises without images

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -117,7 +117,7 @@
         editor: null,
         highlight: false,
         // will be an HTMLCollection, set in mounted()
-        imageEls: {},
+        imageEls: [],
         imageFields: [],
         formulasMenu: {
           isOpen: false,


### PR DESCRIPTION
## Description
When editing exercise content without images, an error would occur:
```
vue.runtime.esm.js:1888 TypeError: Invalid attempt to iterate non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
    at _createForOfIteratorHelper (channel_edit.65365769d7eabef89041.hot-update.js:37)
    at VueComponent.initImageFields (MarkdownEditor.vue:637)
    at VueComponent.imageEls (MarkdownEditor.vue:166)
    at Watcher.run (vue.runtime.esm.js:4568)
    at flushSchedulerQueue (vue.runtime.esm.js:4310)
    at Array.<anonymous> (vue.runtime.esm.js:1980)
    at flushCallbacks (vue.runtime.esm.js:1906)
```
This was because `imageEls` was being initialized as an empty object.

## Steps to Test

- [ ] Open the markdown editor for a question or answer with no images
- [ ] Make sure there aren't any of those errors in the console

## Checklist

- [ ] Is the code clean and well-commented?
