### PR TITLE
Maintain selections between channel tree view & edit modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -245,7 +245,6 @@
           return this.selectedNodeIds;
         },
         set(value) {
-          console.log('set() selected', value);
           this.$store.commit('currentChannel/SET_SELECTED_NODE_IDS', value);
         },
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/index.js
@@ -7,6 +7,7 @@ export default {
   state: () => ({
     currentChannelId: window.channel_id,
     currentChannelStagingDiff: {},
+    selectedNodeIds: [],
   }),
   getters,
   mutations,

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/mutations.js
@@ -61,3 +61,7 @@ export function SAVE_CURRENT_CHANNEL_STAGING_DIFF(state, payload) {
 
   state.currentChannelStagingDiff = stagingDiff;
 }
+
+export function SET_SELECTED_NODE_IDS(state, payload) {
+  state.selectedNodeIds = Set(payload);
+}

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/mutations.js
@@ -1,3 +1,5 @@
+import Vue from 'vue';
+
 export function SAVE_CURRENT_CHANNEL_STAGING_DIFF(state, payload) {
   // convert staging diff API response to a more suitable format
   // (can be removed after API is updated)
@@ -63,5 +65,5 @@ export function SAVE_CURRENT_CHANNEL_STAGING_DIFF(state, payload) {
 }
 
 export function SET_SELECTED_NODE_IDS(state, payload) {
-  state.selectedNodeIds = Set(payload);
+  Vue.set(state, 'selectedNodeIds', Array.from(new Set(payload)));
 }


### PR DESCRIPTION
## Description

In ChannelEdit, when you select a node or nodes using the checkboxes and click the "Edit" button, your selections will remain selected when you return to ChannelEdit's tree view after closing the EditModal.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2239

## Steps to Test

- Select multiple nodes.
- Click the Edit pencil icon
- Close the EditModal
- Your selections should remain selected.

Additionally, please test:
- Clearing all selections, then select a few individual nodes and do the above.
- Selecting all and then do the above
- Selecting all, then deselecting nodes then doing the above.

## Implementation Notes (optional)

Added state to `currentChannel` Vuex module. 

Added get/set computed for `selected` in CurrentTopicView and mapped the new `currentChannel.selectedNodeIds` state.

Also, clearing selections was being done by saying `selectAll = false` which had the right effect, but was unclear what it's actually doing or why so I added a method to clear all selections so that it's more obvious what is happening there to the next person to read the code.