### PR TITLE
Change how we distinct content_ids to avoid a slow order_by

### DIFF
--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -403,9 +403,8 @@ class ChannelViewSet(ValuesViewset):
         # Add the unique count of distinct non-topic node content_ids
         non_topic_content_ids = (
             channel_main_tree_nodes.exclude(kind_id=content_kinds.TOPIC)
-            .order_by("content_id")
-            .distinct("content_id")
             .values_list("content_id", flat=True)
+            .distinct()
         )
 
         queryset = queryset.annotate(


### PR DESCRIPTION
## Description

* Removes an order_by that we can do without to avoid a quicksort inside our count

#### Issue Addressed (if applicable)

Help with our channel endpoint optimizations

