### PR TITLE
When a channel is deleted, show an error page prompting user to contact an administrator

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/router.js
+++ b/contentcuration/contentcuration/frontend/administration/router.js
@@ -21,18 +21,6 @@ const router = new VueRouter({
       ],
     },
     {
-      path: '/restore_channel/:channel_id',
-      redirect(to) {
-        return {
-          name: RouterNames.CHANNELS,
-          query: {
-            deleted: true,
-            keywords: to.params.channel_id,
-          },
-        };
-      },
-    },
-    {
       name: RouterNames.USERS,
       path: '/users/',
       component: UserTable,

--- a/contentcuration/contentcuration/frontend/administration/router.js
+++ b/contentcuration/contentcuration/frontend/administration/router.js
@@ -21,6 +21,18 @@ const router = new VueRouter({
       ],
     },
     {
+      path: '/restore_channel/:channel_id',
+      redirect(to) {
+        return {
+          name: RouterNames.CHANNELS,
+          query: {
+            deleted: true,
+            keywords: to.params.channel_id,
+          },
+        };
+      },
+    },
+    {
       name: RouterNames.USERS,
       path: '/users/',
       component: UserTable,

--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -41,6 +41,7 @@ export const ValidationErrors = {
 // These should match the `channel_error` enum on contentcuration.views.base.channels
 export const ChannelEditPageErrors = Object.freeze({
   CHANNEL_NOT_FOUND: 'CHANNEL_EDIT_ERROR_CHANNEL_NOT_FOUND',
+  CHANNEL_DELETED: 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED',
 });
 
 // should correspond to backend types

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ChannelEditAppError.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ChannelEditAppError.vue
@@ -17,7 +17,6 @@
       <ChannelDeletedError
         v-else-if="showDeletedError"
         :backHomeLink="myChannelsUrl"
-        :restoreChannelLink="restoreChannelsUrl"
       />
 
       <GenericError
@@ -73,12 +72,6 @@
       myChannelsUrl() {
         return {
           href: window.Urls.channels(),
-        };
-      },
-      restoreChannelsUrl() {
-        const channel_id = window.CHANNEL_EDIT_GLOBAL.channel_id;
-        return {
-          href: `${window.Urls.administration()}#/restore_channel/${channel_id}`,
         };
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ChannelEditAppError.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ChannelEditAppError.vue
@@ -14,6 +14,12 @@
         :backHomeLink="myChannelsUrl"
       />
 
+      <ChannelDeletedError
+        v-else-if="showDeletedError"
+        :backHomeLink="myChannelsUrl"
+        :restoreChannelLink="restoreChannelsUrl"
+      />
+
       <GenericError
         v-else
         :error="error"
@@ -32,6 +38,7 @@
   import MainNavigationDrawer from 'shared/views/MainNavigationDrawer';
   import ToolBar from 'shared/views/ToolBar';
   import ChannelNotFoundError from 'shared/views/errors/ChannelNotFoundError';
+  import ChannelDeletedError from 'shared/views/errors/ChannelDeletedError';
   import GenericError from 'shared/views/errors/GenericError';
 
   // NOTE: 404 Error Page for the topic level is contained inside of TreeViewBase
@@ -39,6 +46,7 @@
     name: 'ChannelEditAppError',
     components: {
       ChannelNotFoundError,
+      ChannelDeletedError,
       GenericError,
       MainNavigationDrawer,
       ToolBar,
@@ -58,10 +66,19 @@
       showNotFoundError() {
         return this.error.errorType === ChannelEditPageErrors.CHANNEL_NOT_FOUND;
       },
+      showDeletedError() {
+        return this.error.errorType === ChannelEditPageErrors.CHANNEL_DELETED;
+      },
       // All links exit to "My Channels" tab on ChannelList page
       myChannelsUrl() {
         return {
           href: window.Urls.channels(),
+        };
+      },
+      restoreChannelsUrl() {
+        const channel_id = window.CHANNEL_EDIT_GLOBAL.channel_id;
+        return {
+          href: `${window.Urls.administration()}#/restore_channel/${channel_id}`,
         };
       },
     },

--- a/contentcuration/contentcuration/frontend/shared/views/errors/ChannelDeletedError.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/ChannelDeletedError.vue
@@ -1,0 +1,54 @@
+<template>
+
+  <AppError>
+    <template #header>
+      {{ $tr('channelDeletedHeader') }}
+    </template>
+    <template #details>
+      {{ $tr('channelDeletedDetails') }}
+    </template>
+    <template #actions>
+      <VBtn v-bind="backHomeLink">
+        {{ $tr('backToHomeAction') }}
+      </VBtn>
+      <VBtn v-bind="restoreChannelLink" color="primary">
+        {{ $tr('restoreChannelAction') }}
+      </VBtn>
+    </template>
+  </AppError>
+
+</template>
+
+
+<script>
+
+  import AppError from './AppError';
+
+  export default {
+    name: 'ChannelDeletedError',
+    components: {
+      AppError,
+    },
+    props: {
+      backHomeLink: {
+        type: Object,
+        required: true,
+      },
+      restoreChannelLink: {
+        type: Object,
+        required: true,
+      },
+    },
+    $trs: {
+      channelDeletedHeader: 'Channel not found',
+      channelDeletedDetails:
+        'This channel may have been removed by another administrator. If this was a mistake, you can undo this action in the adminstration page.',
+      backToHomeAction: 'Back to home',
+      restoreChannelAction: 'Restore channel',
+    },
+  };
+
+</script>
+
+
+<style lang="less" scoped></style>

--- a/contentcuration/contentcuration/frontend/shared/views/errors/ChannelDeletedError.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/ChannelDeletedError.vue
@@ -11,9 +11,6 @@
       <VBtn v-bind="backHomeLink">
         {{ $tr('backToHomeAction') }}
       </VBtn>
-      <VBtn v-bind="restoreChannelLink" color="primary">
-        {{ $tr('restoreChannelAction') }}
-      </VBtn>
     </template>
   </AppError>
 
@@ -34,17 +31,12 @@
         type: Object,
         required: true,
       },
-      restoreChannelLink: {
-        type: Object,
-        required: true,
-      },
     },
     $trs: {
       channelDeletedHeader: 'Channel not found',
       channelDeletedDetails:
-        'This channel may have been removed by another administrator. If this was a mistake, you can undo this action in the adminstration page.',
+        'This channel may have been removed. If this was a mistake, please contact us at content@learningequality.org',
       backToHomeAction: 'Back to home',
-      restoreChannelAction: 'Restore channel',
     },
   };
 

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -210,7 +210,7 @@ def channel(request, channel_id):
 
     # Check if channel exists
     try:
-        channel = Channel.objects.get(id=channel_id, deleted=False)
+        channel = Channel.objects.get(id=channel_id)
         channel_id = channel.id
     except Channel.DoesNotExist:
         channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_NOT_FOUND'
@@ -220,6 +220,10 @@ def channel(request, channel_id):
     if channel_id != '':
         try:
             request.user.can_view_channel(channel)
+            # If user can view channel, but it's deleted, then we show
+            # an option to restore the channel in the Administration apge
+            if channel.deleted:
+                channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED'
         except PermissionDenied:
             channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_NOT_FOUND'
 

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -221,7 +221,7 @@ def channel(request, channel_id):
         try:
             request.user.can_view_channel(channel)
             # If user can view channel, but it's deleted, then we show
-            # an option to restore the channel in the Administration apge
+            # an option to restore the channel in the Administration page
             if channel.deleted:
                 channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED'
         except PermissionDenied:


### PR DESCRIPTION
**Please remove any unused sections**

## Description

1. Adds a new type of error for the channel edit SPA (Channel Deleted), which shows a different error page and a path to restoring it in the Administration SPA


#### Issue Addressed (if applicable)

Addresses #*PR# HERE*

#### Before/After Screenshots (if applicable)

<img width="1116" alt="CleanShot 2020-09-22 at 17 01 08@2x" src="https://user-images.githubusercontent.com/10248067/93949480-8e21fa80-fcf5-11ea-9010-4ed2def968db.png">

![CleanShot 2020-09-22 at 17 01 25@2x](https://user-images.githubusercontent.com/10248067/93949505-9da14380-fcf5-11ea-876e-e3c37f896400.png)



## Steps to Test

1. Create a channel, then delete it
1. Try to visit the channel edit page for that channel (try other nodes other than the root node)
1. You should see an error page like the one in the screenshot
1. Clicking the "Restore channel" link should take you the administration with the specific channel the sole entry in the table.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
