### PR TITLE
Some more markdown math rendering fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -574,12 +574,20 @@
             squire.setSelection(selection);
           }
         }
+        // the cursor will get stuck if it's inside of a non-contentEditable parent
+        if (!selection.startContainer.parentElement.isContentEditable) {
+          selection.setStart(selection.startContainer.parentElement, 0);
+        }
+        if (!selection.endContainer.parentElement.isContentEditable) {
+          selection.setEnd(selection.endContainer.parentElement, 0);
+        }
         // if any part of a custom node is in the selection, include the whole thing
         if (isCustomNode(selection.startContainer)) {
           let previousSibling = selection.startContainer.previousSibling;
           selection.setStart(previousSibling, previousSibling.length - 1);
           squire.setSelection(selection);
-        } else if (isCustomNode(selection.endContainer)) {
+        }
+        if (isCustomNode(selection.endContainer)) {
           selection.setEnd(selection.endContainer.nextSibling, 1);
           squire.setSelection(selection);
         }

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -569,6 +569,7 @@
           }
         } else if (event.key === 'Delete') {
           if (spacerAndCustomElementAreRightward(selection)) {
+            // if there's a custom node and a spacer, delete them both
             selection.setEnd(getElementAtRelativeOffset(selection, 2).nextSibling, 1);
             squire.setSelection(selection);
           }
@@ -647,12 +648,15 @@
         }
 
         // open formulas menu if a math field clicked
-        const formulasMenuFormula = mathFieldEl.getVueInstance().latex;
         const formulasMenuPosition = getExtensionMenuPosition({
           editorEl: this.$el,
           targetX: mathFieldEl.getBoundingClientRect().left,
           targetY: mathFieldEl.getBoundingClientRect().bottom,
         });
+
+        // get current formula from the custom element's underlying vue instance
+        const formulasMenuFormula = mathFieldEl.getVueInstance().latex;
+
         // just a little visual enhancement to make clear
         // that the formula menu is linked to a math field
         // element being edited
@@ -752,6 +756,7 @@
         const activeMathFieldEl = this.findActiveMathField();
 
         if (activeMathFieldEl !== null) {
+          // setting `outerHTML` is the preferred way to reset a custom node
           activeMathFieldEl.outerHTML = formulaHTML;
         } else {
           let squire = this.editor.getSquire();

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/__tests__/plugins/formulas/markdownFormulaElement.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/__tests__/plugins/formulas/markdownFormulaElement.spec.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jest-environment-jsdom-sixteen
  */
+// Jsdom@^16 is required to test custom elements.
 
 import { registerMarkdownFormulaElement } from 'shared/views/MarkdownEditor/plugins/formulas/MarkdownFormula';
 

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/MarkdownFormula.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/MarkdownFormula.vue
@@ -13,6 +13,9 @@
   import Vue from 'vue';
   import vueCustomElement from 'vue-custom-element';
   import '../../mathquill/mathquill.js';
+
+  // vue-custom-element can't use SFC styles, so we load our styles directly,
+  // to be passed in when we register this component as a custom element
   import css from '!css-loader!less-loader!./style.less';
 
   const MarkdownFormula = {


### PR DESCRIPTION
## Description

This is a followup on #2232, and includes three main things, following @nucleogenesis's feedback [here](https://github.com/learningequality/studio/pull/2232#pullrequestreview-491667655):

1) More comments throughout the code
2) I renamed "buffers" to "spacers" for clarity (referring to the extra non-breaking spaces that must surround custom editor nodes)
2) A more thorough fix for the delete key behavior, so that you should only need to press delete once to delete a formula.

### How to test this
- [ ] Add some formulas to an exercise question
- [ ] Try deleting them very slowly.  It should work just fine, and you should only need to press the delete and/or backspace key once.

### Checklist
- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?

### Comments
TODO: It'd be nice to have tests for the TUI.editor key handler fixes, but I haven't quite figured out the best way to do this yet.
