### PR TITLE
Account & Storage Form Bugs

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Account/DeleteAccountForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/DeleteAccountForm.vue
@@ -16,6 +16,7 @@
         :label="$tr('emailAddressLabel')"
         :invalid="Boolean(deletionEmailInvalidMessage)"
         :invalidText="deletionEmailInvalidMessage"
+        :showInvalidText="Boolean(deletionEmailInvalidMessage)"
         @input="deletionEmailInvalidMessage = ''"
       />
     </KModal>

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -126,6 +126,7 @@
   import DeleteAccountForm from './DeleteAccountForm';
   import CopyToken from 'shared/views/CopyToken';
   import Alert from 'shared/views/Alert';
+  import get from 'lodash/get';
 
   export default {
     name: 'Account',
@@ -157,7 +158,7 @@
       // are not deleted without deleting such channels or first
       // inviting another user to have the rights to such channels
       channelsAsSoleEditor() {
-        return this.user.channels.filter(c => c.editor_count === 1);
+        return get(this, 'user.channels', []).filter(c => c.editor_count === 1);
       },
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -121,12 +121,12 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
+  import get from 'lodash/get';
   import FullNameForm from './FullNameForm';
   import ChangePasswordForm from './ChangePasswordForm';
   import DeleteAccountForm from './DeleteAccountForm';
   import CopyToken from 'shared/views/CopyToken';
   import Alert from 'shared/views/Alert';
-  import get from 'lodash/get';
 
   export default {
     name: 'Account',

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -15,11 +15,13 @@
       v-model="storage"
       :label="$tr('storageAmountRequestedPlaceholder')"
       :invalid="errors.storage"
+      :showInvalidText="errors.storage"
       :invalidText="$tr('fieldRequiredText')"
     />
     <KTextbox
       v-model="resource_count"
       :invalid="errors.resource_count"
+      :showInvalidText="errors.resource_count"
       :invalidText="$tr('fieldRequiredText')"
       :label="$tr('approximatelyHowManyResourcesLabel')"
       :placeholder="$tr('numberOfResourcesPlaceholder')"
@@ -34,6 +36,7 @@
     <KTextbox
       v-model="kind"
       :invalid="errors.kind"
+      :showInvalidText="errors.kind"
       :invalidText="$tr('fieldRequiredText')"
       :label="$tr('kindOfContentQuestionLabel')"
       :placeholder="$tr('typeOfContentPlaceholder')"
@@ -50,6 +53,7 @@
     <KTextbox
       v-model="sample_link"
       :invalid="errors.sample_link"
+      :showInvalidText="errors.sample_link"
       :invalidText="$tr('fieldRequiredText')"
       :label="$tr('provideSampleLinkLabel')"
       :placeholder="$tr('pasteLinkPlaceholder')"
@@ -88,6 +92,7 @@
     <KTextbox
       v-model="audience"
       :invalid="errors.audience"
+      :showInvalidText="errors.audience"
       :invalidText="$tr('fieldRequiredText')"
       :label="$tr('intendedAudienceLabel')"
       :placeholder="$tr('audiencePlaceholder')"
@@ -100,6 +105,7 @@
     <KTextbox
       v-model="import_count"
       :invalid="errors.import_count"
+      :showInvalidText="errors.import_count"
       :invalidText="$tr('fieldRequiredText')"
       :label="$tr('howOftenImportedToKolibriLabel')"
       :placeholder="$tr('storageAmountRequestedPlaceholder')"
@@ -119,12 +125,14 @@
       v-model="org_or_personal"
       :value="affiliation.value"
       :invalid="errors.org_or_personal"
+      :showInvalidText="errors.org_or_personal"
       :invalidText="$tr('fieldRequiredText')"
       :label="affiliation.text"
     />
     <KTextbox
       v-model="organization"
       :invalid="errors.organization"
+      :showInvalidText="errors.organization"
       :invalidText="$tr('fieldRequiredText')"
       label=" "
       :placeholder="$tr('organizationNamePlaceholder')"
@@ -147,6 +155,7 @@
       v-model="organization_type"
       :value="orgType.value"
       :invalid="errors.organization_type"
+      :showInvalidText="errors.organization_type"
       :invalidText="$tr('fieldRequiredText')"
       :label="orgType.text"
       :disabled="!orgSelected"
@@ -154,6 +163,7 @@
     <KTextbox
       v-model="organization_other"
       :invalid="errors.organization_other"
+      :showInvalidText="errors.organization_other"
       :invalidText="$tr('fieldRequiredText')"
       :label="' '"
       :placeholder="$tr('organizationNamePlaceholder')"
@@ -181,6 +191,7 @@
     <KTextbox
       v-model="message"
       :invalid="errors.message"
+      :showInvalidText="errors.message"
       :invalidText="$tr('fieldRequiredText')"
       :floatingLabel="false"
       label=" "


### PR DESCRIPTION
## Description

Addresses two issues from bug bash:

1.  https://www.notion.so/learningequality/Errors-don-t-show-on-validate-if-I-haven-t-interacted-with-form-fields-on-the-storage-request-form-c0b2768e419b4e41845ecb8c52fb9e60

2. https://www.notion.so/learningequality/Delete-account-validation-isn-t-showing-up-a2c2e2a177b6406e8a6f901f38c0f4d6

I also found a bug where a function tried to read for an array somewhere that the array can be undefined and fixed it. This stopped me from seeing the account page when signed in as my `ivanbot` test account.

## Steps to Test

- Check that the proper fields are being validated as expected on the Storage Request form.
- Check that invalid or nonexistent email addresses i the "Delete Account" form shows when you click to submit.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I used the `showInvalidText` prop on `KTextField` that overrides the default functionality of only showing validation errors for fields that were focused, edited and then blurred.