### PR TITLE
See previous & next resources in preview panel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -305,7 +305,6 @@
 <script>
 
   import sortBy from 'lodash/sortBy';
-  import uniq from 'lodash/uniq';
   import { mapActions, mapGetters } from 'vuex';
   import { RouterNames } from '../constants';
   import AssessmentItemPreview from '../components/AssessmentItemPreview/AssessmentItemPreview';
@@ -362,7 +361,11 @@
       };
     },
     computed: {
-      ...mapGetters('contentNode', ['getContentNode', 'getContentNodes']),
+      ...mapGetters('contentNode', [
+        'getContentNode',
+        'getImmediateNextStepsList',
+        'getImmediatePreviousStepsList',
+      ]),
       ...mapGetters('file', ['getContentNodeFiles', 'contentNodesTotalSize']),
       ...mapGetters('assessmentItem', ['getAssessmentItems']),
       node() {
@@ -445,11 +448,11 @@
         return this.translateConstant(this.node.role_visibility) || this.defaultText;
       },
       previousSteps() {
-        return this.getContentNodes(uniq(this.node.prerequisite));
+        return this.getImmediatePreviousStepsList(this.node.id);
       },
       nextSteps() {
         // TODO: Add in next steps once the data is available
-        return this.getContentNodes(uniq(this.node.prerequisite_of));
+        return this.getImmediateNextStepsList(this.node.id);
       },
       kindCount() {
         // TODO: Add in kind counts once the data is available


### PR DESCRIPTION
## Description

Fix side panel previewer not showing previous and next steps.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2215

## Steps to Test

Have some content nodes that are prerequisites for each other and verify that the same thing is shown in the Related tab of the editor as are shown in the previewer on the right side when you first click a node.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I found the convenient getters for this data and used those to get the data properly.