### PR TITLE
Now you can leave the sharing modal no matter what

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -269,6 +269,7 @@
           },
           query: {
             sharing: true,
+            last: this.$route.name,
           },
         };
       },


### PR DESCRIPTION
## Description

I tested the sharing modal by going to a channel's editor and clicking the top-right context menu and selecting "Share channel" and found that I could not leave the modal unless I hit browser back. Seemed to be missing a param to make it happy.

When you go to the page initially to the "Share" tab - Vuetify doesn't update the selected tab properly so "Details" is seen as 'active'. I could not figure out how to make it act right and gave up on it for now. 

## Steps to Test

Go to a Channel Edit and right click the upper-right context menu -> Share Channel then click the appbar X to leave the modal. It should do what you think it should.