### PR TITLE
Prevent errors when sync returns changes that are not persistable on the server

### DIFF
--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -301,22 +301,25 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
             obj_id = self.child.id_value_lookup(obj)
             obj_validated_data = all_validated_data_by_id.get(obj_id)
 
-            # Reset the child serializer changes attribute
-            self.child.changes = []
-            # use model serializer to actually update the model
-            # in case that method is overwritten
+            # If no valid data was passed back then this will be None
+            if obj_validated_data is not None:
 
-            instance = self.child.update(obj, obj_validated_data)
-            # If the update method does not return an instance for some reason
-            # do not try to run further updates on the model, as there is no
-            # object to udpate.
-            if instance:
-                m2m_fields_by_id[obj_id] = self.child.m2m_fields
-                updated_objects.append(instance)
-            # Collect any registered changes from this run of the loop
-            self.changes.extend(self.child.changes)
+                # Reset the child serializer changes attribute
+                self.child.changes = []
+                # use model serializer to actually update the model
+                # in case that method is overwritten
 
-            updated_keys.add(obj_id)
+                instance = self.child.update(obj, obj_validated_data)
+                # If the update method does not return an instance for some reason
+                # do not try to run further updates on the model, as there is no
+                # object to udpate.
+                if instance:
+                    m2m_fields_by_id[obj_id] = self.child.m2m_fields
+                    updated_objects.append(instance)
+                # Collect any registered changes from this run of the loop
+                self.changes.extend(self.child.changes)
+
+                updated_keys.add(obj_id)
 
         if len(all_validated_data_by_id) != len(updated_keys):
             self.missing_keys = updated_keys.difference(

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -177,6 +177,7 @@ class ContentNodeSerializer(BulkModelSerializer):
             "extra_fields",
             "thumbnail_encoding",
             "parent",
+            "complete",
         )
         list_serializer_class = ContentNodeListSerializer
 


### PR DESCRIPTION
## Description

* Fixes an issue where sync changes with no writeable data would cause None type is not iterable errors
* Adds complete field to the ContentNode serializer

#### Issue Addressed (if applicable)

Fixes #2297
