### PR TITLE
Add tests for unwriteable and empty updates and fix them.

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_assessmentitem.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_assessmentitem.py
@@ -165,6 +165,44 @@ class SyncTestCase(StudioAPITestCase):
             new_question,
         )
 
+    def test_update_assessmentitem_empty(self):
+
+        assessmentitem = models.AssessmentItem.objects.create(
+            **self.assessmentitem_db_metadata
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(
+                    [assessmentitem.contentnode_id, assessmentitem.assessment_id],
+                    ASSESSMENTITEM,
+                    {},
+                )
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_assessmentitem_unwriteable_fields(self):
+
+        assessmentitem = models.AssessmentItem.objects.create(
+            **self.assessmentitem_db_metadata
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(
+                    [assessmentitem.contentnode_id, assessmentitem.assessment_id],
+                    ASSESSMENTITEM,
+                    {"not_a_field": "not_a_value"},
+                )
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
     def test_delete_assessmentitem(self):
 
         assessmentitem = models.AssessmentItem.objects.create(
@@ -314,6 +352,32 @@ class CRUDTestCase(StudioAPITestCase):
             models.AssessmentItem.objects.get(id=assessmentitem.id).question,
             new_question,
         )
+
+    def test_update_assessmentitem_empty(self):
+
+        assessmentitem = models.AssessmentItem.objects.create(
+            **self.assessmentitem_db_metadata
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("assessmentitem-detail", kwargs={"pk": assessmentitem.id}),
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_assessmentitem_unwriteable_fields(self):
+
+        assessmentitem = models.AssessmentItem.objects.create(
+            **self.assessmentitem_db_metadata
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("assessmentitem-detail", kwargs={"pk": assessmentitem.id}),
+            {"not_a_field": "not_a_value"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
 
     def test_delete_assessmentitem(self):
         assessmentitem = models.AssessmentItem.objects.create(

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -331,7 +331,8 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
         for obj in objects_to_update:
             obj_id = self.child.id_value_lookup(obj)
             m2m_fields = m2m_fields_by_id.get(obj_id)
-            self.child.post_save_update(obj, m2m_fields)
+            if m2m_fields is not None:
+                self.child.post_save_update(obj, m2m_fields)
 
         return updated_objects
 


### PR DESCRIPTION
## Description

* Adds tests for empty and unwriteable updates to the assessment item endpoint
* Fixes an issue with m2m_fields being undefined for empty or undefined updates

#### Issue Addressed (if applicable)

Fixes #2304
