### PR TITLE
Properly reference assessmentitem ids.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/actions.js
@@ -35,9 +35,10 @@ export function addAssessmentItem(context, assessmentItem) {
     hints: JSON.stringify(assessmentItem.hints || []),
   };
 
-  return AssessmentItem.put(stringifiedAssessmentItem).then(assessment_id => {
+  return AssessmentItem.put(stringifiedAssessmentItem).then(([contentnode, assessment_id]) => {
     context.commit('ADD_ASSESSMENTITEM', {
       ...assessmentItem,
+      contentnode,
       assessment_id,
     });
   });
@@ -56,7 +57,10 @@ export function updateAssessmentItem(context, assessmentItem) {
     answers: JSON.stringify(assessmentItem.answers || []),
     hints: JSON.stringify(assessmentItem.hints || []),
   };
-  return AssessmentItem.update(stringifiedAssessmentItem);
+  return AssessmentItem.update(
+    [assessmentItem.contentnode, assessmentItem.assessment_id],
+    stringifiedAssessmentItem
+  );
 }
 
 export function copyAssessmentItems(context, { params, updater }) {


### PR DESCRIPTION
## Description

* Fixes issues where assessment items were not being properly referenced by the [contentnode, assessment_id] combined index primary key.

#### Issue Addressed (if applicable)

* Fixes #2305

## Steps to Test

- Create a new assessment item (question) in an exercise
- Delete it
- Refresh the page and confirm that it is deleted.
