### PR TITLE
Validation error errors | ResourcePanel & DetailsTabView

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
@@ -30,6 +30,8 @@
 </template>
 <script>
 
+  import { isNodeComplete } from 'shared/utils/validation';
+
   export default {
     name: 'ContentNodeValidator',
     props: {
@@ -51,7 +53,7 @@
           : '';
       },
       error() {
-        if (!this.node.complete) {
+        if (!isNodeComplete({ nodeDetails: this.node })) {
           return this.$tr('incompleteText');
         } else if (this.node.total_count && this.node.error_count >= this.node.total_count) {
           return this.$tr('allIncompleteDescendantsText', { count: this.node.error_count });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
@@ -30,8 +30,6 @@
 </template>
 <script>
 
-  import { isNodeComplete } from 'shared/utils/validation';
-
   export default {
     name: 'ContentNodeValidator',
     props: {
@@ -53,7 +51,7 @@
           : '';
       },
       error() {
-        if (!isNodeComplete({ nodeDetails: this.node })) {
+        if (!this.node.complete) {
           return this.$tr('incompleteText');
         } else if (this.node.total_count && this.node.error_count >= this.node.total_count) {
           return this.$tr('allIncompleteDescendantsText', { count: this.node.error_count });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -475,14 +475,12 @@
       // Invalid mastery model
       noMasteryModel() {
         // We only validate mastery model on exercises
-        if(this.isExercise) {
+        if (this.isExercise) {
           return (
             this.isExercise &&
-            (
-              !validateNodeMasteryModel(this.node).length ||
+            (!validateNodeMasteryModel(this.node).length ||
               !validateNodeMasteryModelM(this.node).length ||
-              !validateNodeMasteryModelN(this.node).length
-            )
+              !validateNodeMasteryModelN(this.node).length)
           );
         } else {
           return false;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -472,7 +472,6 @@
       noLicenseDescription() {
         return Boolean(
           this.license &&
-            this.license.is_custom &&
             !this.isTopic &&
             validateNodeLicenseDescription(this.node).length
         );

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -477,10 +477,9 @@
         // We only validate mastery model on exercises
         if (this.isExercise) {
           return (
-            this.isExercise &&
-            (!validateNodeMasteryModel(this.node).length ||
-              !validateNodeMasteryModelM(this.node).length ||
-              !validateNodeMasteryModelN(this.node).length)
+            validateNodeMasteryModel(this.node).length ||
+            validateNodeMasteryModelM(this.node).length ||
+            validateNodeMasteryModelN(this.node).length
           );
         } else {
           return false;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -502,7 +502,7 @@
         );
       },
       invalidQuestions() {
-        return !this.assessmentItems.length || this.invalidQuestionCount;
+        return this.isExercise && (!this.assessmentItems.length || this.invalidQuestionCount);
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -470,10 +470,7 @@
       },
       // License description isn't provided on special permissions licenses
       noLicenseDescription() {
-        return Boolean(
-            !this.isTopic &&
-            validateNodeLicenseDescription(this.node).length
-        );
+        return Boolean(!this.isTopic && validateNodeLicenseDescription(this.node).length);
       },
       // Invalid mastery model
       noMasteryModel() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -462,15 +462,20 @@
       /* VALIDATION */
       // License isn't specified
       noLicense() {
-        return !this.isTopic && validateNodeLicense(this.node).length;
+        return Boolean(!this.isTopic && validateNodeLicense(this.node).length);
       },
       // Copyright holder isn't set on non-public domain licenses
       noCopyrightHolder() {
-        return !this.isTopic && !validateNodeCopyrightHolder(this.node).length;
+        return Boolean(!this.isTopic && validateNodeCopyrightHolder(this.node).length);
       },
       // License description isn't provided on special permissions licenses
       noLicenseDescription() {
-        return !this.isTopic && !validateNodeLicenseDescription(this.node).length;
+        return Boolean(
+          this.license &&
+            this.license.is_custom &&
+            !this.isTopic &&
+            validateNodeLicenseDescription(this.node).length
+        );
       },
       // Invalid mastery model
       noMasteryModel() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -474,12 +474,19 @@
       },
       // Invalid mastery model
       noMasteryModel() {
-        return (
-          this.isExercise &&
-          (validateNodeMasteryModel(this.node).length ||
-            validateNodeMasteryModelM(this.node).length ||
-            validateNodeMasteryModelN(this.node).length)
-        );
+        // We only validate mastery model on exercises
+        if(this.isExercise) {
+          return (
+            this.isExercise &&
+            (
+              !validateNodeMasteryModel(this.node).length ||
+              !validateNodeMasteryModelM(this.node).length ||
+              !validateNodeMasteryModelN(this.node).length
+            )
+          );
+        } else {
+          return false;
+        }
       },
       invalidQuestionCount() {
         return (

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -471,7 +471,6 @@
       // License description isn't provided on special permissions licenses
       noLicenseDescription() {
         return Boolean(
-          this.license &&
             !this.isTopic &&
             validateNodeLicenseDescription(this.node).length
         );

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -481,9 +481,9 @@
       noMasteryModel() {
         return (
           this.isExercise &&
-          (!validateNodeMasteryModel(this.node).length ||
-            !validateNodeMasteryModelM(this.node).length ||
-            !validateNodeMasteryModelN(this.node).length)
+          (validateNodeMasteryModel(this.node).length ||
+            validateNodeMasteryModelM(this.node).length ||
+            validateNodeMasteryModelN(this.node).length)
         );
       },
       invalidQuestionCount() {

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -173,7 +173,7 @@ export function validateNodeLicenseDescription(node) {
 export function validateNodeMasteryModel(node) {
   const mastery = _getMasteryModel(node);
   return getMasteryModelValidators()
-    .map(validator => validator(mastery))
+    .map(validator => validator(mastery && mastery.type))
     .filter(value => value !== true);
 }
 


### PR DESCRIPTION
## Description

Some validation fixes:

- The ResourcePanel (right sidebar) `license_description` was showing because logic didn't account for whether the selected license was `is_custom` or not.
- Some fields had a `!` they didn't need in their validation logic.
- Add check for `isExercise` on a question-related validator
- Use `isNodeComplete` rather than `node.complete` in the ContentNodeValidator component.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2314
Fixes https://github.com/learningequality/studio/issues/2334

## Steps to Test

ResourcePanel:

Edit a node so that things are invalid and save the node, go back to the node listing page and select the node again to see that the proper error messages are shown and that there is a red `(!)` on the item. Try all validated fields `copyright_holder` `license` and - when you select the "Special Permissions" license, the `license_description` field and then finally the "Visible to" field.

Details Tab View (Editing the Node Page):

I really couldn't replicate here (surprisingly because I definitely did during or before the bug bash). If you can give a reliable way to break validations here please let me know and I'll address them in this PR quickly.

#### Does this introduce any tech-debt items?

@MisRob the move to "isNodeComplete" in ContentNodeValidator was done because a node where `node.complete ==> false` but `isNodeComplete(node) ==> true`. I'm thinking that some part of https://github.com/learningequality/studio/pull/2281 may not work as expected in this regard? I'd be happy to address this issue in a follow up PR.
