### PR TITLE
Cache channel metadata

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -39,6 +39,7 @@ from django.db.models.query_utils import DeferredAttribute
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import ugettext as _
+from django_cte import CTEManager
 from model_utils import FieldTracker
 from le_utils import proquint
 from le_utils.constants import content_kinds
@@ -1528,6 +1529,23 @@ class File(models.Model):
         indexes = [
             models.Index(fields=['checksum', 'file_size'], name=FILE_DISTINCT_INDEX_NAME),
         ]
+
+
+class FileCTE(models.Model):
+    """
+    CLone of the File model to be used in CTE clauses
+    """
+
+    objects = CTEManager()
+    id = UUIDField(primary_key=True, default=uuid.uuid4)
+    checksum = models.CharField(max_length=400, blank=True, db_index=True)
+    file_size = models.IntegerField(blank=True, null=True)
+    contentnode = models.ForeignKey(
+        ContentNode, related_name="+", blank=True, null=True, db_index=True
+    )
+
+    class Meta:
+        db_table = "contentcuration_file"
 
 
 @receiver(models.signals.post_delete, sender=File)

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1545,6 +1545,7 @@ class FileCTE(models.Model):
     )
 
     class Meta:
+        managed = False
         db_table = "contentcuration_file"
 
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -39,7 +39,6 @@ from django.db.models.query_utils import DeferredAttribute
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import ugettext as _
-from django_cte import CTEManager
 from model_utils import FieldTracker
 from le_utils import proquint
 from le_utils.constants import content_kinds
@@ -53,6 +52,7 @@ from mptt.models import raise_if_unsaved
 from mptt.models import TreeForeignKey
 from rest_framework.authtoken.models import Token
 
+from contentcuration.db.models.manager import CustomManager
 from contentcuration.db.models.manager import CustomContentNodeTreeManager
 from contentcuration.statistics import record_channel_stats
 from contentcuration.utils.cache import delete_public_channel_cache_keys
@@ -1484,6 +1484,7 @@ class File(models.Model):
     source_url = models.CharField(max_length=400, blank=True, null=True)
     uploaded_by = models.ForeignKey(User, related_name='files', blank=True, null=True)
 
+    objects = CustomManager()
     class Admin:
         pass
 
@@ -1529,24 +1530,6 @@ class File(models.Model):
         indexes = [
             models.Index(fields=['checksum', 'file_size'], name=FILE_DISTINCT_INDEX_NAME),
         ]
-
-
-class FileCTE(models.Model):
-    """
-    CLone of the File model to be used in CTE clauses
-    """
-
-    objects = CTEManager()
-    id = UUIDField(primary_key=True, default=uuid.uuid4)
-    checksum = models.CharField(max_length=400, blank=True, db_index=True)
-    file_size = models.IntegerField(blank=True, null=True)
-    contentnode = models.ForeignKey(
-        ContentNode, related_name="+", blank=True, null=True, db_index=True
-    )
-
-    class Meta:
-        managed = False
-        db_table = "contentcuration_file"
 
 
 @receiver(models.signals.post_delete, sender=File)

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -214,7 +214,7 @@ DATABASES = {
         'USER': os.getenv('DATA_DB_USER') or 'learningequality',
         'PASSWORD': os.getenv('DATA_DB_PASS') or 'kolibri',
         'HOST': os.getenv('DATA_DB_HOST') or 'localhost',      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '5438',                      # Set to empty string for default.
+        'PORT': '',                      # Set to empty string for default.
     },
 }
 

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -214,7 +214,7 @@ DATABASES = {
         'USER': os.getenv('DATA_DB_USER') or 'learningequality',
         'PASSWORD': os.getenv('DATA_DB_PASS') or 'kolibri',
         'HOST': os.getenv('DATA_DB_HOST') or 'localhost',      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',                      # Set to empty string for default.
+        'PORT': '5438',                      # Set to empty string for default.
     },
 }
 

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -17,6 +17,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import Task
 from contentcuration.models import User
 from contentcuration.serializers import ContentNodeSerializer
+from contentcuration.utils.channel import cache_channel_size
 from contentcuration.utils.csv_writer import write_channel_csv_file
 from contentcuration.utils.csv_writer import write_user_csv
 from contentcuration.utils.files import _create_zip_thumbnail
@@ -153,6 +154,11 @@ def generatethumbnail_task(filename):
     if filename.endswith('.zip'):
         return _create_zip_thumbnail(filename)
     raise NotImplementedError('Unable to generate thumbnail for {}'.format(filename))
+
+
+@task(name='cache_channel_metadata_task')
+def cache_channel_metadata_task(channel, tree_id):
+    cache_channel_size(channel, tree_id)
 
 
 type_mapping = {

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -157,8 +157,9 @@ def generatethumbnail_task(filename):
 
 
 @task(name='cache_channel_metadata_task')
-def cache_channel_metadata_task(channel, tree_id):
-    calculate_channel_metadata(channel, tree_id)
+def cache_channel_metadata_task(key, channel, tree_id):
+
+    calculate_channel_metadata(key, channel, tree_id)
 
 
 type_mapping = {

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -17,6 +17,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import Task
 from contentcuration.models import User
 from contentcuration.serializers import ContentNodeSerializer
+from contentcuration.utils.channel import cache_multiple_channels_metadata
 from contentcuration.utils.channel import calculate_channel_metadata
 from contentcuration.utils.csv_writer import write_channel_csv_file
 from contentcuration.utils.csv_writer import write_user_csv
@@ -158,8 +159,12 @@ def generatethumbnail_task(filename):
 
 @task(name='cache_channel_metadata_task')
 def cache_channel_metadata_task(key, channel, tree_id):
-
     calculate_channel_metadata(key, channel, tree_id)
+
+
+@task(name='cache_multiple_channels_metadata_task')
+def cache_multiple_channels_metadata_task(channels):
+    cache_multiple_channels_metadata(channels)
 
 
 type_mapping = {

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -17,7 +17,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import Task
 from contentcuration.models import User
 from contentcuration.serializers import ContentNodeSerializer
-from contentcuration.utils.channel import cache_channel_metadata
+from contentcuration.utils.channel import calculate_channel_metadata
 from contentcuration.utils.csv_writer import write_channel_csv_file
 from contentcuration.utils.csv_writer import write_user_csv
 from contentcuration.utils.files import _create_zip_thumbnail
@@ -158,7 +158,7 @@ def generatethumbnail_task(filename):
 
 @task(name='cache_channel_metadata_task')
 def cache_channel_metadata_task(channel, tree_id):
-    cache_channel_metadata(channel, tree_id)
+    calculate_channel_metadata(channel, tree_id)
 
 
 type_mapping = {

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -17,7 +17,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import Task
 from contentcuration.models import User
 from contentcuration.serializers import ContentNodeSerializer
-from contentcuration.utils.channel import cache_channel_size
+from contentcuration.utils.channel import cache_channel_metadata
 from contentcuration.utils.csv_writer import write_channel_csv_file
 from contentcuration.utils.csv_writer import write_user_csv
 from contentcuration.utils.files import _create_zip_thumbnail
@@ -158,7 +158,7 @@ def generatethumbnail_task(filename):
 
 @task(name='cache_channel_metadata_task')
 def cache_channel_metadata_task(channel, tree_id):
-    cache_channel_size(channel, tree_id)
+    cache_channel_metadata(channel, tree_id)
 
 
 type_mapping = {

--- a/contentcuration/contentcuration/utils/cache.py
+++ b/contentcuration/contentcuration/utils/cache.py
@@ -1,7 +1,7 @@
 from django.core.cache import cache
 
 
-DEFERRED_FLAG = "deferred"
+DEFERRED_FLAG = "__DEFERRED"
 
 
 def delete_cache_keys(key_pattern):

--- a/contentcuration/contentcuration/utils/cache.py
+++ b/contentcuration/contentcuration/utils/cache.py
@@ -1,6 +1,9 @@
 from django.core.cache import cache
 
 
+DEFERRED_FLAG = "deferred"
+
+
 def delete_cache_keys(key_pattern):
     """
     Deletes all cache keys that match key_pattern, if found.

--- a/contentcuration/contentcuration/utils/cache.py
+++ b/contentcuration/contentcuration/utils/cache.py
@@ -1,7 +1,78 @@
+import functools
+import math
+import random
+import time
+
 from django.core.cache import cache
 
 
 DEFERRED_FLAG = "__DEFERRED"
+
+
+def cache_stampede(expire, beta=1):
+    """Cache decorator with cache stampede protection.
+    Based on http://www.vldb.org/pvldb/vol8/p886-vattani.pdf (research by
+    Vattani, A.; Chierichetti, F.; Lowenstein, K. (2015), Optimal Probabilistic
+    Cache Stampede Prevention, VLDB, pp. 886-897, ISSN 2150-8097) and the
+    Python implementation at
+    https://github.com/grantjenks/python-diskcache/blob/master/diskcache/recipes.py#L315
+
+    The cache stampede problem (also called dog-piling, cache miss storm,
+    or cache choking) is a situation that occurs when a popular cache item
+    expires, leading to multiple requests seeing a cache miss and
+    regenerating that same item at the same time
+
+    This  decorator implements cache stampede protection through
+    early recomputation. Early recomputation of function results will occur
+    probabilistically before expiration in a background thread of
+    execution.
+
+    IMPORTANT:
+    The decorated function must have the cache key as its first parameter.
+
+    :param float expire: seconds until arguments expire
+    :param int beta: the parameter beta can be set to a value greater than 1 to
+                     favor earlier recomputations and further reduce stampedes but
+                     the paper authors show that setting beta=1 works well in practice
+    :return: callable decorator
+    """
+
+    def decorator(func):
+        def timer(*args, **kwargs):
+            "Time execution of `func` and return result and time delta."
+            start = time.time()
+            result = func(*args, **kwargs)
+            delta = time.time() - start
+            # The variable delta represents the time to recompute the value
+            # and is used to scale the probability distribution appropriately.
+            return result, delta
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            key = args[0]
+            cached = cache.get(key)
+            if cached is not None:
+                metadata = cached["METADATA"]
+                if cached["CALCULATING"]:
+                    return metadata
+                expire_time = cached["EXPIRE"]
+                now = time.time()
+                ttl = expire_time - now
+                delta = cached["DELTA"]
+                if (-delta * math.log(random.random())) < ttl:
+                    return metadata  # Cache hit.
+            metadata, delta = timer(*args, *kwargs)
+            cached_info = {
+                "CALCULATING": False,
+                "METADATA": metadata,
+                "DELTA": delta,
+                "EXPIRE": time.time() + expire,
+            }
+            cache.set(key, cached_info, timeout=None)
+
+        return wrapper
+
+    return decorator
 
 
 def delete_cache_keys(key_pattern):
@@ -16,7 +87,7 @@ def delete_cache_keys(key_pattern):
     :param for_view:
     :return: Number of keys deleted
     """
-    if hasattr(cache, 'delete_pattern'):
+    if hasattr(cache, "delete_pattern"):
         return cache.delete_pattern(key_pattern)
     elif cache.has_key(key_pattern):
         cache.delete(key_pattern)
@@ -28,5 +99,5 @@ def delete_public_channel_cache_keys():
     """
     Delete all caches related to the public channel caching.
     """
-    delete_cache_keys('*get_public_channel_list*')
-    delete_cache_keys('*get_user_public_channels*')
+    delete_cache_keys("*get_public_channel_list*")
+    delete_cache_keys("*get_user_public_channels*")

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -1,0 +1,42 @@
+import time
+
+from django.core.cache import cache
+from django.db.models import Sum
+from django_cte import With
+
+from contentcuration.models import Channel
+from contentcuration.models import ContentNode
+from contentcuration.models import FileCTE
+
+
+def cache_channel_size(channel, tree_id=None):
+    key = "channel_metadata_{}".format(channel)
+    metadata = cache.get(key)
+    if metadata is not None:
+        if metadata["CALCULATING"]:
+            return  # the task is already queue
+    else:
+        # the key will expire if the task is not achieved in one hour
+        cache.set(key, {"CALCULATING": True}, timeout=3600)
+
+        if tree_id is None:
+            tree_id = Channel.objects.get(id=channel).main_tree.id
+
+        nodes = With(
+            ContentNode.objects.values("id", "tree_id")
+            .filter(tree_id=tree_id)
+            .order_by(),
+            name="nodes",
+        )
+        size_sum = (
+            nodes.join(FileCTE, contentnode_id=nodes.col.id)
+            .values("checksum", "file_size")
+            .with_cte(nodes)
+            .distinct()
+            .aggregate(Sum("file_size"))
+        )
+        size = size_sum["file_size__sum"] or 0
+
+        # 1 day timeout, pending to review, maybe 0 (forever):
+        metadata = {"CALCULATING": False, "SIZE": size, "LAST_CALCULATED": time.time()}
+        cache.set(key, metadata, timeout=86400)

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -34,11 +34,6 @@ def cache_stampede(expire, beta=1):
     probabilistically before expiration in a background thread of
     execution.
 
-    If name is set to None (default), the callable name will be determined
-    automatically.
-    The original underlying function is accessible through the `__wrapped__`
-    attribute. This is useful for introspection, for bypassing the cache, or
-    for rewrapping the function with a different cache.
     :param str key: key used to store the value in the cache
     :param float expire: seconds until arguments expire
     :param int beta: the parameter beta can be set to a value greater than 1 to

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -5,7 +5,7 @@ from django_cte import With
 
 from contentcuration.models import Channel
 from contentcuration.models import ContentNode
-from contentcuration.models import FileCTE
+from contentcuration.models import File
 from contentcuration.models import User
 from contentcuration.utils.cache import cache_stampede
 
@@ -34,7 +34,7 @@ def calculate_channel_metadata(key, channel_id=None, tree_id=None):
         name="nodes",
     )
     size_sum = (
-        nodes.join(FileCTE, contentnode_id=nodes.col.id)
+        nodes.join(File, contentnode_id=nodes.col.id)
         .values("checksum", "file_size")
         .with_cte(nodes)
         .distinct()

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -1,3 +1,6 @@
+import functools
+import math
+import random
 import time
 
 from django.core.cache import cache
@@ -13,7 +16,75 @@ from contentcuration.models import User
 CACHE_CHANNEL_KEY = "channel_metadata_{}"
 
 
-def cache_channel_metadata(channel_id=None, tree_id=None):
+def cache_stampede(expire, beta=1):
+    """Cache decorator with cache stampede protection.
+    Based on http://www.vldb.org/pvldb/vol8/p886-vattani.pdf (research by
+    Vattani, A.; Chierichetti, F.; Lowenstein, K. (2015), Optimal Probabilistic
+    Cache Stampede Prevention, VLDB, pp. 886-897, ISSN 2150-8097)
+    The cache stampede problem (also called dog-piling, cache miss storm,
+    or cache choking) is a situation that occurs when a popular cache item
+    expires, leading to multiple requests seeing a cache miss and
+    regenerating that same item at the same time
+
+    This  decorator implements cache stampede protection through
+    early recomputation. Early recomputation of function results will occur
+    probabilistically before expiration in a background thread of
+    execution.
+
+    If name is set to None (default), the callable name will be determined
+    automatically.
+    The original underlying function is accessible through the `__wrapped__`
+    attribute. This is useful for introspection, for bypassing the cache, or
+    for rewrapping the function with a different cache.
+    :param str key: key used to store the value in the cache
+    :param float expire: seconds until arguments expire
+    :param int beta: the parameter beta can be set to a value greater than 1 to
+                     favor earlier recomputations and further reduce stampedes but
+                     the paper authors show that setting beta=1 works well in practice
+    :return: callable decorator
+    """
+
+    def decorator(func):
+        def timer(*args, **kwargs):
+            "Time execution of `func` and return result and time delta."
+            start = time.time()
+            result = func(*args, **kwargs)
+            delta = time.time() - start
+            # The variable delta represents the time to recompute the value
+            # and is used to scale the probability distribution appropriately.
+            return result, delta
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            channel_id = args[0]
+            key = CACHE_CHANNEL_KEY.format(channel_id)
+            cached = cache.get(key)
+            if cached is not None:
+                metadata = cached["METADATA"]
+                if cached["CALCULATING"]:
+                    return metadata
+                expire_time = cached["EXPIRE"]
+                now = time.time()
+                ttl = expire_time - now
+                delta = cached["DELTA"]
+                if (-delta * math.log(random.random())) < ttl:
+                    return metadata  # Cache hit.
+            metadata, delta = timer(*args, *kwargs)
+            cached_info = {
+                "CALCULATING": False,
+                "METADATA": metadata,
+                "DELTA": delta,
+                "EXPIRE": time.time() + expire,
+            }
+            cache.set(key, cached_info, timeout=None)
+
+        return wrapper
+
+    return decorator
+
+
+@cache_stampede(expire=3600)
+def calculate_channel_metadata(channel_id=None, tree_id=None):
     if channel_id is None and tree_id is None:
         return  # this is an error, it should not happen, but just in case
 
@@ -23,57 +94,49 @@ def cache_channel_metadata(channel_id=None, tree_id=None):
         )[0]
 
     key = CACHE_CHANNEL_KEY.format(channel_id)
-    metadata = cache.get(key)
-    if metadata is not None:
-        if metadata["CALCULATING"]:
-            return  # the task is already queue
-    else:
-        # the key will expire if the task is not achieved in one hour
-        cache.set(key, {"CALCULATING": True}, timeout=3600)
+    cached_info = cache.get(key)
+    if cached_info is not None:
+        if cached_info["CALCULATING"]:
+            return  # the task is already queued
+    # the key will expire if the task is not achieved in one hour
+    cache.set(key, {"CALCULATING": True}, timeout=3600)
 
-        if tree_id is None:
-            tree_id = Channel.objects.get(id=channel_id).main_tree.id
+    if tree_id is None:
+        tree_id = Channel.objects.get(id=channel_id).main_tree.id
 
-        nodes = With(
-            ContentNode.objects.values("id", "tree_id")
-            .filter(tree_id=tree_id)
-            .order_by(),
-            name="nodes",
-        )
-        size_sum = (
-            nodes.join(FileCTE, contentnode_id=nodes.col.id)
-            .values("checksum", "file_size")
-            .with_cte(nodes)
-            .distinct()
-            .aggregate(Sum("file_size"))
-        )
-        size = size_sum["file_size__sum"] or 0
+    nodes = With(
+        ContentNode.objects.values("id", "tree_id").filter(tree_id=tree_id).order_by(),
+        name="nodes",
+    )
+    size_sum = (
+        nodes.join(FileCTE, contentnode_id=nodes.col.id)
+        .values("checksum", "file_size")
+        .with_cte(nodes)
+        .distinct()
+        .aggregate(Sum("file_size"))
+    )
+    size = size_sum["file_size__sum"] or 0
 
-        editors = (
-            User.objects.filter(editable_channels__id=channel_id)
-            .values_list("id", flat=True)
-            .distinct()
-            .aggregate(Count("id"))
-        )
-        editors_count = editors["id__count"] or 0
+    editors = (
+        User.objects.filter(editable_channels__id=channel_id)
+        .values_list("id", flat=True)
+        .distinct()
+        .aggregate(Count("id"))
+    )
+    editors_count = editors["id__count"] or 0
 
-        viewers = (
-            User.objects.filter(view_only_channels__id=channel_id)
-            .values_list("id", flat=True)
-            .distinct()
-            .aggregate(Count("id"))
-        )
-        viewers_count = viewers["id__count"] or 0
+    viewers = (
+        User.objects.filter(view_only_channels__id=channel_id)
+        .values_list("id", flat=True)
+        .distinct()
+        .aggregate(Count("id"))
+    )
+    viewers_count = viewers["id__count"] or 0
 
-        # 1 day timeout, pending to review, maybe 0 (forever):
-        metadata = {
-            "size": size,
-            "editors_count": editors_count,
-            "viewers_count": viewers_count,
-        }
-        cached_info = {
-            "CALCULATING": False,
-            "METADATA": metadata,
-            "LAST_CALCULATED": time.time(),
-        }
-        cache.set(key, cached_info, timeout=86400)
+    # 1 day timeout, pending to review, maybe 0 (forever):
+    metadata = {
+        "size": size,
+        "editors_count": editors_count,
+        "viewers_count": viewers_count,
+    }
+    return metadata

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -34,7 +34,6 @@ def cache_stampede(expire, beta=1):
     probabilistically before expiration in a background thread of
     execution.
 
-    :param str key: key used to store the value in the cache
     :param float expire: seconds until arguments expire
     :param int beta: the parameter beta can be set to a value greater than 1 to
                      favor earlier recomputations and further reduce stampedes but

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -20,7 +20,10 @@ def cache_stampede(expire, beta=1):
     """Cache decorator with cache stampede protection.
     Based on http://www.vldb.org/pvldb/vol8/p886-vattani.pdf (research by
     Vattani, A.; Chierichetti, F.; Lowenstein, K. (2015), Optimal Probabilistic
-    Cache Stampede Prevention, VLDB, pp. 886-897, ISSN 2150-8097)
+    Cache Stampede Prevention, VLDB, pp. 886-897, ISSN 2150-8097) and the
+    Python implementation at
+    https://github.com/grantjenks/python-diskcache/blob/master/diskcache/recipes.py#L315
+
     The cache stampede problem (also called dog-piling, cache miss storm,
     or cache choking) is a situation that occurs when a popular cache item
     expires, leading to multiple requests seeing a cache miss and

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -10,6 +10,8 @@ from contentcuration.models import ContentNode
 from contentcuration.models import FileCTE
 from contentcuration.models import User
 
+CACHE_CHANNEL_KEY = "channel_metadata_{}"
+
 
 def cache_channel_metadata(channel=None, tree_id=None):
     if channel is None and tree_id is None:
@@ -20,7 +22,7 @@ def cache_channel_metadata(channel=None, tree_id=None):
             "id", flat=True
         )[0]
 
-    key = "channel_metadata_{}".format(channel)
+    key = CACHE_CHANNEL_KEY.format(channel)
     metadata = cache.get(key)
     if metadata is not None:
         if metadata["CALCULATING"]:
@@ -65,10 +67,13 @@ def cache_channel_metadata(channel=None, tree_id=None):
 
         # 1 day timeout, pending to review, maybe 0 (forever):
         metadata = {
+            "size": size,
+            "editors_count": editors_count,
+            "viewers_count": viewers_count,
+        }
+        cached_info = {
             "CALCULATING": False,
-            "SIZE": size,
-            "EDITORS": editors_count,
-            "VIEWERS": viewers_count,
+            "METADATA": metadata,
             "LAST_CALCULATED": time.time(),
         }
-        cache.set(key, metadata, timeout=86400)
+        cache.set(key, cached_info, timeout=86400)

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -1,15 +1,25 @@
 import time
 
 from django.core.cache import cache
+from django.db.models import Count
 from django.db.models import Sum
 from django_cte import With
 
 from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 from contentcuration.models import FileCTE
+from contentcuration.models import User
 
 
-def cache_channel_size(channel, tree_id=None):
+def cache_channel_metadata(channel=None, tree_id=None):
+    if channel is None and tree_id is None:
+        return  # this is an error, it should not happen, but just in case
+
+    if channel is None:
+        channel = Channel.objects.filter(main_tree__tree_id=319).values_list(
+            "id", flat=True
+        )[0]
+
     key = "channel_metadata_{}".format(channel)
     metadata = cache.get(key)
     if metadata is not None:
@@ -37,6 +47,28 @@ def cache_channel_size(channel, tree_id=None):
         )
         size = size_sum["file_size__sum"] or 0
 
+        editors = (
+            User.objects.filter(editable_channels__id=channel)
+            .values_list("id", flat=True)
+            .distinct()
+            .aggregate(Count("id"))
+        )
+        editors_count = editors["id__count"] or 0
+
+        viewers = (
+            User.objects.filter(view_only_channels__id=channel)
+            .values_list("id", flat=True)
+            .distinct()
+            .aggregate(Count("id"))
+        )
+        viewers_count = viewers["id__count"] or 0
+
         # 1 day timeout, pending to review, maybe 0 (forever):
-        metadata = {"CALCULATING": False, "SIZE": size, "LAST_CALCULATED": time.time()}
+        metadata = {
+            "CALCULATING": False,
+            "SIZE": size,
+            "EDITORS": editors_count,
+            "VIEWERS": viewers_count,
+            "LAST_CALCULATED": time.time(),
+        }
         cache.set(key, metadata, timeout=86400)

--- a/contentcuration/contentcuration/utils/channel.py
+++ b/contentcuration/contentcuration/utils/channel.py
@@ -1,8 +1,3 @@
-import functools
-import math
-import random
-import time
-
 from django.core.cache import cache
 from django.db.models import Count
 from django.db.models import Sum
@@ -12,85 +7,16 @@ from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 from contentcuration.models import FileCTE
 from contentcuration.models import User
+from contentcuration.utils.cache import cache_stampede
 
 CACHE_CHANNEL_KEY = "channel_metadata_{}"
 
 
-def cache_stampede(expire, beta=1):
-    """Cache decorator with cache stampede protection.
-    Based on http://www.vldb.org/pvldb/vol8/p886-vattani.pdf (research by
-    Vattani, A.; Chierichetti, F.; Lowenstein, K. (2015), Optimal Probabilistic
-    Cache Stampede Prevention, VLDB, pp. 886-897, ISSN 2150-8097) and the
-    Python implementation at
-    https://github.com/grantjenks/python-diskcache/blob/master/diskcache/recipes.py#L315
-
-    The cache stampede problem (also called dog-piling, cache miss storm,
-    or cache choking) is a situation that occurs when a popular cache item
-    expires, leading to multiple requests seeing a cache miss and
-    regenerating that same item at the same time
-
-    This  decorator implements cache stampede protection through
-    early recomputation. Early recomputation of function results will occur
-    probabilistically before expiration in a background thread of
-    execution.
-
-    :param float expire: seconds until arguments expire
-    :param int beta: the parameter beta can be set to a value greater than 1 to
-                     favor earlier recomputations and further reduce stampedes but
-                     the paper authors show that setting beta=1 works well in practice
-    :return: callable decorator
-    """
-
-    def decorator(func):
-        def timer(*args, **kwargs):
-            "Time execution of `func` and return result and time delta."
-            start = time.time()
-            result = func(*args, **kwargs)
-            delta = time.time() - start
-            # The variable delta represents the time to recompute the value
-            # and is used to scale the probability distribution appropriately.
-            return result, delta
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            channel_id = args[0]
-            key = CACHE_CHANNEL_KEY.format(channel_id)
-            cached = cache.get(key)
-            if cached is not None:
-                metadata = cached["METADATA"]
-                if cached["CALCULATING"]:
-                    return metadata
-                expire_time = cached["EXPIRE"]
-                now = time.time()
-                ttl = expire_time - now
-                delta = cached["DELTA"]
-                if (-delta * math.log(random.random())) < ttl:
-                    return metadata  # Cache hit.
-            metadata, delta = timer(*args, *kwargs)
-            cached_info = {
-                "CALCULATING": False,
-                "METADATA": metadata,
-                "DELTA": delta,
-                "EXPIRE": time.time() + expire,
-            }
-            cache.set(key, cached_info, timeout=None)
-
-        return wrapper
-
-    return decorator
-
-
 @cache_stampede(expire=3600)
-def calculate_channel_metadata(channel_id=None, tree_id=None):
-    if channel_id is None and tree_id is None:
+def calculate_channel_metadata(key, channel_id=None, tree_id=None):
+    if key is None:
         return  # this is an error, it should not happen, but just in case
 
-    if channel_id is None:
-        channel_id = Channel.objects.filter(main_tree__tree_id=tree_id).values_list(
-            "id", flat=True
-        )[0]
-
-    key = CACHE_CHANNEL_KEY.format(channel_id)
     cached_info = cache.get(key)
     if cached_info is not None:
         if cached_info["CALCULATING"]:

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -25,6 +25,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import generate_storage_url
 from contentcuration.models import SecretToken
 from contentcuration.models import User
+from contentcuration.tasks import cache_channel_metadata_task
 from contentcuration.utils.cache import DEFERRED_FLAG
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
@@ -535,10 +536,7 @@ class AdminChannelViewSet(ChannelViewSet):
         key = "channel_metadata_{}".format(channel)
         metadata = cache.get(key)
         if metadata is None:
-            # here we send the async command
-            from contentcuration.utils.channel import cache_channel_size
-
-            cache_channel_size(channel, tree_id)
+            cache_channel_metadata_task.delay(channel, tree_id)
             return DEFERRED_FLAG
         else:
             if "SIZE" in metadata:

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -405,6 +405,7 @@ class ChannelViewSet(ValuesViewset):
         non_topic_content_ids = (
             channel_main_tree_nodes.exclude(kind_id=content_kinds.TOPIC)
             .values_list("content_id", flat=True)
+            .order_by()
             .distinct()
         )
 
@@ -527,12 +528,12 @@ class AdminChannelViewSet(ChannelViewSet):
     def consolidate(self, items, queryset):
         if items:
             for item_channel in items:
-                item_channel["size"] = self.get_or_cache_channel_size(
+                item_channel["size"] = self.get_or_cache_channel_metadata(
                     item_channel["id"], item_channel["main_tree__tree_id"]
                 )
         return items
 
-    def get_or_cache_channel_size(self, channel, tree_id):
+    def get_or_cache_channel_metadata(self, channel, tree_id):
         key = "channel_metadata_{}".format(channel)
         metadata = cache.get(key)
         if metadata is None:

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -27,7 +27,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import generate_storage_url
 from contentcuration.models import SecretToken
 from contentcuration.models import User
-from contentcuration.tasks import cache_channel_metadata_task
+from contentcuration.tasks import cache_multiple_channels_metadata_task
 from contentcuration.utils.cache import DEFERRED_FLAG
 from contentcuration.utils.channel import CACHE_CHANNEL_KEY
 from contentcuration.viewsets.base import BulkListSerializer
@@ -524,6 +524,7 @@ class AdminChannelViewSet(ChannelViewSet):
                     ] = DEFERRED_FLAG
                 else:
                     item_channel.update(metadata)
+            cache_multiple_channels_metadata_task.delay(items)
         return items
 
     def get_or_cache_channel_metadata(self, channel_id, tree_id):
@@ -534,7 +535,7 @@ class AdminChannelViewSet(ChannelViewSet):
         """
         key = CACHE_CHANNEL_KEY.format(channel_id)
         cached_info = cache.get(key)
-        cache_channel_metadata_task.delay(key, channel_id, tree_id)
+        # cache_channel_metadata_task.delay(key, channel_id, tree_id)
         if cached_info is None:
             # from contentcuration.utils.channel import calculate_channel_metadata
             # calculate_channel_metadata(key, channel_id, tree_id)

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -534,10 +534,10 @@ class AdminChannelViewSet(ChannelViewSet):
         """
         key = CACHE_CHANNEL_KEY.format(channel_id)
         cached_info = cache.get(key)
-        cache_channel_metadata_task.delay(channel_id, tree_id)
+        cache_channel_metadata_task.delay(key, channel_id, tree_id)
         if cached_info is None:
             # from contentcuration.utils.channel import calculate_channel_metadata
-            # calculate_channel_metadata(channel_id, tree_id)
+            # calculate_channel_metadata(key, channel_id, tree_id)
             return DEFERRED_FLAG
         else:
             if "METADATA" in cached_info:


### PR DESCRIPTION
## Description

Removes AdminChannelViewSet annotations and defers them to be executed in an async task that will cache the results.

As operations are executed asynchronously, the values are not immediately available if they have not been previously cached. In this case the values are marked with a DEFERRED_FLAG so the frontend knows that it can request them later.

The structure of the created object can be seen in the contentcuration/contentcuration/utils/channel.py and it's done according to the https://www.notion.so/learningequality/2020-12-24-Team-Sonic-counting-descendants-meeting-7ea0f46d4a6648109a22eefbba124a92 decissions

NOTE: some small optimization have also been done, mainly removing unneded order_by requirements in some of the queries, and the use of CTE to avoid scanning the whole File table after paginating the results.

#### Issue Addressed (if applicable)

Current annotations in AdminChannelViewSet returns queries needing days to be executed (File table  has 76  millions of rows and ContentNode has 10 millions and the queries where scanning and joining both tables)

## Implementation Notes (optional)

- Added an api endpoint for the frontend to retrieve cached metadata.

Example of use: http://localhost:8080/api/admin-channels/deferred_data?id__in=0598c68f00fc562486fc6616b63f267f,c1f2b7e6ac9f56a2bb44fa7a48b66dce


- Two different tasks are implemented:

  - `cache_channel_metadata_task(key, channel, tree_id)` to cache one single channel
  - `cache_multiple_channels_metadata_task(channels) `to cache multiple channels


### Cache invalidation
Cache keys will be stored forever 
The timestamp stored in the key will be used to retrieve data, but will be marked as stale and recalculated after one hour (following a [probabilistic cache invalidation algorithm](https://github.com/grantjenks/python-diskcache/blob/master/diskcache/recipes.py#L315) to avoid a recalculation stampede)


