### PR TITLE
Add permissions filtering for foreign key setting

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -736,7 +736,6 @@ class Channel(models.Model):
     @classmethod
     def filter_edit_queryset(cls, queryset, user):
         user_id = not user.is_anonymous() and user.id
-        user_id = not user.is_anonymous() and user.id
         user_queryset = User.objects.filter(id=user_id)
         queryset = Channel.objects.annotate(
             edit=Exists(user_queryset.filter(editable_channels=OuterRef("id"))),

--- a/contentcuration/contentcuration/tests/viewsets/test_assessmentitem.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_assessmentitem.py
@@ -335,6 +335,22 @@ class CRUDTestCase(StudioAPITestCase):
         except models.AssessmentItem.DoesNotExist:
             self.fail("AssessmentItem was not created")
 
+    def test_create_assessmentitem_no_node_permission(self):
+        self.client.force_authenticate(user=self.user)
+        new_channel = testdata.channel()
+        new_channel_exercise = (
+            new_channel.main_tree.get_descendants()
+            .filter(kind_id=content_kinds.EXERCISE)
+            .first()
+            .id
+        )
+        assessmentitem = self.assessmentitem_metadata
+        assessmentitem["contentnode"] = new_channel_exercise
+        response = self.client.post(
+            reverse("assessmentitem-list"), assessmentitem, format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
     def test_update_assessmentitem(self):
         assessmentitem = models.AssessmentItem.objects.create(
             **self.assessmentitem_db_metadata

--- a/contentcuration/contentcuration/tests/viewsets/test_channelset.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channelset.py
@@ -1,0 +1,298 @@
+from __future__ import absolute_import
+
+import uuid
+
+from django.core.urlresolvers import reverse
+
+from contentcuration import models
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.viewsets.sync.constants import CHANNELSET
+from contentcuration.viewsets.sync.utils import generate_create_event
+from contentcuration.viewsets.sync.utils import generate_delete_event
+from contentcuration.viewsets.sync.utils import generate_update_event
+
+
+class SyncTestCase(StudioAPITestCase):
+    @property
+    def sync_url(self):
+        return reverse("sync")
+
+    @property
+    def channelset_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "channels": [self.channel.id],
+            "name": "channel set test",
+        }
+
+    @property
+    def channelset_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "name": "channel set test",
+        }
+
+    def setUp(self):
+        super(SyncTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+
+    def test_create_channelset(self):
+        self.client.force_authenticate(user=self.user)
+        channelset = self.channelset_metadata
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(channelset["id"], CHANNELSET, channelset,)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ChannelSet.objects.get(id=channelset["id"])
+        except models.ChannelSet.DoesNotExist:
+            self.fail("ChannelSet was not created")
+
+    def test_create_channelsets(self):
+        self.client.force_authenticate(user=self.user)
+        channelset1 = self.channelset_metadata
+        channelset2 = self.channelset_metadata
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_create_event(channelset1["id"], CHANNELSET, channelset1,),
+                generate_create_event(channelset2["id"], CHANNELSET, channelset2,),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ChannelSet.objects.get(id=channelset1["id"])
+        except models.ChannelSet.DoesNotExist:
+            self.fail("ChannelSet 1 was not created")
+
+        try:
+            models.ChannelSet.objects.get(id=channelset2["id"])
+        except models.ChannelSet.DoesNotExist:
+            self.fail("ChannelSet 2 was not created")
+
+    def test_update_channelset(self):
+
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(channelset.id, CHANNELSET, {"channels": []},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertFalse(
+            models.ChannelSet.objects.get(id=channelset.id)
+            .secret_token.channels.filter(pk=self.channel.id)
+            .exists()
+        )
+
+    def test_update_channelsets(self):
+
+        channelset1 = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset1.editors.add(self.user)
+        channelset2 = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset2.editors.add(self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(channelset1.id, CHANNELSET, {"channels": []},),
+                generate_update_event(channelset2.id, CHANNELSET, {"channels": []},),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertFalse(
+            models.ChannelSet.objects.get(id=channelset1.id)
+            .secret_token.channels.filter(pk=self.channel.id)
+            .exists()
+        )
+        self.assertFalse(
+            models.ChannelSet.objects.get(id=channelset2.id)
+            .secret_token.channels.filter(pk=self.channel.id)
+            .exists()
+        )
+
+    def test_update_channelset_empty(self):
+
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(channelset.id, CHANNELSET, {},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_channelset_unwriteable_fields(self):
+
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(
+                    channelset.id, CHANNELSET, {"not_a_field": "not_a_value"},
+                )
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_delete_channelset(self):
+
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_delete_event(channelset.id, CHANNELSET,)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ChannelSet.objects.get(id=channelset.id)
+            self.fail("ChannelSet was not deleted")
+        except models.ChannelSet.DoesNotExist:
+            pass
+
+    def test_delete_channelsets(self):
+        channelset1 = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset2 = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset1.editors.add(self.user)
+        channelset2.editors.add(self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_delete_event(channelset1.id, CHANNELSET,),
+                generate_delete_event(channelset2.id, CHANNELSET,),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ChannelSet.objects.get(id=channelset1.id)
+            self.fail("ChannelSet 1 was not deleted")
+        except models.ChannelSet.DoesNotExist:
+            pass
+
+        try:
+            models.ChannelSet.objects.get(id=channelset2.id)
+            self.fail("ChannelSet 2 was not deleted")
+        except models.ChannelSet.DoesNotExist:
+            pass
+
+
+class CRUDTestCase(StudioAPITestCase):
+    @property
+    def channelset_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "channels": [self.channel.id],
+            "name": "channel set test",
+        }
+
+    @property
+    def channelset_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "name": "channel set test",
+        }
+
+    def setUp(self):
+        super(CRUDTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+
+    def test_create_channelset(self):
+        self.client.force_authenticate(user=self.user)
+        channelset = self.channelset_metadata
+        response = self.client.post(
+            reverse("channelset-list"), channelset, format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        try:
+            models.ChannelSet.objects.get(id=channelset["id"])
+        except models.ChannelSet.DoesNotExist:
+            self.fail("ChannelSet was not created")
+
+    def test_create_channelset_no_channel_permission(self):
+        self.client.force_authenticate(user=self.user)
+        new_channel = testdata.channel()
+        channelset = self.channelset_metadata
+        channelset["channels"] = [new_channel.id]
+        response = self.client.post(
+            reverse("channelset-list"), channelset, format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_update_channelset(self):
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("channelset-detail", kwargs={"pk": channelset.id}),
+            {"channels": [self.channel.id]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertTrue(
+            models.ChannelSet.objects.get(id=channelset.id)
+            .secret_token.channels.filter(pk=self.channel.id)
+            .exists()
+        )
+
+    def test_update_channelset_empty(self):
+
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("channelset-detail", kwargs={"pk": channelset.id}),
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_channelset_unwriteable_fields(self):
+
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("channelset-detail", kwargs={"pk": channelset.id}),
+            {"not_a_field": "not_a_value"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_delete_channelset(self):
+        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
+        channelset.editors.add(self.user)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            reverse("channelset-detail", kwargs={"pk": channelset.id})
+        )
+        self.assertEqual(response.status_code, 204, response.content)
+        try:
+            models.ChannelSet.objects.get(id=channelset.id)
+            self.fail("ChannelSet was not deleted")
+        except models.ChannelSet.DoesNotExist:
+            pass

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import uuid
 
 from django.core.urlresolvers import reverse
+from le_utils.constants import content_kinds
 from le_utils.constants import file_formats
 from le_utils.constants import format_presets
 
@@ -232,6 +233,21 @@ class CRUDTestCase(StudioAPITestCase):
         new_channel_node = new_channel.main_tree.get_descendants().first().id
         file = self.file_metadata
         file["contentnode"] = new_channel_node
+        response = self.client.post(reverse("file-list"), file, format="json",)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_create_file_no_assessmentitem_permission(self):
+        self.client.force_authenticate(user=self.user)
+        new_channel = testdata.channel()
+        new_channel_exercise = (
+            new_channel.main_tree.get_descendants()
+            .filter(kind_id=content_kinds.EXERCISE)
+            .first()
+        )
+        new_channel_assessmentitem = new_channel_exercise.assessment_items.first().id
+        file = self.file_metadata
+        file["assessment_item"] = new_channel_assessmentitem
+        del file["contentnode"]
         response = self.client.post(reverse("file-list"), file, format="json",)
         self.assertEqual(response.status_code, 400, response.content)
 

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -1,0 +1,283 @@
+from __future__ import absolute_import
+
+import uuid
+
+from django.core.urlresolvers import reverse
+from le_utils.constants import file_formats
+from le_utils.constants import format_presets
+
+from contentcuration import models
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.viewsets.sync.constants import FILE
+from contentcuration.viewsets.sync.utils import generate_create_event
+from contentcuration.viewsets.sync.utils import generate_delete_event
+from contentcuration.viewsets.sync.utils import generate_update_event
+
+
+class SyncTestCase(StudioAPITestCase):
+    @property
+    def sync_url(self):
+        return reverse("sync")
+
+    @property
+    def file_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "contentnode": self.channel.main_tree.get_descendants().first().id,
+            "checksum": uuid.uuid4().hex,
+            "preset": format_presets.AUDIO,
+            "file_format": file_formats.MP3,
+            "uploaded_by": self.user.id,
+        }
+
+    @property
+    def file_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "contentnode_id": self.channel.main_tree.get_descendants().first().id,
+            "checksum": uuid.uuid4().hex,
+            "preset_id": format_presets.AUDIO,
+            "file_format_id": file_formats.MP3,
+            "uploaded_by": self.user,
+        }
+
+    def setUp(self):
+        super(SyncTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+
+    def test_create_file(self):
+        self.client.force_authenticate(user=self.user)
+        file = self.file_metadata
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(file["id"], FILE, file,)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.File.objects.get(id=file["id"])
+        except models.File.DoesNotExist:
+            self.fail("File was not created")
+
+    def test_create_files(self):
+        self.client.force_authenticate(user=self.user)
+        file1 = self.file_metadata
+        file2 = self.file_metadata
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_create_event(file1["id"], FILE, file1,),
+                generate_create_event(file2["id"], FILE, file2,),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.File.objects.get(id=file1["id"])
+        except models.File.DoesNotExist:
+            self.fail("File 1 was not created")
+
+        try:
+            models.File.objects.get(id=file2["id"])
+        except models.File.DoesNotExist:
+            self.fail("File 2 was not created")
+
+    def test_update_file(self):
+
+        file = models.File.objects.create(**self.file_db_metadata)
+        new_preset = format_presets.VIDEO_HIGH_RES
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(file.id, FILE, {"preset": new_preset},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.File.objects.get(id=file.id).preset_id, new_preset,
+        )
+
+    def test_update_files(self):
+
+        file1 = models.File.objects.create(**self.file_db_metadata)
+        file2 = models.File.objects.create(**self.file_db_metadata)
+        new_preset = format_presets.VIDEO_HIGH_RES
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(file1.id, FILE, {"preset": new_preset},),
+                generate_update_event(file2.id, FILE, {"preset": new_preset},),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.File.objects.get(id=file1.id).preset_id, new_preset,
+        )
+        self.assertEqual(
+            models.File.objects.get(id=file2.id).preset_id, new_preset,
+        )
+
+    def test_update_file_empty(self):
+
+        file = models.File.objects.create(**self.file_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url, [generate_update_event(file.id, FILE, {},)], format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_file_unwriteable_fields(self):
+
+        file = models.File.objects.create(**self.file_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(file.id, FILE, {"not_a_field": "not_a_value"},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_delete_file(self):
+
+        file = models.File.objects.create(**self.file_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url, [generate_delete_event(file.id, FILE,)], format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.File.objects.get(id=file.id)
+            self.fail("File was not deleted")
+        except models.File.DoesNotExist:
+            pass
+
+    def test_delete_files(self):
+        file1 = models.File.objects.create(**self.file_db_metadata)
+
+        file2 = models.File.objects.create(**self.file_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_delete_event(file1.id, FILE,),
+                generate_delete_event(file2.id, FILE,),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.File.objects.get(id=file1.id)
+            self.fail("File 1 was not deleted")
+        except models.File.DoesNotExist:
+            pass
+
+        try:
+            models.File.objects.get(id=file2.id)
+            self.fail("File 2 was not deleted")
+        except models.File.DoesNotExist:
+            pass
+
+
+class CRUDTestCase(StudioAPITestCase):
+    @property
+    def file_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "contentnode": self.channel.main_tree.get_descendants().first().id,
+            "checksum": uuid.uuid4().hex,
+            "preset": format_presets.AUDIO,
+            "file_format": file_formats.MP3,
+            "uploaded_by": self.user.id,
+        }
+
+    @property
+    def file_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "contentnode_id": self.channel.main_tree.get_descendants().first().id,
+            "checksum": uuid.uuid4().hex,
+            "preset_id": format_presets.AUDIO,
+            "file_format_id": file_formats.MP3,
+            "uploaded_by": self.user,
+        }
+
+    def setUp(self):
+        super(CRUDTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+
+    def test_create_file(self):
+        self.client.force_authenticate(user=self.user)
+        file = self.file_metadata
+        response = self.client.post(reverse("file-list"), file, format="json",)
+        self.assertEqual(response.status_code, 201, response.content)
+        try:
+            models.File.objects.get(id=file["id"])
+        except models.File.DoesNotExist:
+            self.fail("File was not created")
+
+    def test_create_file_no_node_permission(self):
+        self.client.force_authenticate(user=self.user)
+        new_channel = testdata.channel()
+        new_channel_node = new_channel.main_tree.get_descendants().first().id
+        file = self.file_metadata
+        file["contentnode"] = new_channel_node
+        response = self.client.post(reverse("file-list"), file, format="json",)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_update_file(self):
+        file = models.File.objects.create(**self.file_db_metadata)
+        new_preset = format_presets.VIDEO_HIGH_RES
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("file-detail", kwargs={"pk": file.id}),
+            {"preset": new_preset},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.File.objects.get(id=file.id).preset_id, new_preset,
+        )
+
+    def test_update_file_empty(self):
+
+        file = models.File.objects.create(**self.file_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("file-detail", kwargs={"pk": file.id}), {}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_file_unwriteable_fields(self):
+
+        file = models.File.objects.create(**self.file_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("file-detail", kwargs={"pk": file.id}),
+            {"not_a_field": "not_a_value"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_delete_file(self):
+        file = models.File.objects.create(**self.file_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(reverse("file-detail", kwargs={"pk": file.id}))
+        self.assertEqual(response.status_code, 204, response.content)
+        try:
+            models.File.objects.get(id=file.id)
+            self.fail("File was not deleted")
+        except models.File.DoesNotExist:
+            pass

--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -1,0 +1,304 @@
+from __future__ import absolute_import
+
+import uuid
+
+from django.core.urlresolvers import reverse
+
+from contentcuration import models
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.viewsets.sync.constants import INVITATION
+from contentcuration.viewsets.sync.utils import generate_create_event
+from contentcuration.viewsets.sync.utils import generate_delete_event
+from contentcuration.viewsets.sync.utils import generate_update_event
+
+
+class SyncTestCase(StudioAPITestCase):
+    @property
+    def sync_url(self):
+        return reverse("sync")
+
+    @property
+    def invitation_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "channel": self.channel.id,
+            "email": self.invited_user.email,
+        }
+
+    @property
+    def invitation_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "channel_id": self.channel.id,
+            "email": self.invited_user.email,
+        }
+
+    def setUp(self):
+        super(SyncTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+        self.invited_user = testdata.user("inv@inc.com")
+
+    def test_create_invitation(self):
+        self.client.force_authenticate(user=self.user)
+        invitation = self.invitation_metadata
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(invitation["id"], INVITATION, invitation,)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+        except models.Invitation.DoesNotExist:
+            self.fail("Invitation was not created")
+
+    def test_create_invitations(self):
+        self.client.force_authenticate(user=self.user)
+        invitation1 = self.invitation_metadata
+        invitation2 = self.invitation_metadata
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_create_event(invitation1["id"], INVITATION, invitation1,),
+                generate_create_event(invitation2["id"], INVITATION, invitation2,),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation1["id"])
+        except models.Invitation.DoesNotExist:
+            self.fail("Invitation 1 was not created")
+
+        try:
+            models.Invitation.objects.get(id=invitation2["id"])
+        except models.Invitation.DoesNotExist:
+            self.fail("Invitation 2 was not created")
+
+    def test_update_invitation_accept(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(invitation.id, INVITATION, {"accepted": True},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+        self.assertTrue(self.channel.editors.filter(pk=self.invited_user.id).exists())
+
+    def test_update_invitation_decline(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(invitation.id, INVITATION, {"declined": True},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+        self.assertFalse(self.channel.editors.filter(pk=self.invited_user.id).exists())
+
+    def test_update_invitation_empty(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(invitation.id, INVITATION, {},)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_invitation_unwriteable_fields(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(
+                    invitation.id, INVITATION, {"not_a_field": "not_a_value"},
+                )
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_delete_invitation(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_delete_event(invitation.id, INVITATION,)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_delete_invitations(self):
+        invitation1 = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        invitation2 = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_delete_event(invitation1.id, INVITATION,),
+                generate_delete_event(invitation2.id, INVITATION,),
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation1.id)
+            self.fail("Invitation 1 was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+
+        try:
+            models.Invitation.objects.get(id=invitation2.id)
+            self.fail("Invitation 2 was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+
+
+class CRUDTestCase(StudioAPITestCase):
+    @property
+    def invitation_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "channel": self.channel.id,
+            "email": self.invited_user.email,
+        }
+
+    @property
+    def invitation_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "channel_id": self.channel.id,
+            "email": self.invited_user.email,
+        }
+
+    def setUp(self):
+        super(CRUDTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+        self.invited_user = testdata.user("inv@inc.com")
+
+    def test_create_invitation(self):
+        self.client.force_authenticate(user=self.user)
+        invitation = self.invitation_metadata
+        response = self.client.post(
+            reverse("invitation-list"), invitation, format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+        except models.Invitation.DoesNotExist:
+            self.fail("Invitation was not created")
+
+    def test_create_invitation_no_channel_permission(self):
+        self.client.force_authenticate(user=self.user)
+        new_channel = testdata.channel()
+        invitation = self.invitation_metadata
+        invitation["channel"] = new_channel.id
+        response = self.client.post(
+            reverse("invitation-list"), invitation, format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_update_invitation_accept(self):
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("invitation-detail", kwargs={"pk": invitation.id}),
+            {"accepted": True},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+
+        self.assertTrue(self.channel.editors.filter(pk=self.invited_user.id).exists())
+
+    def test_update_invitation_decline(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("invitation-detail", kwargs={"pk": invitation.id}),
+            {"declined": True},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+        self.assertFalse(self.channel.editors.filter(pk=self.invited_user.id).exists())
+
+    def test_update_invitation_empty(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("invitation-detail", kwargs={"pk": invitation.id}),
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_update_invitation_unwriteable_fields(self):
+
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("invitation-detail", kwargs={"pk": invitation.id}),
+            {"not_a_field": "not_a_value"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_delete_invitation(self):
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            reverse("invitation-detail", kwargs={"pk": invitation.id})
+        )
+        self.assertEqual(response.status_code, 204, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass

--- a/contentcuration/contentcuration/tests/viewsets/test_user.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_user.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+
+
+class CRUDTestCase(StudioAPITestCase):
+    def setUp(self):
+        super(CRUDTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+
+    def test_fetch_user(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse("user-detail", kwargs={"pk": self.user.id}), format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_no_create_user(self):
+        self.client.force_authenticate(user=self.user)
+        user = {}
+        response = self.client.post(reverse("user-list"), user, format="json",)
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_no_update_user(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("user-detail", kwargs={"pk": self.user.id}),
+            {"first_name": "janine"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_no_delete_user(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            reverse("user-detail", kwargs={"pk": self.user.id})
+        )
+        self.assertEqual(response.status_code, 405, response.content)

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -28,6 +28,7 @@ from contentcuration.viewsets.base import CopyMixin
 from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.common import NotNullArrayAgg
+from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
 from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.common import UUIDRegexField
 from contentcuration.viewsets.sync.constants import ASSESSMENTITEM
@@ -122,6 +123,9 @@ class AssessmentItemSerializer(BulkModelSerializer):
     # This is set as editable=False on the model so by default DRF does not allow us
     # to set it.
     assessment_id = UUIDRegexField()
+    contentnode = UserFilteredPrimaryKeyRelatedField(
+        queryset=ContentNode.objects.all(), required=False
+    )
 
     class Meta:
         model = AssessmentItem

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -3,10 +3,7 @@ import re
 
 from django.core.files.storage import default_storage
 from django.db import transaction
-from django.db.models import Exists
 from django.db.models import ObjectDoesNotExist
-from django.db.models import OuterRef
-from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from django_s3_storage.storage import S3Error
 from le_utils.constants import exercises
@@ -15,11 +12,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import ValidationError
 
 from contentcuration.models import AssessmentItem
-from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 from contentcuration.models import File
 from contentcuration.models import generate_object_storage_name
-from contentcuration.models import User
 from contentcuration.viewsets.base import BulkCreateMixin
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
@@ -147,35 +142,6 @@ class AssessmentItemSerializer(BulkModelSerializer):
         update_lookup_field = ("contentnode", "assessment_id")
 
 
-channel_trees = (
-    "main_tree",
-    "chef_tree",
-    "trash_tree",
-    "staging_tree",
-    "previous_tree",
-)
-
-edit_filter = Q()
-for tree_name in channel_trees:
-    edit_filter |= Q(
-        **{
-            "editable_channels__{}__tree_id".format(tree_name): OuterRef(
-                "contentnode__tree_id"
-            )
-        }
-    )
-
-view_filter = Q()
-for tree_name in channel_trees:
-    view_filter |= Q(
-        **{
-            "view_only_channels__{}__tree_id".format(tree_name): OuterRef(
-                "contentnode__tree_id"
-            )
-        }
-    )
-
-
 # Apply mixin first to override ValuesViewset
 class AssessmentItemViewSet(BulkCreateMixin, BulkUpdateMixin, ValuesViewset, CopyMixin):
     queryset = AssessmentItem.objects.all()
@@ -201,34 +167,6 @@ class AssessmentItemViewSet(BulkCreateMixin, BulkUpdateMixin, ValuesViewset, Cop
     field_map = {
         "contentnode": "contentnode_id",
     }
-
-    def get_queryset(self):
-        user_id = not self.request.user.is_anonymous() and self.request.user.id
-        user_queryset = User.objects.filter(id=user_id)
-
-        queryset = AssessmentItem.objects.annotate(
-            edit=Exists(user_queryset.filter(edit_filter)),
-            view=Exists(user_queryset.filter(view_filter)),
-            public=Exists(
-                Channel.objects.filter(
-                    public=True, main_tree__tree_id=OuterRef("contentnode__tree_id")
-                )
-            ),
-        )
-        queryset = queryset.filter(Q(view=True) | Q(edit=True) | Q(public=True))
-
-        return queryset
-
-    def get_edit_queryset(self):
-        user_id = not self.request.user.is_anonymous() and self.request.user.id
-        user_queryset = User.objects.filter(id=user_id)
-
-        queryset = AssessmentItem.objects.annotate(
-            edit=Exists(user_queryset.filter(edit_filter)),
-        )
-        queryset = queryset.filter(edit=True)
-
-        return queryset
 
     def annotate_queryset(self, queryset):
         queryset = queryset.annotate(file_ids=NotNullArrayAgg("files__id"))

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -459,11 +459,24 @@ class ReadOnlyValuesViewset(SimpleReprMixin, ReadOnlyModelViewSet):
         # Hack to prevent the renderer logic from breaking completely.
         return Serializer
 
+    def get_queryset(self):
+        queryset = super(ReadOnlyValuesViewset, self).get_queryset()
+        if self.request.user.is_admin:
+            return queryset
+        if hasattr(queryset.model, "filter_view_queryset"):
+            return queryset.model.filter_view_queryset(queryset, self.request.user)
+        return queryset
+
     def get_edit_queryset(self):
         """
         Return a filtered copy of the queryset to only the objects
         that a user is able to edit, rather than view.
         """
+        queryset = super(ReadOnlyValuesViewset, self).get_queryset()
+        if self.request.user.is_admin:
+            return queryset
+        if hasattr(queryset.model, "filter_edit_queryset"):
+            return queryset.model.filter_edit_queryset(queryset, self.request.user)
         return self.get_queryset()
 
     def _get_object_from_queryset(self, queryset):

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -62,25 +62,14 @@ class ChannelSetViewSet(ValuesViewset):
 
     field_map = {"secret_token": "secret_token__token", "channels": clean_channels}
 
-    def get_queryset(self):
-        queryset = ChannelSet.objects.prefetch_related("secret_token").filter(
-            id__in=ChannelSet.objects.filter(editors=self.request.user)
-            .distinct()
-            .values_list("id", flat=True)
-        )
-
-        queryset = queryset.annotate(
+    def annotate_queryset(self, queryset):
+        return queryset.annotate(
             channels=DistinctNotNullArrayAgg(
                 "secret_token__channels__id",
                 filter=Q(main_tree__published=True, deleted=False),
                 output_field=CharField(),
             )
         )
-        return queryset
-
-    def prefetch_queryset(self, queryset):
-        queryset = queryset.select_related("secret_token")
-        return queryset
 
 
 class PublicChannelSetSerializer(BulkModelSerializer):

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -46,9 +46,11 @@ class FileFilter(RequiredFilterSet):
 
 
 class FileSerializer(BulkModelSerializer):
-    contentnode = UserFilteredPrimaryKeyRelatedField(queryset=ContentNode.objects.all())
+    contentnode = UserFilteredPrimaryKeyRelatedField(
+        queryset=ContentNode.objects.all(), required=False
+    )
     assessment_item = UserFilteredPrimaryKeyRelatedField(
-        queryset=AssessmentItem.objects.all()
+        queryset=AssessmentItem.objects.all(), required=False
     )
     uploaded_by = PrimaryKeyRelatedField(queryset=User.objects.all())
 

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -1,7 +1,7 @@
+from django.db import transaction
 from django.db.models import Exists
 from django.db.models import OuterRef
 from django.db.models import Q
-from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import PrimaryKeyRelatedField
@@ -14,13 +14,14 @@ from contentcuration.models import File
 from contentcuration.models import generate_storage_url
 from contentcuration.models import User
 from contentcuration.utils.files import duplicate_file
+from contentcuration.viewsets.base import BulkCreateMixin
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
-from contentcuration.viewsets.base import ValuesViewset
-from contentcuration.viewsets.base import BulkCreateMixin
 from contentcuration.viewsets.base import BulkUpdateMixin
 from contentcuration.viewsets.base import CopyMixin
 from contentcuration.viewsets.base import RequiredFilterSet
+from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
 from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
@@ -45,7 +46,7 @@ class FileFilter(RequiredFilterSet):
 
 
 class FileSerializer(BulkModelSerializer):
-    contentnode = PrimaryKeyRelatedField(queryset=ContentNode.objects.all())
+    contentnode = UserFilteredPrimaryKeyRelatedField(queryset=ContentNode.objects.all())
     uploaded_by = PrimaryKeyRelatedField(queryset=User.objects.all())
 
     class Meta:

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -47,6 +47,9 @@ class FileFilter(RequiredFilterSet):
 
 class FileSerializer(BulkModelSerializer):
     contentnode = UserFilteredPrimaryKeyRelatedField(queryset=ContentNode.objects.all())
+    assessment_item = UserFilteredPrimaryKeyRelatedField(
+        queryset=AssessmentItem.objects.all()
+    )
     uploaded_by = PrimaryKeyRelatedField(queryset=User.objects.all())
 
     class Meta:

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -1,4 +1,3 @@
-from django.db.models import Q
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
@@ -116,21 +115,3 @@ class InvitationViewSet(ValuesViewset):
         "channel": "channel_id",
         "accepted": False,
     }
-
-    def get_queryset(self):
-        return Invitation.objects.filter(
-            Q(email__iexact=self.request.user.email)
-            | Q(sender=self.request.user)
-            | Q(channel__editors=self.request.user)
-            | Q(channel__viewers=self.request.user)
-        ).distinct()
-
-    def get_edit_queryset(self):
-        return Invitation.objects.filter(
-            Q(email__iexact=self.request.user.email)
-            | Q(sender=self.request.user)
-            | Q(channel__editors=self.request.user)
-        ).distinct()
-
-    def prefetch_queryset(self, queryset):
-        return queryset.select_related("sender", "channel")

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -2,13 +2,15 @@ from django.db.models import Q
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
-from rest_framework.permissions import IsAuthenticated
 from rest_framework import serializers
+from rest_framework.permissions import IsAuthenticated
 
+from contentcuration.models import Channel
 from contentcuration.models import Invitation
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
 from contentcuration.viewsets.sync.constants import INVITATION
 from contentcuration.viewsets.sync.utils import add_event_for_user
 from contentcuration.viewsets.sync.utils import generate_update_event
@@ -17,6 +19,7 @@ from contentcuration.viewsets.sync.utils import generate_update_event
 class InvitationSerializer(BulkModelSerializer):
     accepted = serializers.BooleanField(default=False)
     declined = serializers.BooleanField(default=False)
+    channel = UserFilteredPrimaryKeyRelatedField(queryset=Channel.objects.all())
 
     class Meta:
         model = Invitation
@@ -33,6 +36,9 @@ class InvitationSerializer(BulkModelSerializer):
         list_serializer_class = BulkListSerializer
 
     def create(self, validated_data):
+        # Need to remove default values for these non-model fields here
+        validated_data.pop("accepted", None)
+        validated_data.pop("declined", None)
         if "request" in self.context:
             # If this has been newly created add the current user as the sender
             self.validated_data["sender"] = self.context["request"].user

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -131,34 +131,6 @@ class UserViewSet(ReadOnlyValuesViewset):
         "view_only_channels": "view_only_channels__ids",
     }
 
-    def get_queryset(self):
-        assert not self.request.user.is_anonymous()
-
-        if self.request.user.is_admin:
-            queryset = User.objects.all()
-        else:
-            channel_list = Channel.objects.filter(
-                Q(
-                    pk__in=self.request.user.editable_channels.values_list(
-                        "pk", flat=True
-                    )
-                )
-                | Q(
-                    pk__in=self.request.user.view_only_channels.values_list(
-                        "pk", flat=True
-                    )
-                )
-            ).values_list("pk", flat=True)
-            queryset = User.objects.filter(
-                id__in=User.objects.filter(
-                    Q(pk=self.request.user.pk)
-                    | Q(editable_channels__pk__in=channel_list)
-                    | Q(view_only_channels__pk__in=channel_list)
-                )
-            )
-
-        return queryset.order_by("first_name", "last_name")
-
     def annotate_queryset(self, queryset):
         queryset = queryset.annotate(
             editable_channels__ids=NotNullArrayAgg("editable_channels__id"),


### PR DESCRIPTION
## Description

* Adds new class methods to Models to define their queryset filtering behaviour for viewing and editing
* Takes queryset and user arguments, returns filtered queryset
* Implements on Model classes to avoid having to subclass both queryset and manager
* Adds tests for viewsets that had no tests so far
* Adds specific tests to test for Foreign Key permission setting
* Consolidates all queryset filtering by user onto the models, and extends the base values viewset class to look for the model class methods
* Fixes numerous bugs that were uncovered by the addition of the tests

## Steps to Test

- Do all the tests for the endpoints pass?
- Does everything still load as expected for the frontend data?
