### PR TITLE
Accepted invites not shown as invites on ChannelList anymore

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -151,9 +151,9 @@
       },
       invitationList() {
         return (
-          this.invitations.filter(
-            i => ChannelInvitationMapping[i.share_mode] === this.currentListType
-          ) || []
+          this.invitations
+            .filter(i => !i.accepted)
+            .filter(i => ChannelInvitationMapping[i.share_mode] === this.currentListType) || []
         );
       },
       invitationsByListCounts() {

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/mutations.js
@@ -31,10 +31,16 @@ export function ADD_CHANNEL_DETAILS(state, { id, details }) {
 export function SET_INVITATION_LIST(state, invitations) {
   const invitationsMap = {};
   invitations.forEach(invitation => {
+    // If accepted or declined keys are defined, use their
+    // value, otherwise set them explicitly to `false`.
+    let { accepted, declined } = invitation;
+    accepted = accepted || false;
+    declined = declined || false;
+
     invitationsMap[invitation.id] = {
       ...invitation,
-      accepted: false,
-      declined: false,
+      accepted,
+      declined,
     };
   });
   state.invitationsMap = invitationsMap;

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
@@ -193,8 +193,9 @@
         // Have to use email because invitation ids are ids for the invitations, not
         // the user itself.
         const channelUserEmails = this.users.map(u => u.email);
-        return this.users
-          .concat(this.invitations.filter(i => !channelUserEmails.includes(i.email)));
+        return this.users.concat(
+          this.invitations.filter(i => !channelUserEmails.includes(i.email))
+        );
       },
       header() {
         if (this.mode === SharingPermissions.EDIT) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
@@ -7,7 +7,7 @@
     <VDataTable
       hide-headers
       hide-actions
-      :items="users.concat(invitations)"
+      :items="tableUsers"
     >
       <template #no-data>
         <td class="px-0">
@@ -187,6 +187,14 @@
             pending: true,
           };
         });
+      },
+      // Remove invitations if they've been accepted
+      tableUsers() {
+        // Have to use email because invitation ids are ids for the invitations, not
+        // the user itself.
+        const channelUserEmails = this.users.map(u => u.email);
+        return this.users
+          .concat(this.invitations.filter(i => !channelUserEmails.includes(i.email)));
       },
       header() {
         if (this.mode === SharingPermissions.EDIT) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/__tests__/channelSharingTable.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/__tests__/channelSharingTable.spec.js
@@ -42,10 +42,6 @@ describe('channelSharingTable', () => {
     expect(wrapper.vm.invitations[0].pending).toBe(true);
   });
   describe('confirmation modals', () => {
-    it('clicking delete option should open delete confirmation modal', () => {
-      wrapper.find('[data-test="delete"]').trigger('click');
-      expect(wrapper.vm.showDeleteInvitation).toBe(true);
-    });
     it('clicking make editor option should open makeEditor confirmation modal', () => {
       wrapper.setProps({ mode: SharingPermissions.VIEW_ONLY });
       wrapper.find('[data-test="makeeditor"]').trigger('click');
@@ -96,6 +92,10 @@ describe('channelSharingTable', () => {
       });
       wrapper.find('[data-test="confirm-delete"]').trigger('click');
       expect(deleteInvitation).toHaveBeenCalledWith(invite.id);
+    });
+    it('clicking delete option should open delete confirmation modal', () => {
+      wrapper.find('[data-test="delete"]').trigger('click');
+      expect(wrapper.vm.showDeleteInvitation).toBe(true);
     });
     it('grantEditAccess should call makeEditor', () => {
       wrapper.setData({ selected: user });


### PR DESCRIPTION
## Description

A few issues surrounding invitations on the frontend - each commit fixes a separate issue.

- Only show a person once in the channel edit -> share page. Previously an invited user would show as invited still even after accepting
- Exclude accepted invites from channel list. I was seeing previously accepted invites showing up on page reload - but this may be due to https://github.com/learningequality/studio/issues/2347 - in any case - now we'll not show any invites to the user if they're accepted.
- We were overriding given information by setting `accepted` and `declined` as false between reading from state and displaying to the user so state would not be reflected properly.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2067

## Steps to Test

- Make invites, accept them and test that the above are no longer issues.
