### PR TITLE
Different variable names for different values

### DIFF
--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -808,7 +808,7 @@ class MoveMixin(object):
 
     def move_from_changes(self, changes):
         errors = []
-        changes = []
+        changes_to_return = []
         for move in changes:
             # Move change will have key, must also have target property
             # optionally can include the desired position.
@@ -821,8 +821,8 @@ class MoveMixin(object):
                 move.update({"errors": [move_error]})
                 errors.append(move)
             if move_change:
-                changes.append(move_change)
-        return errors, changes
+                changes_to_return.append(move_change)
+        return errors, changes_to_return
 
 
 class RelationMixin(object):


### PR DESCRIPTION
## Description

You can move nodes now. A variable was named `changes` was turning our expected object into an empty array.

However, it does not fix the fact that moves are not triggering the call to sync. They're in the respective `*changes*` tables.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2339

## Steps to Test

Move a node then in your dev tools console call `window.forceServerSync()` and then see that the move has happened as expected.

