### PR TITLE
Poll for unsynced changes then sync them

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -285,6 +285,7 @@
             actionText: this.$tr('goToLocationButton'),
             actionCallback: this.goToLocation,
           });
+          this.$store.commit('currentChannel/SET_SELECTED_NODE_IDS', []);
         });
       },
     },

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -256,6 +256,7 @@ if (process.env.NODE_ENV !== 'production') {
 
   window.pollUnsyncedChanges = function() {
     keepPollingUnsyncedChanges = true;
+    pollUnsyncedChanges();
   };
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -245,6 +245,12 @@ if (process.env.NODE_ENV !== 'production') {
     debouncedSyncChanges();
     debouncedSyncChanges.flush();
   };
+
+  window.forceStopPollingUnsyncedChanges = function() {
+    window.dispatchEvent(new Event('stopPollingUnsyncedChanges'));
+  };
+
+  window.pollUnsyncedChanges = pollUnsyncedChanges;
 }
 
 function handleChanges(changes) {


### PR DESCRIPTION
## Description

Polls for unsynced changes and then syncs them.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2338

Bonus!

Fixes an issue I saw where the selected nodes were still selected when moving nodes by selecting their checkbox and using the move icon in the context menu. https://github.com/learningequality/studio/pull/2356/commits/015331019aa24fcc306919831b8c5ad3982b8a91

*Double Bonus!*

Fixes https://github.com/learningequality/studio/issues/2326 because the trash is just a place to move nodes to and from. 

## Steps to Test

Checkout `develop` and try moving some nodes. Check your `_syncableChanges` table in IDDB and you'll see some sweet changes sitting there getting absolutely no love or attention. No `/sync` call in Network tab - nothing until you refresh the page (it will sync when you refresh the page).

Checkout this PR and move some nodes again - this time, you should see the expected call to `/sync` within 2s of executing your action. You should only see 1 sync and your `_syncableChanges` table should be empty.

Move loads of nodes - one at a time and in bunches please. Try to smash on this hard with any wacky stuff you can think of please. 

Send stuff to the trash and restore it -then try deleting it forever.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I made a function that gets the IDDB changes we care about. 

Then a function that starts polling and does so until a local variable `keepPollingUnsyncedChanges` is falsy (ideally `false`). ~sets up an event listener giving the outside world a hook to stop polling.~

Then it syncs the changes we care about (if there are any) and calls itself all over again until `keepPollingUnsyncedChanges` is no longer truthy - in which case we stop calling the polling fn altogether until it is called again.

Note that once stopped - you cannot restart it again unless you set the local `keepPolling...` variable to true. See the debug window-scoped function.

~When the event listener is triggered, the polling function is called once more but just ensures that the event listener is removed. Otherwise, we just stop the polling.~

#### Does this introduce any tech-debt items?

- We should document the dev-mode only window-scoped methods I think so people know what tools they have available.