### PR TITLE
Assign copyright_holder w/ @input & ensure mastery criteria is saved

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -528,7 +528,7 @@
         deep: true,
         handler: debounce(
           function() {
-            Object.keys(this.diffTracker).forEach(async (id) => {
+            Object.keys(this.diffTracker).forEach(async id => {
               await this.updateContentNode({ id, ...this.diffTracker[id] });
               delete this.diffTracker[id];
             });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -527,8 +527,8 @@
       diffTracker: {
         deep: true,
         handler: debounce(
-          async function() {
-            Object.keys(this.diffTracker).forEach(id => {
+          function() {
+            Object.keys(this.diffTracker).forEach(async (id) => {
               await this.updateContentNode({ id, ...this.diffTracker[id] });
               delete this.diffTracker[id];
             });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -198,6 +198,7 @@
               box
               :value="copyright_holder && copyright_holder.toString()"
               @input.native="e => copyright_holder = e.srcElement.value"
+              @input="e => copyright_holder = e"
             />
           </VFlex>
           <VSpacer />
@@ -526,9 +527,9 @@
       diffTracker: {
         deep: true,
         handler: debounce(
-          function() {
+          async function() {
             Object.keys(this.diffTracker).forEach(id => {
-              this.updateContentNode({ id, ...this.diffTracker[id] });
+              await this.updateContentNode({ id, ...this.diffTracker[id] });
               delete this.diffTracker[id];
             });
           },


### PR DESCRIPTION
## Description

Fixes a couple issues on the edit details page.

For all nodes w/ a license and copyright holder, it was not saving if you took an auto complete suggestion. Now it saves that.

Also - I noticed that the mastery criteria wasn't being saved. That is also fixed.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2324

## Steps to Test

First - replicate the bugs on `develop`:

1. Go to an content node's edit details page. If there is a copyright holder already - remove it and save. In any case you must have already entered a copyright_holder in order to get the suggestion dropdown (see https://github.com/learningequality/studio/issues/2324)  - Ensure that selecting from the list doesn't work

2. Set your mastery criteria and try to save the node, then come back and be disappointed by the failure of the app to save your changes.

3. Check out this branch and see how these things are no longer broken :) 



## Implementation Notes (optional)

#### At a high level, how did you implement this?

Frankly I figured there must be some event getting triggered when selecting from the autocomplete dropdown and that means we use `@input`. 

Then I honestly got lucky w/ the mastery criteria because one of the first things I thought to try seems to have worked. The call to `updateContentNodes` gets a promise back and I figured maybe there was an issue with the code continuing and deleting the difftracker for the content node before the promise resolved. 

