### PR TITLE
Adding delayed calculation of annotation values for AdminUsers

### DIFF
--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -28,6 +28,7 @@ from contentcuration.utils.nodes import move_nodes
 from contentcuration.utils.publish import publish_channel
 from contentcuration.utils.sync import sync_channel
 from contentcuration.utils.sync import sync_nodes
+from contentcuration.utils.user import cache_multiple_users_metadata
 
 
 logger = get_task_logger(__name__)
@@ -165,6 +166,11 @@ def cache_channel_metadata_task(key, channel, tree_id):
 @task(name='cache_multiple_channels_metadata_task')
 def cache_multiple_channels_metadata_task(channels):
     cache_multiple_channels_metadata(channels)
+
+
+@task(name='cache_multiple_users_metadata_task')
+def cache_multiple_users_metadata_task(users):
+    cache_multiple_users_metadata(users)
 
 
 type_mapping = {

--- a/contentcuration/contentcuration/utils/user.py
+++ b/contentcuration/contentcuration/utils/user.py
@@ -1,0 +1,51 @@
+from django.core.cache import cache
+from django.db.models import Count
+
+from contentcuration.models import Channel
+from contentcuration.utils.cache import cache_stampede
+
+CACHE_USER_KEY = "user_metadata_{}"
+
+
+@cache_stampede(expire=3600)
+def calculate_user_metadata(key, user_id=None):
+    if key is None:
+        return  # this is an error, it should not happen, but just in case
+
+    cached_info = cache.get(key)
+    metadata = {}
+    if cached_info is not None:
+        if cached_info["CALCULATING"]:
+            return  # the task is already queued
+        metadata = cached_info.get("METADATA", None)
+    # the key will expire if the task is not achieved in one hour
+    cache.set(key, {"CALCULATING": True, "METADATA": {}}, timeout=3600)
+
+    editors = (
+        Channel.objects.filter(editors__id=user_id, deleted=False)
+        .values_list("id", flat=True)
+        .distinct()
+        .aggregate(Count("id"))
+    )
+    editors_count = editors["id__count"] or 0
+
+    viewers = (
+        Channel.objects.filter(viewers__id=user_id, deleted=False)
+        .values_list("id", flat=True)
+        .distinct()
+        .aggregate(Count("id"))
+    )
+    viewers_count = viewers["id__count"] or 0
+
+    metadata = {
+        "edit_count": editors_count,
+        "view_count": viewers_count,
+    }
+    return metadata
+
+
+def cache_multiple_users_metadata(users):
+    for user in users:
+        user_id = user["id"]
+        key = CACHE_USER_KEY.format(user_id)
+        calculate_user_metadata(key, user_id)


### PR DESCRIPTION
## Description

As done in #2333 , here we're caching and delaying to be asynchronously calculated some of the annotated fields for the `AdminUserViewSet`

#### Issue Addressed (if applicable)

Slow or impossible view with thousands of users in our Studio database

## Implementation Notes (optional)

Added also an api for the frontend to fetch delayed data. Example of use:
http://localhost:8080/api/admin-users/deferred_data?id__in=1,2,3,90

One task to do all the users calculation is implemented (a single user task is not needed by now):
`cache_multiple_users_metadata_task`

#### At a high level, how did you implement this?
Values are stored in the cache and recalculated when they are requested if one hour has passed since its last calculation. To avoid cache stampede the expiration time is calculated with the `@cache_stampede `decorator that uses a randomized gaussian function so not all the calculations are done simultaneously

### General view: Calculating annotated fields for the ViewSet in an asynchronous task
### when (not) to use this:

- Using this approach delays the calculation of the annotated fields. If they are required in real time, don't use it
- Using this approach you don't have data in the first request of the field (user, channel, etc.), instead a DEFERRED_FLAG is returned. After the task is run there's always a returned value, but it might have been calculated some time ago, depending on the expire time used in the `@cache_stampede `decorator 
- Using this approach you can't filter by the annotated fields

### when to use this:
- When using this approach the annotated fields are removed from the main queryset, making it much simpler, thus faster. It usually also removes group_by and order_by commands that add more searchs in the database
- When using this approach, there is always (excepting the first request) an usable value in the redis cache that can be accessed  easily
- The implemented stampede method guaranties the value is requested in the expire interval while ensuring not all the requests are done at the same time, to distribute the database work
- there is an api for the frontend to fetch easily the cached values
- Tasks can be set to calculate the value for a group of items in one single task (to be shown in a table, for example), or to calculate one per task