### PR TITLE
Fix PageNotFound error being pushed out of frame by loading screen

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -72,7 +72,9 @@
     </ResizableNavigationDrawer>
     <VContent>
       <!-- Render this so we can detect if we need to hide the hierarchy panel on page load -->
+      <PageNotFoundError v-if="nodeNotFound" :backHomeLink="pageNotFoundBackHomeLink" />
       <CurrentTopicView
+        v-else
         ref="topicview"
         :topicId="nodeId"
         :detailNodeId="detailNodeId"
@@ -88,7 +90,6 @@
           </div>
         </template>
       </CurrentTopicView>
-      <PageNotFoundError v-if="nodeNotFound" :backHomeLink="pageNotFoundBackHomeLink" />
     </VContent>
   </TreeViewBase>
 


### PR DESCRIPTION
I think because of a layout change to TreeView, the 404 error that was supposed to shown gets pushed out by `CurrentTopicView`, which just shows an infinite loading widget. This fixes the layout so the error page gets shown properly. This can be tested by going to any place in the channel tree and changing a UUID by one character to make it invalid.

Before

![CleanShot 2020-10-05 at 13 17 40@2x](https://user-images.githubusercontent.com/10248067/95127947-a9393500-070d-11eb-92a1-065836e99c5e.png)

After

<img width="1475" alt="CleanShot 2020-10-05 at 13 16 45@2x" src="https://user-images.githubusercontent.com/10248067/95127958-acccbc00-070d-11eb-9e9f-67466d5f9f74.png">
