### PR TITLE
Handle extra fields being null.

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_clipboard.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_clipboard.py
@@ -77,6 +77,21 @@ class SyncTestCase(StudioAPITestCase):
         except models.ContentNode.DoesNotExist:
             self.fail("ContentNode was not created")
 
+    def test_create_clipboard_with_null_extra_fields(self):
+        self.client.force_authenticate(user=self.user)
+        clipboard = self.clipboard_metadata
+        clipboard["extra_fields"] = None
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(clipboard["id"], CLIPBOARD, clipboard)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.ContentNode.objects.get(id=clipboard["id"])
+        except models.ContentNode.DoesNotExist:
+            self.fail("ContentNode was not created")
+
     def test_create_clipboard_with_parent(self):
         channel = testdata.channel()
         channel.editors.add(self.user)

--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -100,6 +100,9 @@ class JSONFieldDictSerializer(serializers.Serializer):
         # get just field name
         value = dictionary.get(self.field_name, dict())
 
+        if value is None:
+            return empty
+
         # then merge in fields with keys like `content_defaults.author`
         multi_value = MultiValueDict()
         multi_value.update(dictionary)


### PR DESCRIPTION
## Description

* In a story as old as time, we have to handle null extra fields.
* Adds a regression test that triggers the original issue.
* Adds special handling to our get_value method for nested update handling.

#### Issue Addressed (if applicable)

* Fixes #2374
