### PR TITLE
Updated edit modal layout

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -653,9 +653,6 @@
     .section .flex {
       margin: 24px 0 !important;
     }
-    .section {
-      max-width: 960px;
-    }
     .auth-section {
       /deep/ .v-autocomplete .v-input__append-inner {
         visibility: hidden;
@@ -663,6 +660,7 @@
     }
 
     .v-form {
+      max-width: 960px;
       .tagbox {
         /deep/ .v-select__selections {
           min-height: 0 !important;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -178,7 +178,7 @@
               @input.native="e => author = e.srcElement.value"
             >
               <template v-slot:append-outer>
-                <HelpTooltip :text="$tr('authorToolTip')" top />
+                <HelpTooltip :text="$tr('authorToolTip')" top :small="false" />
               </template>
             </VCombobox>
 
@@ -196,7 +196,7 @@
               @input.native="e => provider = e.srcElement.value"
             >
               <template v-slot:append-outer>
-                <HelpTooltip :text="$tr('providerToolTip')" top />
+                <HelpTooltip :text="$tr('providerToolTip')" top :small="false" />
               </template>
             </VCombobox>
 
@@ -214,7 +214,7 @@
               @input.native="e => aggregator = e.srcElement.value"
             >
               <template v-slot:append-outer>
-                <HelpTooltip :text="$tr('aggregatorToolTip')" top />
+                <HelpTooltip :text="$tr('aggregatorToolTip')" top :small="false" />
               </template>
             </VCombobox>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div v-if="nodes.length" class="details-edit-view">
-    <VForm ref="form" v-model="valid" :lazy-validation="newContent">
+    <VForm ref="form" v-model="valid" :lazy-validation="newContent" class="px-2">
       <!-- File upload and preview section -->
       <template v-if="oneSelected && allResources && !allExercises">
         <FileUpload
@@ -9,12 +9,11 @@
           :key="firstNode.id"
           :nodeId="firstNode.id"
         />
-        <VDivider />
       </template>
 
-      <!-- Basic information + audience -->
+      <!-- Basic information section -->
       <VLayout row wrap class="section">
-        <VFlex v-if="oneSelected" xs12 sm6 lg7>
+        <VFlex v-if="oneSelected" xs12>
           <h1 class="subheading">
             {{ $tr('basicInfoHeader') }}
           </h1>
@@ -39,33 +38,6 @@
             autoGrow
             box
           />
-        </VFlex>
-        <VSpacer v-if="oneSelected" />
-        <VFlex xs12 sm5 lg4 xl3>
-          <h1 class="subheading">
-            {{ $tr('audienceHeader') }}
-          </h1>
-          <!-- Language -->
-          <LanguageDropdown
-            ref="language"
-            v-model="language"
-            class="mb-2"
-            :hint="languageHint"
-            :placeholder="getPlaceholder('language')"
-            clearable
-            persistent-hint
-          />
-
-          <!-- Visibility -->
-          <VisibilityDropdown
-            v-if="allResources"
-            ref="role_visibility"
-            v-model="role"
-            :placeholder="getPlaceholder('role')"
-            :required="isUnique(role)"
-          />
-        </VFlex>
-        <VFlex xs12>
           <!-- Tags -->
           <VCombobox
             ref="tags"
@@ -95,14 +67,90 @@
         </VFlex>
       </VLayout>
 
+      <!-- Thumbnail section -->
+      <VLayout row wrap class="section">
+        <VFlex v-if="oneSelected" xs12>
+          <h1 class="subheading">
+            {{ $tr('thumbnailHeader') }}
+          </h1>
+          <!-- Thumbnail -->
+          <div style="width:250px;">
+            <ContentNodeThumbnail
+              v-model="thumbnail"
+              :nodeId="firstNode.id"
+              :encoding="thumbnailEncoding"
+              @encoded="setEncoding"
+            />
+          </div>
+        </VFlex>
+      </VLayout>
 
-      <!-- Source + thumbnail -->
+      <!-- Assessment options -->
+      <VLayout v-if="allExercises" row wrap class="section">
+        <VFlex xs12>
+          <VDivider />
+        </VFlex>
+        <VFlex xs12>
+          <h1 class="subheading">
+            {{ $tr('assessmentHeader') }}
+          </h1>
+
+          <!-- Mastery -->
+          <MasteryDropdown
+            v-if="extra_fields"
+            ref="mastery_model"
+            v-model="masteryModelItem"
+            :placeholder="getPlaceholder('mastery_model')"
+            :required="isUnique(mastery_model)"
+            :mPlaceholder="getPlaceholder('m')"
+            :mRequired="isUnique(m)"
+            :nPlaceholder="getPlaceholder('n')"
+            :nRequired="isUnique(n)"
+          />
+
+          <!-- Randomize question order -->
+          <Checkbox
+            ref="randomize"
+            v-model="randomizeOrder"
+            :label="$tr('randomizeQuestionLabel')"
+            :indeterminate="!isUnique(randomizeOrder)"
+          />
+        </VFlex>
+      </VLayout>
+
+      <!-- Audience section -->
+      <VLayout row wrap class="section">
+        <VFlex xs12>
+          <h1 class="subheading">
+            {{ $tr('audienceHeader') }}
+          </h1>
+          <!-- Language -->
+          <LanguageDropdown
+            ref="language"
+            v-model="language"
+            class="mb-2"
+            :hint="languageHint"
+            :placeholder="getPlaceholder('language')"
+            clearable
+            persistent-hint
+          />
+
+          <!-- Visibility -->
+          <VisibilityDropdown
+            v-if="allResources"
+            ref="role_visibility"
+            v-model="role"
+            :placeholder="getPlaceholder('role')"
+            :required="isUnique(role)"
+          />
+        </VFlex>
+      </VLayout>
+
+
+      <!-- Source section -->
       <VLayout row wrap class="section">
         <template v-if="allResources">
-          <VFlex xs12>
-            <VDivider />
-          </VFlex>
-          <VFlex xs12 sm6 class="auth-section">
+          <VFlex xs12 class="auth-section">
             <h1 class="subheading">
               {{ $tr('sourceHeader') }}
             </h1>
@@ -201,64 +249,12 @@
               @input="e => copyright_holder = e"
             />
           </VFlex>
-          <VSpacer />
         </template>
-
-        <VFlex v-if="oneSelected" xs12 sm5 lg4 xl3>
-          <h1 class="subheading">
-            {{ $tr('thumbnailHeader') }}
-          </h1>
-          <!-- Thumbnail -->
-          <div style="width:250px;">
-            <ContentNodeThumbnail
-              v-model="thumbnail"
-              :nodeId="firstNode.id"
-              :encoding="thumbnailEncoding"
-              @encoded="setEncoding"
-            />
-          </div>
-        </VFlex>
-      </VLayout>
-
-      <!-- Assessment options -->
-      <VLayout v-if="allExercises" row wrap class="section">
-        <VFlex xs12>
-          <VDivider />
-        </VFlex>
-        <VFlex xs12>
-          <h1 class="subheading">
-            {{ $tr('assessmentHeader') }}
-          </h1>
-
-          <!-- Mastery -->
-          <MasteryDropdown
-            v-if="extra_fields"
-            ref="mastery_model"
-            v-model="masteryModelItem"
-            :placeholder="getPlaceholder('mastery_model')"
-            :required="isUnique(mastery_model)"
-            :mPlaceholder="getPlaceholder('m')"
-            :mRequired="isUnique(m)"
-            :nPlaceholder="getPlaceholder('n')"
-            :nRequired="isUnique(n)"
-          />
-
-          <!-- Randomize question order -->
-          <Checkbox
-            ref="randomize"
-            v-model="randomizeOrder"
-            :label="$tr('randomizeQuestionLabel')"
-            :indeterminate="!isUnique(randomizeOrder)"
-          />
-        </VFlex>
       </VLayout>
 
       <!-- Subtitles -->
       <VLayout v-if="videoSelected" row wrap class="section">
         <VFlex xs12>
-          <VDivider />
-        </VFlex>
-        <VFlex xs12 md8 lg7>
           <SubtitlesList :nodeId="firstNode.id" />
         </VFlex>
       </VLayout>
@@ -660,6 +656,9 @@
     .section .flex {
       margin: 24px 0 !important;
     }
+    .section {
+      max-width: 900px;
+    }
     .auth-section {
       /deep/ .v-autocomplete .v-input__append-inner {
         visibility: hidden;
@@ -667,7 +666,6 @@
     }
 
     .v-form {
-      margin-top: 30px;
       .tagbox {
         /deep/ .v-select__selections {
           min-height: 0 !important;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -88,9 +88,6 @@
       <!-- Assessment options -->
       <VLayout v-if="allExercises" row wrap class="section">
         <VFlex xs12>
-          <VDivider />
-        </VFlex>
-        <VFlex xs12>
           <h1 class="subheading">
             {{ $tr('assessmentHeader') }}
           </h1>
@@ -657,7 +654,7 @@
       margin: 24px 0 !important;
     }
     .section {
-      max-width: 900px;
+      max-width: 960px;
     }
     .auth-section {
       /deep/ .v-autocomplete .v-input__append-inner {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -67,24 +67,6 @@
         </VFlex>
       </VLayout>
 
-      <!-- Thumbnail section -->
-      <VLayout row wrap class="section">
-        <VFlex v-if="oneSelected" xs12>
-          <h1 class="subheading">
-            {{ $tr('thumbnailHeader') }}
-          </h1>
-          <!-- Thumbnail -->
-          <div style="width:250px;">
-            <ContentNodeThumbnail
-              v-model="thumbnail"
-              :nodeId="firstNode.id"
-              :encoding="thumbnailEncoding"
-              @encoded="setEncoding"
-            />
-          </div>
-        </VFlex>
-      </VLayout>
-
       <!-- Assessment options -->
       <VLayout v-if="allExercises" row wrap class="section">
         <VFlex xs12>
@@ -112,6 +94,24 @@
             :label="$tr('randomizeQuestionLabel')"
             :indeterminate="!isUnique(randomizeOrder)"
           />
+        </VFlex>
+      </VLayout>
+
+      <!-- Thumbnail section -->
+      <VLayout row wrap class="section">
+        <VFlex v-if="oneSelected" xs12>
+          <h1 class="subheading">
+            {{ $tr('thumbnailHeader') }}
+          </h1>
+          <!-- Thumbnail -->
+          <div style="width:250px;">
+            <ContentNodeThumbnail
+              v-model="thumbnail"
+              :nodeId="firstNode.id"
+              :encoding="thumbnailEncoding"
+              @encoded="setEncoding"
+            />
+          </div>
         </VFlex>
       </VLayout>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditList.vue
@@ -7,7 +7,6 @@
       class="mt-0 mb-2 pa-2"
       :label="$tr('selectAllLabel')"
     />
-    <VDivider />
     <EditListItem
       v-for="nodeId in nodeIds"
       :key="nodeId"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditList.vue
@@ -4,7 +4,7 @@
     <!-- Select all checkbox -->
     <Checkbox
       v-model="selectAll"
-      class="mt-0 mb-2 pa-2"
+      class="mt-0 mb-2 py-2 px-3 ml-1"
       :label="$tr('selectAllLabel')"
     />
     <EditListItem

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -33,45 +33,41 @@
                 <div class="py-3">
                   <OfflineText indicator />
                 </div>
-                <div class="py-3 mt-1">
-                  <SavingIndicator :nodeIds="nodeIds" />
-                </div>
-                <VBtn flat @click="handleClose">
-                  {{ $tr('finishButton') }}
-                </VBtn>
               </VToolbarItems>
-              <template v-if="showToolbar && !loading && !loadError" #extension>
-                <VToolbar light color="white" flat>
-                  <VBtn v-if="addTopicsMode" color="greyBackground" @click="createTopic">
-                    {{ $tr('addTopic') }}
-                  </VBtn>
-                  <VBtn v-else-if="uploadMode" color="greyBackground" @click="openFileDialog">
-                    {{ $tr('uploadButton') }}
-                  </VBtn>
-                  <VSpacer />
-                  <VFlex v-if="showStorage" class="text-xs-right">
-                    <FileStorage />
-                  </VFlex>
-                </VToolbar>
-              </template>
             </VToolbar>
 
             <!-- List items -->
             <ResizableNavigationDrawer
-              v-if="multipleNodes && !loading"
+              v-if="showDrawer"
               localName="edit-modal"
               stateless
               clipped
               app
               :minWidth="150"
               :maxWidth="500"
+              @scroll="scroll"
             >
               <FileDropzone fill :disabled="!uploadMode" @dropped="handleFiles">
-                <EditList
-                  v-model="selected"
-                  :nodeIds="nodeIds"
-                  @input="enableValidation(nodeIds);"
-                />
+                <ToolBar
+                  v-if="addTopicsMode || uploadMode"
+                  :flat="!listElevated"
+                  class="add-wrapper"
+                  color="white"
+                >
+                  <VBtn v-if="addTopicsMode" color="greyBackground" @click="createTopic">
+                    {{ $tr('addTopic') }}
+                  </VBtn>
+                  <VBtn v-else-if="uploadMode" color="greyBackground" @click="openFileDialog">
+                    {{ $tr('uploadButton') }}
+                  </VBtn>
+                </ToolBar>
+                <div ref="list">
+                  <EditList
+                    v-model="selected"
+                    :nodeIds="nodeIds"
+                    @input="enableValidation(nodeIds);"
+                  />
+                </div>
               </FileDropzone>
             </ResizableNavigationDrawer>
 
@@ -101,6 +97,24 @@
           </template>
         </Uploader>
       </VCard>
+      <BottomBar v-if="showToolbar && !loading && !loadError">
+        <VLayout row align-center fill-height class="px-2">
+          <VFlex v-if="showStorage" shrink>
+            <FileStorage />
+          </VFlex>
+          <VSpacer />
+          <VFlex v-if="online" shrink>
+            <div class="py-3 mt-1">
+              <SavingIndicator :nodeIds="nodeIds" />
+            </div>
+          </VFlex>
+          <VFlex shrink>
+            <VBtn color="primary" @click="handleClose">
+              {{ $tr('finishButton') }}
+            </VBtn>
+          </VFlex>
+        </VLayout>
+      </BottomBar>
     </VDialog>
 
     <!-- Dialog for catching unsaved changes -->
@@ -156,7 +170,7 @@
 
 <script>
 
-  import { mapActions, mapGetters, mapMutations } from 'vuex';
+  import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
   import { RouterNames, TabNames } from '../../constants';
   import FileUploadDefault from '../../views/files/FileUploadDefault';
   import EditList from './EditList';
@@ -170,6 +184,8 @@
   import LoadingText from 'shared/views/LoadingText';
   import FormatPresets from 'shared/leUtils/FormatPresets';
   import OfflineText from 'shared/views/OfflineText';
+  import ToolBar from 'shared/views/ToolBar';
+  import BottomBar from 'shared/views/BottomBar';
   import FileDropzone from 'shared/views/files/FileDropzone';
 
   export default {
@@ -186,6 +202,8 @@
       OfflineText,
       FileDropzone,
       SavingIndicator,
+      ToolBar,
+      BottomBar,
     },
     mixins: [fileSizeMixin],
     props: {
@@ -212,12 +230,16 @@
         promptInvalid: false,
         promptUploading: false,
         promptFailed: false,
+        listElevated: false,
       };
     },
     computed: {
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeIsValid']),
       ...mapGetters('currentChannel', ['canEdit']),
       ...mapGetters('file', ['contentNodesAreUploading']),
+      ...mapState({
+        online: state => state.connection.online,
+      }),
       multipleNodes() {
         // Only hide drawer when editing a single item
         return this.nodeIds.length > 1;
@@ -242,6 +264,12 @@
       showToolbar() {
         return this.addTopicsMode || this.editMode || (this.uploadMode && this.nodeIds.length);
       },
+      showDrawer() {
+        return (
+          !this.loading &&
+          (this.multipleNodes || (this.uploadMode && this.nodeIds.length) || this.addTopicsMode)
+        );
+      },
       nodeIds() {
         return (this.detailNodeIds && this.detailNodeIds.split(',')) || [];
       },
@@ -249,7 +277,7 @@
         if (this.createExerciseMode) {
           return this.$tr('createExerciseHeader');
         } else if (this.uploadMode) {
-          return this.$tr('uploadFilesHeader');
+          return this.nodeIds.length ? this.$tr('editFilesHeader') : this.$tr('uploadFilesHeader');
         } else if (this.addTopicsMode) {
           return this.$tr('addTopicsHeader');
         }
@@ -334,6 +362,9 @@
           ? 'overflow-y: hidden !important;'
           : 'overflow-y: auto !important';
       },
+      scroll(e) {
+        this.listElevated = e.target.scrollTop > 0;
+      },
 
       /* Button actions */
       handleClose() {
@@ -402,6 +433,7 @@
     $trs: {
       editingDetailsHeader: 'Edit details',
       uploadFilesHeader: 'Upload files',
+      editFilesHeader: 'Edit files',
       createExerciseHeader: 'New exercise',
       addTopicsHeader: 'New topics',
       invalidNodesFound:
@@ -412,8 +444,8 @@
       keepEditingButton: 'Keep editing',
       saveFailedHeader: 'Save failed',
       saveFailedText: 'There was a problem saving your content',
-      addTopic: 'Add another topic',
-      uploadButton: 'Upload more files',
+      addTopic: 'Add new topic',
+      uploadButton: 'Upload more',
       uploadInProgressHeader: 'Upload in progress',
       uploadInProgressText: 'Uploads that are in progress will be lost if you exit',
       dismissDialogButton: 'Cancel',
@@ -446,6 +478,15 @@
   /deep/ .v-content__wrap {
     max-height: calc(100vh - 128px);
     overflow-y: auto;
+  }
+
+  .add-wrapper {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    width: calc(100% + 4px);
+    margin: 0 -3px;
+    margin-top: -4px !important;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -43,6 +43,7 @@
               stateless
               clipped
               app
+              style="height: calc(100% - 64px);"
               :minWidth="150"
               :maxWidth="500"
               @scroll="scroll"
@@ -435,7 +436,7 @@
       uploadFilesHeader: 'Upload files',
       editFilesHeader: 'Edit files',
       createExerciseHeader: 'New exercise',
-      addTopicsHeader: 'New topics',
+      addTopicsHeader: 'New topic',
       invalidNodesFound:
         '{count, plural,\n =1 {# incomplete resource found}\n other {# incomplete resources found}}',
       invalidNodesFoundText:

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VContainer ref="editview" fluid fill-height class="pa-0">
+  <VContainer ref="editview" fluid class="wrapper pa-0" @scroll="scroll">
     <VContainer v-if="!nodeIds.length" fluid>
       <VLayout justify-center align-center fill-height>
         <VFlex grow class="text-xs-center title grey--text">
@@ -10,48 +10,50 @@
     </VContainer>
     <VLayout v-else>
       <VFlex grow>
-        <Tabs v-model="currentTab" slider-color="primary" height="60px">
-          <!-- Details tab -->
-          <VTab ref="detailstab" :href="`#${tabs.DETAILS}`">
-            {{ $tr(tabs.DETAILS) }}
-            <VTooltip v-if="!areDetailsValid || !areFilesValid" top>
-              <template v-slot:activator="{ on }">
-                <Icon color="red" dark small class="ml-2" v-on="on">
-                  error
-                </Icon>
-              </template>
-              <span>{{ $tr('invalidFieldsToolTip') }}</span>
-            </VTooltip>
-          </VTab>
+        <ToolBar :flat="!tabsElevated" class="tabs" color="white">
+          <Tabs v-model="currentTab" slider-color="primary" height="60px">
+            <!-- Details tab -->
+            <VTab ref="detailstab" :href="`#${tabs.DETAILS}`">
+              {{ $tr(tabs.DETAILS) }}
+              <VTooltip v-if="!areDetailsValid || !areFilesValid" top>
+                <template v-slot:activator="{ on }">
+                  <Icon color="red" dark small class="ml-2" v-on="on">
+                    error
+                  </Icon>
+                </template>
+                <span>{{ $tr('invalidFieldsToolTip') }}</span>
+              </VTooltip>
+            </VTab>
 
-          <!-- Questions tab -->
-          <VTab v-if="showQuestionsTab" ref="questiontab" :href="`#${tabs.QUESTIONS}`">
-            {{ $tr(tabs.QUESTIONS) }}
-            <VTooltip v-if="!areAssessmentItemsValid" top>
-              <template v-slot:activator="{ on }">
-                <Icon color="red" dark v-on="on">
-                  error
-                </Icon>
-              </template>
-              <span>{{ $tr('invalidFieldsToolTip') }}</span>
-            </VTooltip>
-            <VChip v-else color="gray" dark>
-              {{ assessmentItemsCount }}
-            </VChip>
-          </VTab>
+            <!-- Questions tab -->
+            <VTab v-if="showQuestionsTab" ref="questiontab" :href="`#${tabs.QUESTIONS}`">
+              {{ $tr(tabs.QUESTIONS) }}
+              <VTooltip v-if="!areAssessmentItemsValid" top>
+                <template v-slot:activator="{ on }">
+                  <Icon color="red" dark v-on="on">
+                    error
+                  </Icon>
+                </template>
+                <span>{{ $tr('invalidFieldsToolTip') }}</span>
+              </VTooltip>
+              <VChip v-else color="gray" dark>
+                {{ assessmentItemsCount }}
+              </VChip>
+            </VTab>
 
-          <!-- Related resources tab -->
-          <VTab
-            v-if="showRelatedResourcesTab"
-            ref="related-resources-tab"
-            :href="`#${tabs.RELATED}`"
-          >
-            {{ $tr(tabs.RELATED) }}
-            <VChip color="gray" dark>
-              {{ relatedResourcesCount }}
-            </VChip>
-          </VTab>
-        </Tabs>
+            <!-- Related resources tab -->
+            <VTab
+              v-if="showRelatedResourcesTab"
+              ref="related-resources-tab"
+              :href="`#${tabs.RELATED}`"
+            >
+              {{ $tr(tabs.RELATED) }}
+              <VChip color="gray" dark>
+                {{ relatedResourcesCount }}
+              </VChip>
+            </VTab>
+          </Tabs>
+        </ToolBar>
         <VContainer fluid>
           <VTabsItems v-model="currentTab">
             <VTabItem :key="tabs.DETAILS" ref="detailswindow" :value="tabs.DETAILS" lazy>
@@ -91,6 +93,7 @@
   import RelatedResourcesTab from '../../components/RelatedResourcesTab/RelatedResourcesTab';
   import DetailsTabView from './DetailsTabView';
   import Tabs from 'shared/views/Tabs';
+  import ToolBar from 'shared/views/ToolBar';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
   export default {
@@ -100,6 +103,7 @@
       AssessmentTab,
       RelatedResourcesTab,
       Tabs,
+      ToolBar,
     },
     props: {
       isClipboard: {
@@ -118,6 +122,7 @@
     data() {
       return {
         currentTab: null,
+        tabsElevated: false,
       };
     },
     computed: {
@@ -221,6 +226,11 @@
     created() {
       this.currentTab = this.tab ? this.tab : TabNames.DETAILS;
     },
+    methods: {
+      scroll(e) {
+        this.tabsElevated = e.target.scrollTop > 0;
+      },
+    },
     $trs: {
       [TabNames.DETAILS]: 'Details',
       [TabNames.PREVIEW]: 'Preview',
@@ -238,6 +248,12 @@
 
 <style lang="less" scoped>
 
+  .tabs {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  }
+
   .container {
     width: unset;
   }
@@ -246,10 +262,6 @@
     padding: 10px;
     margin: 15px;
     font-weight: bold;
-  }
-
-  .v-tabs {
-    border-bottom: 1px solid var(--v-grey-lighten3);
   }
 
   .v-tabs__div {
@@ -269,6 +281,11 @@
   .error-icon {
     margin-bottom: 20px;
     font-size: 45pt;
+  }
+  .wrapper {
+    min-width: 100%;
+    max-height: inherit;
+    overflow: auto;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -11,7 +11,7 @@
     <VLayout v-else>
       <VFlex grow>
         <ToolBar :flat="!tabsElevated" class="tabs" color="white">
-          <Tabs v-model="currentTab" slider-color="primary" height="60px">
+          <Tabs v-model="currentTab" slider-color="primary" height="64px">
             <!-- Details tab -->
             <VTab ref="detailstab" :href="`#${tabs.DETAILS}`">
               {{ $tr(tabs.DETAILS) }}

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -10,7 +10,7 @@
     </VContainer>
     <VLayout v-else>
       <VFlex grow>
-        <ToolBar :flat="!tabsElevated" class="tabs" color="white">
+        <ToolBar v-if="showTabs" :flat="!tabsElevated" class="tabs" color="white">
           <Tabs v-model="currentTab" slider-color="primary" height="64px">
             <!-- Details tab -->
             <VTab ref="detailstab" :href="`#${tabs.DETAILS}`">
@@ -106,10 +106,6 @@
       ToolBar,
     },
     props: {
-      isClipboard: {
-        type: Boolean,
-        default: false,
-      },
       nodeIds: {
         type: Array,
         default: () => [],
@@ -139,7 +135,6 @@
       nodes() {
         return this.getContentNodes(this.nodeIds);
       },
-
       noItemText() {
         return this.$tr('noItemsToEditText');
       },
@@ -149,13 +144,14 @@
       oneSelected() {
         return this.nodes.length === 1;
       },
+      showTabs() {
+        return this.oneSelected && this.nodes[0].kind !== ContentKindsNames.TOPIC;
+      },
       showQuestionsTab() {
         return this.oneSelected && this.firstNode && this.firstNode.kind === 'exercise';
       },
       showRelatedResourcesTab() {
-        return (
-          this.oneSelected && !this.isClipboard && this.firstNode && this.firstNode.kind !== 'topic'
-        );
+        return this.oneSelected && this.firstNode && this.firstNode.kind !== 'topic';
       },
       countText() {
         const totals = reduce(
@@ -224,7 +220,7 @@
       },
     },
     created() {
-      this.currentTab = this.tab ? this.tab : TabNames.DETAILS;
+      this.currentTab = this.tab && this.nodeIds.length <= 1 ? this.tab : TabNames.DETAILS;
     },
     methods: {
       scroll(e) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/SavingIndicator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/SavingIndicator.vue
@@ -2,7 +2,7 @@
 
   <div class="mx-2">
     <template v-if="hasChanges">
-      <VProgressCircular indeterminate size="16" width="2" color="white" />
+      <VProgressCircular indeterminate size="16" width="2" color="secondary" />
       <span class="mx-2" style="vertical-align: middle;">
         {{ $tr('savingIndicator') }}
       </span>

--- a/contentcuration/contentcuration/frontend/shared/views/BottomBar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/BottomBar.vue
@@ -19,7 +19,7 @@
     bottom: 0;
     z-index: 3;
     width: 100%;
-    height: 72px;
+    height: 64px;
     background-color: #ffffff;
     border-top: 1px solid #dddddd;
   }

--- a/contentcuration/contentcuration/frontend/shared/views/HelpTooltip.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/HelpTooltip.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VTooltip maxWidth="150px" v-bind="$attrs">
-    <Icon slot="activator" color="primary" small>
+    <Icon slot="activator" color="primary" :small="small">
       {{ icon }}
     </Icon>
     <span class="text-xs-center">{{ text }}</span>
@@ -21,6 +21,10 @@
       icon: {
         type: String,
         default: 'info',
+      },
+      small: {
+        type: Boolean,
+        default: true,
       },
     },
   };

--- a/contentcuration/contentcuration/frontend/shared/views/ResizableNavigationDrawer.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ResizableNavigationDrawer.vue
@@ -14,7 +14,7 @@
       draggable: !temporary
     }"
   >
-    <div class="drawer-contents">
+    <div class="drawer-contents" @scroll="e => $emit('scroll', e)">
       <slot></slot>
     </div>
   </VNavigationDrawer>


### PR DESCRIPTION
## Description

Updated the layout for the edit modal:
* Added bottom toolbar with saving indicator, finish button, and storage information
* Moved add more button to edit list
* Fixed the tabs to the top of the screen (added shadow effect when scrolled)
* Removed dividers
* Switched to single column layout

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2318
Fixes https://github.com/learningequality/studio/issues/2308

Also fixes:
* [Move 'finish' button to white bottom bar](https://www.notion.so/learningequality/Move-finish-button-to-white-bottom-bar-4d41285eba9545a1a60feee3be77261d)
* [On exercise editor, 'Assessment options' section should maybe be moved up - and/or 'Editing exercise' title should be added to top of screen](https://www.notion.so/learningequality/On-exercise-editor-Assessment-options-section-should-maybe-be-moved-up-and-or-Editing-exercise-c6c93c47635741d091009b85f3702069)
* [When I finished editing the content node modal, instincts did not match behavior](https://www.notion.so/learningequality/When-I-finished-editing-the-content-node-modal-instincts-did-not-match-behavior-15fd48925191473390d78c56d5827824)
* [In Topic Editing - no need for a "Details" tab when there are no other tabs possible for that content node kind such as when creating a topic](https://www.notion.so/learningequality/In-Topic-Editing-no-need-for-a-Details-tab-when-there-are-no-other-tabs-possible-for-that-conten-57f468c8d783443fb58a7eff4c8c2aa8)

#### Before/After Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/7447496/95122349-362bc080-0705-11eb-9351-e68ab5435eb9.png)

![layout](https://user-images.githubusercontent.com/7447496/95140025-b4e32680-0722-11eb-8627-395d92ab1f7d.gif)

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
