### PR TITLE
Channel edit modal fields fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -188,7 +188,9 @@
       },
       name: {
         get() {
-          return this.diffTracker.name || this.channel.name || '';
+          return this.diffTracker.hasOwnProperty('name')
+            ? this.diffTracker.name
+            : this.channel.name || '';
         },
         set(name) {
           this.setChannel({ name });
@@ -196,7 +198,9 @@
       },
       description: {
         get() {
-          return this.diffTracker.description || this.channel.description || '';
+          return this.diffTracker.hasOwnProperty('description')
+            ? this.diffTracker.description
+            : this.channel.description || '';
         },
         set(description) {
           this.setChannel({ description });
@@ -204,7 +208,9 @@
       },
       language: {
         get() {
-          return this.diffTracker.language || this.channel.language || this.currentLanguage;
+          return this.diffTracker.hasOwnProperty('language')
+            ? this.diffTracker.language
+            : this.channel.language || this.currentLanguage;
         },
         set(language) {
           this.setChannel({ language });

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -42,7 +42,7 @@
                   v-model="name"
                   box
                   :label="$tr('channelName')"
-                  :rules="[() => name.length ? true : $tr('channelError')]"
+                  :rules="nameRules"
                   required
                 />
                 <LanguageDropdown
@@ -165,6 +165,9 @@
             },
           });
         },
+      },
+      nameRules() {
+        return [name => (name.length && name.trim().length ? true : this.$tr('channelError'))];
       },
       thumbnail: {
         get() {


### PR DESCRIPTION
New empty values were being overridden by the original channel values because of implicit conditions which caused issues when new values were empty. I used the same `diffTracker` technique that's used for thumbnails to fix it.

#### Issue Addressed

Fixes #2418
Fixes #2407

## Steps to Test
Please test the whole channel edit modal workflow with focus on deleting values. Try to save the modal and check that correct values were saved to backend (you can remove IndexedDB and reload the page after saving the modal).

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
