### PR TITLE
Catch non-objects being passed to dot path mixin.

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -430,6 +430,19 @@ class SyncTestCase(StudioAPITestCase):
             .exists()
         )
 
+    def test_update_contentnode_tags_list(self):
+        user = testdata.user()
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        tag = "howzat!"
+
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {"tags": [tag]})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
     def test_update_contentnodes(self):
         user = testdata.user()
         contentnode1 = models.ContentNode.objects.create(**self.contentnode_db_metadata)

--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -116,6 +116,9 @@ class DotPathValueMixin(object):
         if value is None:
             return empty
 
+        if not isinstance(value, dict):
+            raise ValidationError("Must be an object or null")
+
         # then merge in fields with keys like `content_defaults.author`
         multi_value = MultiValueDict()
         multi_value.update(dictionary)


### PR DESCRIPTION
## Description

* Prevents errors caused by a non-object being passed to the dot path mixin
* Primarily to prevent errors from an Array being erroneously passed back

#### Issue Addressed (if applicable)

* Fixes #2424
