### PR TITLE
Add login form banner message shown when authentication is needed to proceed

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -4,7 +4,6 @@
     <VLayout
       fill-height
       justify-center
-      :style="{backgroundColor: $vuetify.theme.primary}"
       class="pt-5 main"
     >
       <div>

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -63,6 +63,7 @@
         </p>
       </div>
     </VLayout>
+    <GlobalSnackbar />
   </VApp>
 
 </template>
@@ -76,6 +77,9 @@
   import Banner from 'shared/views/Banner';
   import PrivacyPolicyModal from 'shared/views/policies/PrivacyPolicyModal';
   import TermsOfServiceModal from 'shared/views/policies/TermsOfServiceModal';
+  import GlobalSnackbar from 'shared/views/GlobalSnackbar';
+
+  const NEXT_PARAM = 'next';
 
   export default {
     name: 'Main',
@@ -85,6 +89,7 @@
       Banner,
       PrivacyPolicyModal,
       TermsOfServiceModal,
+      GlobalSnackbar,
     },
     data() {
       return {
@@ -95,8 +100,24 @@
         showTermsOfService: false,
       };
     },
+    computed: {
+      searchParams() {
+        return new URLSearchParams(window.location.search.substring(1));
+      },
+    },
+    mounted() {
+      // Check for `next` param, and if it exists, we'll show
+      // a snackbar instructing them to login to proceed
+      if (this.searchParams.get(NEXT_PARAM)) {
+        this.$nextTick(() => {
+          this.showSnackbar({
+            text: this.$tr('loginToProceed'),
+          });
+        });
+      }
+    },
     methods: {
-      ...mapActions(['login']),
+      ...mapActions(['login', 'showSnackbar']),
       submit() {
         if (this.$refs.form.validate()) {
           let credentials = {
@@ -105,8 +126,7 @@
           };
           return this.login(credentials)
             .then(() => {
-              let params = new URLSearchParams(window.location.href.split('?')[1]);
-              window.location.assign(params.get('next') || '/channels');
+              window.location.assign(this.searchParams.get(NEXT_PARAM) || '/channels');
             })
             .catch(err => {
               if (err.response.status === 405) {
@@ -129,6 +149,7 @@
       privacyPolicyLink: 'Privacy policy',
       TOSLink: 'Terms of service',
       copyright: '© {year} Learning Equality',
+      loginToProceed: 'You must sign in to view that page',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -16,11 +16,17 @@
             :lazy-src="require('shared/images/kolibri-logo.svg')"
             :src="require('shared/images/kolibri-logo.svg')"
           />
-          <h2 class="text-xs-center primary--text">
+          <h2 class="text-xs-center primary--text py-2">
             {{ $tr('kolibriStudio') }}
           </h2>
-          <Banner :value="loginFailed" :text="$tr('loginFailed')" error class="mb-4" />
-          <VForm ref="form" lazy-validation class="py-4" @submit.prevent="submit">
+          <Banner :value="loginFailed" :text="$tr('loginFailed')" error />
+          <Banner
+            :value="Boolean(nextParam)"
+            :text="$tr('loginToProceed')"
+            class="px-0 pb-0"
+            data-test="loginToProceed"
+          />
+          <VForm ref="form" lazy-validation class="py-3" @submit.prevent="submit">
             <EmailField v-model="username" autofocus />
             <PasswordField v-model="password" :label="$tr('passwordLabel')" />
             <p>
@@ -63,7 +69,6 @@
         </p>
       </div>
     </VLayout>
-    <GlobalSnackbar />
   </VApp>
 
 </template>
@@ -77,9 +82,6 @@
   import Banner from 'shared/views/Banner';
   import PrivacyPolicyModal from 'shared/views/policies/PrivacyPolicyModal';
   import TermsOfServiceModal from 'shared/views/policies/TermsOfServiceModal';
-  import GlobalSnackbar from 'shared/views/GlobalSnackbar';
-
-  const NEXT_PARAM = 'next';
 
   export default {
     name: 'Main',
@@ -89,7 +91,6 @@
       Banner,
       PrivacyPolicyModal,
       TermsOfServiceModal,
-      GlobalSnackbar,
     },
     data() {
       return {
@@ -101,23 +102,13 @@
       };
     },
     computed: {
-      searchParams() {
-        return new URLSearchParams(window.location.search.substring(1));
+      nextParam() {
+        const params = new URLSearchParams(window.location.search.substring(1));
+        return params.get('next');
       },
     },
-    mounted() {
-      // Check for `next` param, and if it exists, we'll show
-      // a snackbar instructing them to login to proceed
-      if (this.searchParams.get(NEXT_PARAM)) {
-        this.$nextTick(() => {
-          this.showSnackbar({
-            text: this.$tr('loginToProceed'),
-          });
-        });
-      }
-    },
     methods: {
-      ...mapActions(['login', 'showSnackbar']),
+      ...mapActions(['login']),
       submit() {
         if (this.$refs.form.validate()) {
           let credentials = {
@@ -126,7 +117,7 @@
           };
           return this.login(credentials)
             .then(() => {
-              window.location.assign(this.searchParams.get(NEXT_PARAM) || '/channels');
+              window.location.assign(this.nextParam || '/channels');
             })
             .catch(err => {
               if (err.response.status === 405) {

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/main.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/main.spec.js
@@ -3,9 +3,13 @@ import router from '../../router';
 import Main from '../Main';
 
 const login = jest.fn();
+const showSnackbar = jest.fn();
 
 function makeWrapper() {
-  let wrapper = mount(Main, { router });
+  let wrapper = mount(Main, {
+    router,
+    stubs: ['GlobalSnackbar'],
+  });
   wrapper.setMethods({
     login: data => {
       return new Promise(resolve => {
@@ -13,6 +17,7 @@ function makeWrapper() {
         resolve();
       });
     },
+    showSnackbar: (...args) => showSnackbar(...args),
   });
   wrapper.setData({
     username: 'test@test.com',
@@ -38,41 +43,63 @@ describe('main', () => {
   beforeEach(() => {
     wrapper = makeWrapper();
     login.mockReset();
+    showSnackbar.mockReset();
+  });
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.destroy();
+    }
   });
   it('should trigger submit method when form is submitted', () => {
+    expect(showSnackbar).not.toHaveBeenCalled();
     const submit = jest.fn();
     wrapper.setMethods({ submit });
     wrapper.find({ ref: 'form' }).trigger('submit');
     expect(submit).toHaveBeenCalled();
   });
   it('should call login with username and password provided', () => {
+    expect(showSnackbar).not.toHaveBeenCalled();
     wrapper.vm.submit();
     expect(login).toHaveBeenCalled();
   });
   it('should fail if username is not provided', () => {
+    expect(showSnackbar).not.toHaveBeenCalled();
     wrapper.setData({ username: ' ' });
     wrapper.vm.submit();
     expect(login).not.toHaveBeenCalled();
   });
   it('should fail if password is not provided', () => {
+    expect(showSnackbar).not.toHaveBeenCalled();
     wrapper.setData({ password: '' });
     wrapper.vm.submit();
     expect(login).not.toHaveBeenCalled();
   });
   it('should set loginFailed if login fails', async () => {
+    expect(showSnackbar).not.toHaveBeenCalled();
     wrapper.setMethods({ login: makeFailedPromise() });
     await wrapper.vm.submit();
     expect(wrapper.vm.loginFailed).toBe(true);
   });
   it('should say account has not been activated if login returns 405', async () => {
+    expect(showSnackbar).not.toHaveBeenCalled();
     wrapper.setMethods({ login: makeFailedPromise() });
     await wrapper.vm.submit();
     expect(wrapper.vm.loginFailed).toBe(true);
   });
   it('should navigate to next url if next query param is set', async () => {
-    window.location.assign = jest.fn();
     const testUrl = '/testnext/';
-    router.push(`/account/?next=${testUrl}`);
+    const location = new URL(`http://studio.time/?next=${testUrl}`);
+
+    delete window.location;
+    window.location = location;
+    window.location.assign = jest.fn();
+
+    wrapper.destroy();
+    wrapper = makeWrapper();
+    await wrapper.vm.$nextTick();
+
+    expect(showSnackbar).toHaveBeenCalled();
+
     await wrapper.vm.submit();
     expect(window.location.assign.mock.calls[0][0]).toBe(testUrl);
   });


### PR DESCRIPTION
## Description

Adds a banner to the login form that that shows when the page has a `next` URL query parameter, instructing the user they must sign in to proceed.

#### Issue Addressed (if applicable)

https://github.com/learningequality/studio/issues/2119

#### Before/After Screenshots (if applicable)
Login error (existing):
![error](https://user-images.githubusercontent.com/819838/95624477-c92d6900-0a2b-11eb-95b9-52c28161b149.png)

New banner:
![Screenshot from 2020-10-09 12-20-28](https://user-images.githubusercontent.com/819838/95624424-b6b32f80-0a2b-11eb-9229-508132d60ba2.png)

New banner with login error:
![Screenshot from 2020-10-09 12-20-58](https://user-images.githubusercontent.com/819838/95624539-e2361a00-0a2b-11eb-9f83-c799a065051e.png)


## Steps to Test

With `next` param:
- [ ] Open a new incognito window
- [ ] Go to `/channels/30b9311f6b39401a86f62abe860ab401` or some other private channel url
- [ ] Verify the banner shows

Without `next` param
- [ ] Open a new incognito window
- [ ] Go to `/channels`
- [ ] Click <kbd>Sign In</kbd>
- [ ] Verify the banner doesn't show


## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [x] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
