### PR TITLE
Do a full recursive loading of requisite relations from indexedDB.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -1,0 +1,51 @@
+import sortBy from 'lodash/sortBy';
+import { ContentNode, ContentNodePrerequisite } from 'shared/data/resources';
+
+describe('ContentNodePrerequisite methods', () => {
+  const mappings = [
+    { target_node: 'id-integrals', prerequisite: 'id-elementary-math' },
+    { target_node: 'id-elementary-math', prerequisite: 'id-reading' },
+    { target_node: 'id-physics', prerequisite: 'id-integrals' },
+    { target_node: 'id-astronomy', prerequisite: 'id-physics' },
+    { target_node: 'id-spaceships-contruction', prerequisite: 'id-astronomy' },
+    { target_node: 'id-chemistry', prerequisite: 'id-integrals' },
+    { target_node: 'id-lab', prerequisite: 'id-chemistry' },
+  ];
+  let spy;
+  beforeEach(() => {
+    spy = jest
+      .spyOn(ContentNode, 'fetchRequisites')
+      .mockImplementation(() => Promise.resolve(mappings));
+    return ContentNodePrerequisite.table.bulkPut(mappings);
+  });
+  afterEach(() => {
+    spy.mockRestore();
+    return ContentNodePrerequisite.table.clear();
+  });
+  describe('getRequisites method', () => {
+    it('should return all associated requisites', () => {
+      return ContentNode.getRequisites('id-integrals').then(entries => {
+        expect(sortBy(entries, 'target_node')).toEqual(sortBy(mappings, 'target_node'));
+        expect(spy).toHaveBeenCalled();
+      });
+    });
+    it('should return all associated requisites, even when there is a cyclic dependency', () => {
+      const cyclic = { target_node: 'id-chemistry', prerequisite: 'id-lab' };
+      return ContentNodePrerequisite.put(cyclic).then(() => {
+        return ContentNode.getRequisites('id-integrals').then(entries => {
+          expect(sortBy(entries, 'target_node')).toEqual(
+            sortBy(mappings.concat([cyclic]), 'target_node')
+          );
+        });
+      });
+    });
+    it('should return all associated requisites from the backend', () => {
+      return ContentNodePrerequisite.table.clear().then(() => {
+        return ContentNode.getRequisites('id-integrals').then(entries => {
+          expect(sortBy(entries, 'target_node')).toEqual(sortBy(mappings, 'target_node'));
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

* Fixes an error caused by only doing a shallow loading of requisite relationships from IndexedDB
* Does a recursive load of all requisite relationships from indexedDB
* Adds a test to guarantee this behaviour
* Adds a block for cyclic relationships
* Adds a test to ensure cyclic relationships do not result in infinite recursion

#### Issue Addressed (if applicable)

* Fixes #2422

#### Before/After Screenshots (if applicable)
Nodes are unselectable even after a refresh:

![Screenshot from 2020-10-12 11-18-57](https://user-images.githubusercontent.com/1680573/95778500-1ce2c100-0c7d-11eb-8d68-ab2abbab73e8.png)
