### PR TITLE
Catch a missing kolibri model, not CC model.

### DIFF
--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -531,7 +531,7 @@ def map_prerequisites(root_node):
         try:
             target_node = kolibrimodels.ContentNode.objects.get(pk=n['target_node__node_id'])
             target_node.has_prerequisite.add(n['prerequisite__node_id'])
-        except ccmodels.ContentNode.DoesNotExist as e:
+        except kolibrimodels.ContentNode.DoesNotExist as e:
             logging.error('Unable to find prerequisite {}'.format(str(e)))
 
 


### PR DESCRIPTION
## Description

* Updates the prerequisite error catch to catch a missing kolibri contentnode, not a missing content curation content node
* There is a test for this, but it doesn't seem to be testing what it is meant to be testing, and I think my pipenv is now broken.

#### Issue Addressed (if applicable)

* Fixes #2431
