### PR TITLE
Add maxlength and counter attributes to TextFields that need them

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -27,15 +27,21 @@
         </h1>
         <TextField
           v-model="form.first_name"
+          maxlength="100"
+          counter
           :label="$tr('firstNameLabel')"
           autofocus
         />
         <TextField
           v-model="form.last_name"
+          maxlength="100"
+          counter
           :label="$tr('lastNameLabel')"
         />
         <EmailField
           v-model="form.email"
+          maxlength="100"
+          counter
           :disabled="Boolean($route.query.email)"
           :error-messages="emailErrors"
           @input="emailErrors = []"

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
@@ -128,6 +128,8 @@
           <VTextField
             v-model="channel.demo_server_url"
             label="Demo URL"
+            maxlength="200"
+            counter
             autofocus
             box
             class="mt-4"
@@ -161,6 +163,8 @@
         <template #input>
           <VTextField
             v-model="channel.source_url"
+            maxlength="200"
+            counter
             label="Source URL"
             box
             class="mt-4"

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserPrivilegeModal.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserPrivilegeModal.vue
@@ -10,6 +10,8 @@
       <VTextField
         v-model="emailConfirm"
         box
+        maxlength="100"
+        counter
         required
         :rules="emailRules"
         label="Email address"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -21,8 +21,8 @@
           <VTextField
             ref="title"
             v-model="title"
-            :counter="200"
             maxlength="200"
+            counter
             :rules="titleRules"
             :label="$tr('titleLabel')"
             autofocus
@@ -34,7 +34,8 @@
             ref="description"
             v-model="description"
             :label="$tr('descriptionLabel')"
-            :counter="400"
+            maxlength="400"
+            counter
             autoGrow
             box
           />
@@ -171,6 +172,7 @@
               :label="$tr('authorLabel')"
               :readonly="disableAuthEdits"
               maxlength="200"
+              counter
               autoSelectFirst
               box
               :placeholder="getPlaceholder('author')"
@@ -189,6 +191,7 @@
               :label="$tr('providerLabel')"
               :readonly="disableAuthEdits"
               maxlength="200"
+              counter
               :placeholder="getPlaceholder('provider')"
               autoSelectFirst
               box
@@ -207,6 +210,7 @@
               :label="$tr('aggregatorLabel')"
               :readonly="disableAuthEdits"
               maxlength="200"
+              counter
               autoSelectFirst
               :placeholder="getPlaceholder('aggregator')"
               box
@@ -235,6 +239,7 @@
               :items="copyrightHolders"
               :label="$tr('copyrightHolderLabel')"
               maxlength="200"
+              counter
               :required="isUnique(copyright_holder) && !disableAuthEdits"
               :rules="copyrightHolderRules"
               :placeholder="getPlaceholder('copyright_holder')"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/NewTopicModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/NewTopicModal.vue
@@ -8,6 +8,8 @@
     >
       <VTextField
         v-model="title"
+        maxlength="200"
+        counter
         :label="$tr('topicTitle')"
         box
         :rules="titleRules"

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/FullNameForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/FullNameForm.vue
@@ -10,12 +10,16 @@
   >
     <KTextbox
       v-model="first_name"
+      :maxlength="100"
+      counter
       :label="$tr('firstNameLabel')"
       :invalid="errors.first_name"
       :invalidText="$tr('fieldRequired')"
     />
     <KTextbox
       v-model="last_name"
+      :maxlength="100"
+      counter
       :label="$tr('lastNameLabel')"
       :invalid="errors.last_name"
       :invalidText="$tr('fieldRequired')"

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -41,6 +41,8 @@
                 <VTextField
                   v-model="name"
                   box
+                  maxlength="200"
+                  counter
                   :label="$tr('channelName')"
                   :rules="nameRules"
                   required

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharing.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharing.vue
@@ -19,6 +19,8 @@
             v-model="email"
             box
             color="primary"
+            maxlength="100"
+            counter
             :label="$tr('emailLabel')"
             :error-messages="error? [error] : []"
             @input="error = null"

--- a/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
@@ -12,6 +12,8 @@
       <VTextField
         v-model="author"
         box
+        maxlength="200"
+        counter
         data-name="author"
         :label="$tr('author')"
         @change="emitChange"
@@ -19,6 +21,8 @@
       <VTextField
         v-model="provider"
         box
+        maxlength="200"
+        counter
         data-name="provider"
         :label="$tr('provider')"
         @change="emitChange"
@@ -26,6 +30,8 @@
       <VTextField
         v-model="aggregator"
         box
+        maxlength="200"
+        counter
         data-name="aggregator"
         :label="$tr('aggregator')"
         @change="emitChange"
@@ -33,6 +39,8 @@
       <VTextField
         v-model="copyrightHolder"
         box
+        maxlength="200"
+        counter
         data-name="copyrightHolder"
         :label="$tr('copyrightHolder')"
         @change="emitChange"
@@ -50,6 +58,8 @@
         v-if="isCustomLicense"
         v-model="licenseDescription"
         box
+        maxlength="400"
+        counter
         data-name="licenseDescription"
         :label="$tr('licenseDescription')"
         auto-grow


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Adds `maxlength` and `counter` attributes/props to all the TextFields that need them in order to provide some basic validation for CharField models.

Hopefully fixes #1411 , although I have no idea where that original error came from.


#### Issue Addressed (if applicable)

Addresses #*PR# HERE*

#### Before/After Screenshots (if applicable)

Example: The channel details modal now has counters for all the text fields

![image](https://user-images.githubusercontent.com/10248067/95801175-60a1ee80-0cae-11eb-9e6f-e07edc928f9b.png)



## Steps to Test

- Go to every form you can think of. If the value is going into a DJango model CharField, it will have a counter and max-length validation.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
