### PR TITLE
fix hint preview rendering for long hints

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemPreview/AssessmentItemPreview.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemPreview/AssessmentItemPreview.vue
@@ -84,19 +84,21 @@
               <span>{{ hintsToggleLabel }}</span>
             </span>
 
-            <VList v-if="areHintsOpen">
-              <VListTile
+            <div v-if="areHintsOpen">
+              <VLayout
                 v-for="(hint, hintIdx) in hints"
                 :key="hintIdx"
+                class="hint"
+                flat
               >
-                <VFlex xs1>
+                <VFlex class="hint-number" shrink>
                   {{ hintIdx + 1 }}
                 </VFlex>
-                <VFlex class="px-2">
+                <VFlex>
                   <MarkdownViewer :markdown="hint.hint" />
                 </VFlex>
-              </VListTile>
-            </VList>
+              </VLayout>
+            </div>
           </div>
         </div>
       </VFlex>
@@ -260,6 +262,10 @@
   /deep/ img {
     max-width: 100%;
     height: auto;
+  }
+
+  .hint-number {
+    padding: 11px;
   }
 
 </style>


### PR DESCRIPTION
## Description

Make sure hint previews render nicely for long hints

#### Issue Addressed
Fixes #2403 
#### Before/After Screenshots
##### Before
![image](https://user-images.githubusercontent.com/389782/95805795-da94a080-0ccb-11eb-8c99-56b8fcad58fb.png)

##### After
![image](https://user-images.githubusercontent.com/389782/95805787-d2d4fc00-0ccb-11eb-93ba-ffb67deb5c0d.png)

## Steps to Test

- [ ] Make an exercise question with some long hints
- [ ] Check them out in the details tab
