### PR TITLE
Collection ui fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelItem.vue
@@ -7,13 +7,13 @@
     <VFlex xs12 sm8 md9 lg10>
       <VLayout align-center>
         <VCardText class="py-0">
-          <h3 class="headline mb-0" dir="auto">
+          <h3 class="card-header notranslate font-weight-bold" dir="auto">
             {{ channel.name }}
           </h3>
-          <p class="grey--text subheading">
+          <p class="grey--text subheading metadata-section">
             {{ $tr("versionText", {'version': channel.version}) }}
           </p>
-          <p dir="auto">
+          <p dir="auto" class="notranslate">
             {{ channel.description }}
           </p>
         </VCardText>
@@ -56,5 +56,13 @@
 
 
 <style lang="less" scoped>
+
+  .card-header {
+    font-size: 18px;
+  }
+  .metadata-section {
+    // Double space metadata section
+    line-height: 3;
+  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VContainer class="list-items" fluid>
-    <VLayout row wrap align-center justify-center>
+    <VLayout row wrap align-end justify-center>
       <VFlex>
         <ActionLink
           :text="$tr('aboutChannelSetsLink')"
@@ -38,7 +38,7 @@
         </VBtn>
       </VFlex>
     </VLayout>
-    <VLayout row justify-center class="pt-4">
+    <VLayout row justify-center class="pt-2">
       <VFlex xs12>
         <template v-if="loading">
           <LoadingText />

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -1,12 +1,13 @@
 <template>
 
   <VContainer class="list-items" fluid>
-    <VLayout row wrap justify-center>
+    <VLayout row wrap align-center justify-center>
       <VFlex>
-        <VBtn flat color="primary" class="ma-0" @click="infoDialog=true">
-          <Icon>info</Icon>
-          <span class="mx-2">{{ $tr('aboutChannelSetsLink') }}</span>
-        </VBtn>
+        <ActionLink
+          :text="$tr('aboutChannelSetsLink')"
+          class="mx-2"
+          @click="infoDialog=true"
+        />
         <MessageDialog v-model="infoDialog" :header="$tr('aboutChannelSets')">
           <p>
             {{ $tr('channelSetsDescriptionText') }}
@@ -19,7 +20,7 @@
           </p>
           <template #buttons>
             <VSpacer />
-            <VBtn color="primary" @click="infoDialog=false">
+            <VBtn @click="infoDialog=false">
               {{ $tr('cancelButtonLabel') }}
             </VBtn>
           </template>

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -15,11 +15,6 @@
         </Icon>
       </VBtn>
     </template>
-    <template v-if="step === 1" #action>
-      <VBtn flat data-test="save" @click="save">
-        {{ saveText }}
-      </VBtn>
-    </template>
     <VWindow v-model="step">
       <VWindowItem :value="1">
         <VContainer class="ml-5 pt-5">
@@ -125,12 +120,21 @@
         </VBtn>
       </template>
     </MessageDialog>
-    <template v-if="step === 2" #bottom>
+    <template #bottom>
       <div class="subheading mx-4">
         {{ $tr('channelSelectedCountText', {'channelCount': channels.length}) }}
       </div>
       <VSpacer />
       <VBtn
+        v-if="step === 1"
+        color="primary"
+        data-test="save"
+        @click="save"
+      >
+        {{ saveText }}
+      </VBtn>
+      <VBtn
+        v-else
         color="primary"
         data-test="finish"
         @click="step --"
@@ -254,7 +258,7 @@
         this.dialog = value;
       },
       nameValid(name) {
-        return name && name.length > 0 ? true : this.$tr('titleRequiredText');
+        return name && name.trim().length > 0 ? true : this.$tr('titleRequiredText');
       },
       saveChannels() {
         const oldChannels = this.channelSet.channels;

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -37,6 +37,7 @@ function makeWrapper(setData = {}, methods = {}) {
   let wrapper = mount(ChannelSetModal, {
     router,
     store,
+    sync: false,
     propsData: {
       channelSetId: channelSetId,
     },
@@ -54,6 +55,7 @@ function makeWrapper(setData = {}, methods = {}) {
       },
       ...methods,
     },
+    stubs: ['ChannelSelectionList', 'ChannelItem'],
   });
   wrapper.vm.setup();
   return wrapper;
@@ -108,13 +110,14 @@ describe('channelSetModal', () => {
   describe('on save', () => {
     it('clicking save should call save method', () => {
       const save = jest.fn();
-      wrapper.setMethods({ save });
+      wrapper = makeWrapper({}, { save });
       wrapper.find('[data-test="save"]').trigger('click');
       expect(save).toHaveBeenCalled();
     });
     it('should not save if fields are invalid', () => {
+      wrapper.setData({ step: 1 });
       const setChannels = jest.fn();
-      wrapper.setMethods({ setChannels });
+      wrapper = makeWrapper({}, { setChannels });
       wrapper.find('[data-test="save"]').trigger('click');
       expect(setChannels).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Addresses the following items:
* [Collection info modal should use secondary color](https://www.notion.so/learningequality/Collection-info-modal-should-use-secondary-color-605701276264409cbfac9e1d47267a90)
* [This looks like an icon button that we don't use. Should be a link](https://www.notion.so/learningequality/This-looks-like-an-icon-button-that-we-don-t-use-Should-be-a-link-b0eec3be9c204111a98fd6a4bf11f584)
* [New collection "create" needs to be a final action in a bottom bar. With # channels selected as the left info indicator](https://www.notion.so/learningequality/New-collection-create-needs-to-be-a-final-action-in-a-bottom-bar-With-channels-selected-as-the--4d597c915d274554bddfa235643c2e9d)
* [Need to add dir="auto" to channels under collection modal](https://www.notion.so/learningequality/Need-to-add-dir-auto-to-channels-under-collection-modal-01cc851b69b545dda5d7cee0ffe8b796)
* Fixes https://github.com/learningequality/studio/issues/1778
* [Bring over catalog card selection UI over to collection creation](https://www.notion.so/learningequality/Bring-over-catalog-card-selection-UI-over-to-collection-creation-0360c70b45414e0abf7d4c2a48dc7b84)