### PR TITLE
Select All checkbox shows proper state during and after navigation

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -265,7 +265,11 @@
       },
       selectAll: {
         get() {
-          return this.selected.length === this.children.length;
+          // Cannot "select all" of nothing
+          if (this.children.length) {
+            return this.selected.length === this.children.length;
+          }
+          return false;
         },
         set(value) {
           if (value) {
@@ -314,6 +318,8 @@
     },
     watch: {
       topicId() {
+        // Clear selections when topic changes
+        this.selected = [];
         this.loadingAncestors = true;
         this.loadAncestors({ id: this.topicId }).then(() => {
           this.loadingAncestors = false;


### PR DESCRIPTION
## Description

Fixes an issue where Select All checkbox's state on channel edit wasn't working properly.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2311

## Steps to Test

### Error 1:

1. Navigate to a topic

Make sure this is fixed - only happens after first page load on first navigation to a topic when broken:

> Error 1: select all checkbox is checked, even if no items are loaded. Probably better to hide it until the items load so user doesn't interact with it beforehand

### Error 2:

1. Select some items

2. Navigate to another topic

Make sure this is fixed and state is reset between topic navigations

> Error 2: select all checkbox shows as being partially checked, but selection should get reset between navigations


## Implementation Notes (optional)

#### At a high level, how did you implement this?

Select All previously was `this.selected === this.children` but it really only matters if `this.children.length > 0` so we check for length on the children before going to the proper check.

We already watch the `topicId` so I reset `this.selected` to `[]` in that watcher (only changes when navigating topics).

