### PR TITLE
Avoid error replacing route with same route

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -182,13 +182,16 @@
           return sharing && String(sharing) === 'true' ? 'share' : 'edit';
         },
         set(value) {
-          this.$router.replace({
-            ...this.$route,
-            query: {
-              ...this.$route.query,
-              sharing: value === 'share',
-            },
-          });
+          // Only navigate if we're changing locations
+          if (value !== this.currentTab) {
+            this.$router.replace({
+              ...this.$route,
+              query: {
+                ...this.$route.query,
+                sharing: value === 'share',
+              },
+            });
+          }
         },
       },
       nameRules() {
@@ -287,7 +290,7 @@
           }
         } else {
           // Go back to Details tab to show validation errors
-          this.currentTab = false;
+          this.currentTab = 'edit';
         }
       },
       onDialogInput(value) {


### PR DESCRIPTION
## Description

Get rid of the Vue Router "How dare you try to navigate to the same route I refuse to do this and will complain loudly about it" error.

Also - I saw a place in the code where `this.currentTab` was being set to `false`.

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2394

## Steps to Test

Go to edit a channel's details (name, description, etc) and change between Sharing & Details tabs then click the same tab you're on and you should no longer see Vue Router saying it avoided redundant navigation.