### PR TITLE
Clipboard ui fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -4,7 +4,7 @@
     <ContextMenu slot-scope="{ hover }">
       <VListTile
         v-if="contentNode"
-        class="content-item py-2"
+        class="content-item py-1"
         :class="{hover, selected}"
         :style="{'padding-left': indentPadding}"
       >

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -44,6 +44,7 @@
                 flat
                 class="ma-0"
                 v-on="on"
+                @click.stop
               >
                 <Icon>more_horiz</Icon>
               </VBtn>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/TopicNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/TopicNode.vue
@@ -12,16 +12,16 @@
         :nodeId="nodeId"
         :level="level"
       >
-        <VListTileContent class="description-col py-2 pl-2 shrink">
-          <VBadge color="primary">
-            <template #badge>
-              <span class="caption font-weight-bold">{{ contentNode.resource_count }}</span>
-            </template>
-            <VListTileTitle class="text-truncate pr-2" :class="getTitleClass(contentNode)">
-              {{ getTitle(contentNode) }}
-            </VListTileTitle>
-          </VBadge>
+        <VListTileContent class="description-col pl-2 shrink">
+          <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
+            {{ getTitle(contentNode) }}
+          </VListTileTitle>
         </VListTileContent>
+        <VListTileAction style="min-width: unset;" class="px-3">
+          <div class="badge caption font-weight-bold">
+            {{ contentNode.resource_count }}
+          </div>
+        </VListTileAction>
 
         <!-- Custom placement of dropdown indicator -->
         <VListTileAction
@@ -105,13 +105,14 @@
     display: none;
   }
 
-  .description-col {
-    padding-right: 32px;
-  }
-
-  /deep/ .v-badge__badge {
+  .badge {
     top: 0;
-    right: -32px;
+    width: max-content;
+    min-width: 22px;
+    padding: 0 3px;
+    color: white;
+    text-align: center;
+    background-color: var(--v-primary-base);
     border-radius: 3px;
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -6,7 +6,7 @@
       right
       :localName="localName"
       :minWidth="450"
-      :maxWidth="700"
+      :maxWidth="750"
       permanent
       clipped
       class="clipboard elevation-4"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -5,7 +5,7 @@
       v-if="open"
       right
       :localName="localName"
-      :minWidth="400"
+      :minWidth="450"
       :maxWidth="700"
       permanent
       clipped


### PR DESCRIPTION
Addresses the following issues:
* [Need better handling for clipboard counter](https://www.notion.so/learningequality/Need-better-handling-for-clipboard-counter-d4b61eeeca9243a18002fd35b9b09b25)
* [Clicking the menu icon on topics in the clipboard opens the topic. Should only open the menu](https://www.notion.so/learningequality/Clicking-the-menu-icon-on-topics-in-the-clipboard-opens-the-topic-Should-only-open-the-menu-b3f797ce306a41eda675568416f61a21)
* [Reduce padding between clipboard items to save space](https://www.notion.so/learningequality/Reduce-padding-between-clipboard-items-to-save-space-c126b16c5ec64846bcf2fb26fbc043f9)
* [clipboard width can use another 100px. too narrow](https://www.notion.so/learningequality/clipboard-width-can-use-another-100px-too-narrow-315c930f922f4b58a85560d490cd60d7)