### PR TITLE
Updates to file uploading

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <Uploader ref="uploader" :presetID="imagePreset" @uploading="handleUploading">
+  <Uploader ref="uploader" :presetID="imagePreset" :uploadingHandler="handleUploading">
     <template #default="{handleFiles}">
       <VLayout>
         <VFlex xs7 lg5>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -458,7 +458,7 @@
           return this.nodeFiles.find(f => f.preset.thumbnail);
         },
         set(file) {
-          file ? this.updateFile(file) : this.deleteFile(this.thumbnail);
+          file ? this.updateFile(file) : this.thumbnail ? this.deleteFile(this.thumbnail) : null;
         },
       },
       thumbnailEncoding: generateGetterSetter('thumbnail_encoding'),
@@ -580,10 +580,19 @@
         return value !== nonUniqueValue;
       },
       getValueFromNodes(key) {
+        if (this.diffTracker.hasOwnProperty(key)) {
+          return this.diffTracker[key];
+        }
         let results = uniq(this.nodes.map(node => node[key] || null));
         return getValueFromResults(results);
       },
       getExtraFieldsValueFromNodes(key) {
+        if (
+          this.diffTracker.hasOwnProperty('extra_fields') &&
+          this.diffTracker.extra_fields.hasOwnProperty(key)
+        ) {
+          return this.diffTracker.extra_fields[key];
+        }
         let results = uniq(this.nodes.map(node => node.extra_fields[key] || null));
         return getValueFromResults(results);
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -458,7 +458,7 @@
           return this.nodeFiles.find(f => f.preset.thumbnail);
         },
         set(file) {
-          file ? this.createFile(file) : this.deleteFile(this.thumbnail);
+          file ? this.updateFile(file) : this.deleteFile(this.thumbnail);
         },
       },
       thumbnailEncoding: generateGetterSetter('thumbnail_encoding'),
@@ -533,7 +533,7 @@
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode', 'addTags', 'removeTags']),
-      ...mapActions('file', ['createFile', 'deleteFile']),
+      ...mapActions('file', ['updateFile', 'deleteFile']),
       update(payload) {
         this.nodeIds.forEach(id => {
           const node = this.getContentNode(id);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -12,7 +12,7 @@
       persistent
     >
       <VCard class="edit-modal-wrapper">
-        <Uploader allowMultiple displayOnly @uploading="createNodesFromUploads">
+        <Uploader allowMultiple displayOnly :uploadingHandler="createNodesFromUploads">
           <template #default="{openFileDialog, handleFiles}">
             <!-- Toolbar + extension -->
             <VToolbar

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -346,7 +346,7 @@
         'loadRelatedResources',
         'createContentNode',
       ]),
-      ...mapActions('file', ['loadFiles', 'createFile']),
+      ...mapActions('file', ['loadFiles', 'updateFile']),
       ...mapActions('assessmentItem', ['loadAssessmentItems']),
       ...mapMutations('contentNode', { enableValidation: 'ENABLE_VALIDATION_ON_NODES' }),
       closeModal() {
@@ -427,7 +427,7 @@
             if (index === 0) {
               this.selected = [newNodeId];
             }
-            this.createFile({
+            this.updateFile({
               contentnode: newNodeId,
               ...file,
             });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -428,8 +428,8 @@
               this.selected = [newNodeId];
             }
             this.updateFile({
-              contentnode: newNodeId,
               ...file,
+              contentnode: newNodeId,
             });
           });
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/store.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/store.js
@@ -12,40 +12,44 @@ import storeFactory from 'shared/vuex/baseStore';
 import persistFactory from 'shared/vuex/persistFactory';
 import DraggablePlugin from 'shared/vuex/draggablePlugin';
 
-const store = storeFactory({
-  state() {
-    return {
-      /**
-       * The current view mode of the channel edit page,
-       * which right now only controls the density of the
-       * node list.
-       *
-       * See viewMode.* constants for options.
-       */
-      viewMode: null,
+export function factory() {
+  return storeFactory({
+    state() {
+      return {
+        /**
+         * The current view mode of the channel edit page,
+         * which right now only controls the density of the
+         * node list.
+         *
+         * See viewMode.* constants for options.
+         */
+        viewMode: null,
 
-      /**
-       * The view mode can be overridden by modals or panels,
-       * and this allows for that to happen. See the
-       * `isCompactViewMode` getter for how these are merged
-       * to override the current `viewMode`.
-       */
-      viewModeOverrides: [],
-    };
-  },
-  actions,
-  mutations,
-  getters,
-  plugins: [DraggablePlugin, persistFactory('channelEdit', ['SET_VIEW_MODE'])],
-  modules: {
-    task,
-    template,
-    assessmentItem,
-    clipboard,
-    contentNode,
-    currentChannel,
-    importFromChannels,
-  },
-});
+        /**
+         * The view mode can be overridden by modals or panels,
+         * and this allows for that to happen. See the
+         * `isCompactViewMode` getter for how these are merged
+         * to override the current `viewMode`.
+         */
+        viewModeOverrides: [],
+      };
+    },
+    actions,
+    mutations,
+    getters,
+    plugins: [DraggablePlugin, persistFactory('channelEdit', ['SET_VIEW_MODE'])],
+    modules: {
+      task,
+      template,
+      assessmentItem,
+      clipboard,
+      contentNode,
+      currentChannel,
+      importFromChannels,
+    },
+  });
+}
+
+const store = factory();
 
 export default store;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -8,7 +8,7 @@
     </VCard>
     <VCard v-else-if="file.uploading || file.error" flat class="message-card">
       <VLayout align-center justify-center fill-height data-test="progress">
-        <FileStatus :id="file.id" large />
+        <FileStatus :fileId="file.id" large />
       </VLayout>
     </VCard>
     <VFlex v-else-if="isVideo">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -8,7 +8,7 @@
     </VCard>
     <VCard v-else-if="file.uploading || file.error" flat class="message-card">
       <VLayout align-center justify-center fill-height data-test="progress">
-        <FileStatus :checksum="file.checksum" large />
+        <FileStatus :id="file.id" large />
       </VLayout>
     </VCard>
     <VFlex v-else-if="isVideo">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
@@ -140,13 +140,13 @@
       this.selectFirstFile();
     },
     methods: {
-      ...mapActions('file', ['createFile', 'deleteFile']),
+      ...mapActions('file', ['updateFile', 'deleteFile']),
       selectFirstFile() {
         let firstFile = sortBy(this.files, f => f.preset.order)[0];
         this.selected = firstFile && firstFile.id;
       },
       handleUploading(fileUpload) {
-        this.createFile({
+        this.updateFile({
           contentnode: this.nodeId,
           ...fileUpload,
         }).then(id => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
@@ -52,8 +52,8 @@
                   :file="item.file"
                   :preset="item.preset"
                   :allowFileRemove="allowFileRemove"
+                  :uploadCompleteHandler="handleUploadComplete"
                   @selected="selected = item.file.id"
-                  @uploading="handleUploading"
                   @remove="handleRemoveFile"
                 />
               </VList>
@@ -145,7 +145,7 @@
         let firstFile = sortBy(this.files, f => f.preset.order)[0];
         this.selected = firstFile && firstFile.id;
       },
-      handleUploading(fileUpload) {
+      handleUploadComplete(fileUpload) {
         this.updateFile({
           ...fileUpload,
           contentnode: this.nodeId,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
@@ -147,10 +147,10 @@
       },
       handleUploading(fileUpload) {
         this.updateFile({
-          contentnode: this.nodeId,
           ...fileUpload,
-        }).then(id => {
-          this.selected = id;
+          contentnode: this.nodeId,
+        }).then(() => {
+          this.selected = fileUpload.id;
         });
       },
       handleRemoveFile(file) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -3,7 +3,8 @@
   <Uploader
     :key="`file-${file && file.id}`"
     :presetID="preset.id"
-    @uploading="file => $emit('uploading', file)"
+    :uploadingHandler="uploadingHandler"
+    :uploadCompleteHandler="completeUpload"
   >
     <template #default="{openFileDialog, handleFiles}">
       <FileDropzone @dropped="handleFiles">
@@ -25,9 +26,9 @@
             <VListTileSubTitle>{{ translateConstant(preset.id) }}</VListTileSubTitle>
             <VListTileTitle>
               <ActionLink
-                v-if="file"
+                v-if="fileDisplay"
                 class="notranslate"
-                :text="file.original_filename"
+                :text="fileDisplay.original_filename"
                 @click="openFileDialog"
               />
               <ActionLink
@@ -37,17 +38,17 @@
                 @click="openFileDialog"
               />
             </VListTileTitle>
-            <VListTileSubTitle v-if="file && (file.error || uploading)" data-test="status">
-              <FileStatusText :id="file.id" @open="openFileDialog" />
+            <VListTileSubTitle v-if="fileUpload && (uploadError || uploading)" data-test="status">
+              <FileStatusText :id="fileUpload.id" :readonly="true" />
             </VListTileSubTitle>
-            <VListTileSubTitle v-else-if="file">
-              {{ formatFileSize(file.file_size) }}
+            <VListTileSubTitle v-else-if="fileDisplay">
+              {{ formatFileSize(fileDisplay.file_size) }}
             </VListTileSubTitle>
 
           </VListTileContent>
           <VSpacer />
-          <VListTileAction v-if="file">
-            <div v-if="file.error || allowFileRemove" class="remove-icon">
+          <VListTileAction v-if="fileDisplay">
+            <div v-if="allowFileRemove" class="remove-icon">
               <IconButton
                 icon="clear"
                 color="grey"
@@ -66,6 +67,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import FileStatusText from 'shared/views/files/FileStatusText';
   import Uploader from 'shared/views/files/Uploader';
   import IconButton from 'shared/views/IconButton';
@@ -97,10 +99,53 @@
         type: Boolean,
         default: false,
       },
+      uploadCompleteHandler: {
+        type: Function,
+        required: false,
+      },
+    },
+    data() {
+      return {
+        fileUploadId: null,
+      };
     },
     computed: {
+      ...mapGetters('file', ['getFileUpload']),
+      fileUpload() {
+        return this.fileUploadId && this.getFileUpload(this.fileUploadId);
+      },
       uploading() {
-        return this.file && this.file.uploading;
+        return this.fileUpload && this.fileUpload.uploading;
+      },
+      fileDisplay() {
+        if (
+          this.fileUpload &&
+          (!this.file || this.fileUpload.id !== this.file.id) &&
+          !this.uploadError
+        ) {
+          return this.fileUpload;
+        }
+        return this.file;
+      },
+      uploadError() {
+        return this.fileUpload && this.fileUpload.error;
+      },
+    },
+    watch: {
+      'file.id': {
+        handler() {
+          this.fileUploadId = null;
+        },
+      },
+    },
+    methods: {
+      completeUpload(fileUpload) {
+        if (fileUpload.id === this.fileUploadId) {
+          this.uploadCompleteHandler(fileUpload);
+        }
+      },
+      uploadingHandler(fileUpload) {
+        this.fileUploadId = fileUpload.id;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -38,9 +38,9 @@
                 @click="openFileDialog"
               />
             </VListTileTitle>
-            <VListTileSubTitle v-if="uploadError || uploading" data-test="status">
+            <VListTileSubTitle v-if="erroredFile || uploading" data-test="status">
               <FileStatusText
-                :fileId="fileDisplay.id"
+                :fileId="erroredFile.id"
                 :readonly="Boolean(fileUploadId)"
                 @open="openFileDialog"
               />
@@ -131,8 +131,14 @@
         }
         return this.file;
       },
-      uploadError() {
-        return this.fileDisplay && this.fileDisplay.error;
+      erroredFile() {
+        if (this.fileUpload && this.fileUpload.error) {
+          return this.fileUpload;
+        }
+        if (this.file && this.file.error) {
+          return this.file;
+        }
+        return null;
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -38,7 +38,7 @@
               />
             </VListTileTitle>
             <VListTileSubTitle v-if="file && (file.error || uploading)" data-test="status">
-              <FileStatusText :checksum="file.checksum" @open="openFileDialog" />
+              <FileStatusText :id="file.id" @open="openFileDialog" />
             </VListTileSubTitle>
             <VListTileSubTitle v-else-if="file">
               {{ formatFileSize(file.file_size) }}

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -40,7 +40,7 @@
             </VListTileTitle>
             <VListTileSubTitle v-if="uploadError || uploading" data-test="status">
               <FileStatusText
-                :id="fileDisplay.id"
+                :fileId="fileDisplay.id"
                 :readonly="Boolean(fileUploadId)"
                 @open="openFileDialog"
               />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -38,8 +38,12 @@
                 @click="openFileDialog"
               />
             </VListTileTitle>
-            <VListTileSubTitle v-if="fileUpload && (uploadError || uploading)" data-test="status">
-              <FileStatusText :id="fileUpload.id" :readonly="true" />
+            <VListTileSubTitle v-if="uploadError || uploading" data-test="status">
+              <FileStatusText
+                :id="fileDisplay.id"
+                :readonly="Boolean(fileUploadId)"
+                @open="openFileDialog"
+              />
             </VListTileSubTitle>
             <VListTileSubTitle v-else-if="fileDisplay">
               {{ formatFileSize(fileDisplay.file_size) }}
@@ -115,20 +119,20 @@
         return this.fileUploadId && this.getFileUpload(this.fileUploadId);
       },
       uploading() {
-        return this.fileUpload && this.fileUpload.uploading;
+        return this.fileDisplay && this.fileDisplay.uploading;
       },
       fileDisplay() {
         if (
           this.fileUpload &&
           (!this.file || this.fileUpload.id !== this.file.id) &&
-          !this.uploadError
+          !this.fileUpload.error
         ) {
           return this.fileUpload;
         }
         return this.file;
       },
       uploadError() {
-        return this.fileUpload && this.fileUpload.error;
+        return this.fileDisplay && this.fileDisplay.error;
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentNodeThumbnail.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentNodeThumbnail.spec.js
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils';
 import ContentNodeThumbnail from '../thumbnails/ContentNodeThumbnail';
 import store from '../../../store';
-import Uploader from 'shared/views/files/Uploader';
 import IconButton from 'shared/views/IconButton';
 
 const testThumbnail = {
@@ -98,8 +97,8 @@ describe('thumbnail', () => {
       wrapper.find('[data-test="cancel-upload"]').trigger('click');
       expect(wrapper.emitted('input')[0][0]).toEqual(null);
     });
-    it('should emit input event with file data when Uploader uploading event is fired', () => {
-      wrapper.find(Uploader).vm.$emit('uploading', { id: 'testfile' });
+    it('should emit input event with file data when uploadCompleteHandler is run', () => {
+      wrapper.vm.handleUploadComplete({ id: 'testfile' });
 
       expect(wrapper.emitted('input')[0][0].id).toBe('testfile');
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentNodeThumbnail.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentNodeThumbnail.spec.js
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import ContentNodeThumbnail from '../thumbnails/ContentNodeThumbnail';
-import store from '../../../store';
+import { factory } from '../../../store';
 import IconButton from 'shared/views/IconButton';
 
 const testThumbnail = {
@@ -26,7 +26,23 @@ const testDocument = {
   },
 };
 
+const fileUploadId = 'upload-id';
+
 function makeWrapper(props = {}, progress) {
+  const store = factory();
+  store.commit('file/ADD_FILE', {
+    id: fileUploadId,
+    loaded: progress,
+    total: 1,
+    url: 'new.png',
+    file_size: 100,
+    original_filename: 'new.png',
+    preset: {
+      id: 'document_thumbnail',
+      thumbnail: true,
+      supplementary: true,
+    },
+  });
   return mount(ContentNodeThumbnail, {
     store,
     attachToDocument: true,
@@ -37,9 +53,6 @@ function makeWrapper(props = {}, progress) {
           files: [],
           kind: 'document',
         };
-      },
-      uploading() {
-        return progress < 1;
       },
       getContentNodeFiles() {
         return () => {
@@ -84,23 +97,26 @@ describe('thumbnail', () => {
   describe('upload workflow', () => {
     beforeEach(() => {
       wrapper = makeWrapper({ value: testThumbnail }, 0.5);
+      wrapper.setData({ fileUploadId });
     });
     it('progress should be shown during upload', () => {
       expect(wrapper.find('[data-test="progress"]').exists()).toBe(true);
     });
     it('hasError should be true if file upload fails', () => {
-      wrapper.setProps({ value: { ...testThumbnail, error: true } });
+      wrapper.vm.$store.commit('file/ADD_FILE', { id: fileUploadId, error: 'ERROR' });
       expect(wrapper.vm.hasError).toBe(true);
     });
     it('cancelling upload should revert to the original state', () => {
       wrapper.setData({ removeOnCancel: true });
+      wrapper.vm.deleteFile = jest.fn();
       wrapper.find('[data-test="cancel-upload"]').trigger('click');
-      expect(wrapper.emitted('input')[0][0]).toEqual(null);
+      expect(wrapper.vm.deleteFile).toHaveBeenCalled();
     });
-    it('should emit input event with file data when uploadCompleteHandler is run', () => {
-      wrapper.vm.handleUploadComplete({ id: 'testfile' });
-
-      expect(wrapper.emitted('input')[0][0].id).toBe('testfile');
+    it('should set cropping equal true when uploadCompleteHandler is run', () => {
+      wrapper.vm.handleUploadComplete({ id: fileUploadId });
+      return wrapper.vm.$nextTick().then(() => {
+        expect(wrapper.vm.cropping).toBe(true);
+      });
     });
   });
   describe('cropping workflow', () => {
@@ -140,7 +156,6 @@ describe('thumbnail', () => {
       wrapper.setData({ removeOnCancel: true });
       wrapper.find('[data-test="cancel"]').trigger('click');
       expect(wrapper.vm.cropping).toBe(false);
-      expect(wrapper.emitted('input')[0][0]).toBe(null);
     });
   });
   describe('generation workflow', () => {
@@ -149,7 +164,7 @@ describe('thumbnail', () => {
     });
     it('progress should be shown during generation', () => {
       wrapper.setData({ generating: true });
-      wrapper.vm.$nextTick(() => {
+      return wrapper.vm.$nextTick().then(() => {
         expect(wrapper.find('[data-test="generating"]').exists()).toBe(true);
       });
     });
@@ -158,12 +173,10 @@ describe('thumbnail', () => {
       expect(wrapper.vm.primaryFilePath).toBe(testDocument.url);
     });
     it('cancelling upload should revert to the original state', () => {
-      wrapper.setData({ lastThumbnail: null });
       wrapper.vm.startGenerating();
-      wrapper.vm.$nextTick(() => {
+      return wrapper.vm.$nextTick().then(() => {
         wrapper.find('[data-test="cancel-upload"]').trigger('click');
         expect(wrapper.vm.generating).toBe(false);
-        expect(wrapper.emitted('input')[0][0]).toBeFalsy();
       });
     });
     it('clicking generate button should set generating to true', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUpload.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUpload.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import FileUpload from '../FileUpload';
 import FileUploadItem from '../FileUploadItem';
-import store from '../../../store';
+import { factory } from '../../../store';
 
 const testFiles = [
   {
@@ -36,6 +36,7 @@ function makeWrapper(files) {
     f.url = 'path';
     f.file_format = 'mp3';
   });
+  const store = factory();
   return mount(FileUpload, {
     store,
     attachToDocument: true,
@@ -109,10 +110,10 @@ describe('fileUpload', () => {
       expect(deleteFile).toHaveBeenCalled();
       expect(deleteFile.mock.calls[0][0]).toBe(testFiles[0]);
     });
-    it('emitted uploading event should trigger update file', () => {
+    it('calling uploadCompleteHandler should trigger update file', () => {
       let updateFile = jest.fn(() => Promise.resolve());
       wrapper.setMethods({ updateFile });
-      uploadItem.vm.$emit('uploading', testFiles[1]);
+      uploadItem.vm.uploadCompleteHandler(testFiles[1]);
       expect(updateFile).toHaveBeenCalled();
       expect(updateFile.mock.calls[0][0]).toEqual({
         ...testFiles[1],

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUpload.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUpload.spec.js
@@ -51,7 +51,7 @@ function makeWrapper(files) {
       },
     },
     methods: {
-      createFile() {
+      updateFile() {
         return Promise.resolve();
       },
     },
@@ -109,12 +109,12 @@ describe('fileUpload', () => {
       expect(deleteFile).toHaveBeenCalled();
       expect(deleteFile.mock.calls[0][0]).toBe(testFiles[0]);
     });
-    it('emitted uploading event should trigger create file', () => {
-      let createFile = jest.fn(() => Promise.resolve());
-      wrapper.setMethods({ createFile });
+    it('emitted uploading event should trigger update file', () => {
+      let updateFile = jest.fn(() => Promise.resolve());
+      wrapper.setMethods({ updateFile });
       uploadItem.vm.$emit('uploading', testFiles[1]);
-      expect(createFile).toHaveBeenCalled();
-      expect(createFile.mock.calls[0][0]).toEqual({
+      expect(updateFile).toHaveBeenCalled();
+      expect(updateFile.mock.calls[0][0]).toEqual({
         ...testFiles[1],
         contentnode: 'testnode',
       });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUploadItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUploadItem.spec.js
@@ -1,10 +1,11 @@
 import { mount } from '@vue/test-utils';
 import FileUploadItem from '../FileUploadItem';
-import store from '../../../store';
+import { factory } from '../../../store';
 import Uploader from 'shared/views/files/Uploader';
 
 const testFile = { id: 'test' };
 function makeWrapper(props = {}, file = {}) {
+  const store = factory();
   return mount(FileUploadItem, {
     store,
     attachToDocument: true,
@@ -53,12 +54,24 @@ describe('fileUploadItem', () => {
     beforeEach(() => {
       wrapper = makeWrapper();
     });
-    it('Uploader emitted uploading event should get emitted with emitted file', () => {
+    it('Uploader uploadingHandler should call uploadingHandler with file', () => {
       const file = {
-        checksum: 'file-1',
+        id: 'file-1',
       };
-      wrapper.find(Uploader).vm.$emit('uploading', file);
-      expect(wrapper.emitted('uploading')[0][0]).toBe(file);
+      const uploadingHandler = jest.fn();
+      wrapper.setMethods({ uploadingHandler });
+      wrapper.find(Uploader).vm.uploadingHandler(file);
+      expect(uploadingHandler).toHaveBeenCalledWith(file);
+    });
+    it('Uploader uploadCompleteHandler should call uploadCompleteHandler with file', () => {
+      const file = {
+        id: 'file-1',
+      };
+      const uploadCompleteHandler = jest.fn();
+      wrapper.setProps({ uploadCompleteHandler });
+      wrapper.setData({ fileUploadId: file.id });
+      wrapper.find(Uploader).vm.uploadCompleteHandler(file);
+      expect(uploadCompleteHandler).toHaveBeenCalledWith(file);
     });
     it('clicking a list item should emit a selected event if a file is available', () => {
       wrapper.find('[data-test="list-item"]').trigger('click');

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
@@ -1,9 +1,10 @@
 import { mount } from '@vue/test-utils';
 import SupplementaryItem from '../supplementaryLists/SupplementaryItem';
-import store from '../../../store';
+import { factory } from '../../../store';
 import Uploader from 'shared/views/files/Uploader';
 
 function makeWrapper(props = {}) {
+  const store = factory();
   return mount(SupplementaryItem, {
     store,
     attachToDocument: true,
@@ -39,9 +40,15 @@ describe('supplementaryItem', () => {
     wrapper.setProps({ readonly: true });
     expect(wrapper.find('[data-test="remove"]').exists()).toBe(false);
   });
-  it('should emit an uploading event when Uploader starts uploading file', () => {
-    wrapper.find(Uploader).vm.$emit('uploading', { checksum: 'file1' });
-    expect(wrapper.emitted('uploading')[0][0].checksum).toBe('file1');
+  it('should call uploadingHandler when Uploader starts uploading file', () => {
+    wrapper.find(Uploader).vm.uploadingHandler({ id: 'file1' });
+    expect(wrapper.vm.fileUploadId).toBe('file1');
+  });
+  it('should call uploadCompleteHandler when Uploader finishes uploading file', () => {
+    const uploadCompleteHandler = jest.fn();
+    wrapper.setProps({ uploadCompleteHandler });
+    wrapper.find(Uploader).vm.uploadCompleteHandler({ id: 'file1' });
+    expect(uploadCompleteHandler).toHaveBeenCalledWith({ id: 'file1' });
   });
   it('uploading should be true if progress < 1', () => {
     expect(wrapper.find('[data-test="uploading"]').exists()).toBe(false);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryList.spec.js
@@ -1,13 +1,14 @@
 import { mount } from '@vue/test-utils';
 import SupplementaryList from '../supplementaryLists/SupplementaryList';
 import SupplementaryItem from '../supplementaryLists/SupplementaryItem';
-import store from '../../../store';
+import { factory } from '../../../store';
 import Uploader from 'shared/views/files/Uploader';
 
 const testNodeId = 'testnode';
 const testFile = { id: 'file-1', language: { id: 'en' }, preset: { id: 'video_subtitle' } };
 
 function makeWrapper() {
+  const store = factory();
   return mount(SupplementaryList, {
     store,
     attachToDocument: true,
@@ -59,18 +60,18 @@ describe('supplementaryList', () => {
       expect(deleteFile).toHaveBeenCalled();
       expect(deleteFile.mock.calls[0][0]).toEqual(testFile);
     });
-    it('emitted uploading event should call updateFile action', () => {
+    it('calling uploadCompleteHandler should call updateFile action', () => {
       let updateFile = jest.fn();
       wrapper.setMethods({ updateFile });
 
       let listItem = wrapper.find(SupplementaryItem);
       let replacementFile = { id: 'replacementFile' };
-      listItem.vm.$emit('uploading', replacementFile);
+      listItem.vm.uploadCompleteHandler(replacementFile);
       expect(updateFile).toHaveBeenCalled();
       expect(updateFile.mock.calls[0][0].id).toBe(replacementFile.id);
       expect(updateFile.mock.calls[0][0].language.id).toBe('en');
     });
-    it('emitted uploading event from Uploader should call updateFile', () => {
+    it('calling uploadingHandler on Uploader should call updateFile', () => {
       let uploadFile = { id: 'filetest' };
       let updateFile = jest.fn(() => Promise.resolve());
       let uploader = wrapper.find(Uploader);
@@ -78,7 +79,7 @@ describe('supplementaryList', () => {
       wrapper.setMethods({ updateFile });
       wrapper.setData({ selectedLanguage: 'en-PT' });
 
-      uploader.vm.$emit('uploading', uploadFile);
+      uploader.vm.uploadingHandler(uploadFile);
 
       expect(updateFile).toHaveBeenCalled();
       expect(updateFile.mock.calls[0][0].id).toBe(uploadFile.id);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryList.spec.js
@@ -59,30 +59,30 @@ describe('supplementaryList', () => {
       expect(deleteFile).toHaveBeenCalled();
       expect(deleteFile.mock.calls[0][0]).toEqual(testFile);
     });
-    it('emitted uploading event should call createFile action', () => {
-      let createFile = jest.fn();
-      wrapper.setMethods({ createFile });
+    it('emitted uploading event should call updateFile action', () => {
+      let updateFile = jest.fn();
+      wrapper.setMethods({ updateFile });
 
       let listItem = wrapper.find(SupplementaryItem);
       let replacementFile = { id: 'replacementFile' };
       listItem.vm.$emit('uploading', replacementFile);
-      expect(createFile).toHaveBeenCalled();
-      expect(createFile.mock.calls[0][0].id).toBe(replacementFile.id);
-      expect(createFile.mock.calls[0][0].language.id).toBe('en');
+      expect(updateFile).toHaveBeenCalled();
+      expect(updateFile.mock.calls[0][0].id).toBe(replacementFile.id);
+      expect(updateFile.mock.calls[0][0].language.id).toBe('en');
     });
-    it('emitted uploading event from Uploader should call createFile', () => {
+    it('emitted uploading event from Uploader should call updateFile', () => {
       let uploadFile = { id: 'filetest' };
-      let createFile = jest.fn(() => Promise.resolve());
+      let updateFile = jest.fn(() => Promise.resolve());
       let uploader = wrapper.find(Uploader);
 
-      wrapper.setMethods({ createFile });
+      wrapper.setMethods({ updateFile });
       wrapper.setData({ selectedLanguage: 'en-PT' });
 
       uploader.vm.$emit('uploading', uploadFile);
 
-      expect(createFile).toHaveBeenCalled();
-      expect(createFile.mock.calls[0][0].id).toBe(uploadFile.id);
-      expect(createFile.mock.calls[0][0].language).toBe('en-PT');
+      expect(updateFile).toHaveBeenCalled();
+      expect(updateFile.mock.calls[0][0].id).toBe(uploadFile.id);
+      expect(updateFile.mock.calls[0][0].language).toBe('en-PT');
     });
   });
   describe('uploading workflow', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/thumbnailGenerator.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/thumbnailGenerator.spec.js
@@ -1,8 +1,9 @@
 import { mount } from '@vue/test-utils';
 import ThumbnailGenerator from '../thumbnails/ThumbnailGenerator';
-import store from '../../../store';
+import { factory } from '../../../store';
 
 function makeWrapper(filePath) {
+  const store = factory();
   return mount(ThumbnailGenerator, {
     store,
     attachToDocument: true,
@@ -17,7 +18,8 @@ describe('thumbnailGenerator', () => {
   it('correct generation code should be called', () => {
     let generateVideoThumbnail = jest.fn();
     let videoWrapper = makeWrapper('test.mp4');
-    videoWrapper.setMethods({ generateVideoThumbnail });
+    const fileExists = jest.fn(() => true);
+    videoWrapper.setMethods({ fileExists, generateVideoThumbnail });
     videoWrapper.vm.generate();
     expect(generateVideoThumbnail).toHaveBeenCalled();
 
@@ -29,7 +31,17 @@ describe('thumbnailGenerator', () => {
   });
   it('error alert should show if the file path is an unrecognized type', () => {
     let wrapper = makeWrapper('test.wut');
+    const fileExists = jest.fn(() => true);
+    wrapper.setMethods({ fileExists });
     wrapper.vm.generate();
     expect(wrapper.vm.showErrorAlert).toBe(true);
+  });
+  it('handleGenerated should not call handleFiles if cancelled', () => {
+    let wrapper = makeWrapper('test.wut');
+    const handleFiles = jest.fn(() => true);
+    wrapper.setMethods({ handleFiles });
+    wrapper.setData({ cancelled: true });
+    wrapper.vm.handleGenerated('');
+    expect(handleFiles).not.toHaveBeenCalled();
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
@@ -15,8 +15,8 @@
             </span>
             <FileStatusText
               v-else-if="file.error"
+              :id="file.id"
               data-test="error"
-              :checksum="file.checksum"
               @open="openFileDialog"
             />
             <ActionLink
@@ -34,7 +34,7 @@
         <VListTileContent>
           <VListTileTitle class="text-xs-right grey--text">
             <span v-if="file.uploading" data-test="uploading">
-              <FileStatusText :checksum="file.checksum" />
+              <FileStatusText :id="file.id" />
             </span>
             <span v-else-if="!file.error">
               {{ formatFileSize(file.file_size) }}

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
@@ -16,7 +16,7 @@
             </span>
             <FileStatusText
               v-else-if="fileDisplay.error"
-              :id="fileDisplay.id"
+              :fileId="fileDisplay.id"
               data-test="error"
               @open="openFileDialog"
             />
@@ -35,7 +35,7 @@
         <VListTileContent>
           <VListTileTitle class="text-xs-right grey--text">
             <span v-if="fileDisplay.uploading" data-test="uploading">
-              <FileStatusText :id="fileDisplay.id" @open="openFileDialog" />
+              <FileStatusText :fileId="fileDisplay.id" @open="openFileDialog" />
             </span>
             <span v-else-if="!fileDisplay.error">
               {{ formatFileSize(fileDisplay.file_size) }}

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
@@ -14,17 +14,18 @@
             <span v-if="readonly || fileDisplay.uploading">
               {{ fileDisplay.original_filename }}
             </span>
-            <FileStatusText
-              v-else-if="fileDisplay.error"
-              :fileId="fileDisplay.id"
-              data-test="error"
-              @open="openFileDialog"
-            />
             <ActionLink
               v-else
               data-test="upload-file"
               :text="fileDisplay.original_filename"
               @click="openFileDialog"
+            />
+            <FileStatusText
+              v-if="erroredFile"
+              :fileId="erroredFile.id"
+              :readonly="Boolean(fileUploadId)"
+              data-test="error"
+              @open="openFileDialog"
             />
           </VListTileTitle>
           <VListTileSubTitle v-if="fileDisplay.language">
@@ -106,6 +107,15 @@
           return this.fileUpload;
         }
         return this.file;
+      },
+      erroredFile() {
+        if (this.fileUpload && this.fileUpload.error) {
+          return this.fileUpload;
+        }
+        if (this.file && this.file.error) {
+          return this.file;
+        }
+        return null;
       },
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryItem.vue
@@ -4,40 +4,41 @@
     :key="file.id"
     :presetID="presetID"
     :readonly="readonly"
-    @uploading="newFile => $emit('uploading', newFile)"
+    :uploadCompleteHandler="uploadCompleteHandler"
+    :uploadingHandler="uploadingHandler"
   >
     <template #default="{openFileDialog}">
-      <VListTile @click="!readonly && !uploading && openFileDialog()">
+      <VListTile @click="!readonly && !fileDisplay.uploading && openFileDialog()">
         <VListTileContent>
           <VListTileTitle>
-            <span v-if="readonly || file.uploading">
-              {{ file.original_filename }}
+            <span v-if="readonly || fileDisplay.uploading">
+              {{ fileDisplay.original_filename }}
             </span>
             <FileStatusText
-              v-else-if="file.error"
-              :id="file.id"
+              v-else-if="fileDisplay.error"
+              :id="fileDisplay.id"
               data-test="error"
               @open="openFileDialog"
             />
             <ActionLink
               v-else
               data-test="upload-file"
-              :text="file.original_filename"
+              :text="fileDisplay.original_filename"
               @click="openFileDialog"
             />
           </VListTileTitle>
-          <VListTileSubTitle>
+          <VListTileSubTitle v-if="fileDisplay.language">
             {{ $tr('languageText', {
-              language: file.language.native_name, code: file.language.id}) }}
+              language: fileDisplay.language.native_name, code: fileDisplay.language.id}) }}
           </VListTileSubTitle>
         </VListTileContent>
         <VListTileContent>
           <VListTileTitle class="text-xs-right grey--text">
-            <span v-if="file.uploading" data-test="uploading">
-              <FileStatusText :id="file.id" />
+            <span v-if="fileDisplay.uploading" data-test="uploading">
+              <FileStatusText :id="fileDisplay.id" @open="openFileDialog" />
             </span>
-            <span v-else-if="!file.error">
-              {{ formatFileSize(file.file_size) }}
+            <span v-else-if="!fileDisplay.error">
+              {{ formatFileSize(fileDisplay.file_size) }}
             </span>
           </VListTileTitle>
         </VListTileContent>
@@ -56,6 +57,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import FileStatusText from 'shared/views/files/FileStatusText';
   import { fileSizeMixin } from 'shared/mixins';
   import Uploader from 'shared/views/files/Uploader';
@@ -79,6 +81,36 @@
       readonly: {
         type: Boolean,
         default: false,
+      },
+      uploadCompleteHandler: {
+        type: Function,
+        required: false,
+      },
+    },
+    data() {
+      return {
+        fileUploadId: null,
+      };
+    },
+    computed: {
+      ...mapGetters('file', ['getFileUpload']),
+      fileUpload() {
+        return this.fileUploadId && this.getFileUpload(this.fileUploadId);
+      },
+      fileDisplay() {
+        if (
+          this.fileUpload &&
+          (!this.file || this.fileUpload.id !== this.file.id) &&
+          !this.fileUpload.error
+        ) {
+          return this.fileUpload;
+        }
+        return this.file;
+      },
+    },
+    methods: {
+      uploadingHandler(fileUpload) {
+        this.fileUploadId = fileUpload.id;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
@@ -7,7 +7,7 @@
       :file="file"
       :presetID="presetID"
       :readonly="readonly"
-      @uploading="newFile => replace(file, newFile)"
+      :uploadCompleteHandler="newFile => replace(file, newFile)"
       @remove="deleteFile(file)"
     />
     <Uploader

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
@@ -14,7 +14,7 @@
       v-if="!readonly"
       :readonly="!addingFile || !selectedLanguage"
       :presetID="presetID"
-      @uploading="add"
+      :uploadingHandler="add"
     >
       <template #default="{openFileDialog}">
         <VListTile @click.stop>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
@@ -114,12 +114,12 @@
       },
     },
     methods: {
-      ...mapActions('file', ['createFile', 'deleteFile']),
+      ...mapActions('file', ['updateFile', 'deleteFile']),
       add(file) {
         this.makeFile(file).then(this.reset);
       },
       makeFile(file) {
-        return this.createFile({
+        return this.updateFile({
           ...file,
           language: file.language || this.selectedLanguage,
           preset: this.presetID,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -7,7 +7,7 @@
         <VLayout row align-center :class="hasError? 'red--text' : 'grey--text'" class="body-1">
           <FileStatusText
             v-if="value && value.error || uploading"
-            :checksum="value && value.checksum"
+            :id="value && value.id"
             @open="openFileDialog"
           />
           <template v-else>
@@ -34,7 +34,7 @@
                   data-test="generating"
                   color="greenSuccess"
                 />
-                <FileStatus v-else :checksum="value.checksum" large data-test="progress" />
+                <FileStatus v-else :id="value.id" large data-test="progress" />
               </p>
               <ActionLink
                 v-if="!hasError"
@@ -263,7 +263,7 @@
         if (this.generating) {
           return this.$tr('generatingThumbnail');
         } else if (this.hasError) {
-          return this.errorMessage(this.value.checksum);
+          return this.errorMessage(this.value.id);
         } else if (this.uploading) {
           return this.$tr('uploadingThumbnail');
         } else if (!this.value) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -1,7 +1,11 @@
 <template>
 
   <div :key="`thumbnail-${nodeId}-${fileUploadId || (value && value.id)}`">
-    <Uploader :presetID="thumbnailPresetID" @uploading="handleUploading">
+    <Uploader
+      :presetID="thumbnailPresetID"
+      :uploadingHandler="handleUploading"
+      :uploadCompleteHandler="handleUploadComplete"
+    >
       <template #default="{openFileDialog, handleFiles}">
         <!-- Thumbnail status -->
         <VLayout row align-center :class="hasError? 'red--text' : 'grey--text'" class="body-1">
@@ -339,14 +343,6 @@
       hasError(error) {
         if (error) this.reset();
       },
-      fileUpload: {
-        deep: true,
-        handler(newValue, oldValue) {
-          if (newValue && !newValue.uploading && !(oldValue && !oldValue.uploading)) {
-            this.handleUploadFinished();
-          }
-        },
-      },
     },
     methods: {
       ...mapActions('file', ['deleteFile']),
@@ -356,11 +352,13 @@
         this.newEncoding = {};
         this.fileUploadId = fileUpload.id;
       },
-      handleUploadFinished() {
-        this.$nextTick(() => {
-          this.startCropping(true);
-          this.generating = false;
-        });
+      handleUploadComplete(fileUpload) {
+        if (fileUpload.id === this.fileUploadId) {
+          this.$nextTick(() => {
+            this.startCropping(true);
+            this.generating = false;
+          });
+        }
       },
       startGenerating() {
         this.generating = true;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -262,7 +262,7 @@
         return this.uploading || this.generating;
       },
       hasError() {
-        return this.fileUpload && this.fileUpload.error;
+        return Boolean(this.fileUpload && this.fileUpload.error);
       },
       showFileSize() {
         return this.fileUpload && !this.hasError && !this.loading && !this.cropping;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -276,7 +276,7 @@
         return fileparts.slice(0, fileparts.length - 1).join('.');
       },
       thumbnailSrc() {
-        return this.value && this.value.url;
+        return this.value && (this.value.uploading ? this.value.previewSrc : this.value.url);
       },
       uploading() {
         return this.value && this.value.uploading;
@@ -312,9 +312,9 @@
         this.lastEncoding = this.encoding;
         this.$emit('encoded', null);
         this.$emit('input', {
+          ...fileUpload,
           preset: this.thumbnailPresetID,
           contentnode: this.nodeId,
-          ...fileUpload,
         });
         this.startCropping(true);
         this.generating = false;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -11,7 +11,7 @@
         <VLayout row align-center :class="hasError? 'red--text' : 'grey--text'" class="body-1">
           <FileStatusText
             v-if="fileUpload && fileUpload.error || uploading"
-            :id="fileUpload && fileUpload.id"
+            :fileId="fileUpload && fileUpload.id"
             @open="openFileDialog"
           />
           <template v-else>
@@ -38,7 +38,7 @@
                   data-test="generating"
                   color="greenSuccess"
                 />
-                <FileStatus v-else :id="fileUpload.id" large data-test="progress" />
+                <FileStatus v-else :fileId="fileUpload.id" large data-test="progress" />
               </p>
               <ActionLink
                 v-if="!hasError"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -365,6 +365,9 @@
         this.removeOnCancel = true;
       },
       cancelPendingFile() {
+        if (this.generating) {
+          this.$refs.generator.cancel();
+        }
         if (this.removeOnCancel) {
           if (this.fileUpload) {
             this.deleteFile(this.fileUpload);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
@@ -20,6 +20,7 @@
   import max from 'lodash/max';
   import pdfJSLib from 'pdfjs-dist';
   import epubJS from 'epubjs';
+  import client from 'shared/client';
   import Alert from 'shared/views/Alert';
   import { ASPECT_RATIO, THUMBNAIL_WIDTH } from 'shared/constants';
   // Based off of solution here: https://github.com/mozilla/pdf.js/issues/7612
@@ -190,20 +191,25 @@
         const file = new File(byteArrays, filename, { type: 'image/png' });
         this.handleFiles([file]);
       },
-      generate() {
-        this.$emit('generating');
-        if (this.isVideo) {
-          this.generateVideoThumbnail();
-        } else if (this.isAudio) {
-          this.generateAudioThumbnail();
-        } else if (this.isPDF) {
-          this.generatePDFThumbnail();
-        } else if (this.isEPub) {
-          this.generateEPubThumbnail();
-        } else if (this.isHTML) {
-          this.generateThumbnailOnServer();
-        } else {
-          this.handleError();
+      async generate() {
+        try {
+          await client.head(this.filePath);
+          this.$emit('generating');
+          if (this.isVideo) {
+            this.generateVideoThumbnail();
+          } else if (this.isAudio) {
+            this.generateAudioThumbnail();
+          } else if (this.isPDF) {
+            this.generatePDFThumbnail();
+          } else if (this.isEPub) {
+            this.generateEPubThumbnail();
+          } else if (this.isHTML) {
+            this.generateThumbnailOnServer();
+          } else {
+            throw TypeError('Unrecognized content!');
+          }
+        } catch (e) {
+          this.handleError(e);
         }
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
@@ -21,6 +21,7 @@
   import pdfJSLib from 'pdfjs-dist';
   import epubJS from 'epubjs';
   import Alert from 'shared/views/Alert';
+  import { ASPECT_RATIO, THUMBNAIL_WIDTH } from 'shared/constants';
   // Based off of solution here: https://github.com/mozilla/pdf.js/issues/7612
   import PDFJSWorker from '!!file-loader!pdfjs-dist/build/pdf.worker.min.js';
 
@@ -33,10 +34,6 @@
       Alert,
     },
     props: {
-      width: {
-        type: Number,
-        default: 320,
-      },
       filePath: {
         type: String,
         required: false,
@@ -53,8 +50,11 @@
       };
     },
     computed: {
+      width() {
+        return THUMBNAIL_WIDTH;
+      },
       height() {
-        return (this.width * 9) / 16;
+        return this.width / ASPECT_RATIO;
       },
       isVideo() {
         return this.filePath.endsWith('mp4');

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -162,7 +162,6 @@ export function createContentNode(context, { parent, kind = ContentKindsNames.TO
     title: '',
     description: '',
     kind,
-    files: [],
     tags: {},
     extra_fields: {},
     isNew: true,
@@ -175,10 +174,6 @@ export function createContentNode(context, { parent, kind = ContentKindsNames.TO
   };
 
   return ContentNode.put(contentNodeData).then(id => {
-    // Add files to content node
-    contentNodeData.files.forEach(file => {
-      context.dispatch('file/updateFile', { id: file, contentnode: id }, { root: true });
-    });
     context.commit('ADD_CONTENTNODE', {
       id,
       ...contentNodeData,

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -63,6 +63,8 @@ export const MAX_FILE_SIZE = 209715200;
 
 export const ASPECT_RATIO = 16 / 9;
 
+export const THUMBNAIL_WIDTH = 250;
+
 export const ONE_B = 1;
 export const ONE_KB = 10 ** 3;
 export const ONE_MB = 10 ** 6;

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -57,12 +57,12 @@ export const fileStatusMixin = {
     ...mapGetters('file', ['getFileUpload']),
   },
   methods: {
-    statusMessage(checksum) {
-      const errorMessage = this.errorMessage(checksum);
+    statusMessage(id) {
+      const errorMessage = this.errorMessage(id);
       if (errorMessage) {
         return errorMessage;
       }
-      const file = this.getFileUpload(checksum);
+      const file = this.getFileUpload(id);
       if (file && file.total) {
         return statusStrings.$tr('uploadFileSize', {
           uploaded: bytesForHumans(file.loaded),
@@ -70,8 +70,8 @@ export const fileStatusMixin = {
         });
       }
     },
-    errorMessage(checksum) {
-      const file = this.getFileUpload(checksum);
+    errorMessage(id) {
+      const file = this.getFileUpload(id);
       if (!file) {
         return;
       }

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/ImagesMenu/ImagesMenu.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/ImagesMenu/ImagesMenu.vue
@@ -23,9 +23,9 @@
       <VCardText>
         <div class="body-1 mb-2 mx-2">
           <FileStatusText
-            v-if="uploadingChecksum"
+            v-if="uploadingId"
+            :id="uploadingId"
             permanent
-            :checksum="uploadingChecksum"
             @open="openFileDialog"
           />
           <span v-else-if="fileSrc" class="grey--text">
@@ -47,7 +47,7 @@
               <VLayout wrap align-center justify-center style="max-height: 0px;">
                 <div class="text-xs-center" style="position: absolute;">
                   <p>
-                    <FileStatus :checksum="uploadingChecksum" large />
+                    <FileStatus :id="uploadingId" large />
                   </p>
                   <ActionLink
                     v-if="!hasError"
@@ -152,7 +152,7 @@
     },
     data() {
       return {
-        uploadingChecksum: '',
+        uploadingId: '',
         altText: '',
       };
     },
@@ -174,7 +174,7 @@
         return FormatPresetsMap.get(this.imagePreset).allowed_formats.join(', ');
       },
       file() {
-        return this.getFileUpload(this.uploadingChecksum);
+        return this.getFileUpload(this.uploadingId);
       },
       fileSrc() {
         return (this.file && this.file.url) || this.src;
@@ -203,13 +203,13 @@
       handleFiles(files) {
         this.handleFileUpload(files).then(files => {
           const fileUpload = files[0];
-          if (fileUpload && fileUpload.checksum) {
-            this.uploadingChecksum = fileUpload.checksum;
+          if (fileUpload && fileUpload.id) {
+            this.uploadingId = fileUpload.id;
           }
         });
       },
       cancelPendingFile() {
-        this.uploadingChecksum = '';
+        this.uploadingId = '';
       },
       openFileDialog() {
         this.$refs.fileUpload.click();

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/ImagesMenu/ImagesMenu.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/ImagesMenu/ImagesMenu.vue
@@ -24,7 +24,7 @@
         <div class="body-1 mb-2 mx-2">
           <FileStatusText
             v-if="uploadingId"
-            :id="uploadingId"
+            :fileId="uploadingId"
             permanent
             @open="openFileDialog"
           />
@@ -47,7 +47,7 @@
               <VLayout wrap align-center justify-center style="max-height: 0px;">
                 <div class="text-xs-center" style="position: absolute;">
                   <p>
-                    <FileStatus :id="uploadingId" large />
+                    <FileStatus :fileId="uploadingId" large />
                   </p>
                   <ActionLink
                     v-if="!hasError"

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -146,7 +146,7 @@
   import FileStatusText from 'shared/views/files/FileStatusText';
   import Thumbnail from 'shared/views/files/Thumbnail';
   import FileDropzone from 'shared/views/files/FileDropzone';
-  import { ASPECT_RATIO } from 'shared/constants';
+  import { ASPECT_RATIO, THUMBNAIL_WIDTH } from 'shared/constants';
 
   const DEFAULT_THUMBNAIL = {
     thumbnail: null,
@@ -177,10 +177,6 @@
         type: Boolean,
         default: false,
       },
-      width: {
-        type: Number,
-        default: 250,
-      },
     },
     data() {
       return {
@@ -201,6 +197,9 @@
       },
       uploading() {
         return this.uploadingId && this.file.uploading;
+      },
+      width() {
+        return THUMBNAIL_WIDTH;
       },
       height() {
         return this.width / ASPECT_RATIO;

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -21,7 +21,7 @@
               <VLayout wrap align-center justify-center style="max-height: 0px;">
                 <div class="text-xs-center" style="position: absolute;">
                   <p>
-                    <FileStatus :id="uploadingId" large data-test="progress" />
+                    <FileStatus :fileId="uploadingId" large data-test="progress" />
                   </p>
                   <ActionLink
                     v-if="!hasError"
@@ -71,7 +71,7 @@
           <template v-if="hasError">
             <span class="red--text body-1">
               <FileStatusText
-                :id="uploadingId"
+                :fileId="uploadingId"
                 @open="openFileDialog"
               />
             </span>

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -120,14 +120,14 @@
               @click="openFileDialog"
             />
             <IconButton
-              v-if="thumbnailSrc || displayEncoding"
+              v-if="hasThumbnail"
               icon="crop"
               :text="$tr('crop')"
               @click="cropping = true"
             />
             <VSpacer />
             <IconButton
-              v-if="thumbnailSrc || displayEncoding"
+              v-if="hasThumbnail"
               icon="clear"
               data-test="remove"
               :text="$tr('remove')"
@@ -224,7 +224,10 @@
         if (this.newEncoding) {
           return this.newEncoding;
         }
-        return this.value.thumbnail_encoding && this.value.thumbnail_encoding.base64;
+        return this.value.thumbnail_encoding;
+      },
+      hasThumbnail() {
+        return this.thumbnailSrc.length || Object.keys(this.displayEncoding || {}).length;
       },
     },
     methods: {
@@ -256,7 +259,7 @@
 
       /* CROPPING FUNCTION */
       cropperLoaded() {
-        this.Cropper.applyMetadata(this.value.thumbnail_encoding);
+        this.Cropper.applyMetadata(this.displayEncoding);
       },
       cropZoomIn() {
         if (!this.zoomInterval) {
@@ -278,17 +281,25 @@
       },
       remove() {
         this.updateThumbnail(DEFAULT_THUMBNAIL);
+        this.newEncoding = null;
+        this.reset();
       },
       save() {
         this.newEncoding = {
           ...this.Cropper.getMetadata(),
           base64: this.Cropper.generateDataUrl(),
         };
-        this.updateThumbnail({
-          thumbnail: `${this.file.checksum}.${this.file.file_format}`,
-          thumbnail_url: this.file.url,
-          thumbnail_encoding: this.newEncoding,
-        });
+        if (this.file) {
+          this.updateThumbnail({
+            thumbnail: `${this.file.checksum}.${this.file.file_format}`,
+            thumbnail_url: this.file.url,
+            thumbnail_encoding: this.newEncoding,
+          });
+        } else {
+          this.updateThumbnail({
+            thumbnail_encoding: this.newEncoding,
+          });
+        }
         this.reset();
       },
     },

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -20,7 +20,7 @@
               <VLayout wrap align-center justify-center style="max-height: 0px;">
                 <div class="text-xs-center" style="position: absolute;">
                   <p>
-                    <FileStatus :checksum="uploadingChecksum" large data-test="progress" />
+                    <FileStatus :id="uploadingId" large data-test="progress" />
                   </p>
                   <ActionLink
                     v-if="!hasError"
@@ -67,7 +67,7 @@
           <template v-if="hasError">
             <span class="red--text body-1">
               <FileStatusText
-                :checksum="uploadingChecksum"
+                :id="uploadingId"
                 @open="openFileDialog"
               />
             </span>
@@ -188,19 +188,19 @@
         lastThumbnail: null,
         Cropper: {},
         zoomInterval: null,
-        uploadingChecksum: null,
+        uploadingId: null,
       };
     },
     computed: {
       ...mapGetters('file', ['getFileUpload']),
       file() {
-        return this.getFileUpload(this.uploadingChecksum);
+        return this.getFileUpload(this.uploadingId);
       },
       hasError() {
         return this.file && this.file.error;
       },
       uploading() {
-        return this.uploadingChecksum && this.file.uploading;
+        return this.uploadingId && this.file.uploading;
       },
       height() {
         return this.width / ASPECT_RATIO;
@@ -212,7 +212,7 @@
     },
     watch: {
       uploading(uploading) {
-        if (!uploading && this.uploadingChecksum) {
+        if (!uploading && this.uploadingId) {
           this.updateThumbnail({
             thumbnail: `${this.file.checksum}.${this.file.file_format}`,
             thumbnail_url: this.file.url,
@@ -230,8 +230,8 @@
         this.$emit('input', thumbnailData);
       },
       handleUploading(fileUpload) {
-        if (fileUpload.checksum) {
-          this.uploadingChecksum = fileUpload.checksum;
+        if (fileUpload.id) {
+          this.uploadingId = fileUpload.id;
           this.cropping = true;
         }
       },
@@ -260,7 +260,7 @@
       },
       reset() {
         this.cropping = false;
-        this.uploadingChecksum = null;
+        this.uploadingId = null;
       },
       remove() {
         this.updateThumbnail(DEFAULT_THUMBNAIL);

--- a/contentcuration/contentcuration/frontend/shared/views/files/FileStatus.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/FileStatus.vue
@@ -39,7 +39,7 @@
     name: 'FileStatus',
     mixins: [fileSizeMixin, fileStatusMixin],
     props: {
-      id: {
+      fileId: {
         type: String,
         required: true,
       },
@@ -51,11 +51,11 @@
     computed: {
       ...mapGetters('file', ['getFileUpload']),
       progress() {
-        const file = this.getFileUpload(this.id);
+        const file = this.getFileUpload(this.fileId);
         return file && file.progress;
       },
       hasErrors() {
-        return Boolean(this.errorMessage(this.id));
+        return Boolean(this.errorMessage(this.fileId));
       },
     },
   };

--- a/contentcuration/contentcuration/frontend/shared/views/files/FileStatus.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/FileStatus.vue
@@ -7,7 +7,7 @@
           error
         </Icon>
       </template>
-      <span>{{ statusMessage(checksum) }}</span>
+      <span>{{ statusMessage(id) }}</span>
     </VTooltip>
     <Icon
       v-else-if="progress >= 1"
@@ -39,7 +39,7 @@
     name: 'FileStatus',
     mixins: [fileSizeMixin, fileStatusMixin],
     props: {
-      checksum: {
+      id: {
         type: String,
         required: true,
       },
@@ -51,11 +51,11 @@
     computed: {
       ...mapGetters('file', ['getFileUpload']),
       progress() {
-        const file = this.getFileUpload(this.checksum);
+        const file = this.getFileUpload(this.id);
         return file && file.progress;
       },
       hasErrors() {
-        return Boolean(this.errorMessage(this.checksum));
+        return Boolean(this.errorMessage(this.id));
       },
     },
   };

--- a/contentcuration/contentcuration/frontend/shared/views/files/FileStatusText.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/FileStatusText.vue
@@ -34,7 +34,7 @@
     name: 'FileStatusText',
     mixins: [fileStatusMixin],
     props: {
-      id: {
+      fileId: {
         type: String,
         required: true,
       },
@@ -51,13 +51,13 @@
     computed: {
       ...mapGetters('file', ['getFileUpload']),
       file() {
-        return this.getFileUpload(this.id);
+        return this.getFileUpload(this.fileId);
       },
       uploading() {
         return this.file && this.file.uploading;
       },
       message() {
-        return this.statusMessage(this.id);
+        return this.statusMessage(this.fileId);
       },
       invalidFile() {
         return this.file && this.file.error;

--- a/contentcuration/contentcuration/frontend/shared/views/files/FileStatusText.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/FileStatusText.vue
@@ -34,7 +34,7 @@
     name: 'FileStatusText',
     mixins: [fileStatusMixin],
     props: {
-      checksum: {
+      id: {
         type: String,
         required: true,
       },
@@ -51,13 +51,13 @@
     computed: {
       ...mapGetters('file', ['getFileUpload']),
       file() {
-        return this.getFileUpload(this.checksum);
+        return this.getFileUpload(this.id);
       },
       uploading() {
         return this.file && this.file.uploading;
       },
       message() {
-        return this.statusMessage(this.checksum);
+        return this.statusMessage(this.id);
       },
       invalidFile() {
         return this.file && this.file.error;

--- a/contentcuration/contentcuration/frontend/shared/views/files/Uploader.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Uploader.vue
@@ -146,8 +146,9 @@
       },
       validateFiles(files) {
         // Get unsupported file types
-        let partitionedFiles = partition(files, f =>
-          this.acceptedExtensions.includes(last(f.name.split('.')).toLowerCase())
+        let partitionedFiles = partition(
+          files,
+          f => f && this.acceptedExtensions.includes(last(f.name.split('.')).toLowerCase())
         );
         files = partitionedFiles[0];
         this.unsupportedFiles = partitionedFiles[1];

--- a/contentcuration/contentcuration/frontend/shared/views/files/Uploader.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Uploader.vue
@@ -199,11 +199,9 @@
                   }
                 });
               }
-              const uploadingValue = this.allowMultiple ? objects : objects[0];
               if (isFunction(this.uploadingHandler)) {
-                this.uploadingHandler(uploadingValue);
+                this.uploadingHandler(this.allowMultiple ? objects : objects[0]);
               }
-              this.$emit('uploading', uploadingValue);
             }
             return objects;
           });

--- a/contentcuration/contentcuration/frontend/shared/views/files/Uploader.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Uploader.vue
@@ -177,14 +177,11 @@
           } else if (this.tooLargeFiles.length) {
             this.showTooLargeFilesAlert = true;
           }
-          return this.handleUploads(files).then(fileUploadObjects => {
-            if (fileUploadObjects.length) {
-              this.$emit(
-                'uploading',
-                this.allowMultiple ? fileUploadObjects : fileUploadObjects[0]
-              );
+          return this.handleUploads(files).then(fileObjects => {
+            if (fileObjects.length) {
+              this.$emit('uploading', this.allowMultiple ? fileObjects : fileObjects[0]);
             }
-            return fileUploadObjects;
+            return fileObjects;
           });
         }
       },
@@ -192,17 +189,13 @@
         // Catch any errors from file uploads and just
         // return null for the fileUploadObject if so
         return Promise.all(
-          [...files].map(file => this.uploadFile({ file }).catch(() => null))
-        ).then(fileUploadObjects => {
           // Make sure preset is getting set on files in case
           // need to distinguish between presets with same extension
           // (e.g. high res vs. low res videos)
-          if (this.presetID) {
-            fileUploadObjects.forEach(f => (f.preset = this.presetID));
-          }
-
+          [...files].map(file => this.uploadFile({ file, preset: this.presetID }).catch(() => null))
+        ).then(fileObjects => {
           // Filter out any null values here
-          return fileUploadObjects.filter(Boolean);
+          return fileObjects.filter(Boolean);
         });
       },
     },

--- a/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatus.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatus.spec.js
@@ -3,10 +3,16 @@ import FileStatus from '../FileStatus.vue';
 import storeFactory from 'shared/vuex/baseStore';
 import { fileErrors } from 'shared/constants';
 
+const preset = {
+  id: 'document',
+  supplementary: false,
+  order: 2,
+};
+
 const fileUploads = {
-  'file-1': { id: 'file-1', loaded: 2, total: 2 },
-  'file-2': { id: 'file-2', loaded: 1, total: 2 },
-  'file-3': { id: 'file-3', error: fileErrors.NO_STORAGE },
+  'file-1': { id: 'file-1', loaded: 2, total: 2, preset },
+  'file-2': { id: 'file-2', loaded: 1, total: 2, preset },
+  'file-3': { id: 'file-3', error: fileErrors.NO_STORAGE, preset },
 };
 
 function makeWrapper(fileId) {

--- a/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatus.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatus.spec.js
@@ -4,19 +4,19 @@ import storeFactory from 'shared/vuex/baseStore';
 import { fileErrors } from 'shared/constants';
 
 const fileUploads = {
-  'file-1': { checksum: 'file-1', loaded: 2, total: 2 },
-  'file-2': { checksum: 'file-2', loaded: 1, total: 2 },
-  'file-3': { checksum: 'file-3', error: fileErrors.NO_STORAGE },
+  'file-1': { id: 'file-1', loaded: 2, total: 2 },
+  'file-2': { id: 'file-2', loaded: 1, total: 2 },
+  'file-3': { id: 'file-3', error: fileErrors.NO_STORAGE },
 };
 
-function makeWrapper(checksum) {
+function makeWrapper(fileId) {
   const store = storeFactory();
-  store.state.file.fileUploadsMap[checksum] = fileUploads[checksum];
+  store.state.file.fileUploadsMap[fileId] = fileUploads[fileId];
   return mount(FileStatus, {
     store,
     attachToDocument: true,
     propsData: {
-      checksum,
+      fileId,
     },
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatusText.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatusText.spec.js
@@ -3,10 +3,16 @@ import FileStatusText from '../FileStatusText.vue';
 import storeFactory from 'shared/vuex/baseStore';
 import { fileErrors } from 'shared/constants';
 
+const preset = {
+  id: 'document',
+  supplementary: false,
+  order: 2,
+};
+
 const fileUploads = {
-  'file-1': { id: 'file-1', loaded: 2, total: 2 },
-  'file-2': { id: 'file-2', loaded: 1, total: 2 },
-  'file-3': { id: 'file-3', error: fileErrors.UPLOAD_FAILED },
+  'file-1': { id: 'file-1', loaded: 2, total: 2, preset },
+  'file-2': { id: 'file-2', loaded: 1, total: 2, preset },
+  'file-3': { id: 'file-3', error: fileErrors.UPLOAD_FAILED, preset },
 };
 
 function makeWrapper(fileId) {

--- a/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatusText.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/files/__tests__/fileStatusText.spec.js
@@ -4,19 +4,19 @@ import storeFactory from 'shared/vuex/baseStore';
 import { fileErrors } from 'shared/constants';
 
 const fileUploads = {
-  'file-1': { checksum: 'file-1', loaded: 2, total: 2 },
-  'file-2': { checksum: 'file-2', loaded: 1, total: 2 },
-  'file-3': { checksum: 'file-3', error: fileErrors.UPLOAD_FAILED },
+  'file-1': { id: 'file-1', loaded: 2, total: 2 },
+  'file-2': { id: 'file-2', loaded: 1, total: 2 },
+  'file-3': { id: 'file-3', error: fileErrors.UPLOAD_FAILED },
 };
 
-function makeWrapper(checksum) {
+function makeWrapper(fileId) {
   const store = storeFactory();
-  store.state.file.fileUploadsMap[checksum] = fileUploads[checksum];
+  store.state.file.fileUploadsMap[fileId] = fileUploads[fileId];
   return mount(FileStatusText, {
     store,
     attachToDocument: true,
     propsData: {
-      checksum,
+      fileId,
     },
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
@@ -83,39 +83,6 @@ describe('file store', () => {
         });
       });
     });
-    describe('createFile action', () => {
-      it('should add a new file with an id and other fields set', () => {
-        const payload = {
-          original_filename: 'abc.pdf',
-          file_size: 100,
-          contentnode,
-          checksum: 'checksum',
-          file_format: 'pdf',
-        };
-        return store.dispatch('file/createFile', payload).then(newId => {
-          const file = store.getters['file/getContentNodeFileById'](contentnode, newId);
-          expect(file).not.toBeUndefined();
-          expect(file.preset.id).toBe('document');
-          expect(file.file_size).toBe(100);
-          expect(file.uploaded_by).toBe(userId);
-          expect(file.original_filename).toBe('abc.pdf');
-        });
-      });
-      it('should set the preset if presetId is provided', () => {
-        const payload = {
-          name: 'abc.pdf',
-          size: 100,
-          preset: 'high_res_video',
-          contentnode,
-          checksum: 'checksum',
-        };
-        return store.dispatch('file/createFile', payload).then(newId => {
-          const file = store.getters['file/getContentNodeFileById'](contentnode, newId);
-          expect(file).not.toBeUndefined();
-          expect(file.preset.id).toBe('high_res_video');
-        });
-      });
-    });
     describe('updateFile action for an existing file', () => {
       it('should call File.update', () => {
         store.commit('file/ADD_FILE', {

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -136,19 +136,32 @@ export function uploadFileToStorage(
       });
     })
     .catch(() => {
-      return client.put(url, file, {
-        headers: {
-          'Content-Type': contentType,
-          'Content-MD5': hexToBase64(checksum),
-        },
-        onUploadProgress: progressEvent => {
+      return client
+        .put(url, file, {
+          headers: {
+            'Content-Type': contentType,
+            'Content-MD5': hexToBase64(checksum),
+          },
+          onUploadProgress: progressEvent => {
+            context.commit('ADD_FILE', {
+              checksum,
+              // Always assign loaded to a maximum of 1 less than the total
+              // to prevent progress being shown as 100% until the upload has
+              // completed
+              loaded: Math.min(progressEvent.loaded, progressEvent.total - 1),
+              total: progressEvent.total,
+            });
+          },
+        })
+        .then(() => {
+          // Set download progress to 100% now as we have confirmation of the
+          // completion of the file upload by the put request completing.
           context.commit('ADD_FILE', {
             checksum,
-            loaded: progressEvent.loaded,
-            total: progressEvent.total,
+            loaded: file.size,
+            total: file.size,
           });
-        },
-      });
+        });
     });
 }
 

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -194,6 +194,17 @@ export function uploadFile(context, { file, preset = null } = {}) {
             context.commit('ADD_FILE', fileObject);
             // Resolve with a summary of the uploaded file
             resolve(fileObject);
+            // Asynchronously generate file preview
+            const reader = new FileReader();
+            reader.readAsDataURL(file);
+            reader.onloadend = () => {
+              if (reader.result) {
+                context.commit('ADD_FILE', {
+                  checksum,
+                  previewSrc: reader.result,
+                });
+              }
+            };
             // 3. Upload file
             return context
               .dispatch('uploadFileToStorage', {

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -125,11 +125,7 @@ export function uploadFileToStorage(
   context,
   { id, file_format, mightSkip, checksum, file, url, contentType }
 ) {
-  let contentResponse = Promise.reject();
-  if (mightSkip) {
-    contentResponse = client.head(storageUrl(checksum, file_format));
-  }
-  return contentResponse
+  return (mightSkip ? client.head(storageUrl(checksum, file_format)) : Promise.reject())
     .then(() => {
       context.commit('ADD_FILE', {
         id,
@@ -200,7 +196,7 @@ export function uploadFile(context, { file, preset = null } = {}) {
             reader.onloadend = () => {
               if (reader.result) {
                 context.commit('ADD_FILE', {
-                  checksum,
+                  id: data.file.id,
                   previewSrc: reader.result,
                 });
               }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -1,8 +1,8 @@
-import { getHash, inferPreset } from './utils';
+import { getHash, inferPreset, storageUrl } from './utils';
 import { File } from 'shared/data/resources';
 import client from 'shared/client';
 import { fileErrors, NOVALUE } from 'shared/constants';
-import FormatPresetsMap, { FormatPresetsList } from 'shared/leUtils/FormatPresets';
+import FormatPresetsMap from 'shared/leUtils/FormatPresets';
 
 export function loadFiles(context, params = {}) {
   return File.where(params).then(files => {
@@ -22,36 +22,6 @@ export function loadFile(context, id) {
     });
 }
 
-export function createFile(context, file) {
-  const preset =
-    file.preset ||
-    FormatPresetsList.find(
-      ftype => ftype.allowed_formats.includes(file.file_format) && ftype.display
-    );
-  const newFile = generateFileData({
-    ...file,
-    preset,
-  });
-  newFile.uploaded_by = context.rootGetters.currentUserId;
-
-  return File.put(newFile).then(id => {
-    // Remove files with same preset/language combination
-    if (file.contentnode) {
-      const presetObj = FormatPresetsMap.get(preset.id || preset);
-      const files = context.getters.getContentNodeFiles(file.contentnode);
-      files
-        .filter(
-          f =>
-            f.preset.id === presetObj.id &&
-            (!presetObj.multi_language || f.language.id === newFile.language)
-        )
-        .forEach(f => context.dispatch('deleteFile', f));
-    }
-    context.commit('ADD_FILE', { id, ...newFile });
-    return id;
-  });
-}
-
 function generateFileData({
   checksum = NOVALUE,
   file_size = NOVALUE,
@@ -66,9 +36,6 @@ function generateFileData({
   source_url = NOVALUE,
   error = NOVALUE,
 } = {}) {
-  if (!contentnode || !assessment_item) {
-    throw ReferenceError('Either contentnode or assessment_item must be defined to update a file');
-  }
   const fileData = {};
   if (checksum !== NOVALUE) {
     fileData.checksum = checksum;
@@ -93,10 +60,10 @@ function generateFileData({
     fileData.file_format = file_format;
   }
   if (preset !== NOVALUE) {
-    fileData.preset = preset.id || preset;
+    fileData.preset = (preset || {}).id || preset;
   }
   if (language !== NOVALUE) {
-    fileData.language = language.id || language;
+    fileData.language = (language || {}).id || language;
   }
   if (original_filename !== NOVALUE) {
     fileData.original_filename = original_filename;
@@ -115,8 +82,22 @@ export function updateFile(context, { id, ...payload }) {
     throw ReferenceError('id must be defined to update a file');
   }
   const fileData = generateFileData(payload);
+
   context.commit('ADD_FILE', { id, ...fileData });
-  return File.update(id, fileData);
+  return File.update(id, fileData).then(() => {
+    // Remove files with same preset/language combination
+    if (fileData.contentnode) {
+      const presetObj = FormatPresetsMap.get(fileData.preset);
+      const files = context.getters.getContentNodeFiles(fileData.contentnode);
+      files
+        .filter(
+          f =>
+            f.preset.id === presetObj.id &&
+            (!presetObj.multi_language || f.language.id === fileData.language)
+        )
+        .forEach(f => context.dispatch('deleteFile', f));
+    }
+  });
 }
 
 export function deleteFile(context, file) {
@@ -138,68 +119,78 @@ function hexToBase64(str) {
   );
 }
 
-export function uploadFileToStorage(context, { checksum, file, url, contentType }) {
-  return client.put(url, file, {
-    headers: {
-      'Content-Type': contentType,
-      'Content-MD5': hexToBase64(checksum),
-    },
-    onUploadProgress: progressEvent => {
-      context.commit('ADD_FILEUPLOAD', {
+export function uploadFileToStorage(
+  context,
+  { file_format, mightSkip, checksum, file, url, contentType }
+) {
+  let contentResponse = Promise.reject();
+  if (mightSkip) {
+    contentResponse = client.head(storageUrl(checksum, file_format));
+  }
+  return contentResponse
+    .then(() => {
+      context.commit('ADD_FILE', {
         checksum,
-        loaded: progressEvent.loaded,
-        total: progressEvent.total,
+        loaded: file.size,
+        total: file.size,
       });
-    },
-  });
+    })
+    .catch(() => {
+      return client.put(url, file, {
+        headers: {
+          'Content-Type': contentType,
+          'Content-MD5': hexToBase64(checksum),
+        },
+        onUploadProgress: progressEvent => {
+          context.commit('ADD_FILE', {
+            checksum,
+            loaded: progressEvent.loaded,
+            total: progressEvent.total,
+          });
+        },
+      });
+    });
 }
 
-export function uploadFile(context, { file }) {
+export function uploadFile(context, { file, preset = null } = {}) {
   return new Promise((resolve, reject) => {
     // 1. Get the checksum of the file
-    Promise.all([getHash(file), inferPreset(file)])
+    Promise.all([getHash(file), preset ? Promise.resolve() : inferPreset(file)])
       .then(([checksum, presetId]) => {
         const file_format = file.name
           .split('.')
           .pop()
           .toLowerCase();
-        const fileUploadObject = {
-          checksum,
-          loaded: 0,
-          total: file.size,
-          file_size: file.size,
-          original_filename: file.name,
-          file_format,
-          preset: presetId,
-        };
-        context.commit('ADD_FILEUPLOAD', fileUploadObject);
         // 2. Get the upload url
-        client
-          .post(window.Urls.upload_url(), {
-            checksum,
-            size: file.size,
-            type: file.type,
-            name: file.name,
-          })
-          .then(response => {
-            if (!response) {
-              reject(fileErrors.UPLOAD_FAILED);
-              context.commit('ADD_FILEUPLOAD', {
-                checksum,
-                error: fileErrors.UPLOAD_FAILED,
-              });
-              return;
-            }
+        File.uploadUrl({
+          checksum,
+          size: file.size,
+          type: file.type,
+          name: file.name,
+          file_format,
+          preset: preset || presetId,
+        })
+          .then(data => {
+            const fileObject = {
+              ...data.file,
+              loaded: 0,
+              total: file.size,
+            };
+            context.commit('ADD_FILE', fileObject);
+            // Resolve with a summary of the uploaded file
+            resolve(fileObject);
             // 3. Upload file
             return context
               .dispatch('uploadFileToStorage', {
                 checksum,
                 file,
-                url: response.data['uploadURL'],
-                contentType: response.data['mimetype'],
+                file_format,
+                url: data['uploadURL'],
+                contentType: data['mimetype'],
+                mightSkip: data['might_skip'],
               })
               .catch(() => {
-                context.commit('ADD_FILEUPLOAD', {
+                context.commit('ADD_FILE', {
                   checksum,
                   error: fileErrors.UPLOAD_FAILED,
                 });
@@ -210,13 +201,20 @@ export function uploadFile(context, { file }) {
             if (error.response && error.response.status === 418) {
               errorType = fileErrors.NO_STORAGE;
             }
-            context.commit('ADD_FILEUPLOAD', {
+            const fileObject = {
               checksum,
+              loaded: 0,
+              total: file.size,
+              file_size: file.size,
+              original_filename: file.name,
+              file_format,
+              preset: presetId,
               error: errorType,
-            });
+            };
+            context.commit('ADD_FILE', fileObject);
+            // Resolve with a summary of the uploaded file
+            resolve(fileObject);
           }); // End get upload url
-        // Resolve with a summary of the uploaded file
-        resolve(fileUploadObject);
       })
       .catch(() => {
         reject(fileErrors.CHECKSUM_HASH_FAILED);

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -121,7 +121,7 @@ function hexToBase64(str) {
 
 export function uploadFileToStorage(
   context,
-  { file_format, mightSkip, checksum, file, url, contentType }
+  { id, file_format, mightSkip, checksum, file, url, contentType }
 ) {
   let contentResponse = Promise.reject();
   if (mightSkip) {
@@ -130,7 +130,7 @@ export function uploadFileToStorage(
   return contentResponse
     .then(() => {
       context.commit('ADD_FILE', {
-        checksum,
+        id,
         loaded: file.size,
         total: file.size,
       });
@@ -144,7 +144,7 @@ export function uploadFileToStorage(
           },
           onUploadProgress: progressEvent => {
             context.commit('ADD_FILE', {
-              checksum,
+              id,
               // Always assign loaded to a maximum of 1 less than the total
               // to prevent progress being shown as 100% until the upload has
               // completed
@@ -157,7 +157,7 @@ export function uploadFileToStorage(
           // Set download progress to 100% now as we have confirmation of the
           // completion of the file upload by the put request completing.
           context.commit('ADD_FILE', {
-            checksum,
+            id,
             loaded: file.size,
             total: file.size,
           });
@@ -195,6 +195,7 @@ export function uploadFile(context, { file, preset = null } = {}) {
             // 3. Upload file
             return context
               .dispatch('uploadFileToStorage', {
+                id: fileObject.id,
                 checksum,
                 file,
                 file_format,

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -89,13 +89,15 @@ export function updateFile(context, { id, ...payload }) {
     if (fileData.contentnode) {
       const presetObj = FormatPresetsMap.get(fileData.preset);
       const files = context.getters.getContentNodeFiles(fileData.contentnode);
-      files
-        .filter(
-          f =>
-            f.preset.id === presetObj.id &&
-            (!presetObj.multi_language || f.language.id === fileData.language)
-        )
-        .forEach(f => context.dispatch('deleteFile', f));
+      for (let f of files) {
+        if (
+          f.preset.id === presetObj.id &&
+          (!presetObj.multi_language || f.language.id === fileData.language) &&
+          f.id !== id
+        ) {
+          context.dispatch('deleteFile', f);
+        }
+      }
     }
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/getters.js
@@ -29,7 +29,7 @@ function parseFileObject(state, file) {
     let language = file.language && (file.language.id || file.language);
     let url = storageUrl(file.checksum, file.file_format);
     return {
-      ...(getFileUpload(state)(file.checksum) || {}),
+      ...(getFileUpload(state)(file.id) || {}),
       ...file,
       preset: FormatPresets.get(preset),
       language: Languages.get(language),

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/getters.js
@@ -4,36 +4,31 @@ import FormatPresets from 'shared/leUtils/FormatPresets';
 import Languages from 'shared/leUtils/Languages';
 
 export function getFileUpload(state) {
-  return function(checksum) {
-    const fileUpload = state.fileUploadsMap[checksum];
+  return function(id) {
+    const fileUpload = state.fileUploadsMap[id];
     if (fileUpload) {
-      const progressCalc = fileUpload.loaded / fileUpload.total;
-      const progress = isFinite(progressCalc) && !isNaN(progressCalc) ? progressCalc : undefined;
-      const url = storageUrl(checksum, fileUpload.file_format);
-      return {
-        ...fileUpload,
-        url,
-        progress: progress,
-        // Add this flag so that we can quickly check that an upload
-        // is in progress, when this is mixed into the data for a
-        // regular file object
-        uploading: !isNaN(progress) && progress < 1,
-      };
+      return parseFileObject(fileUpload);
     }
   };
 }
 
-function parseFileObject(state, file) {
+function parseFileObject(file) {
   if (file) {
-    let preset = file.preset.id || file.preset;
-    let language = file.language && (file.language.id || file.language);
-    let url = storageUrl(file.checksum, file.file_format);
+    const preset = file.preset.id || file.preset;
+    const language = file.language && (file.language.id || file.language);
+    const url = storageUrl(file.checksum, file.file_format);
+    const progressCalc = file.loaded / file.total;
+    const progress = isFinite(progressCalc) && !isNaN(progressCalc) ? progressCalc : undefined;
     return {
-      ...(getFileUpload(state)(file.id) || {}),
       ...file,
       preset: FormatPresets.get(preset),
       language: Languages.get(language),
-      url: url,
+      url,
+      progress: progress,
+      // Add this flag so that we can quickly check that an upload
+      // is in progress, when this is mixed into the data for a
+      // regular file object
+      uploading: !isNaN(progress) && progress < 1,
     };
   }
   return null;
@@ -43,7 +38,7 @@ export function getContentNodeFileById(state) {
   return function(contentNodeId, fileId) {
     const file = (state.contentNodeFilesMap[contentNodeId] || {})[fileId];
     if (file) {
-      return parseFileObject(state, file);
+      return parseFileObject(file);
     }
   };
 }
@@ -51,7 +46,7 @@ export function getContentNodeFileById(state) {
 export function getContentNodeFiles(state) {
   return function(contentNodeId) {
     return Object.values(state.contentNodeFilesMap[contentNodeId] || {})
-      .map(file => parseFileObject(state, file))
+      .map(parseFileObject)
       .filter(f => f);
   };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/index.js
@@ -17,7 +17,7 @@ export default {
       contentNodeFilesMap: {},
       assessmentItemFilesMap: {},
       // A map for tracking file upload info
-      // keyed by file checksum
+      // keyed by file id
       fileUploadsMap: {},
     };
   },
@@ -28,7 +28,7 @@ export default {
     [TABLE_NAMES.FILE]: {
       [CHANGE_TYPES.CREATED]: 'ADD_FILE',
       [CHANGE_TYPES.UPDATED]: 'ADD_FILE',
-      // [CHANGE_TYPES.DELETED]: 'REMOVE_ASSESSMENTITEM',
+      [CHANGE_TYPES.DELETED]: 'REMOVE_FILE',
     },
   },
 };

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -6,6 +6,8 @@ export function ADD_FILE(state, file) {
     return;
   }
   state.fileUploadsMap = mergeMapItem(state.fileUploadsMap || {}, file);
+  // Get the merged item in case there is incomplete information in the file payload
+  file = state.fileUploadsMap[file.id];
   if (file.assessment_item) {
     Vue.set(
       state.assessmentItemFilesMap,

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -5,6 +5,7 @@ export function ADD_FILE(state, file) {
   if (!file.id) {
     return;
   }
+  state.fileUploadsMap = mergeMapItem(state.fileUploadsMap || {}, file);
   if (file.assessment_item) {
     Vue.set(
       state.assessmentItemFilesMap,
@@ -33,6 +34,7 @@ export function REMOVE_FILE(state, file) {
   if (!file.id) {
     return;
   }
+  Vue.delete(state.fileUploadsMap, file.id);
   if (file.assessment_item) {
     Vue.delete(state.assessmentItemFilesMap[file.assessment_item], file.id);
     return;
@@ -41,15 +43,4 @@ export function REMOVE_FILE(state, file) {
     Vue.delete(state.contentNodeFilesMap[file.contentnode], file.id);
     return;
   }
-}
-
-export function ADD_FILEUPLOAD(state, file) {
-  if (!file.checksum) {
-    throw ReferenceError('checksum must be defined to update a file upload');
-  }
-  state.fileUploadsMap = mergeMapItem(state.fileUploadsMap || {}, file, 'checksum');
-}
-
-export function REMOVE_FILEUPLOAD(state, file) {
-  Vue.delete(state.fileUploadsMap, file.checksum);
 }

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1736,14 +1736,14 @@ class File(models.Model):
 
         return os.path.basename(self.file_on_disk.name)
 
-    def save(self, *args, **kwargs):
+    def save(self, set_by_file_on_disk=True, *args, **kwargs):
         """
         Overrider the default save method.
         If the file_on_disk FileField gets passed a content copy:
             1. generate the MD5 from the content copy
             2. fill the other fields accordingly
         """
-        if self.file_on_disk:  # if file_on_disk is supplied, hash out the file
+        if set_by_file_on_disk and self.file_on_disk:  # if file_on_disk is supplied, hash out the file
             if self.checksum is None or self.checksum == "":
                 md5 = hashlib.md5()
                 for chunk in self.file_on_disk.chunks():

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -188,7 +188,6 @@ urlpatterns += [
 # Add file api enpoints
 urlpatterns += [
     url(r'^zipcontent/(?P<zipped_filename>[^/]+)/(?P<embedded_filepath>.*)', zip_views.ZipContentView.as_view(), {}, "zipcontent"),
-    url(r'^api/upload_url/', file_views.upload_url, name='upload_url'),
     url(r'^api/create_thumbnail/(?P<channel_id>[^/]*)/(?P<filename>[^/]*)$', file_views.create_thumbnail, name='create_thumbnail'),
 ]
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@sentry/browser": "^5.9.1",
     "@toast-ui/editor": "^2.3.1",
-    "axios": "^0.19.0",
+    "axios": "^0.20.0",
     "broadcast-channel": "^3.0.3",
     "clipboard-polyfill": "^2.8.1",
     "core-js": "^3.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,12 +2969,12 @@ axios@^0.18.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
+  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -7797,6 +7797,11 @@ follow-redirects@^1.0.0:
   integrity sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==
   dependencies:
     debug "^3.0.0"
+
+follow-redirects@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 fontfaceobserver@^2.0.13:
   version "2.1.0"


### PR DESCRIPTION
## Description

* Creates a file object when we request a file upload URL
* Adds extra handling for failed file uploads to prevent premature deletion of file objects
* Updates all uses of Uploader to leverage this extra handling if needed
* Adds handling for files that have already been uploaded
* Skips uploading files if they already exist on GCS
* Prevent visual regression to previous file when we emit an input event for a new file upload
* Handles this in both Thumbnail uploaders and other file upload boxes where existing files are replaced

#### Issue Addressed (if applicable)

* First step towards #2170
* Fixes #2189
* Fixes #2312
* Fixes #2313
* Fixes #2378
* Fixes #2397
* Fixes #2402