### PR TITLE
Import from channel card interaction improvements

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -43,10 +43,8 @@
               </VTooltip>
             </span>
           </VLayout>
-          <h3 class="text-truncate my-2">
-            <a class="headline" :class="getTitleClass(node)" @click.stop="$emit('preview')">
-              {{ getTitle(node) }}
-            </a>
+          <h3 class="card-header text-truncate my-2">
+            {{ getTitle(node) }}
           </h3>
           <ToggleText
             v-if="node.description"
@@ -68,6 +66,12 @@
         target="_blank"
         :href="openLocationUrl"
         :text="goToLocationLabel"
+      />
+      <IconButton
+        :text="$tr('addToClipboardAction')"
+        icon="info"
+        :color="$themeTokens.primary"
+        @click="$emit('preview', node)"
       />
       <IconButton
         :text="$tr('addToClipboardAction')"
@@ -175,7 +179,7 @@
         if (!this.inSearch && this.isTopic) {
           this.$router.push(this.topicRoute);
         } else if (!this.ancestorIsSelected) {
-          this.$emit('click');
+          this.$emit('preview', this.node);
         }
       },
     },
@@ -188,7 +192,7 @@
       resourcesCount: '{count, number} {count, plural, one {resource} other {resources}}',
       coach: 'Resource for coaches',
       hasCoachTooltip:
-        '{value, number, integer} {value, plural, one {resourece for coaches} other {resources for coaches}}',
+        '{value, number, integer} {value, plural, one {resource for coaches} other {resources for coaches}}',
     },
   };
 
@@ -228,6 +232,16 @@
     a {
       text-decoration: underline;
     }
+  }
+
+  .v-card__title {
+    /* removes default non-top padding to improve spacing */
+    padding: 16px 0 0;
+  }
+
+  .card-header {
+    /* same as channel listing titles */
+    font-size: 18px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -37,7 +37,6 @@
             :ancestorIsSelected="ancestorIsSelected"
             :inSearch="false"
             @preview="$emit('preview', node)"
-            @click="toggleSelected(node)"
             @copy_to_clipboard="$emit('copy_to_clipboard', node)"
           />
         </VFlex>


### PR DESCRIPTION
## Description

Apply several suggested improvements per @jtamiace's notes in #2414 in the Import from Channel modal.

- Added an `info` icon button that opens the content details overlay for content items (not topics)
- Clicking a content item's card opens the details overlay
- Remove the <a> tag link-style card title - also I made sure its the same font size as the cards on the channel list (18px)

Not mentioned in the issue:

- Fix misspelling `resourece -> resource` (noted to @radinamatic and she has updated it directly in Crowdin).
- I also removed some padding to make give everything a cleaner appearance (IMO) - happy to revert this.

**NOTE** I took the screenshots before fixing the fact that the info icon is showing on the topic - that is no longer the case.

BEFORE - Notice the extra whitespace on the bottom

![image](https://user-images.githubusercontent.com/6356129/96052120-b9e65b00-0e31-11eb-831a-157c96ebec92.png)

AFTER

![image](https://user-images.githubusercontent.com/6356129/96052388-4db82700-0e32-11eb-8e9c-186467d64053.png)


#### Issue Addressed (if applicable)

Fixes #2414 


#### Before/After Screenshots (if applicable)

See above


## Steps to Test

Spin up `develop` locally (or go to the develop test site) then go to import from channel in the Channel Editor. You'll see the old one.

Checkout this PR and reload when the new assets are loaded (or checkout the qa-ready server) and BOOM much better appearance and interactions :) 