### PR TITLE
ChannelSetModal fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -28,7 +28,7 @@
               <VForm ref="channelsetform">
                 <VTextField
                   v-model="name"
-                  :rules="[nameValid]"
+                  :rules="nameRules"
                   :label="$tr('titleLabel')"
                   maxlength="200"
                   counter
@@ -193,6 +193,9 @@
       isNew() {
         return Boolean(this.channelSet[NEW_OBJECT]);
       },
+      nameRules() {
+        return [name => (name.length && name.trim().length ? true : this.$tr('titleRequiredText'))];
+      },
       name: {
         get() {
           return this.diffTracker.hasOwnProperty('name')
@@ -252,9 +255,6 @@
           return;
         }
         this.dialog = value;
-      },
-      nameValid(name) {
-        return name && name.length > 0 ? true : this.$tr('titleRequiredText');
       },
       saveChannels() {
         const oldChannels = this.channelSet.channels;

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -16,12 +16,12 @@
       </VBtn>
     </template>
     <template v-if="step === 1" #action>
-      <VBtn flat data-test="save" @click="save">
+      <VBtn flat data-test="button-save" @click="save">
         {{ saveText }}
       </VBtn>
     </template>
     <VWindow v-model="step">
-      <VWindowItem :value="1">
+      <VWindowItem :value="1" data-test="collection-channels-view">
         <VContainer class="ml-5 pt-5">
           <VLayout row>
             <VFlex md12 lg10 xl8>
@@ -33,6 +33,7 @@
                   maxlength="200"
                   counter
                   box
+                  data-test="input-name"
                 />
               </VForm>
 
@@ -50,7 +51,7 @@
               <h1 class="headline mt-4 pt-4 font-weight-bold">
                 {{ $tr('channels') }}
               </h1>
-              <p class="subheading">
+              <p v-if="!loadingChannels" class="subheading">
                 {{ $tr('channelCountText', {'channelCount': channels.length}) }}
               </p>
 
@@ -59,7 +60,7 @@
                 <LoadingText />
               </VCardText>
               <div v-else fluid>
-                <VBtn color="primary" class="mb-4" data-test="select" @click="step ++">
+                <VBtn color="primary" class="mb-4" data-test="button-select" @click="step ++">
                   {{ $tr('selectChannelsHeader') }}
                 </VBtn>
                 <VCard v-for="channelId in channels" :key="channelId" flat>
@@ -68,7 +69,6 @@
                       flat
                       class="ma-0"
                       color="primary"
-                      data-test="remove"
                       @click="removeChannel(channelId)"
                     >
                       {{ $tr('removeText') }}
@@ -80,7 +80,7 @@
           </VLayout>
         </VContainer>
       </VWindowItem>
-      <VWindowItem :value="2" lazy>
+      <VWindowItem :value="2" lazy data-test="channels-selection-view">
         <VContainer fill-height class="ml-5 pt-5">
           <VLayout row>
             <VFlex md12 lg10 xl8>
@@ -114,13 +114,15 @@
       v-model="showUnsavedDialog"
       :header="$tr('unsavedChangesHeader')"
       :text="$tr('unsavedChangesText')"
+      data-test="dialog-unsaved"
+      :data-test-visible="showUnsavedDialog"
     >
       <template #buttons="{close}">
         <VSpacer />
         <VBtn flat @click="confirmCancel">
           {{ $tr('closeButton') }}
         </VBtn>
-        <VBtn color="primary" data-test="confirm-save" @click="save">
+        <VBtn color="primary" @click="save">
           {{ $tr('saveButton') }}
         </VBtn>
       </template>
@@ -132,7 +134,7 @@
       <VSpacer />
       <VBtn
         color="primary"
-        data-test="finish"
+        data-test="button-finish"
         @click="step --"
       >
         {{ $tr('finish') }}
@@ -321,7 +323,7 @@
       },
       confirmCancel() {
         if (this.isNew) {
-          return this.deleteChannelSet(this.channelSetId).then(this.close);
+          return this.deleteChannelSet(this.channelSet).then(this.close);
         }
         this.close();
       },
@@ -339,12 +341,11 @@
             resolve();
             return;
           }
-          this.loading = true;
+
           // If not, try to load the channel
           this.loadChannelSet(channelSetId).then(channelset => {
             // Did our fetch return any channels, then we have a channel!
             if (channelset) {
-              this.loading = false;
               this.setup();
               resolve();
               return;

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -237,7 +237,7 @@
       },
     },
     beforeMount() {
-      return this.verifyChannelSet(this.$route.params.channelSetId);
+      return this.verifyChannelSet(this.channelSetId);
     },
     methods: {
       ...mapActions('channel', ['loadChannelList']),

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -7,18 +7,6 @@ import { RouterNames } from '../../../constants';
 import ChannelSetModal from '../ChannelSetModal.vue';
 import { NEW_OBJECT } from 'shared/constants';
 
-jest.mock('shared/data/changes', () => {
-  return {
-    ChangeTracker: jest.fn().mockImplementation(() => {
-      return {
-        revert: jest.fn().mockReturnValue(Promise.resolve()),
-        start: jest.fn().mockReturnValue(Promise.resolve()),
-        dismiss: jest.fn().mockReturnValue(Promise.resolve()),
-      };
-    }),
-  };
-});
-
 Vue.use(VueRouter);
 
 const channelSetId = 'testing';

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -1,110 +1,325 @@
-import Vue from 'vue';
-import { mount } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
 import VueRouter from 'vue-router';
-import store from '../../../store';
-import router from '../../../router';
+import { cloneDeep } from 'lodash';
+import flushPromises from 'flush-promises';
+
 import { RouterNames } from '../../../constants';
-import ChannelSetModal from '../ChannelSetModal.vue';
+import router from '../../../router';
+import channelSet from '../../../vuex/channelSet';
+import ChannelSetModal from '../ChannelSetModal';
 import { NEW_OBJECT } from 'shared/constants';
+import storeFactory from 'shared/vuex/baseStore';
+import channel from 'shared/vuex/channel';
 
-Vue.use(VueRouter);
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(VueRouter);
 
-const channelSetId = 'testing';
+const STORE_CONFIG = {
+  modules: { channel, channelSet },
+};
 
-function makeWrapper(setData = {}, methods = {}) {
-  router.push({
-    name: RouterNames.CHANNEL_SET_DETAILS,
-    params: {
+const CHANNEL_1 = {
+  id: 'id-channel-1',
+  name: 'Channel 1',
+  description: 'First channel description',
+};
+const CHANNEL_2 = {
+  id: 'id-channel-2',
+  name: 'Channel 2',
+  description: 'Second channel description',
+};
+
+const CHANNEL_SET = {
+  id: 'id-channel-set',
+  channels: {
+    [CHANNEL_1.id]: true,
+    [CHANNEL_2.id]: true,
+  },
+};
+
+const NEW_CHANNEL_SET = {
+  id: 'id-new-channel-set',
+  channels: [],
+  [NEW_OBJECT]: true,
+};
+
+const makeWrapper = ({ store, channelSetId }) => {
+  if (router.currentRoute.name !== RouterNames.CHANNEL_SET_DETAILS) {
+    router.push({
+      name: RouterNames.CHANNEL_SET_DETAILS,
+      params: {
+        channelSetId,
+      },
+    });
+  }
+
+  return mount(ChannelSetModal, {
+    propsData: {
       channelSetId,
     },
-  });
-  if (setData.isNew) {
-    delete setData.isNew;
-    setData[NEW_OBJECT] = true;
-  }
-  let wrapper = mount(ChannelSetModal, {
     router,
+    localVue,
     store,
-    propsData: {
-      channelSetId: channelSetId,
-    },
-    computed: {
-      channelSet() {
-        return {
-          channelSetId,
-          ...setData,
-        };
-      },
-    },
-    methods: {
-      loadChannelSet() {
-        return Promise.resolve({ channelSetId });
-      },
-      ...methods,
-    },
   });
-  wrapper.vm.setup();
-  return wrapper;
-}
+};
 
-describe('channelSetModal', () => {
-  let wrapper;
+const loadChannelSetMock = channelSet => {
+  return jest.fn().mockImplementation(({ commit }) => {
+    commit('ADD_CHANNELSET', channelSet);
+    return Promise.resolve(channelSet);
+  });
+};
+
+const getCollectionNameInput = wrapper => {
+  return wrapper.find('[data-test="input-name"]');
+};
+
+const getUnsavedDialog = wrapper => {
+  return wrapper.find('[data-test="dialog-unsaved"]');
+};
+
+const getCloseButton = wrapper => {
+  return wrapper.find('[data-test="close"]');
+};
+
+const getSaveButton = wrapper => {
+  return wrapper.find('[data-test="button-save"]');
+};
+
+const getSelectChannelsButton = wrapper => {
+  return wrapper.find('[data-test="button-select"]');
+};
+
+const getFinishButton = wrapper => {
+  return wrapper.find('[data-test="button-finish"]');
+};
+
+describe('ChannelSetModal', () => {
   beforeEach(() => {
-    wrapper = makeWrapper();
+    jest.resetAllMocks();
   });
-  describe('on load', () => {
-    it('should load channels', () => {
-      const loadChannelList = jest.fn().mockReturnValue(Promise.resolve());
-      wrapper = makeWrapper({ channels: ['mock-channel-id'] }, { loadChannelList });
-      expect(loadChannelList).toHaveBeenCalled();
+
+  it('should show collection channels view at first', () => {
+    const storeConfig = cloneDeep(STORE_CONFIG);
+    const store = storeFactory(storeConfig);
+    const wrapper = makeWrapper({ store, channelSetId: CHANNEL_SET.id });
+
+    expect(wrapper.find('[data-test="collection-channels-view"]').isVisible()).toBe(true);
+  });
+
+  describe('if there are no data for a channel set yet', () => {
+    let loadChannelSet, loadChannelList;
+
+    beforeEach(() => {
+      const storeConfig = cloneDeep(STORE_CONFIG);
+      loadChannelSet = loadChannelSetMock(CHANNEL_SET);
+      loadChannelList = jest.fn();
+      storeConfig.modules.channelSet.actions.loadChannelSet = loadChannelSet;
+      storeConfig.modules.channel.actions.loadChannelList = loadChannelList;
+
+      const store = storeFactory(storeConfig);
+
+      makeWrapper({ store, channelSetId: CHANNEL_SET.id });
+    });
+
+    it('should load the channel set', () => {
+      expect(loadChannelSet).toHaveBeenCalledTimes(1);
+      expect(loadChannelSet.mock.calls[0][1]).toBe(CHANNEL_SET.id);
+    });
+
+    it('should load channels of the channel set', () => {
+      expect(loadChannelList).toHaveBeenCalledTimes(1);
+      expect(loadChannelList.mock.calls[0][1]).toEqual({ id__in: [CHANNEL_1.id, CHANNEL_2.id] });
     });
   });
-  describe('navigation', () => {
-    it('clicking select channels button should navigate to channel selection view', () => {
-      wrapper.setData({ loadingChannels: false });
-      wrapper.find('[data-test="select"]').trigger('click');
-      expect(wrapper.vm.step).toBe(2);
+
+  describe('if a channel set has been already loaded', () => {
+    let store, loadChannelSet, loadChannelList;
+
+    beforeEach(() => {
+      const storeConfig = cloneDeep(STORE_CONFIG);
+      loadChannelSet = jest.fn();
+      loadChannelList = jest.fn();
+      storeConfig.modules.channelSet.actions.loadChannelSet = loadChannelSet;
+      storeConfig.modules.channel.actions.loadChannelList = loadChannelList;
+
+      store = storeFactory(storeConfig);
+      store.commit('channelSet/ADD_CHANNELSET', CHANNEL_SET);
+
+      makeWrapper({ store, channelSetId: CHANNEL_SET.id });
     });
-    it('clicking finish should navigate back to collection details view', () => {
-      wrapper.setData({ loadingChannels: false, step: 2 });
-      return wrapper.vm.$nextTick().then(() => {
-        wrapper.find('[data-test="finish"]').trigger('click');
-        expect(wrapper.vm.step).toBe(1);
-      });
+
+    it("shouldn't load the channel set", () => {
+      expect(loadChannelSet).not.toHaveBeenCalled();
+    });
+
+    it('should load channels from the channel set', () => {
+      expect(loadChannelList).toHaveBeenCalledTimes(1);
+      expect(loadChannelList.mock.calls[0][1]).toEqual({ id__in: [CHANNEL_1.id, CHANNEL_2.id] });
     });
   });
-  describe('on close', () => {
-    it('clicking close button should close the modal', () => {
-      wrapper.find('[data-test="close"]').trigger('click');
-      wrapper.vm.$nextTick(() => {
+
+  describe('collection channels view', () => {
+    let wrapper, updateChannelSet;
+
+    beforeEach(() => {
+      const storeConfig = cloneDeep(STORE_CONFIG);
+      updateChannelSet = jest.fn();
+      storeConfig.modules.channel.actions.loadChannelList = jest.fn().mockResolvedValue();
+      storeConfig.modules.channelSet.actions.updateChannelSet = updateChannelSet;
+      const store = storeFactory(storeConfig);
+      store.commit('channelSet/ADD_CHANNELSET', CHANNEL_SET);
+      store.commit('channel/ADD_CHANNELS', [CHANNEL_1, CHANNEL_2]);
+
+      wrapper = makeWrapper({ store, channelSetId: CHANNEL_SET.id });
+    });
+
+    it('should render a collection name input', () => {
+      expect(getCollectionNameInput(wrapper).isVisible()).toBe(true);
+    });
+
+    it('should render select channels button', () => {
+      expect(getSelectChannelsButton(wrapper).isVisible()).toBe(true);
+    });
+
+    it('should render save button', () => {
+      expect(getSaveButton(wrapper).isVisible()).toBe(true);
+    });
+
+    it('should render close button', () => {
+      expect(getCloseButton(wrapper).isVisible()).toBe(true);
+    });
+
+    it('should render a correct channels count', () => {
+      expect(wrapper.find('.subheading').html()).toContain('2 channels');
+    });
+
+    it("should render channels' names, descriptions and remove buttons", () => {
+      const channelItems = wrapper.findAll({ name: 'ChannelItem' });
+
+      expect(channelItems.length).toBe(2);
+
+      expect(channelItems.at(0).html()).toContain('Channel 1');
+      expect(channelItems.at(0).html()).toContain('First channel description');
+      expect(
+        channelItems
+          .at(0)
+          .find('button')
+          .text()
+      ).toBe('Remove');
+
+      expect(channelItems.at(1).html()).toContain('Channel 2');
+      expect(channelItems.at(1).html()).toContain('Second channel description');
+      expect(
+        channelItems
+          .at(1)
+          .find('button')
+          .text()
+      ).toBe('Remove');
+    });
+
+    it('clicking select channels button should navigate to channels selection view', async () => {
+      getSelectChannelsButton(wrapper).trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-test="collection-channels-view"]').isVisible()).toBe(false);
+      expect(wrapper.find('[data-test="channels-selection-view"]').isVisible()).toBe(true);
+    });
+
+    describe('clicking close button', () => {
+      it('should redirect to channel sets page', () => {
+        getCloseButton(wrapper).trigger('click');
+
         expect(wrapper.vm.$route.name).toBe(RouterNames.CHANNEL_SETS);
       });
+
+      it('should delete a channel set if it is new', () => {
+        const storeConfig = cloneDeep(STORE_CONFIG);
+        const deleteChannelSet = jest.fn();
+        storeConfig.modules.channelSet.actions.deleteChannelSet = deleteChannelSet;
+        const store = storeFactory(storeConfig);
+        store.commit('channelSet/ADD_CHANNELSET', NEW_CHANNEL_SET);
+
+        wrapper = makeWrapper({ store, channelSetId: NEW_CHANNEL_SET.id });
+
+        getCloseButton(wrapper).trigger('click');
+        expect(deleteChannelSet).toHaveBeenCalledTimes(1);
+        expect(deleteChannelSet.mock.calls[0][1]).toEqual(NEW_CHANNEL_SET);
+      });
+
+      it('should prompt user if there are unsaved changes', () => {
+        expect(getUnsavedDialog(wrapper).attributes('data-test-visible')).toBeFalsy();
+
+        getCollectionNameInput(wrapper).setValue('My collection');
+        getCloseButton(wrapper).trigger('click');
+
+        expect(getUnsavedDialog(wrapper).attributes('data-test-visible')).toBeTruthy();
+      });
     });
-    it('should close the modal if collection is new and delete the collection', () => {
-      const deleteChannelSet = jest.fn(() => Promise.resolve());
-      wrapper = makeWrapper({ isNew: true });
-      wrapper.setMethods({ deleteChannelSet });
-      wrapper.find('[data-test="close"]').trigger('click');
-      expect(deleteChannelSet).toHaveBeenCalled();
-    });
-    it('should prompt user if there are unsaved changes', () => {
-      wrapper.setData({ changed: true });
-      wrapper.find('[data-test="close"]').trigger('click');
-      expect(wrapper.vm.showUnsavedDialog).toBe(true);
+
+    describe('clicking save button', () => {
+      it("shouldn't update a channel set when a collection name is missing", async () => {
+        getCollectionNameInput(wrapper).setValue('');
+        getSaveButton(wrapper).trigger('click');
+        await flushPromises();
+
+        expect(updateChannelSet).not.toHaveBeenCalled();
+      });
+
+      it("shouldn't update a channel set when a collection name is made of empty characters", async () => {
+        getCollectionNameInput(wrapper).setValue(' ');
+        getSaveButton(wrapper).trigger('click');
+        await flushPromises();
+
+        expect(updateChannelSet).not.toHaveBeenCalled();
+      });
+
+      it('should update a channel set when a collection name is valid', async () => {
+        getCollectionNameInput(wrapper).setValue('My collection');
+        getSaveButton(wrapper).trigger('click');
+        await flushPromises();
+
+        expect(updateChannelSet).toHaveBeenCalledTimes(1);
+        expect(updateChannelSet.mock.calls[0][1]).toEqual({
+          id: CHANNEL_SET.id,
+          name: 'My collection',
+        });
+      });
     });
   });
-  describe('on save', () => {
-    it('clicking save should call save method', () => {
-      const save = jest.fn();
-      wrapper.setMethods({ save });
-      wrapper.find('[data-test="save"]').trigger('click');
-      expect(save).toHaveBeenCalled();
+
+  describe('channels selection view', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+      const storeConfig = cloneDeep(STORE_CONFIG);
+      storeConfig.modules.channel.actions.loadChannelList = jest.fn().mockResolvedValue();
+      const store = storeFactory(storeConfig);
+      store.commit('channelSet/ADD_CHANNELSET', CHANNEL_SET);
+      store.commit('channel/ADD_CHANNELS', [CHANNEL_1, CHANNEL_2]);
+
+      wrapper = makeWrapper({ store, channelSetId: CHANNEL_SET.id });
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      getSelectChannelsButton(wrapper).trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-test="channels-selection-view"]').isVisible()).toBe(true);
     });
-    it('should not save if fields are invalid', () => {
-      const setChannels = jest.fn();
-      wrapper.setMethods({ setChannels });
-      wrapper.find('[data-test="save"]').trigger('click');
-      expect(setChannels).not.toHaveBeenCalled();
+
+    it('should render finish button', () => {
+      expect(getFinishButton(wrapper).isVisible()).toBe(true);
+    });
+
+    it('clicking finish button should navigate back to collection channels view', async () => {
+      getFinishButton(wrapper).trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-test="channels-selection-view"]').isVisible()).toBe(false);
+      expect(wrapper.find('[data-test="collection-channels-view"]').isVisible()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Description

Bug fixes and more specs for `ChannelSetModal`, which is responsible for adding new or updating existing collections.

Regarding existing tests, I've removed functionality reaching to `ChannelSetModal`'s internals and simulated users' behavior whenever possible instead, so that we don't need to refactor tests when updating `ChannelSetModal`'s internal methods, data etc.

#### Issue Addressed
Fixes #1778
Fixes an issue when it wasn't possible to close the modal immediately after adding a new collection

## Steps to Test

- [ ] *Add a new collection*
- [ ] *Update an existing collection*
- [ ] *Test saving and closing the modal*
- [ ] *Test a collection name validation*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
