### PR TITLE
Array agg needs to know the field type

### DIFF
--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -81,7 +81,7 @@ class SQSum(Subquery):
 
 class SQArrayAgg(Subquery):
     # Include ALIAS at the end to support Postgres
-    template = "(SELECT ARRAY_AGG(%(field)s) FROM (%(subquery)s) AS %(field)s__sum)"
+    template = "(SELECT ARRAY_AGG(%(field)s::text) FROM (%(subquery)s) AS %(field)s__sum)"
     output_field = ArrayField(CharField())
 
 


### PR DESCRIPTION
## Description

Forces casting of the field used in the array_agg postgresql subquery

#### Issue Addressed (if applicable)

Fixes #2367 

## Steps to Test

1. Edit a channel
2. Click on Add - Import from channel
3. Open the browser dev tools
4. Do a search
5. Check no server errors appear in the dev tools


## Comments

As the ouptut field of the `SQArrayAgg` class is `ArrayField(CharField())`
casting the field to `text` should not have any side effect.
If other type of fields were going to be aggregated  a different class should be used