### PR TITLE
Ensure latest KDS

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "jest-each": "^24.8.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-serializer-vue": "^2.0.2",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v0.2.x",
+    "kolibri-design-system": "git+https://github.com/learningequality/kolibri-design-system#v0.2.x",
     "kolibri-tools": "0.13.0-dev.9",
     "less": "^3.0.1",
     "less-loader": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11279,9 +11279,9 @@ kolibri-components@0.13.0-dev.9:
     popper.js "^1.14.6"
     purecss "^0.6.2"
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v0.2.x":
-  version "0.2.2-beta"
-  resolved "https://github.com/learningequality/kolibri-design-system#75da08120e3e2e5285fa12a7454960901ee16a3b"
+"kolibri-design-system@git+https://github.com/learningequality/kolibri-design-system#v0.2.x":
+  version "0.2.2-beta3"
+  resolved "git+https://github.com/learningequality/kolibri-design-system#92507d3b4a4a3df2a8cde64fb6fbbb045d18491a"
   dependencies:
     "@babel/core" "^7.9.6"
     "@babel/preset-env" "^7.9.6"


### PR DESCRIPTION
So if you put `git+` in front of the URL to a package on Github that you want it will always check for and use the latest. 

- Fixes clipboard icon
- Will ensure latest KDS is in Studio until we pin it