### PR TITLE
Get rid of circular dependency chain

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -38,8 +38,8 @@ describe('channelEdit utils', () => {
       });
 
       const expectedLink = `${window.Urls.channel('source-channel-id') + expectedRoute.href}`;
-      expect(importedChannelLink(importedContent)).toBe(expectedLink);
-      expect(importedChannelLink(notImportedContent)).toBe(null);
+      expect(importedChannelLink(importedContent, router)).toBe(expectedLink);
+      expect(importedChannelLink(notImportedContent, router)).toBe(null);
     });
   });
   describe('getCorrectAnswersIndices', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -382,7 +382,7 @@
         return isImportedContent(this.firstNode);
       },
       importedChannelLink() {
-        return importedChannelLink(this.firstNode);
+        return importedChannelLink(this.firstNode, this.$router);
       },
       importedChannelName() {
         return this.firstNode.original_channel_name;

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -1,5 +1,4 @@
 import translator from './translator';
-import router from './router';
 import { RouterNames } from './constants';
 import { AssessmentItemTypes } from 'shared/constants';
 
@@ -129,7 +128,7 @@ export function isImportedContent(node) {
   return !!(node && node.original_source_node_id && node.node_id !== node.original_source_node_id);
 }
 
-export function importedChannelLink(node) {
+export function importedChannelLink(node, router) {
   if (node && isImportedContent(node)) {
     const channelURI = window.Urls.channel(node.original_channel_id);
     const sourceNodeRoute = router.resolve({

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ResourcePanel.vue
@@ -395,7 +395,7 @@
         return isImportedContent(this.node);
       },
       importedChannelLink() {
-        return importedChannelLink(this.node);
+        return importedChannelLink(this.node, this.$router);
       },
       importedChannelName() {
         return this.node.original_channel_name;


### PR DESCRIPTION
## Description

This gets rid of a circular dependency chain, which was causing lots of extra warnings in the console.

### Before
![image](https://user-images.githubusercontent.com/389782/96320901-5303a600-0fd9-11eb-98dd-397fd07a049c.png)

### After
![image](https://user-images.githubusercontent.com/389782/96320930-69a9fd00-0fd9-11eb-8357-f63ebaea9d71.png)
