### PR TITLE
Use only the DRF JSONRenderer in production

### DIFF
--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+# ignore the entire file in general, since we do a lot of overrides here which break pep8 compat
 from __future__ import absolute_import
 
 from . import settings as base_settings

--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from . import settings as base_settings
 from .settings import *  # noqa
 from contentcuration.utils.secretmanagement import get_secret
+
 # production_settings.py -- production studio settings override
 #
 # noinspection PyUnresolvedReferences
@@ -43,3 +44,8 @@ if SITE_READ_ONLY:
     CACHES['default']['BACKEND'] = "django_prometheus.cache.backends.locmem.LocMemCache"
 
 DATABASES["default"]["ENGINE"] = "django_prometheus.db.backends.postgresql"
+
+
+REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = [
+    "rest_framework.renderers.JSONRenderer",
+]


### PR DESCRIPTION
This sets JSONRenderer the only available renderer in production. Pretty simple.

I also added a flake8 ignore for the production settings file since it has a lot of violations.

Tested manually by running with `production_settings` on my local machine.