### PR TITLE
file permissions

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -49,42 +49,49 @@ class SyncTestCase(StudioAPITestCase):
         self.user = testdata.user()
         self.channel.editors.add(self.user)
 
-    def test_create_file(self):
+    def test_cannot_create_file(self):
         self.client.force_authenticate(user=self.user)
         file = self.file_metadata
-        response = self.client.post(
-            self.sync_url,
-            [generate_create_event(file["id"], FILE, file,)],
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
+        with self.settings(TEST_ENV=False):
+            # Override test env here to check what will happen in production
+            response = self.client.post(
+                self.sync_url,
+                [generate_create_event(file["id"], FILE, file,)],
+                format="json",
+            )
+        self.assertEqual(response.status_code, 400, response.content)
         try:
             models.File.objects.get(id=file["id"])
+            self.fail("File was created")
         except models.File.DoesNotExist:
-            self.fail("File was not created")
+            pass
 
-    def test_create_files(self):
+    def test_cannot_create_files(self):
         self.client.force_authenticate(user=self.user)
         file1 = self.file_metadata
         file2 = self.file_metadata
-        response = self.client.post(
-            self.sync_url,
-            [
-                generate_create_event(file1["id"], FILE, file1,),
-                generate_create_event(file2["id"], FILE, file2,),
-            ],
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
+        with self.settings(TEST_ENV=False):
+            # Override test env here to check what will happen in production
+            response = self.client.post(
+                self.sync_url,
+                [
+                    generate_create_event(file1["id"], FILE, file1,),
+                    generate_create_event(file2["id"], FILE, file2,),
+                ],
+                format="json",
+            )
+        self.assertEqual(response.status_code, 400, response.content)
         try:
             models.File.objects.get(id=file1["id"])
+            self.fail("File 1 was created")
         except models.File.DoesNotExist:
-            self.fail("File 1 was not created")
+            pass
 
         try:
             models.File.objects.get(id=file2["id"])
+            self.fail("File 2 was created")
         except models.File.DoesNotExist:
-            self.fail("File 2 was not created")
+            pass
 
     def test_update_file(self):
 
@@ -217,39 +224,16 @@ class CRUDTestCase(StudioAPITestCase):
         self.user = testdata.user()
         self.channel.editors.add(self.user)
 
-    def test_create_file(self):
+    def test_cannot_create_file(self):
         self.client.force_authenticate(user=self.user)
         file = self.file_metadata
         response = self.client.post(reverse("file-list"), file, format="json",)
-        self.assertEqual(response.status_code, 201, response.content)
+        self.assertEqual(response.status_code, 405, response.content)
         try:
             models.File.objects.get(id=file["id"])
+            self.fail("File was created")
         except models.File.DoesNotExist:
-            self.fail("File was not created")
-
-    def test_create_file_no_node_permission(self):
-        self.client.force_authenticate(user=self.user)
-        new_channel = testdata.channel()
-        new_channel_node = new_channel.main_tree.get_descendants().first().id
-        file = self.file_metadata
-        file["contentnode"] = new_channel_node
-        response = self.client.post(reverse("file-list"), file, format="json",)
-        self.assertEqual(response.status_code, 400, response.content)
-
-    def test_create_file_no_assessmentitem_permission(self):
-        self.client.force_authenticate(user=self.user)
-        new_channel = testdata.channel()
-        new_channel_exercise = (
-            new_channel.main_tree.get_descendants()
-            .filter(kind_id=content_kinds.EXERCISE)
-            .first()
-        )
-        new_channel_assessmentitem = new_channel_exercise.assessment_items.first().id
-        file = self.file_metadata
-        file["assessment_item"] = new_channel_assessmentitem
-        del file["contentnode"]
-        response = self.client.post(reverse("file-list"), file, format="json",)
-        self.assertEqual(response.status_code, 400, response.content)
+            pass
 
     def test_update_file(self):
         file = models.File.objects.create(**self.file_db_metadata)
@@ -265,6 +249,37 @@ class CRUDTestCase(StudioAPITestCase):
         self.assertEqual(
             models.File.objects.get(id=file.id).preset_id, new_preset,
         )
+
+    def test_update_file_no_node_permission(self):
+        file = models.File.objects.create(**self.file_db_metadata)
+        new_channel = testdata.channel()
+        new_channel_node = new_channel.main_tree.get_descendants().first().id
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("file-detail", kwargs={"pk": file.id}),
+            {"contentnode": new_channel_node},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_update_file_no_assessmentitem_permission(self):
+        file = models.File.objects.create(**self.file_db_metadata)
+        new_channel = testdata.channel()
+        new_channel_exercise = (
+            new_channel.main_tree.get_descendants()
+            .filter(kind_id=content_kinds.EXERCISE)
+            .first()
+        )
+        new_channel_assessmentitem = new_channel_exercise.assessment_items.first().id
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("file-detail", kwargs={"pk": file.id}),
+            {"assessment_item": new_channel_assessmentitem},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
 
     def test_update_file_empty(self):
 

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -657,7 +657,7 @@ class ValuesViewset(
     pass
 
 
-class BulkCreateMixin(object):
+class BulkCreateMixin(CreateModelMixin):
     def perform_bulk_create(self, serializer):
         serializer.save()
 
@@ -685,7 +685,7 @@ class BulkCreateMixin(object):
         return errors, serializer.changes
 
 
-class BulkUpdateMixin(object):
+class BulkUpdateMixin(UpdateModelMixin):
     def perform_bulk_update(self, serializer):
         serializer.save()
 
@@ -740,7 +740,7 @@ class BulkUpdateMixin(object):
         return errors, serializer.changes
 
 
-class BulkDeleteMixin(object):
+class BulkDeleteMixin(DestroyModelMixin):
     def delete_from_changes(self, changes):
         keys = [change["key"] for change in changes]
         queryset = self.filter_queryset_from_keys(

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -13,12 +13,12 @@ from contentcuration.models import File
 from contentcuration.models import generate_object_storage_name
 from contentcuration.models import generate_storage_url
 from contentcuration.utils.storage_common import get_presigned_upload_url
-from contentcuration.viewsets.base import BulkCreateMixin
+from contentcuration.viewsets.base import BulkDeleteMixin
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import BulkUpdateMixin
+from contentcuration.viewsets.base import ReadOnlyValuesViewset
 from contentcuration.viewsets.base import RequiredFilterSet
-from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
 from contentcuration.viewsets.common import UUIDInFilter
 
@@ -65,8 +65,7 @@ def retrieve_storage_url(item):
     return generate_storage_url("{}.{}".format(item["checksum"], item["file_format"]))
 
 
-# Apply mixin first to override ValuesViewset
-class FileViewSet(BulkCreateMixin, BulkUpdateMixin, ValuesViewset):
+class FileViewSet(BulkDeleteMixin, BulkUpdateMixin, ReadOnlyValuesViewset):
     queryset = File.objects.all()
     serializer_class = FileSerializer
     permission_classes = [IsAuthenticated]

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -67,10 +67,29 @@ class SlowSyncError(Exception):
         self.time = time
         self.changes = changes
 
-        message = "Change type {} took {} seconds to complete, exceeding {} second threshold."
-        self.message = message.format(self.change_type, self.time, SLOW_UPDATE_THRESHOLD)
+        message = (
+            "Change type {} took {} seconds to complete, exceeding {} second threshold."
+        )
+        self.message = message.format(
+            self.change_type, self.time, SLOW_UPDATE_THRESHOLD
+        )
 
         super(SlowSyncError, self).__init__(self.message)
+
+
+class ChangeNotAllowed(Exception):
+    """
+    Used to report changes that are not supported by the backend
+    """
+
+    def __init__(self, change_type, viewset_class):
+        self.change_type = change_type
+        self.viewset_class = viewset_class
+        self.message = "Change type {} not allowed on viewset {}.".format(
+            change_type, viewset_class
+        )
+
+        super(ChangeNotAllowed, self).__init__(self.message)
 
 
 # Uses ordered dict behaviour to enforce operation orders
@@ -106,7 +125,9 @@ change_order = [
     MOVED,
 ]
 
-table_name_indices = {table_name: i for i, table_name in enumerate(viewset_mapping.keys())}
+table_name_indices = {
+    table_name: i for i, table_name in enumerate(viewset_mapping.keys())
+}
 
 
 def get_table(obj):
@@ -141,38 +162,39 @@ event_handlers = {
 def handle_changes(request, viewset_class, change_type, changes):
     try:
         change_type = int(change_type)
-    except ValueError:
-        pass
-    else:
         viewset = viewset_class(request=request)
         viewset.initial(request)
         if change_type in event_handlers:
-            try:
-                start = time.time()
-                result = getattr(viewset, event_handlers[change_type])(changes)
-                elapsed = time.time() - start
+            start = time.time()
+            event_handler = getattr(viewset, event_handlers[change_type], None)
+            if event_handler is None:
+                raise ChangeNotAllowed(change_type, viewset_class)
+            result = event_handler(changes)
+            elapsed = time.time() - start
 
-                if elapsed > SLOW_UPDATE_THRESHOLD:
-                    # This is really a warning rather than an actual error,
-                    # but using exceptions simplifies reporting it to Sentry,
-                    # so create and pass along the error but do not raise it.
-                    try:
-                        # we need to raise it to get Python to fill out the stack trace.
-                        raise SlowSyncError(change_type, elapsed, changes)
-                    except SlowSyncError as e:
-                        report_exception(e)
-                return result
-            except Exception as e:
-                # Capture exception and report, but allow sync
-                # to complete properly.
-                report_exception(e)
+            if elapsed > SLOW_UPDATE_THRESHOLD:
+                # This is really a warning rather than an actual error,
+                # but using exceptions simplifies reporting it to Sentry,
+                # so create and pass along the error but do not raise it.
+                try:
+                    # we need to raise it to get Python to fill out the stack trace.
+                    raise SlowSyncError(change_type, elapsed, changes)
+                except SlowSyncError as e:
+                    report_exception(e)
+            return result
+    except Exception as e:
+        # Capture exception and report, but allow sync
+        # to complete properly.
+        report_exception(e)
 
-                if getattr(settings, "DEBUG", False) or getattr(settings, "TEST_ENV", False):
-                    raise
-                else:
-                    # make sure we leave a record in the logs just in case.
-                    logging.error(e)
-                return changes, None
+        if getattr(settings, "DEBUG", False) or getattr(settings, "TEST_ENV", False):
+            raise
+        else:
+            # make sure we leave a record in the logs just in case.
+            logging.error(e)
+        for change in changes:
+            change["errors"] = [str(e)]
+        return changes, None
 
 
 @authentication_classes((TokenAuthentication, SessionAuthentication))
@@ -193,7 +215,9 @@ def sync(request):
             group = sorted(group, key=get_change_order)
             for change_type, changes in groupby(group, get_change_type):
                 # Coerce changes iterator to list so it can be read multiple times
-                es, cs = handle_changes(request, viewset_class, change_type, list(changes))
+                es, cs = handle_changes(
+                    request, viewset_class, change_type, list(changes)
+                )
                 if es:
                     errors.extend(es)
                 if cs:
@@ -209,7 +233,10 @@ def sync(request):
             return Response({})
     elif len(errors) < len(data) or len(changes_to_return):
         # If there are some errors, but not all, or all errors and some changes return a mixed response
-        return Response({"changes": changes_to_return, "errors": errors}, status=HTTP_207_MULTI_STATUS,)
+        return Response(
+            {"changes": changes_to_return, "errors": errors},
+            status=HTTP_207_MULTI_STATUS,
+        )
     else:
         # If the errors are total, and there are no changes reject the response outright!
         return Response({"errors": errors}, status=HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Description

* #2340 accidentally removed permissions filtering for file objects
* This reinstates these, and adds tests for this behaviour
* Enhances file permissions to allow unclaimed uploaded files to be edited (required for the upload file workflow)
* Reduces the capabilities of the file endpoint so that all file object creation has to happen through upload_url requests
* Adds tests for no file creation through CRUD or sync, and adds handling for unsupported sync changes on the sync endpoint
