### PR TITLE
Don't publish nodes that are incomplete.

### DIFF
--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -9,6 +9,7 @@ import logging
 import os
 import random
 import string
+import uuid
 from io import BytesIO
 from tempfile import TemporaryFile
 
@@ -115,6 +116,8 @@ def node_json(data):
 def node(data, parent=None):
     new_node = None
     # Create topics
+    if not 'node_id' in data:
+        data['node_id'] = uuid.uuid4()
     if data['kind_id'] == "topic":
         new_node = cc.ContentNode(
             kind=topic(),
@@ -126,8 +129,9 @@ def node(data, parent=None):
         )
         new_node.save()
 
-        for child in data['children']:
-            node(child, parent=new_node)
+        if 'children' in data:
+            for child in data['children']:
+                node(child, parent=new_node)
 
     # Create videos
     elif data['kind_id'] == "video":

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -152,7 +152,7 @@ def map_content_nodes(root_node, default_language, channel_id, channel_name, use
                 logging.debug("Mapping node with id {id}".format(
                     id=node.pk))
 
-                if node.get_descendants(include_self=True).exclude(kind_id=content_kinds.TOPIC).exists():
+                if node.get_descendants(include_self=True).exclude(kind_id=content_kinds.TOPIC).exists() and node.complete:
                     children = (node.children.all())
                     node_queue.extend(children)
 


### PR DESCRIPTION
## Description

Kevin finally got around to making incomplete nodes not publish!

Also, this PR fixes false negatives in publishing tests that were caused by the way we constructed our test channel. Fortunately, switching to the channel fixture in `testdata` allowed us to remove this test data entirely, and removed the false negatives.

## Steps to Test

- [ ] Don't finish what you started (i.e. create a node with incomplete data in Studio)
- [ ] Publish channel (I tested via ricecooker and unit tests, I think there's a publishing fix coming for the GUI)

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

This is not a new item, but we don't update the counts precisely right during publish. If we have empty topics or, now, incomplete nodes, we still count them as "one" node in the progress update. This is not very noticeable because we set the progress to the right value at the end of the step, so I don't think it is worth addressing at this point in time. 


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
