### PR TITLE
Add unit tests for extendSlot helper and make it more robust

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -26,33 +26,31 @@
     v-else
     draggableUniverse="contentNodes"
   >
-    <template #default="draggableProps">
-      <div class="node-list" @scroll="$emit('scroll', $event)">
-        <VList
-          class="pt-0"
-          :style="{backgroundColor: $vuetify.theme.backgroundColor}"
+    <div class="node-list" @scroll="$emit('scroll', $event)">
+      <VList
+        class="pt-0"
+        :style="{backgroundColor: $vuetify.theme.backgroundColor}"
+      >
+        <template
+          v-for="child in children"
         >
-          <template
-            v-for="child in children"
-          >
-            <ContentNodeEditListItem
-              :key="child.id"
-              :nodeId="child.id"
-              :compact="isCompactViewMode"
-              :comfortable="isComfortableViewMode"
-              :select="selected.indexOf(child.id) >= 0"
-              :previewing="$route.params.detailNodeId === child.id"
-              :hasSelection="selected.length > 0"
-              @select="$emit('select', child.id)"
-              @deselect="$emit('deselect', child.id)"
-              @infoClick="goToNodeDetail(child.id)"
-              @topicChevronClick="goToTopic(child.id)"
-              @dblclick.native="onNodeDoubleClick(child)"
-            />
-          </template>
-        </VList>
-      </div>
-    </template>
+          <ContentNodeEditListItem
+            :key="child.id"
+            :nodeId="child.id"
+            :compact="isCompactViewMode"
+            :comfortable="isComfortableViewMode"
+            :select="selected.indexOf(child.id) >= 0"
+            :previewing="$route.params.detailNodeId === child.id"
+            :hasSelection="selected.length > 0"
+            @select="$emit('select', child.id)"
+            @deselect="$emit('deselect', child.id)"
+            @infoClick="goToNodeDetail(child.id)"
+            @topicChevronClick="goToTopic(child.id)"
+            @dblclick.native="onNodeDoubleClick(child)"
+          />
+        </template>
+      </VList>
+    </div>
   </DraggableRegion>
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -65,21 +65,19 @@
         </div>
       </VToolbar>
       <DraggableRegion draggableUniverse="contentNodes">
-        <template #default>
-          <div class="pl-3 my-5">
-            <LoadingText v-if="loading" />
-            <StudioTree
-              v-else
-              :treeId="rootId"
-              :nodeId="rootId"
-              :selectedNodeId="nodeId"
-              :onNodeClick="onTreeNodeClick"
-              :allowEditing="true"
-              :root="true"
-              :dataPreloaded="true"
-            />
-          </div>
-        </template>
+        <div class="pl-3 my-5">
+          <LoadingText v-if="loading" />
+          <StudioTree
+            v-else
+            :treeId="rootId"
+            :nodeId="rootId"
+            :selectedNodeId="nodeId"
+            :onNodeClick="onTreeNodeClick"
+            :allowEditing="true"
+            :root="true"
+            :dataPreloaded="true"
+          />
+        </div>
       </DraggableRegion>
     </ResizableNavigationDrawer>
     <VContent>

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -2,7 +2,7 @@ import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
 import baseMixin from './base';
 import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
-import { animationThrottle, extendAndRender } from 'shared/utils/helpers';
+import { animationThrottle, extendSlot } from 'shared/utils/helpers';
 
 export default {
   mixins: [baseMixin],
@@ -277,7 +277,7 @@ export default {
     /**
      * Add custom method for rendering
      */
-    extendAndRender,
+    extendSlot,
   },
   created() {
     // Debounce the leave emitter since it can get fired multiple times, and there are some browser
@@ -331,7 +331,7 @@ export default {
       dynamicClasses[this.afterComputedClass] = afterCondition;
     }
 
-    return this.extendAndRender(
+    return this.extendSlot(
       'default',
       {
         class: dynamicClasses,

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -1,7 +1,7 @@
 import { mapActions, mapGetters } from 'vuex';
 import baseMixin from './base';
 import { DraggableTypes } from './constants';
-import { animationThrottle, extendAndRender } from 'shared/utils/helpers';
+import { animationThrottle, extendSlot } from 'shared/utils/helpers';
 
 export default {
   mixins: [baseMixin],
@@ -111,7 +111,7 @@ export default {
       this.resetDraggableDirection();
       this.$nextTick(() => this.resetActiveDraggable());
     },
-    extendAndRender,
+    extendSlot,
   },
   created() {
     this.throttledUpdateDraggableDirection = animationThrottle(args =>
@@ -121,7 +121,7 @@ export default {
   render() {
     const { isDragging, draggable } = this;
 
-    return this.extendAndRender(
+    return this.extendSlot(
       'default',
       {
         class: {

--- a/contentcuration/contentcuration/frontend/shared/utils/helpers.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/helpers.js
@@ -3,6 +3,8 @@ import merge from 'lodash/merge';
 
 import { LicensesList } from 'shared/leUtils/Licenses';
 
+const EXTENDED_SLOT = '__extendedSlot';
+
 /**
  * Insert an item into an array before another item.
  * @param {Array} arr
@@ -384,13 +386,17 @@ export function extendSlot(slotName, vNodeData = {}, scopeProps = {}) {
     return element;
   }
 
-  // TODO: Fix component rendering
-  const { componentOptions } = element;
-  if (componentOptions) {
-    return element;
+  // Must be an update! This forces classes and styles to update,
+  // which do not update otherwise
+  if (element.data[EXTENDED_SLOT] && element.context) {
+    element.context.$nextTick(function() {
+      this.$forceUpdate();
+    });
   }
 
-  // If it's a component and not an ordinary HTML element, we can pass in the
-  // component options and it will update it with our changes
-  return this.$createElement(element.tag, element.data, element.children);
+  merge(element.data, {
+    [EXTENDED_SLOT]: true,
+  });
+
+  return element;
 }

--- a/contentcuration/contentcuration/frontend/shared/utils/helpers.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/helpers.spec.js
@@ -1,6 +1,8 @@
+import Vue from 'vue';
+import { mount } from '@vue/test-utils';
 import each from 'jest-each';
 
-import { insertBefore, insertAfter, swapElements } from './helpers';
+import { insertBefore, insertAfter, swapElements, extendSlot } from './helpers';
 
 describe('insertBefore', () => {
   each([
@@ -30,5 +32,218 @@ describe('swapElements', () => {
     [['blue', 'yellow', 'violet'], 0, 2, ['violet', 'yellow', 'blue']],
   ]).it('swaps two elements', (arr, idx1, idx2, expected) => {
     expect(swapElements(arr, idx1, idx2)).toEqual(expected);
+  });
+});
+
+describe('extendSlot', () => {
+  // Component that implements extendSlot functionality
+  const extenderComponent = Vue.component('extender', {
+    data() {
+      return {
+        val: 0,
+      };
+    },
+    methods: {
+      /**
+       * @public
+       * @param val
+       */
+      setVal(val) {
+        this.val = val;
+      },
+      eventTestEmitter() {
+        this.$emit('eventTest');
+      },
+      extendSlot,
+    },
+    render() {
+      return this.extendSlot(
+        'default',
+        {
+          class: {
+            'greater-than-one': this.val > 1,
+            'less-than-one': this.val < 1,
+          },
+          on: {
+            click: this.eventTestEmitter,
+          },
+        },
+        { val: this.val }
+      );
+    },
+  });
+
+  function withLayout(template, overrides = {}) {
+    const component = Vue.component('test-root', {
+      template,
+      ...overrides,
+    });
+
+    let root = null;
+    let eventTest = null;
+
+    beforeEach(async () => {
+      eventTest = jest.fn();
+      root = mount(component, { methods: { eventTest } });
+      await root.vm.$nextTick();
+    });
+    afterEach(() => {
+      if (root) {
+        root.destroy();
+      }
+
+      root = null;
+      eventTest = null;
+    });
+
+    return {
+      $nextTick: () => root.vm.$nextTick(),
+      get root() {
+        return root;
+      },
+      get extender() {
+        return this.get(extenderComponent);
+      },
+      get(selector) {
+        const els = root.findAll(selector);
+        expect(els.length).toBeLessThanOrEqual(1);
+        return els.length ? els.at(0) : null;
+      },
+      events: {
+        get eventTest() {
+          return eventTest;
+        },
+      },
+    };
+  }
+
+  describe('with scoped slot', () => {
+    const layout = withLayout(`
+      <extender @eventTest="eventTest">
+        <template #default="{ val }">
+          <div class="scoped-el" :data-val="val">
+            <span>Something</span>
+          </div>
+        </template>
+      </extender>
+    `);
+
+    it('should render correctly initially', async () => {
+      const el = layout.get('.scoped-el');
+      expect(el).not.toBeNull();
+      expect(el.contains('span')).toBe(true);
+    });
+
+    it('should pass scoped parameters and update', async () => {
+      const el = layout.get('.scoped-el');
+      expect(el.attributes('data-val')).toBe('0');
+
+      layout.extender.vm.setVal(2);
+      await layout.$nextTick();
+
+      expect(el.attributes('data-val')).toBe('2');
+    });
+
+    it('should allow extending CSS classes', async () => {
+      const el = layout.get('.scoped-el');
+
+      expect(el.classes('less-than-one')).toBe(true);
+      expect(el.classes('greater-than-one')).toBe(false);
+
+      layout.extender.vm.setVal(2);
+      await layout.$nextTick();
+
+      expect(el.classes('less-than-one')).toBe(false);
+      expect(el.classes('greater-than-one')).toBe(true);
+    });
+
+    it('should allow hooking in events', async () => {
+      const el = layout.get('.scoped-el');
+      await el.trigger('click');
+      await layout.$nextTick();
+      expect(layout.events.eventTest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with unscoped slot', () => {
+    describe('containing simple element', () => {
+      const layout = withLayout(`
+        <extender data-prop="something" @eventTest="eventTest">
+          <div class="unscoped-el">
+            <span>Something</span>
+          </div>
+        </extender>
+      `);
+
+      it('should render correctly initially', async () => {
+        const el = layout.get('.unscoped-el');
+        expect(el).not.toBeNull();
+        expect(el.contains('span')).toBe(true);
+      });
+
+      it('should allow extending CSS classes', async () => {
+        const el = layout.get('.unscoped-el');
+
+        expect(el.classes('less-than-one')).toBe(true);
+        expect(el.classes('greater-than-one')).toBe(false);
+
+        layout.extender.vm.setVal(2);
+        await layout.$nextTick();
+        await layout.$nextTick();
+
+        expect(el.classes('less-than-one')).toBe(false);
+        expect(el.classes('greater-than-one')).toBe(true);
+      });
+
+      it('should allow hooking in events', async () => {
+        const el = layout.get('.unscoped-el');
+        await el.trigger('click');
+        await layout.$nextTick();
+        expect(layout.events.eventTest).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('containing component', () => {
+    const other = Vue.component('other', {
+      template: `<div class="unscoped-el"><slot></slot></div>`,
+    });
+    const layout = withLayout(
+      `
+      <extender data-prop="something" @eventTest="eventTest">
+        <other>
+          <span>Something</span>
+        </other>
+      </extender>
+    `,
+      { components: { other } }
+    );
+
+    it('should render correctly initially', async () => {
+      const el = layout.get('.unscoped-el');
+      expect(el).not.toBeNull();
+      expect(el.contains('span')).toBe(true);
+    });
+
+    it('should allow extending CSS classes', async () => {
+      const el = layout.get('.unscoped-el');
+
+      expect(el.classes('less-than-one')).toBe(true);
+      expect(el.classes('greater-than-one')).toBe(false);
+
+      layout.extender.vm.setVal(2);
+      await layout.$nextTick();
+      await layout.$nextTick();
+
+      expect(el.classes('less-than-one')).toBe(false);
+      expect(el.classes('greater-than-one')).toBe(true);
+    });
+
+    it('should allow hooking in events', async () => {
+      const el = layout.get('.unscoped-el');
+      await el.trigger('click');
+      await layout.$nextTick();
+      expect(layout.events.eventTest).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue
@@ -1,7 +1,7 @@
 <script>
 
   import { mapGetters, mapMutations } from 'vuex';
-  import { extendAndRender } from 'shared/utils/helpers';
+  import { extendSlot } from 'shared/utils/helpers';
 
   /**
    * Invisibly wraps the element with context menu handling, providing the information
@@ -37,14 +37,14 @@
         this.y = e.clientY;
         this.setMenu(this._uid);
       },
-      extendAndRender,
+      extendSlot,
     },
     render() {
       if (this.disabled) {
-        return this.extendAndRender('default');
+        return this.extendSlot('default');
       }
 
-      return this.extendAndRender(
+      return this.extendSlot(
         'default',
         {
           on: {


### PR DESCRIPTION
## Description
The `extendSlot` helper consolidates modifying `VNode`s from elements passed into a specified slot. It is used for our `Draggable*` components, which transparently wrap elements to add draggable functionality. This PR adds some tests for the `extendSlot` helper, and ensures that it behaves as expected. 

## Steps to Test

- [ ] *Check for regressions on frontend*
- [ ] *Ensure new tests pass*

## Implementation Notes (optional)

#### At a high level, how did you implement this?
My main concern was ensuring we had some test coverage on the helper, and that it functioned as expected regardless of using scoped or unscoped slots. With unscoped slots, updates are now handled differently to protect against any confusing bugs or gotchas related to implementing components that use the helper. This is a achieved by utilizing a flag on the `VNodeData` to determine when we're inserting vs updating, and when updating the `VNode` it will force an update.

#### Does this introduce any tech-debt items?
It _addresses_ tech-debt that I added with the draggable work.


## Checklist

- [X] Is the code clean and well-commented?
- [X] Are there tests for this change?
