### PR TITLE
Misc fixes to draggable state and components, and context menu fix

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -119,6 +119,7 @@
                   <TaskProgress :taskId="taskId" />
                 </div>
                 <div v-if="copying" class="disabled-overlay"></div>
+                <slot name="context-menu" v-bind="contextMenuProps"></slot>
               </VListTile>
             </template>
           </DraggableHandle>

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -264,11 +264,6 @@ export default {
      * @param {DragEvent|null} e
      */
     emitDraggableDragLeave(e) {
-      if (e && !this.$el.isSameNode(e.target) && this.$el.contains(e.target)) {
-        e.preventDefault();
-        return;
-      }
-
       if (this.draggableDragEntered) {
         this.debouncedResetHoverDraggable.cancel();
         this.throttledUpdateHoverDraggable.cancel();

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -23,9 +23,13 @@ export default {
       type: Boolean,
       default: false,
     },
-    effectsAllowed: {
+    effectAllowed: {
       type: String,
-      default: 'move copy',
+      default: 'copyMove',
+      /** @see https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/effectAllowed */
+      validator(val) {
+        return Boolean(['copy', 'move', 'copyMove', 'none'].find(effect => effect === val));
+      },
     },
   },
   data() {
@@ -77,13 +81,14 @@ export default {
         return;
       }
 
-      // Set draggable image
+      // Set draggable image to transparent 1x1 pixel image, overriding default browser behavior
+      // that generates a static PNG from the element
       const dragImage = new Image();
       dragImage.src =
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgDTD2qgAAAAASUVORK5CYII=';
       e.dataTransfer.setDragImage(dragImage, 1, 1);
       e.dataTransfer.setData('draggableIdentity', JSON.stringify(this.draggableIdentity));
-      e.dataTransfer.effectAllowed = this.effectsAllowed;
+      e.dataTransfer.effectAllowed = this.effectAllowed;
 
       this.throttledUpdateDraggableDirection.cancel();
       this.emitDraggableDrag(e);

--- a/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue
@@ -48,7 +48,7 @@
         'default',
         {
           on: {
-            contextmenu: e => this.showMenu(e),
+            contextmenu: this.showMenu,
           },
         },
         {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/constants.js
@@ -15,3 +15,15 @@ export const DraggableFlags = {
   LEFT: 4,
   RIGHT: 8,
 };
+
+/**
+ * Structure and defaults for draggable identity
+ */
+export const DraggableIdentityDefaults = {
+  id: null,
+  itemId: null,
+  collectionId: null,
+  regionId: null,
+  ancestors: null,
+  metadata: null,
+};

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
@@ -15,14 +15,14 @@ export function isInActiveDraggableUniverse(state, getters, rootState) {
  * @return {Number|null}
  */
 export function activeDraggableId(state) {
-  return (state.activeDraggable || {}).id;
+  return state.activeDraggable.id;
 }
 
 /**
  * @return {Number|null}
  */
 export function hoverDraggableId(state) {
-  return (state.hoverDraggable || {}).id;
+  return state.hoverDraggable.id;
 }
 
 export function isHoverDraggableAncestor(state) {
@@ -31,7 +31,7 @@ export function isHoverDraggableAncestor(state) {
    * @return {Boolean}
    */
   return function(identity) {
-    const { ancestors } = state.hoverDraggable || { ancestors: [] };
+    const ancestors = state.hoverDraggable.ancestors || [];
     return Boolean(ancestors.find(a => a.id === identity.id && a.type === identity.type));
   };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
@@ -1,7 +1,9 @@
-import { DraggableFlags } from '../constants';
+import { DraggableFlags, DraggableIdentityDefaults } from '../constants';
 import * as getters from './getters';
 import * as mutations from './mutations';
 import * as actions from './actions';
+
+const defaultIdentityClone = () => Object.assign({}, DraggableIdentityDefaults);
 
 export default function draggableSubmodule(draggableType) {
   return {
@@ -9,10 +11,10 @@ export default function draggableSubmodule(draggableType) {
     state() {
       return {
         draggableType,
-        activeDraggable: null,
+        activeDraggable: defaultIdentityClone(),
         activeDraggableSize: null,
-        hoverDraggable: null,
-        lastHoverDraggable: null,
+        hoverDraggable: defaultIdentityClone(),
+        lastHoverDraggable: defaultIdentityClone(),
         hoverDraggableSection: DraggableFlags.NONE,
         lastHoverDraggableSection: DraggableFlags.NONE,
       };

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/mutations.js
@@ -1,11 +1,27 @@
-import { DraggableFlags } from '../constants';
+import Vue from 'vue';
+import { DraggableFlags, DraggableIdentityDefaults } from '../constants';
+
+/**
+ * @param {Vuex.State} state
+ * @param {String} name
+ * @param {Object|null} [obj]
+ */
+function setIdentity(state, name, obj = null) {
+  if (!obj) {
+    obj = DraggableIdentityDefaults;
+  }
+
+  Object.keys(obj).forEach(key => {
+    Vue.set(state[name], key, obj[key]);
+  });
+}
 
 export function SET_ACTIVE_DRAGGABLE(state, identity) {
-  state.activeDraggable = identity;
+  setIdentity(state, 'activeDraggable', identity);
 }
 
 export function RESET_ACTIVE_DRAGGABLE(state) {
-  state.activeDraggable = null;
+  setIdentity(state, 'activeDraggable');
 }
 
 export function SET_ACTIVE_DRAGGABLE_SIZE(state, size) {
@@ -13,19 +29,19 @@ export function SET_ACTIVE_DRAGGABLE_SIZE(state, size) {
 }
 
 export function SET_HOVER_DRAGGABLE(state, identity) {
-  state.hoverDraggable = identity;
+  setIdentity(state, 'hoverDraggable', identity);
 }
 
 export function RESET_HOVER_DRAGGABLE(state) {
-  state.hoverDraggable = null;
+  setIdentity(state, 'hoverDraggable');
 }
 
 export function SET_LAST_HOVER_DRAGGABLE(state, identity) {
-  state.lastHoverDraggable = identity;
+  setIdentity(state, 'lastHoverDraggable', identity);
 }
 
 export function RESET_LAST_HOVER_DRAGGABLE(state) {
-  state.lastHoverDraggable = null;
+  setIdentity(state, 'lastHoverDraggable');
 }
 
 export function SET_HOVER_DRAGGABLE_SECTION(state, sectionMask) {


### PR DESCRIPTION
## Description
First, it looks like after I added Draggable to the `ContentNodeListItem` along with changes to the context menu, I lost the slot I added for the context menu so it was no longer showing. Also, there were a variety duplicate reference and reactivity issues with the Draggable code that this addresses.

## Steps to Test

- [ ] *No regressions*
- [ ] *Smoother more elegant dragging*

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
