### PR TITLE
Ensure that topics load when restoring from trash

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -142,6 +142,12 @@
       MoveModal,
     },
     mixins: [titleMixin],
+    props: {
+      nodeId: {
+        type: String,
+        required: true,
+      },
+    },
     data() {
       return {
         dialog: true,
@@ -153,7 +159,7 @@
       };
     },
     computed: {
-      ...mapGetters('currentChannel', ['currentChannel', 'trashId']),
+      ...mapGetters('currentChannel', ['currentChannel', 'trashId', 'rootId']),
       ...mapGetters('contentNode', ['getContentNodeChildren', 'getTopicAndResourceCounts']),
       headers() {
         return [
@@ -192,6 +198,12 @@
         }
       },
     },
+    created() {
+      Promise.all([
+        this.loadContentNodes({ parent__in: [this.rootId] }),
+        this.loadAncestors({ id: this.nodeId }),
+      ]);
+    },
     mounted() {
       this.loading = true;
       if (!this.trashId) {
@@ -203,7 +215,13 @@
       });
     },
     methods: {
-      ...mapActions('contentNode', ['deleteContentNodes', 'loadChildren', 'moveContentNodes']),
+      ...mapActions('contentNode', [
+        'deleteContentNodes',
+        'loadChildren',
+        'moveContentNodes',
+        'loadContentNodes',
+        'loadAncestors',
+      ]),
       moveNodes(target) {
         return this.moveContentNodes({ id__in: this.selected, parent: target }).then(() => {
           this.reset();

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -52,6 +52,10 @@ function makeWrapper(items) {
         };
       },
     },
+    methods: {
+      loadContentNodes: jest.fn(),
+      loadAncestors: jest.fn(),
+    },
     stubs: {
       ResourceDrawer: true,
       OfflineText: true,


### PR DESCRIPTION
## Description
Ensures that the channel's topics load when restoring from the trash, even if the user has refreshed the page.

#### Issue Addressed (if applicable)
Fixes #2307

## Steps to Test

- [ ] Delete something in a channel
- [ ] Open the trash
- [ ] Do a hard refresh (e.g. `ctl-shift-R` or `cmd-shift-R`)
- [ ] Attempt to restore your item by selecting it and clicking "restore"
- [ ] Ensure that the channel's topics have loaded into the move modal and that you can navigate to find a location to restore to
- [ ] Click "move to" to restore the content

## Implementation Notes

#### At a high level, how did you implement this?

Made sure a channel's contentnodes are loaded into the Vuex state upon navigating to the `TrashModal` component in cases where previously they hadn't been loaded.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Are there tests for this change?