### PR TITLE
Use separate Vuex stores for each test suite

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/store.js
+++ b/contentcuration/contentcuration/frontend/accounts/store.js
@@ -1,10 +1,14 @@
 import account from './vuex';
 import storeFactory from 'shared/vuex/baseStore';
 
-const store = storeFactory({
-  modules: {
-    account,
-  },
-});
+export function factory() {
+  return storeFactory({
+    modules: {
+      account,
+    },
+  });
+}
+
+const store = factory();
 
 export default store;

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelActionsDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelActionsDropdown.spec.js
@@ -1,7 +1,9 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import ChannelActionsDropdown from '../ChannelActionsDropdown';
+
+const store = factory();
 
 const channelId = '11111111111111111111111111111111';
 const updateChannel = jest.fn().mockReturnValue(Promise.resolve());

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelDetails.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelDetails.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import { RouterNames } from '../../../constants';
 import ChannelDetails from './../ChannelDetails';
+
+const store = factory();
 
 const channelId = '11111111111111111111111111111111';
 

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelItem.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelItem.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import { RouterNames } from '../../../constants';
 import ChannelItem from '../ChannelItem';
+
+const store = factory();
 
 const channelId = '11111111111111111111111111111111';
 const channel = {

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelTable.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import { RouterNames } from '../../../constants';
 import ChannelTable from '../ChannelTable';
+
+const store = factory();
 
 const loadChannels = jest.fn().mockReturnValue(Promise.resolve());
 const channelList = ['test', 'channel', 'table'];

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userActionsDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userActionsDropdown.spec.js
@@ -1,7 +1,9 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import UserActionsDropdown from '../UserActionsDropdown';
+
+const store = factory();
 
 const userId = 'test-user-id';
 const updateUser = jest.fn().mockReturnValue(Promise.resolve());

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userDetails.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userDetails.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import { RouterNames } from '../../../constants';
 import UserDetails from '../UserDetails';
+
+const store = factory();
 
 const userId = 'test-user-id';
 const user = {

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userItem.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userItem.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import { RouterNames } from '../../../constants';
 import UserItem from '../UserItem';
+
+const store = factory();
 
 const userId = 'test-user-id';
 const user = {

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import { RouterNames } from '../../../constants';
 import UserTable from '../UserTable';
+
+const store = factory();
 
 const loadUsers = jest.fn().mockReturnValue(Promise.resolve());
 const userList = ['test', 'user', 'table'];

--- a/contentcuration/contentcuration/frontend/administration/store.js
+++ b/contentcuration/contentcuration/frontend/administration/store.js
@@ -2,16 +2,20 @@ import channelAdmin from './vuex/channelAdmin';
 import userAdmin from './vuex/userAdmin';
 import storeFactory from 'shared/vuex/baseStore';
 
-const store = storeFactory({
-  modules: {
-    channelAdmin,
-    userAdmin,
-  },
-  getters: {
-    currentUserIsAdmin(state, getters, rootState) {
-      return rootState.session.currentUser.is_admin;
+export function factory() {
+  return storeFactory({
+    modules: {
+      channelAdmin,
+      userAdmin,
     },
-  },
-});
+    getters: {
+      currentUserIsAdmin(state, getters, rootState) {
+        return rootState.session.currentUser.is_admin;
+      },
+    },
+  });
+}
+
+const store = factory();
 
 export default store;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.spec.js
@@ -1,8 +1,10 @@
 import { shallowMount, mount } from '@vue/test-utils';
 
-import store from '../../store';
+import { factory } from '../../store';
 import AssessmentItemEditor from './AssessmentItemEditor';
 import { AssessmentItemTypes, ValidationErrors } from 'shared/constants';
+
+const store = factory();
 
 jest.mock('shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue');
 jest.mock('shared/views/MarkdownEditor/MarkdownViewer/MarkdownViewer.vue');

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/__tests__/moveModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/__tests__/moveModal.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import MoveModal from '../MoveModal.vue';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 const testNodeId = 'test';
 const testNode = {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/__tests__/newTopicModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/__tests__/newTopicModal.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import NewTopicModal from '../NewTopicModal.vue';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 function makeWrapper() {
   return mount(NewTopicModal, {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/publish/__tests__/publishModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/publish/__tests__/publishModal.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import PublishModal from '../PublishModal';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 const steps = {
   VALIDATION: 0,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentRenderer.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentRenderer.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import ContentRenderer from '../ContentRenderer.vue';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 const testFile = {
   id: 'test',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/filePreview.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/filePreview.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import FilePreview from '../FilePreview.vue';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 function makeWrapper(props = {}) {
   return mount(FilePreview, {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUpload.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUpload.spec.js
@@ -3,6 +3,8 @@ import FileUpload from '../FileUpload';
 import FileUploadItem from '../FileUploadItem';
 import { factory } from '../../../store';
 
+const store = factory();
+
 const testFiles = [
   {
     id: 'file-1',
@@ -36,7 +38,7 @@ function makeWrapper(files) {
     f.url = 'path';
     f.file_format = 'mp3';
   });
-  const store = factory();
+
   return mount(FileUpload, {
     store,
     attachToDocument: true,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressBar.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressBar.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import ProgressBar from '../ProgressBar';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 function makeWrapper(computed = {}) {
   return mount(ProgressBar, {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import ProgressModal from '../ProgressModal';
-import store from '../../../store';
+import { factory } from '../../../store';
+
+const store = factory();
 
 const task = { task: { id: 123, task_type: 'test-task' } };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import TrashModal from '../TrashModal';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import { RouterNames } from '../../../constants';
+
+const store = factory();
 
 const testChildren = [
   {

--- a/contentcuration/contentcuration/frontend/channelList/store.js
+++ b/contentcuration/contentcuration/frontend/channelList/store.js
@@ -2,11 +2,15 @@ import channelList from './vuex/channelList';
 import channelSet from './vuex/channelSet';
 import storeFactory from 'shared/vuex/baseStore';
 
-const store = storeFactory({
-  modules: {
-    channelList,
-    channelSet,
-  },
-});
+export function factory() {
+  return storeFactory({
+    modules: {
+      channelList,
+      channelSet,
+    },
+  });
+}
+
+const store = factory();
 
 export default store;

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilterBar.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilterBar.spec.js
@@ -1,7 +1,9 @@
 import { mount } from '@vue/test-utils';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import CatalogFilterBar from '../CatalogFilterBar';
+
+const store = factory();
 
 const collection = {
   id: 'test-collection',

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilters.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilters.spec.js
@@ -1,7 +1,9 @@
 import { mount } from '@vue/test-utils';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import CatalogFilters from '../CatalogFilters';
+
+const store = factory();
 
 function makeWrapper(computed = {}) {
   return mount(CatalogFilters, {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogList.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import { RouterNames } from '../../../constants';
 import CatalogList from '../CatalogList';
+
+const store = factory();
 
 router.push({ name: RouterNames.CATALOG_ITEMS });
 

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/channelItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/channelItem.spec.js
@@ -1,10 +1,12 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import VueRouter from 'vue-router';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import { RouterNames } from '../../../constants';
 import ChannelItem from '../ChannelItem.vue';
+
+const store = factory();
 
 Vue.use(VueRouter);
 const channelId = 'testing';

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetItem.spec.js
@@ -1,14 +1,17 @@
 import { mount } from '@vue/test-utils';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import { RouterNames } from '../../../constants';
 import ChannelSetItem from '../ChannelSetItem.vue';
+
+const store = factory();
 
 const channelSet = {
   id: 'testing',
   channels: [],
   secret_token: '1234567890',
 };
+
 store.commit('channelSet/ADD_CHANNELSET', channelSet);
 
 function makeWrapper(deleteStub) {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetList.spec.js
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
-import store from '../../../store';
+import { factory } from '../../../store';
 import router from '../../../router';
 import { RouterNames } from '../../../constants';
 import ChannelSetList from '../ChannelSetList.vue';
+
+const store = factory();
 
 const id = '00000000000000000000000000000000';
 

--- a/contentcuration/contentcuration/frontend/settings/pages/__tests__/deleteAccountForm.spec.js
+++ b/contentcuration/contentcuration/frontend/settings/pages/__tests__/deleteAccountForm.spec.js
@@ -1,7 +1,8 @@
 import { mount } from '@vue/test-utils';
-import store from '../../store';
+import { factory } from '../../store';
 import DeleteAccountForm from '../Account/DeleteAccountForm';
 
+const store = factory();
 const email = 'test@testing.com';
 function makeWrapper() {
   return mount(DeleteAccountForm, {

--- a/contentcuration/contentcuration/frontend/settings/pages/__tests__/fullNameForm.spec.js
+++ b/contentcuration/contentcuration/frontend/settings/pages/__tests__/fullNameForm.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
-import store from '../../store';
+import { factory } from '../../store';
 import FullNameForm from '../Account/FullNameForm';
+
+const store = factory();
 
 function makeWrapper() {
   return mount(FullNameForm, {

--- a/contentcuration/contentcuration/frontend/settings/pages/__tests__/requestForm.spec.js
+++ b/contentcuration/contentcuration/frontend/settings/pages/__tests__/requestForm.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
-import store from '../../store';
+import { factory } from '../../store';
 import RequestForm from '../Storage/RequestForm';
+
+const store = factory();
 
 const minimumForm = {
   storage: 'storage',

--- a/contentcuration/contentcuration/frontend/settings/store.js
+++ b/contentcuration/contentcuration/frontend/settings/store.js
@@ -1,10 +1,14 @@
 import settings from './vuex';
 import storeFactory from 'shared/vuex/baseStore';
 
-const store = storeFactory({
-  modules: {
-    settings,
-  },
-});
+export function factory() {
+  return storeFactory({
+    modules: {
+      settings,
+    },
+  });
+}
+
+const store = factory();
 
 export default store;


### PR DESCRIPTION
## Description
This PR implements a factory pattern for Vuex stores, so that tests can get fresh Vuex stores and avoid interfering with each other.  

### Context

> Noticing a pattern in some of our frontend tests to directly import the store for the relevant app page into the tests and reuse it, e.g. import store from '../../store'; - this can sometimes be problematic as it means each test doesn't get a fresh store state - and when running locally (where tests don't run in band like they do on travis) it can lead to inconsistent test behaviour as tests pollute each other.
> The pattern that JB set up in Kolibri was to expose a storeFactory function in each store module - the module still exports the output of that factory function as its default, but also exports the factory function for encapsulated testing. I've replicated that pattern in the base store, and now in the channelEdit store in this PR: https://github.com/learningequality/studio/pull/2443 so if you're seeing weird test failures locally, this might be something to check and implement!

[- @rtibbles](https://learningequality.slack.com/archives/C0LK8QS9J/p1602854958070700)

This should keep different test cases better isolated from each other, so that changes in one part of the application don't cause tests in some completely different part of the application to suddenly fail unpredictably.

I ran into an issue this week where for one of my pull requests, tests were passing locally but failing on Travis.  The failing test suite was for a different part of the application that my PR hadn't even directly touched.

As it turns out, the test suite for the part of the application that my PR had modified was directly importing the Vuex store, and  it seems that some changes to asynchronous behavior in my PR were messing with up the timing of a completely separate test suite.