### PR TITLE
Fixes copying assessment item files

### DIFF
--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -509,8 +509,8 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
 
         for file in node_assessmentitem_files:
             file.id = None
-            file.assessmentitem_id = assessmentitem_new_id_lookup[
-                file.assessmentitem_id
+            file.assessment_item_id = assessmentitem_new_id_lookup[
+                file.assessment_item_id
             ]
 
         File.objects.bulk_create(node_assessmentitem_files)


### PR DESCRIPTION
## Description

* Fixes typo that caused an error when copying assessment item files
* Adds regression test

#### Issue Addressed (if applicable)

Fixes #2497
