### PR TITLE
Associate uploaded exercise images with assessment items on save

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <Uploader ref="uploader" :presetID="imagePreset" :uploadingHandler="handleUploading">
+  <Uploader ref="uploader" :presetID="imagePreset">
     <template #default="{handleFiles}">
       <VLayout>
         <VFlex xs7 lg5>
@@ -397,11 +397,6 @@
       },
       closeAnswer() {
         this.openAnswerIdx = null;
-      },
-      handleUploading(newFile) {
-        if (newFile.checksum) {
-          // TODO: set assessment id on file
-        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
@@ -12,16 +12,13 @@ export const imageMdToParams = imageMd => {
     return {};
   }
   const description = match[1];
-  const filePathWithPlaceholder = match[2];
   const fileNameWithExtension = match[3];
   const width = match[4];
   const height = match[5];
   const [checksum, extension] = fileNameWithExtension.split('.');
 
-  const imagePath = storageUrl(checksum, extension);
-  const src = filePathWithPlaceholder.replace(IMAGE_PLACEHOLDER, imagePath);
-
-  return { imageMd, imagePath, src, width, height, checksum, alt: description };
+  const src = storageUrl(checksum, extension);
+  return { imageMd, src, width, height, checksum, alt: description };
 };
 
 export const paramsToImageMd = ({ src, alt, width, height }) => {

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
@@ -1,6 +1,7 @@
 import './image-upload.css';
 import { IMAGE_PLACEHOLDER } from '../../constants';
 import imageUploadExtension from './image-upload.js';
+import { storageUrl } from 'shared/vuex/file/utils';
 
 export const IMAGE_REGEX = /!\[([^\]]*)]\(([^/]+\/([^\s]+))(?:\s=([0-9.]+)x([0-9.]+))*\)/g;
 export const SINGLE_IMAGE_REGEX = /!\[([^\]]*)]\(([^/]+\/([^\s]+))(?:\s=([0-9.]+)x([0-9.]+))*\)/;
@@ -15,10 +16,10 @@ export const imageMdToParams = imageMd => {
   const fileNameWithExtension = match[3];
   const width = match[4];
   const height = match[5];
+  const [checksum, extension] = fileNameWithExtension.split('.');
 
-  const imagePath = `/content/storage/${fileNameWithExtension[0]}/${fileNameWithExtension[1]}`;
+  const imagePath = storageUrl(checksum, extension);
   const src = filePathWithPlaceholder.replace(IMAGE_PLACEHOLDER, imagePath);
-  const checksum = fileNameWithExtension.split('.')[0];
 
   return { imageMd, imagePath, src, width, height, checksum, alt: description };
 };

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -366,6 +366,27 @@ class SyncTestCase(StudioAPITestCase):
         except models.ContentNode.DoesNotExist:
             self.fail("ContentNode was not created")
 
+    def test_create_contentnode_tag(self):
+        user = testdata.user()
+        tag = "howzat!"
+
+        self.client.force_authenticate(user=user)
+        contentnode = self.contentnode_metadata
+        contentnode["tags"] = {
+            tag: True,
+        }
+        response = self.client.post(
+            self.sync_url,
+            [generate_create_event(contentnode["id"], CONTENTNODE, contentnode)],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertTrue(
+            models.ContentNode.objects.get(id=contentnode["id"])
+            .tags.filter(tag_name=tag)
+            .exists()
+        )
+
     def test_create_contentnode_with_parent(self):
         channel = testdata.channel()
         user = testdata.user()
@@ -1214,6 +1235,25 @@ class CRUDTestCase(StudioAPITestCase):
             models.ContentNode.objects.get(id=contentnode["id"])
         except models.ContentNode.DoesNotExist:
             self.fail("ContentNode was not created")
+
+    def test_create_contentnode_tag(self):
+        user = testdata.user()
+        tag = "howzat!"
+
+        self.client.force_authenticate(user=user)
+        contentnode = self.contentnode_metadata
+        contentnode["tags"] = {
+            tag: True,
+        }
+        response = self.client.post(
+            reverse("contentnode-list"), contentnode, format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        self.assertTrue(
+            models.ContentNode.objects.get(id=contentnode["id"])
+            .tags.filter(tag_name=tag)
+            .exists()
+        )
 
     def test_update_contentnode(self):
         user = testdata.user()

--- a/jest_config/setup.js
+++ b/jest_config/setup.js
@@ -33,6 +33,8 @@ global.afterEach(() => {
 
 window.jQuery = window.$ = jquery;
 
+window.storageBaseUrl = '/content/storage/';
+
 Vue.use(VueRouter);
 Vue.use(Vuex);
 Vue.use(Vuetify, {


### PR DESCRIPTION
## Description

* Updates the existing assessment item file association code to limit queries
* Adds tests to ensure file editing and removal
* Updates frontend image rendering logic to use storageUrl utility

#### Issue Addressed (if applicable)

* Fixes #2080

## Implementation Notes (optional)

* This explicitly does not follow the same pattern as contentnode file handling
* I initially tried to do this in parallel to contentnode file management
  * This was complex due to the fact we don't use assessment item FKs on the frontend
  * And we can't generate assessment item PKs no the frontend because they are autoincrementing integers
* I then tried to do it as managed many to many keys on the assessment item
  * This fixed the issues above with FKs
  * However, it would have required a more complex structure on the frontend to encode the checksum and file format
  * Without this, we would not have been able to remove files from the assessment item
* Because of these complications, I reverted to the strategy currently being used on Studio master of analysis of the MD fields for which images are used
* I further restricted image setting to require that an 'unclaimed' file object by the editing user exist, i.e. that one was created from the upload_url endpoint
