### PR TITLE
Add preemptive lock for node deletion.

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1537,7 +1537,9 @@ class ContentNode(MPTTModel, models.Model):
         if parent:
             parent.changed = True
             parent.save()
-        return super(ContentNode, self).delete(*args, **kwargs)
+        # Lock the mptt fields for the tree of this node
+        with ContentNode.objects.lock_mptt(self.tree_id):
+            return super(ContentNode, self).delete(*args, **kwargs)
 
     # Copied from MPTT
     delete.alters_data = True


### PR DESCRIPTION
## Description

* Deleting nodes causes reordering of MPTT fields
* This adds an mptt field DB lock when deleting content nodes
