### PR TITLE
Annotate after paginate (and some more stuff)

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -145,7 +145,7 @@
         if (this.isTopic) {
           return `${baseUrl}#/${this.node.id}`;
         }
-        return `${baseUrl}#/${this.node.parent_id}/${this.node.id}`;
+        return `${baseUrl}#/${this.node.parent}/${this.node.id}`;
       },
       resourcesMsg() {
         let count;

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
@@ -6,7 +6,7 @@ import { Channel, SavedSearch } from 'shared/data/resources';
 export function fetchResourceSearchResults(context, params) {
   params = { ...params };
   delete params['last'];
-  params.page_size = params.page_size || 50;
+  params.page_size = params.page_size || 25;
   params.channel_list = params.channel_list || ChannelListTypes.PUBLIC;
   return client.get(window.Urls.search_list(), { params }).then(response => {
     context.commit('contentNode/ADD_CONTENTNODES', response.data.results, { root: true });

--- a/contentcuration/search/viewsets/contentnode.py
+++ b/contentcuration/search/viewsets/contentnode.py
@@ -98,7 +98,7 @@ class ContentNodeFilter(RequiredFilterSet):
         filter_query = Q(title__icontains=value) | Q(description__icontains=value)
         tags_node_ids = ContentNode.tags.through.objects.filter(
             contenttag__tag_name__icontains=value
-        ).values_list("contentnode_id", flat=True)
+        ).values_list("contentnode_id", flat=True)[:100]
         # Check if we have a Kolibri node id or ids and add them to the search if so.
         # Add to, rather than replace, the filters so that we never misinterpret a search term as a UUID.
         # node_ids = uuid_re.findall(value) + list(tags_node_ids)
@@ -209,7 +209,7 @@ class SearchContentNodeViewSet(ContentNodeViewSet):
         """
         search_results_ids = list(queryset.order_by().values_list("id", flat=True))
         queryset = self._annotate_channel_id(
-            ContentNode.objects.filter(id__in=search_results_ids)
+            ContentNode.objects.filter(id__in=search_results_ids[:200])
         )
 
         # Get accessible content nodes that match the content id


### PR DESCRIPTION
## Description

* Changes the default page_size in the search frontend request to sync it with the backend params
* When searching in tags, the number of possible results is limited to 250. It's not limited when searching in description or title
* Multiple fields, annotations and grouping from `ContentNodeViewSet` have been removed as they proved to be unneeded for the search results.
* Paginate first, then do the annotations (drastically reduce the queries from minutes to a few seconds)
* Cache count results for five minutes, so browsing between pages is much faster

After making measurements:
- Worst cases are for searches on very generic words as 'maths', they take around 17 seconds for the first page of results and 3 seconds for the next pages . Before this PR it took more than 20 minutes

#### Issue Addressed (if applicable)

Relates #2510 


## Implementation Notes (optional)
Most of the ContentNodeViewSet fields are not needed in Search, so they are removed. 

Following the usual DRF pattern, pagination happens after the whole queryset is built. This means pagination is done over a bunch of grouping and calculations that are done over the whole database instead of being doing over the number of fields that are shown in the page. With this PR , first the ids of the nodes belonging to a page (taking into account permissions) are fetched, then annotations are done only over this reduced number of  nodes.

After the above mechanism is implemented, counting the total number of records to be shown in the results page is the most consuming time, so this PR also caches it, so the count is done for the first page, the other pages use the cached result that's maitained for 5 minutes.

Due to the way tags are stored in the database (completely n ormalized so several joins and loops are needed to fetch them), adding them in the search query makes it totally unusable. For this reason, first tags are searched and its nodes are included to the final result. A limit in the number of results is needed in this case and it has been set to 250. For the search in description and titles there is no limit on the number of results.



There is still room for improvement, but I don't think it's worth at this moment:

- Implementing Postgresql full search, with gin indexes
- Removing `location_ids` annotation for the results as its usage in the user page is very limited
- Denormalizing tags, using a jsonb filed so a fully search could be done 