### PR TITLE
Fix typos in indexes and migrations.

### DIFF
--- a/contentcuration/contentcuration/migrations/0121_auto_20200917_1912.py
+++ b/contentcuration/contentcuration/migrations/0121_auto_20200917_1912.py
@@ -7,10 +7,11 @@ from django.db import models
 
 import contentcuration.models
 
+
 class Migration(migrations.Migration):
     atomic = False
     dependencies = [
-        ('contentcuration', '0120_auto_20200917_1912'),
+        ("contentcuration", "0120_auto_20200917_1912"),
     ]
 
     operations = [
@@ -18,7 +19,9 @@ class Migration(migrations.Migration):
             state_operations=[
                 migrations.AddIndex(
                     model_name="contentnode",
-                    index=models.Index(fields=["~modified"], name="node_modified_desc_idx"),
+                    index=models.Index(
+                        fields=["-modified"], name="node_modified_desc_idx"
+                    ),
                 ),
             ],
             database_operations=[

--- a/contentcuration/contentcuration/migrations/0122_assessment_id_index.py
+++ b/contentcuration/contentcuration/migrations/0122_assessment_id_index.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             state_operations=[
                 migrations.AddIndex(
-                    model_name="contentnode",
+                    model_name="assessmentitem",
                     index=models.Index(
                         fields=["assessment_id"],
                         name=contentcuration.models.ASSESSMENT_ID_INDEX_NAME,

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1566,7 +1566,7 @@ class ContentNode(MPTTModel, models.Model):
         # unique_together = ('parent', 'title')
         indexes = [
             models.Index(fields=["node_id"], name=NODE_ID_INDEX_NAME),
-            models.Index(fields=["~modified"], name=NODE_MODIFIED_DESC_INDEX_NAME),
+            models.Index(fields=["-modified"], name=NODE_MODIFIED_DESC_INDEX_NAME),
         ]
 
 


### PR DESCRIPTION
## Description

* Fixes a typo in index where `~modified` was used instead of `-modified`
* Fixes a typo in index migration where `contentnode` model was set instead of `assessmentitem`
* Neither of these affect the created migrations, but will cause Django to be confused in the future
