### PR TITLE
Added channels to settings pages for delete account and storage form sections

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -122,7 +122,6 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
-  import get from 'lodash/get';
   import FullNameForm from './FullNameForm';
   import ChangePasswordForm from './ChangePasswordForm';
   import DeleteAccountForm from './DeleteAccountForm';
@@ -150,6 +149,7 @@
       ...mapState({
         user: state => state.session.currentUser,
       }),
+      ...mapState('settings', ['channels']),
       fullName() {
         return `${this.user.first_name} ${this.user.last_name}`;
       },
@@ -159,7 +159,7 @@
       // are not deleted without deleting such channels or first
       // inviting another user to have the rights to such channels
       channelsAsSoleEditor() {
-        return get(this, 'user.channels', []).filter(c => c.editor_count === 1);
+        return this.channels.filter(c => c.editor_count === 1);
       },
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -290,9 +290,7 @@
     },
     mixins: [constantsTranslationMixin, formMixin],
     computed: {
-      ...mapState({
-        user: state => state.session.currentUser,
-      }),
+      ...mapState('settings', ['channels']),
       orgSelected() {
         return this.org_or_personal === 'Organization';
       },
@@ -332,7 +330,7 @@
         ];
       },
       publicChannelOptions() {
-        return sortBy(this.user.channels, c => c.name.toLowerCase());
+        return sortBy(this.channels, c => c.name.toLowerCase()).filter(c => !c.public);
       },
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/settings/pages/__tests__/account.spec.js
+++ b/contentcuration/contentcuration/frontend/settings/pages/__tests__/account.spec.js
@@ -9,9 +9,11 @@ function makeWrapper(currentUser = {}) {
           email: 'test@testing.com',
           first_name: 'First',
           last_name: 'Last',
-          channels: [{ editor_count: 1 }],
           ...currentUser,
         };
+      },
+      channels() {
+        return currentUser.channels || [];
       },
     },
     stubs: {
@@ -34,6 +36,7 @@ describe('account tab', () => {
       expect(wrapper.find('[data-test="delete"]').exists()).toBe(false);
     });
     it('should be hidden if user is sole editor on a channel', () => {
+      wrapper = makeWrapper({ channels: [{ editor_count: 1 }] });
       expect(wrapper.find('[data-test="delete"]').exists()).toBe(false);
     });
     it('should be visible if user is not a sole editor on any channels', () => {

--- a/contentcuration/contentcuration/frontend/settings/vuex/index.js
+++ b/contentcuration/contentcuration/frontend/settings/vuex/index.js
@@ -2,6 +2,9 @@ import client from 'shared/client';
 
 export default {
   namespaced: true,
+  state: {
+    channels: window.channels,
+  },
   actions: {
     exportData() {
       return client.get(window.Urls.export_user_data());

--- a/contentcuration/contentcuration/templates/settings.html
+++ b/contentcuration/contentcuration/templates/settings.html
@@ -10,5 +10,8 @@
 {% endblock css_bundle %}
 
 {% block content %}
+	<script>
+		var channels = JSON.parse({{ channels | safe }});
+	</script>
 	{% render_bundle 'settings' 'js' %}
 {% endblock content %}

--- a/contentcuration/contentcuration/views/settings.py
+++ b/contentcuration/contentcuration/views/settings.py
@@ -47,9 +47,7 @@ MESSAGES = "i18n_messages"
 @browser_is_supported
 def settings(request):
     current_user = current_user_for_context(request.user)
-    channel_query = request.user.editable_channels \
-        .prefetch_related("editors") \
-        .annotate(editor_count=Count("editors"))
+    channel_query = request.user.editable_channels.annotate(editor_count=Count("editors"))
 
     return render(
         request,

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -648,3 +648,16 @@ class AdminChannelViewSet(ChannelViewSet):
             output.append(result)
 
         return Response(output)
+
+
+class SettingsChannelSerializer(BulkModelSerializer):
+    """ Used for displaying list of user's channels on settings page """
+    editor_count = serializers.SerializerMethodField()
+
+    def get_editor_count(self, value):
+        return value.editor_count
+
+    class Meta:
+        model = Channel
+        fields = ("id", "name", "editor_count", "public")
+        read_only_fields = ("id", "name", "editor_count", "public")


### PR DESCRIPTION
## Description

Bootstraps user's editable channels onto settings pages for use under storage form public channel question and delete account section

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2468

## Steps to Test

- [ ] Create a channel
- [ ] Navigate to settings page
- [ ] Verify new channel is listed under Account > Delete account
- [ ] Verify all channels are listed under Storage > request form > public channel question dropdown

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?