### PR TITLE
Fixed z-index on hierarchy panel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -31,7 +31,7 @@
       localName="topic-tree"
       :maxWidth="drawer.maxWidth"
       :minWidth="200"
-      style="z-index: 5;"
+      style="z-index: 4;"
       :style="{backgroundColor: $vuetify.theme.backgroundColor}"
       :app="hasTopics"
       :hide-overlay="drawer.hideOverlay"


### PR DESCRIPTION
Fixes issue where hierarchy drawer was appearing above overlay

![image](https://user-images.githubusercontent.com/7447496/98407294-44cb0780-2024-11eb-8e9d-1e97de436ec0.png)
