### PR TITLE
Dragging placeholder component + RTL support

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -166,7 +166,7 @@
       v-if="draggingData"
       class="drag-placeholder"
       :style="{
-        left: `${clientX + 8}px`,
+        left: `${clientX + ($isRTL? -488 : 8)}px`,
         top: `${clientY + 8}px`,
       }"
     >

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -162,29 +162,25 @@
     />
 
     <!-- Dragging placeholder -->
-    <VCard
-      v-if="draggingData"
-      class="drag-placeholder"
-      :style="{
-        left: `${clientX + ($isRTL? -488 : 8)}px`,
-        top: `${clientY + 8}px`,
-      }"
-    >
-      <VLayout class="px-4 py-3">
-        <VFlex shrink>
-          <ContentNodeIcon
-            :kind="draggingData.kind"
-            :isEmpty="draggingData.total_count === 0"
-          />
-        </VFlex>
-        <VFlex
-          class="text-truncate pl-2 subheading text"
-          :class="getTitleClass(draggingData)"
-        >
-          {{ getTitle(draggingData) }}
-        </VFlex>
-      </VLayout>
-    </VCard>
+    <!-- TODO: update to use metadata directly instead of calling getContentNode -->
+    <DraggablePlaceholder draggableUniverse="contentNodes">
+      <template #default="{ metadata }">
+        <VLayout class="px-4 py-3">
+          <VFlex shrink>
+            <ContentNodeIcon
+              :kind="getContentNode(metadata.itemId).kind"
+              :isEmpty="getContentNode(metadata.itemId).total_count === 0"
+            />
+          </VFlex>
+          <VFlex
+            class="text-truncate px-2 subheading text"
+            :class="getTitleClass(getContentNode(metadata.itemId))"
+          >
+            {{ getTitle(getContentNode(metadata.itemId)) }}
+          </VFlex>
+        </VLayout>
+      </template>
+    </DraggablePlaceholder>
 
   </VContainer>
 
@@ -193,7 +189,7 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapGetters } from 'vuex';
   import { RouterNames } from '../../constants';
   import PublishModal from '../../components/publish/PublishModal';
   import ProgressModal from '../progress/ProgressModal';
@@ -207,6 +203,7 @@
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
   import { RouterNames as ChannelRouterNames } from 'frontend/channelList/constants';
   import { titleMixin } from 'shared/mixins';
+  import DraggablePlaceholder from 'shared/views/draggable/DraggablePlaceholder';
 
   export default {
     name: 'TreeViewBase',
@@ -221,6 +218,7 @@
       Clipboard,
       OfflineText,
       ContentNodeIcon,
+      DraggablePlaceholder,
     },
     mixins: [titleMixin],
     data() {
@@ -235,8 +233,6 @@
     computed: {
       ...mapGetters('contentNode', ['getContentNode']),
       ...mapGetters('currentChannel', ['currentChannel', 'canEdit', 'canManage', 'rootId']),
-      ...mapState('draggable', ['activeDraggableUniverse', 'clientX', 'clientY']),
-      ...mapState('draggable/handles', ['activeDraggable']),
       rootNode() {
         return this.getContentNode(this.rootId);
       },
@@ -317,13 +313,6 @@
       },
       showClipboardSpeedDial() {
         return this.$route.name !== RouterNames.STAGING_TREE_VIEW;
-      },
-      draggingData() {
-        if (this.activeDraggableUniverse === 'contentNodes') {
-          // TODO: return metadata prop set on drag state directly
-          return this.getContentNode(this.activeDraggable.itemId);
-        }
-        return null;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/shared/views/draggable/DraggablePlaceholder.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/draggable/DraggablePlaceholder.vue
@@ -1,0 +1,54 @@
+<template>
+
+  <!-- Dragging placeholder -->
+  <VCard
+    v-if="draggingData"
+    class="drag-placeholder"
+    :style="{
+      left: `${clientX + ($isRTL? -488 : 8)}px`,
+      top: `${clientY + 8}px`,
+    }"
+  >
+    <slot :metadata="draggingData"></slot>
+  </VCard>
+
+</template>
+
+
+<script>
+
+  import { mapState } from 'vuex';
+
+  export default {
+    name: 'DraggablePlaceholder',
+    props: {
+      draggableUniverse: {
+        type: String,
+        required: true,
+      },
+    },
+    computed: {
+      ...mapState('draggable', ['activeDraggableUniverse', 'clientX', 'clientY']),
+      ...mapState('draggable/handles', ['activeDraggable']),
+      draggingData() {
+        if (this.activeDraggableUniverse === this.draggableUniverse) {
+          // TODO: return metadata prop set on drag state directly
+          return this.activeDraggable;
+        }
+        return null;
+      },
+    },
+    $trs: {},
+  };
+
+</script>
+
+
+<style lang="less" scoped>
+
+  .drag-placeholder {
+    position: absolute;
+    z-index: 24;
+  }
+
+</style>


### PR DESCRIPTION
## Description

Made draggable placeholder into a shared component and made it support RTL
![image](https://user-images.githubusercontent.com/7447496/98411195-7fd03980-202a-11eb-8b99-e45593060ea6.png)

## Implementation Notes (optional)

#### Does this introduce any tech-debt items?

Still need to add grouped item view


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?