### PR TITLE
Retain channel list type between browsing/reviewing/searching in import modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -137,6 +137,7 @@
             nodeId: this.node.id,
             channelId: this.inSearch ? this.node.channel_id : this.$route.params.channelId,
           },
+          query: this.$route.query,
         };
       },
       openLocationUrl() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -3,7 +3,7 @@
   <VCard @click="handleClick">
     <VCardTitle>
       <VLayout row wrap>
-        <VFlex sm2 xs12 class="pt-2 px-4">
+        <VFlex lg2 md4 sm5 xs12 class="pt-2 px-4">
           <Thumbnail
             :src="node.thumbnail_src"
             :kind="node.kind"
@@ -11,7 +11,7 @@
           />
         </VFlex>
 
-        <VFlex sm10 xs12>
+        <VFlex lg10 md8 sm7 xs12>
           <h3
             class="title font-weight-bold text-truncate mt-2"
             :class="getTitleClass(node)"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -30,7 +30,7 @@
             <span v-if="node.coach_count || isCoach">
               <VTooltip bottom>
                 <template #activator="{ on }">
-                  <div class="my-1" v-on="on">
+                  <div class="my-1" style="display: inline-block;" v-on="on">
                     <Icon color="primary" small style="vertical-align: text-top;" class="mx-1">
                       local_library
                     </Icon>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
@@ -73,6 +73,7 @@
             channelId: this.channel.id,
             nodeId: this.channel.root_id,
           },
+          query: this.$route.query,
         };
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
@@ -3,7 +3,7 @@
   <VCard :to="channelRoute">
     <VCardTitle>
       <VLayout row wrap>
-        <VFlex sm2 xs12 class="px-3">
+        <VFlex lg2 md4 sm5 xs12 class="px-3">
           <VLayout align-center justify-center fill-height>
             <Thumbnail
               v-if="channel.thumbnail_url"
@@ -17,7 +17,7 @@
           </VLayout>
         </VFlex>
 
-        <VFlex sm10 xs12>
+        <VFlex lg10 md8 sm7 xs12>
           <h3 class="title notranslate font-weight-bold text-truncate" dir="auto">
             {{ channel.name }}
           </h3>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -60,7 +60,6 @@
     mixins: [constantsTranslationMixin],
     data() {
       return {
-        channelFilter: ChannelListTypes.PUBLIC,
         languageFilter: '',
         channels: [],
         pageCount: 0,
@@ -69,6 +68,21 @@
     },
     computed: {
       ...mapState('currentChannel', ['currentChannelId']),
+      channelFilter: {
+        get() {
+          return this.$route.query.channel_list || ChannelListTypes.PUBLIC;
+        },
+        set(channel_list) {
+          this.$router.push({
+            ...this.$route,
+            query: {
+              ...this.$route.query,
+              channel_list,
+            },
+          });
+          this.loadPage();
+        },
+      },
       channelFilterOptions() {
         return Object.values(ChannelListTypes).map(value => {
           return {
@@ -80,9 +94,6 @@
     },
     watch: {
       '$route.query.page'() {
-        this.loadPage();
-      },
-      channelFilter() {
         this.loadPage();
       },
       languageFilter() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -133,6 +133,7 @@
             to: {
               name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
               params: {},
+              query: this.$route.query,
             },
           },
           ...ancestorsLinks,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -141,10 +141,11 @@
       },
       backToBrowseRoute() {
         if (this.$route.query.last) {
-          return { path: this.$route.query.last };
+          return { path: this.$route.query.last, query: this.$route.query };
         }
         return {
           name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          query: this.$route.query,
         };
       },
       selectedResourcesCount() {
@@ -194,6 +195,7 @@
         this.$router.push({
           name: RouterNames.IMPORT_FROM_CHANNELS_REVIEW,
           query: {
+            ...this.$route.query,
             last: this.$route.path,
           },
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -119,7 +119,7 @@
   import Checkbox from 'shared/views/form/Checkbox';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
 
-  const excludedKinds = new Set(['topic', 'exercise']);
+  const excludedKinds = new Set(['topic', 'exercise', 'h5p']);
   const includedKinds = ContentKindsList.filter(kind => !excludedKinds.has(kind));
 
   export default {
@@ -196,7 +196,10 @@
       loadChannels(listType) {
         this.loadingChannels = true;
         this.loadChannelList({ listType }).then(channels => {
-          this.channels = [];
+          if (this.channels.length) {
+            this.channels = [];
+          }
+
           this.channelOptions = channels.filter(c => c.id !== this.currentChannelId);
           this.loadingChannels = false;
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -100,11 +100,15 @@
         return this.$route.name === RouterNames.IMPORT_FROM_CHANNELS_BROWSE;
       },
       backToBrowseRoute() {
+        const query = {
+          channel_list: this.$route.query.channel_list,
+        };
         if (this.$route.query.last) {
-          return { path: this.$route.query.last };
+          return { path: this.$route.query.last, query };
         }
         return {
           name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          query,
         };
       },
       searchIsValid() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -112,7 +112,10 @@
         };
       },
       searchIsValid() {
-        return (this.searchTerm || '').trim().length > 0;
+        return (
+          (this.searchTerm || '').trim().length > 0 &&
+          this.searchTerm.trim() !== this.$route.params.searchTerm
+        );
       },
     },
     mounted() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -80,6 +80,7 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
+  import debounce from 'lodash/debounce';
   import find from 'lodash/find';
   import BrowsingCard from './BrowsingCard';
   import SavedSearchesModal from './SavedSearchesModal';
@@ -166,18 +167,25 @@
       ...mapActions('importFromChannels', ['fetchResourceSearchResults', 'createSearch']),
       fetch() {
         this.loading = true;
-        this.fetchResourceSearchResults({
-          ...this.$route.query,
-          keywords: this.currentSearchTerm,
-          exclude_channel: this.currentChannelId,
-          last: undefined,
-        }).then(page => {
-          this.loading = false;
-          this.nodeIds = page.results.map(n => n.id);
-          this.pageCount = page.total_pages;
-          this.totalCount = page.count;
-        });
+        this.fetchResultsDebounced();
       },
+      fetchResultsDebounced: debounce(
+        function() {
+          this.fetchResourceSearchResults({
+            ...this.$route.query,
+            keywords: this.currentSearchTerm,
+            exclude_channel: this.currentChannelId,
+            last: undefined,
+          }).then(page => {
+            this.loading = false;
+            this.nodeIds = page.results.map(n => n.id);
+            this.pageCount = page.total_pages;
+            this.totalCount = page.count;
+          });
+        },
+        1000,
+        { trailing: true }
+      ),
       handleClickSaveSearch() {
         let params = { ...this.$route.query };
         delete params.last;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -162,9 +162,6 @@
       this.showSavedSearches = false;
       next();
     },
-    mounted() {
-      this.fetch();
-    },
     methods: {
       ...mapActions('importFromChannels', ['fetchResourceSearchResults', 'createSearch']),
       fetch() {

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash/isEqual';
 import transform from 'lodash/transform';
 import uniq from 'lodash/uniq';
 import { mapGetters } from 'vuex';
@@ -278,19 +279,21 @@ export function generateSearchMixin(filterMap) {
         this.navigate({});
       },
       navigate(params) {
-        this.$router
-          .replace({
-            ...this.$route,
-            query: {
-              ...params,
-              page: 1, // Make sure we're on page 1 for every new query
-            },
-          })
-          .catch(error => {
-            if (error && error.name != 'NavigationDuplicated') {
-              throw error;
-            }
-          });
+        if (!isEqual(this.$route.query, params)) {
+          this.$router
+            .replace({
+              ...this.$route,
+              query: {
+                ...params,
+                page: 1, // Make sure we're on page 1 for every new query
+              },
+            })
+            .catch(error => {
+              if (error && error.name != 'NavigationDuplicated') {
+                throw error;
+              }
+            });
+        }
       },
     },
   };


### PR DESCRIPTION
#### Issue Addressed

Fixes https://github.com/learningequality/studio/issues/2506
Fixes https://github.com/learningequality/studio/issues/2512
Fixes https://github.com/learningequality/studio/issues/2507
Fixes https://github.com/learningequality/studio/issues/2577

## Steps to Test

**Browse resources -> Browse channels**
- [x] Open the import modal
- [x] Select a channel list type
- [x] Browse through a channel's resources
- [x] Click the "Channels" link in the breadcrumb to go back to the default browse view
- [x] Verify that the channel list type filter matches your selection still

**Browse -> Search**
- [x] Open the import modal
- [x] Select a channel list type
- [x] Search for a keyword
- [x] Verify that the channel list type filter matches your selection still

**Search-> Browse**
- [x] Open the import modal
- [x] Search for a keyword
- [x] Select a channel list type
- [x] Go back to browsing mode
- [x] Verify that the channel list type filter matches your selection still

**Review -> Browse**
- [x] Open the import modal
- [x] Select a channel list type
- [x] Select an item under browsing mode
- [x] Click review
- [x] Go back
- [x] Verify that the channel list type filter matches your selection still

**Review -> Search**
- [x] Open the import modal
- [x] Search for a keyword
- [x] Select a channel list type
- [x] Select an item from the search results list
- [x] Click review
- [x] Go back
- [x] Verify that the channel list type filter matches your selection still

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?