### PR TITLE
Trigger content node operations off drag and drop events

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
@@ -1,14 +1,13 @@
 <template>
 
-  <VListGroup
+  <LazyListGroup
     v-model="open"
-    append-icon="arrow_drop_down"
+    appendIcon="arrow_drop_down"
     class="channel-item"
     :style="{'border-left-color': channelColor}"
-    lazy
   >
-    <template v-slot:activator>
-      <VListTile class="py-2">
+    <template #header>
+      <VListTile class="py-2" inactive>
         <VListTileAction class="select-col">
           <Checkbox
             ref="checkbox"
@@ -46,7 +45,7 @@
       />
     </transition-group>
 
-  </VListGroup>
+  </LazyListGroup>
 
 </template>
 <script>
@@ -56,12 +55,14 @@
   import clipboardMixin, { parentMixin } from './mixins';
   import Checkbox from 'shared/views/form/Checkbox';
   import { SelectionFlags } from 'frontend/channelEdit/vuex/clipboard/constants';
+  import LazyListGroup from 'shared/views/LazyListGroup';
 
   export default {
     name: 'Channel',
     components: {
       ContentNode,
       Checkbox,
+      LazyListGroup,
     },
     mixins: [clipboardMixin, parentMixin],
     props: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -1,33 +1,40 @@
 <template>
 
-  <DraggableCollection :draggableMetadata="contentNode">
-    <VListGroup
+  <DraggableCollection
+    v-if="contentNode"
+    :draggableMetadata="contentNode"
+    :dropEffect="dropEffectAndAllowed"
+  >
+    <LazyListGroup
       v-model="open"
-      append-icon="arrow_drop_down"
       class="parent-item"
-      lazy
-      sub-group
+      subGroup
     >
-      <template v-slot:activator>
+      <template #header>
         <VHover>
           <ContextMenu slot-scope="{ hover }">
-            <DraggableItem :draggableMetadata="contentNode">
-              <VListTile
-                v-if="contentNode"
-                class="content-item py-1"
-                :class="{hover, selected}"
-                :style="{'padding-left': indentPadding}"
+            <DraggableItem
+              :draggableMetadata="contentNode"
+              :dropEffect="dropEffectAndAllowed"
+            >
+              <DraggableHandle
+                :effectAllowed="dropEffectAndAllowed"
               >
-                <VListTileAction class="action-col">
-                  <Checkbox
-                    ref="checkbox"
-                    class="mt-0 pt-0"
-                    :value="selected"
-                    :indeterminate="indeterminate"
-                    @click.stop.prevent="goNextSelectionState"
-                  />
-                </VListTileAction>
-                <DraggableHandle effectAllowed="copy">
+                <VListTile
+                  class="content-item py-1"
+                  :class="{hover, selected}"
+                  :style="{'padding-left': indentPadding}"
+                  inactive
+                >
+                  <VListTileAction class="action-col">
+                    <Checkbox
+                      ref="checkbox"
+                      class="mt-0 pt-0"
+                      :value="selected"
+                      :indeterminate="indeterminate"
+                      @click.stop.prevent="goNextSelectionState"
+                    />
+                  </VListTileAction>
                   <div
                     class="thumbnail-col py-2"
                   >
@@ -37,58 +44,54 @@
                       compact
                     />
                   </div>
-                </DraggableHandle>
 
-                <template v-if="contentNode.kind === 'topic'">
-                  <DraggableHandle effectAllowed="copy">
+                  <template v-if="contentNode.kind === 'topic'">
                     <VListTileContent class="description-col pl-2 shrink">
                       <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
                         {{ getTitle(contentNode) }}
                       </VListTileTitle>
                     </VListTileContent>
-                  </DraggableHandle>
-                  <VListTileAction style="min-width: unset;" class="px-3">
-                    <div class="badge caption font-weight-bold">
-                      {{ contentNode.resource_count }}
-                    </div>
-                  </VListTileAction>
-                  <!-- Custom placement of dropdown indicator -->
-                  <VListTileAction
-                    class="v-list__group__header__append-icon action-col px-1"
-                  >
-                    <Icon>arrow_drop_down</Icon>
-                  </VListTileAction>
-                  <VSpacer />
-                </template>
-                <template v-else>
-                  <DraggableHandle effectAllowed="copy">
+                    <VListTileAction style="min-width: unset;" class="px-3">
+                      <div class="badge caption font-weight-bold">
+                        {{ contentNode.resource_count }}
+                      </div>
+                    </VListTileAction>
+                    <!-- Custom placement of dropdown indicator -->
+                    <VListTileAction
+                      class="v-list__group__header__append-icon action-col px-1"
+                    >
+                      <Icon>arrow_drop_down</Icon>
+                    </VListTileAction>
+                    <VSpacer />
+                  </template>
+                  <template v-else>
                     <VListTileContent class="description-col pa-2" @click="handlePreview">
                       <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
                         {{ getTitle(contentNode) }}
                       </VListTileTitle>
                     </VListTileContent>
-                  </DraggableHandle>
-                </template>
+                  </template>
 
-                <VListTileAction class="action-col option-col" :aria-hidden="!hover">
-                  <VMenu offset-y left>
-                    <template #activator="{ on }">
-                      <VBtn
-                        small
-                        icon
-                        flat
-                        class="ma-0"
-                        v-on="on"
-                        @click.stop
-                      >
-                        <Icon>more_horiz</Icon>
-                      </VBtn>
-                    </template>
+                  <VListTileAction class="action-col option-col" :aria-hidden="!hover">
+                    <VMenu offset-y left>
+                      <template #activator="{ on }">
+                        <VBtn
+                          small
+                          icon
+                          flat
+                          class="ma-0"
+                          v-on="on"
+                          @click.stop
+                        >
+                          <Icon>more_horiz</Icon>
+                        </VBtn>
+                      </template>
 
-                    <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
-                  </VMenu>
-                </VListTileAction>
-              </VListTile>
+                      <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
+                    </VMenu>
+                  </VListTileAction>
+                </VListTile>
+              </DraggableHandle>
             </DraggableItem>
             <template v-if="contentNode" #menu>
               <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
@@ -108,7 +111,7 @@
         />
       </transition-group>
 
-    </VListGroup>
+    </LazyListGroup>
   </DraggableCollection>
 
 </template>
@@ -124,6 +127,8 @@
   import DraggableCollection from 'shared/views/draggable/DraggableCollection';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
   import DraggableHandle from 'shared/views/draggable/DraggableHandle';
+  import LazyListGroup from 'shared/views/LazyListGroup';
+  import { EffectAllowed } from 'shared/mixins/draggable/constants';
 
   export default {
     name: 'ContentNode',
@@ -135,6 +140,7 @@
       DraggableCollection,
       DraggableHandle,
       DraggableItem,
+      LazyListGroup,
     },
     mixins: [clipboardMixin, parentMixin, titleMixin],
     data() {
@@ -162,6 +168,9 @@
       },
       loadClipboardNodesPayload() {
         return { parent: this.nodeId, ancestorId: this.childAncestorId };
+      },
+      dropEffectAndAllowed() {
+        return EffectAllowed.COPY;
       },
     },
     watch: {
@@ -240,10 +249,6 @@
     max-width: 100%;
   }
 
-  /deep/ .v-list__group__header .v-list__group__header__prepend-icon {
-    display: none;
-  }
-
   .badge {
     top: 0;
     width: max-content;
@@ -255,7 +260,8 @@
     border-radius: 3px;
   }
 
-  .content-item:hover {
+  .content-item:hover,
+  /deep/ .content-item > .v-list__tile:hover {
     background: #eeeeee;
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -1,105 +1,115 @@
 <template>
 
-  <VListGroup
-    v-model="open"
-    append-icon="arrow_drop_down"
-    class="parent-item"
-    lazy
-    sub-group
-  >
-    <template v-slot:activator>
-      <VHover>
-        <ContextMenu slot-scope="{ hover }">
-          <VListTile
-            v-if="contentNode"
-            class="content-item py-1"
-            :class="{hover, selected}"
-            :style="{'padding-left': indentPadding}"
-          >
-            <VListTileAction class="action-col">
-              <Checkbox
-                ref="checkbox"
-                class="mt-0 pt-0"
-                :value="selected"
-                :indeterminate="indeterminate"
-                @click.stop.prevent="goNextSelectionState"
-              />
-            </VListTileAction>
-            <div
-              class="thumbnail-col py-2"
-            >
-              <Thumbnail
-                v-bind="thumbnailAttrs"
-                :isEmpty="contentNode.resource_count === 0"
-                compact
-              />
-            </div>
-
-            <template v-if="contentNode.kind === 'topic'">
-              <VListTileContent class="description-col pl-2 shrink">
-                <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
-                  {{ getTitle(contentNode) }}
-                </VListTileTitle>
-              </VListTileContent>
-              <VListTileAction style="min-width: unset;" class="px-3">
-                <div class="badge caption font-weight-bold">
-                  {{ contentNode.resource_count }}
-                </div>
-              </VListTileAction>
-              <!-- Custom placement of dropdown indicator -->
-              <VListTileAction
-                class="v-list__group__header__append-icon action-col px-1"
+  <DraggableCollection :draggableMetadata="contentNode">
+    <VListGroup
+      v-model="open"
+      append-icon="arrow_drop_down"
+      class="parent-item"
+      lazy
+      sub-group
+    >
+      <template v-slot:activator>
+        <VHover>
+          <ContextMenu slot-scope="{ hover }">
+            <DraggableItem :draggableMetadata="contentNode">
+              <VListTile
+                v-if="contentNode"
+                class="content-item py-1"
+                :class="{hover, selected}"
+                :style="{'padding-left': indentPadding}"
               >
-                <Icon>arrow_drop_down</Icon>
-              </VListTileAction>
-              <VSpacer />
-            </template>
-            <template v-else>
-              <VListTileContent class="description-col pa-2" @click="handlePreview">
-                <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
-                  {{ getTitle(contentNode) }}
-                </VListTileTitle>
-              </VListTileContent>
-            </template>
-
-            <VListTileAction class="action-col option-col" :aria-hidden="!hover">
-              <VMenu offset-y left>
-                <template #activator="{ on }">
-                  <VBtn
-                    small
-                    icon
-                    flat
-                    class="ma-0"
-                    v-on="on"
-                    @click.stop
+                <VListTileAction class="action-col">
+                  <Checkbox
+                    ref="checkbox"
+                    class="mt-0 pt-0"
+                    :value="selected"
+                    :indeterminate="indeterminate"
+                    @click.stop.prevent="goNextSelectionState"
+                  />
+                </VListTileAction>
+                <DraggableHandle effectAllowed="copy">
+                  <div
+                    class="thumbnail-col py-2"
                   >
-                    <Icon>more_horiz</Icon>
-                  </VBtn>
+                    <Thumbnail
+                      v-bind="thumbnailAttrs"
+                      :isEmpty="contentNode.resource_count === 0"
+                      compact
+                    />
+                  </div>
+                </DraggableHandle>
+
+                <template v-if="contentNode.kind === 'topic'">
+                  <DraggableHandle effectAllowed="copy">
+                    <VListTileContent class="description-col pl-2 shrink">
+                      <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
+                        {{ getTitle(contentNode) }}
+                      </VListTileTitle>
+                    </VListTileContent>
+                  </DraggableHandle>
+                  <VListTileAction style="min-width: unset;" class="px-3">
+                    <div class="badge caption font-weight-bold">
+                      {{ contentNode.resource_count }}
+                    </div>
+                  </VListTileAction>
+                  <!-- Custom placement of dropdown indicator -->
+                  <VListTileAction
+                    class="v-list__group__header__append-icon action-col px-1"
+                  >
+                    <Icon>arrow_drop_down</Icon>
+                  </VListTileAction>
+                  <VSpacer />
+                </template>
+                <template v-else>
+                  <DraggableHandle effectAllowed="copy">
+                    <VListTileContent class="description-col pa-2" @click="handlePreview">
+                      <VListTileTitle class="text-truncate" :class="getTitleClass(contentNode)">
+                        {{ getTitle(contentNode) }}
+                      </VListTileTitle>
+                    </VListTileContent>
+                  </DraggableHandle>
                 </template>
 
-                <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
-              </VMenu>
-            </VListTileAction>
-          </VListTile>
-          <template v-if="contentNode" #menu>
-            <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
-          </template>
-        </ContextMenu>
-      </VHover>
-    </template>
+                <VListTileAction class="action-col option-col" :aria-hidden="!hover">
+                  <VMenu offset-y left>
+                    <template #activator="{ on }">
+                      <VBtn
+                        small
+                        icon
+                        flat
+                        class="ma-0"
+                        v-on="on"
+                        @click.stop
+                      >
+                        <Icon>more_horiz</Icon>
+                      </VBtn>
+                    </template>
 
-    <transition-group>
-      <ContentNode
-        v-for="child in children"
-        ref="children"
-        :key="child.id"
-        :nodeId="child.id"
-        :level="level + 1"
-        :ancestorId="childAncestorId"
-      />
-    </transition-group>
+                    <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
+                  </VMenu>
+                </VListTileAction>
+              </VListTile>
+            </DraggableItem>
+            <template v-if="contentNode" #menu>
+              <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
+            </template>
+          </ContextMenu>
+        </VHover>
+      </template>
 
-  </VListGroup>
+      <transition-group>
+        <ContentNode
+          v-for="child in children"
+          ref="children"
+          :key="child.id"
+          :nodeId="child.id"
+          :level="level + 1"
+          :ancestorId="childAncestorId"
+        />
+      </transition-group>
+
+    </VListGroup>
+  </DraggableCollection>
 
 </template>
 <script>
@@ -111,6 +121,9 @@
   import Thumbnail from 'shared/views/files/Thumbnail';
   import ContextMenu from 'shared/views/ContextMenu';
   import { titleMixin } from 'shared/mixins';
+  import DraggableCollection from 'shared/views/draggable/DraggableCollection';
+  import DraggableItem from 'shared/views/draggable/DraggableItem';
+  import DraggableHandle from 'shared/views/draggable/DraggableHandle';
 
   export default {
     name: 'ContentNode',
@@ -119,6 +132,9 @@
       ContentNodeOptions,
       Thumbnail,
       ContextMenu,
+      DraggableCollection,
+      DraggableHandle,
+      DraggableItem,
     },
     mixins: [clipboardMixin, parentMixin, titleMixin],
     data() {
@@ -142,7 +158,7 @@
         return {};
       },
       shouldPreload() {
-        return this.contentNode.total_count > 0;
+        return this.contentNode && this.contentNode.total_count > 0;
       },
       loadClipboardNodesPayload() {
         return { parent: this.nodeId, ancestorId: this.childAncestorId };

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -294,8 +294,6 @@
         this.elevated = false;
       },
       handleDraggableDrop(drop) {
-        drop.stopPropagation();
-
         const sourceIds = drop.data.sources
           .filter(source => {
             const { region } = new DraggableIdentityHelper(source);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -24,7 +24,7 @@
         >
           <VLayout class="container pa-0 ma-0" column>
             <ToolBar
-              class="header pa-0 ma-0"
+              class="header pa-0 ma-0 ml-1"
               color="white"
               :flat="!elevated"
             >
@@ -430,6 +430,10 @@
     position: relative;
   }
 
+  .header {
+    width: calc(100% - 1px);
+  }
+
   .header,
   .dragging-overlay {
     z-index: 4;
@@ -465,7 +469,7 @@
     padding: 0 0 64px;
   }
 
-  .channel-item:nth-child(n + 2) {
+  .channel-item:nth-child(2n) {
     background-color: #f9f9f9;
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -297,7 +297,7 @@
         const sourceIds = drop.data.sources
           .filter(source => {
             const { region } = new DraggableIdentityHelper(source);
-            return region.id !== DraggableRegions.CLIPBOARD;
+            return region && region.id !== DraggableRegions.CLIPBOARD;
           })
           .map(source => source.metadata.id);
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -193,7 +193,7 @@
       height: 0;
       overflow: hidden;
       content: ' ';
-      background: #cccccc;
+      background: var(--v-draggableDropZone-base);
       transition: height ease 0.2s, bottom ease 0.2s;
     }
 
@@ -216,6 +216,9 @@
         &::before {
           bottom: 0;
         }
+      }
+      &:not(.dragging-over) {
+        border-bottom: 0;
       }
     }
   }

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <DraggableItem :draggableId="contentNode.id">
+  <DraggableItem
+    :draggableId="contentNode.id"
+    :draggableMetadata="contentNode"
+  >
     <template #default="draggableProps">
       <ContentNodeListItem
         :node="contentNode"
@@ -8,7 +11,7 @@
         :comfortable="comfortable"
         :active="active"
         :canEdit="canEdit"
-        :draggableHandle="{ grouped: selected, draggable }"
+        :draggableHandle="{ grouped: selected, draggable, draggableMetadata: contentNode }"
         :aria-selected="selected"
         class="content-node-edit-item"
         @infoClick="$emit('infoClick', $event)"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -4,6 +4,7 @@
     :draggableId="contentNode.id"
     :draggableMetadata="contentNode"
     :dragEffect="dragEffect"
+    :dropEffect="draggableDropEffect"
     :beforeStyle="dragBeforeStyle"
     :afterStyle="dragAfterStyle"
   >
@@ -84,7 +85,8 @@
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
   import { COPYING_FLAG } from 'shared/data/constants';
-  import { DragEffect } from 'shared/mixins/draggable/constants';
+  import { DragEffect, DropEffect } from 'shared/mixins/draggable/constants';
+  import { DraggableRegions } from 'frontend/channelEdit/constants';
 
   export default {
     name: 'ContentNodeEditListItem',
@@ -134,6 +136,7 @@
     computed: {
       ...mapGetters('currentChannel', ['canEdit']),
       ...mapGetters('contentNode', ['getContentNode']),
+      ...mapGetters('draggable', ['activeDraggableRegionId']),
       selected: {
         get() {
           return this.select;
@@ -156,6 +159,11 @@
       },
       dragEffect() {
         return DragEffect.SORT;
+      },
+      draggableDropEffect() {
+        return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
+          ? DropEffect.COPY
+          : DropEffect.MOVE;
       },
       dragBeforeStyle() {
         return (size, height) => ({

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -24,7 +24,7 @@
         <template #actions-start="{ hover }">
           <VListTileAction class="handle-col" :aria-hidden="!hover" @click.stop>
             <transition name="fade">
-              <VBtn v-if="canEdit" :disabled="copying" flat icon>
+              <VBtn :disabled="copying" flat icon>
                 <Icon color="#686868">
                   drag_indicator
                 </Icon>
@@ -123,6 +123,7 @@
        * The `hasSelection` prop is used for disabling draggability specifically to handle
        * behaviors related to selecting and dragging multiple items.
        */
+      /* eslint-disable-next-line kolibri/vue-no-unused-properties */
       hasSelection: {
         type: Boolean,
         default: false,
@@ -152,7 +153,9 @@
         return this.getContentNode(this.nodeId);
       },
       draggable() {
-        return this.canEdit && (this.selected || !this.hasSelection);
+        // TODO: When we allow selecting multiple and then dragging
+        // return (this.selected || !this.hasSelection);
+        return !this.copying;
       },
       copying() {
         return this.contentNode[COPYING_FLAG];
@@ -161,6 +164,10 @@
         return DragEffect.SORT;
       },
       draggableDropEffect() {
+        if (!this.canEdit) {
+          return DropEffect.NONE;
+        }
+
         return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
           ? DropEffect.COPY
           : DropEffect.MOVE;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -158,16 +158,16 @@
         return DragEffect.SORT;
       },
       dragBeforeStyle() {
-        return size => ({
+        return (size, height) => ({
           '::before': {
-            height: `${size}px`,
+            height: `${height}px`,
           },
         });
       },
       dragAfterStyle() {
-        return size => ({
+        return (size, height) => ({
           '::after': {
-            height: `${size}px`,
+            height: `${height}px`,
           },
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -3,6 +3,9 @@
   <DraggableItem
     :draggableId="contentNode.id"
     :draggableMetadata="contentNode"
+    :dragEffect="dragEffect"
+    :beforeStyle="dragBeforeStyle"
+    :afterStyle="dragAfterStyle"
   >
     <template #default="draggableProps">
       <ContentNodeListItem
@@ -81,6 +84,7 @@
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
   import { COPYING_FLAG } from 'shared/data/constants';
+  import { DragEffect } from 'shared/mixins/draggable/constants';
 
   export default {
     name: 'ContentNodeEditListItem',
@@ -149,6 +153,23 @@
       },
       copying() {
         return this.contentNode[COPYING_FLAG];
+      },
+      dragEffect() {
+        return DragEffect.SORT;
+      },
+      dragBeforeStyle() {
+        return size => ({
+          '::before': {
+            height: `${size}px`,
+          },
+        });
+      },
+      dragAfterStyle() {
+        return size => ({
+          '::after': {
+            height: `${size}px`,
+          },
+        });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -15,7 +15,12 @@
         :comfortable="comfortable"
         :active="active"
         :canEdit="canEdit"
-        :draggableHandle="{ grouped: selected, draggable, draggableMetadata: contentNode }"
+        :draggableHandle="{
+          grouped: selected,
+          draggable,
+          draggableMetadata: contentNode,
+          effectAllowed: draggableEffectAllowed,
+        }"
         :aria-selected="selected"
         class="content-node-edit-item"
         @infoClick="$emit('infoClick', $event)"
@@ -85,7 +90,7 @@
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
   import { COPYING_FLAG } from 'shared/data/constants';
-  import { DragEffect, DropEffect } from 'shared/mixins/draggable/constants';
+  import { DragEffect, DropEffect, EffectAllowed } from 'shared/mixins/draggable/constants';
   import { DraggableRegions } from 'frontend/channelEdit/constants';
 
   export default {
@@ -171,6 +176,14 @@
         return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
           ? DropEffect.COPY
           : DropEffect.MOVE;
+      },
+      draggableEffectAllowed() {
+        if (this.canEdit && !this.copying) {
+          return EffectAllowed.COPY_OR_MOVE;
+        } else if (!this.copying) {
+          return EffectAllowed.COPY;
+        }
+        return EffectAllowed.NONE;
       },
       dragBeforeStyle() {
         return (size, height) => ({

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -4,7 +4,7 @@
     <template #default="{ hover }">
       <ContextMenuCloak :disabled="contextMenuDisabled">
         <template #default="contextMenuProps">
-          <DraggableHandle :draggable="canEdit && !copying" v-bind="draggableHandle">
+          <DraggableHandle v-bind="draggableHandle">
             <template #default="draggableProps">
               <VListTile
                 v-if="node"
@@ -156,6 +156,7 @@
   import DraggableHandle from 'shared/views/draggable/DraggableHandle';
   import { titleMixin } from 'shared/mixins';
   import { COPYING_FLAG, TASK_ID } from 'shared/data/constants';
+  import { EffectAllowed } from 'shared/mixins/draggable/constants';
 
   export default {
     name: 'ContentNodeListItem',
@@ -193,7 +194,10 @@
       },
       draggableHandle: {
         type: Object,
-        default: () => ({}),
+        default: () => ({
+          draggable: false,
+          effectAllowed: EffectAllowed.NONE,
+        }),
       },
     },
     data() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -3,6 +3,7 @@
   <DraggableCollection
     :draggableSize="draggableSize"
     :draggableMetadata="node"
+    :dropEffect="dropEffect"
   >
     <VLayout
       class="tree-container"
@@ -14,6 +15,7 @@
       <DraggableItem
         :draggableSize="draggableSize"
         :draggableMetadata="node"
+        :dropEffect="dropEffect"
         @draggableDragEnter="dragEnter"
         @draggableDragLeave="dragLeave"
       >
@@ -155,6 +157,7 @@
               :selectedNodeId="selectedNodeId"
               :allowEditing="allowEditing"
               :onNodeClick="onNodeClick"
+              :dropEffect="dropEffect"
               @selected="onDescendentSelected"
             />
           </div>
@@ -184,6 +187,8 @@
   import DraggableHandle from 'shared/views/draggable/DraggableHandle';
   import { titleMixin } from 'shared/mixins';
   import { COPYING_FLAG, TASK_ID } from 'shared/data/constants';
+  import { DropEffect } from 'shared/mixins/draggable/constants';
+  import { objectValuesValidator } from 'shared/mixins/draggable/utils';
 
   export default {
     name: 'StudioTree',
@@ -227,6 +232,11 @@
       dataPreloaded: {
         type: Boolean,
         default: false,
+      },
+      dropEffect: {
+        type: String,
+        default: DropEffect.NONE,
+        validator: objectValuesValidator(DropEffect),
       },
     },
     data() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -41,6 +41,7 @@
                 <DraggableHandle
                   :draggable="draggable"
                   :draggableMetadata="node"
+                  :effectAllowed="draggableEffectAllowed"
                 >
                   <VLayout
                     row
@@ -187,7 +188,7 @@
   import DraggableHandle from 'shared/views/draggable/DraggableHandle';
   import { titleMixin } from 'shared/mixins';
   import { COPYING_FLAG, TASK_ID } from 'shared/data/constants';
-  import { DropEffect } from 'shared/mixins/draggable/constants';
+  import { DropEffect, EffectAllowed } from 'shared/mixins/draggable/constants';
   import { objectValuesValidator } from 'shared/mixins/draggable/utils';
 
   export default {
@@ -283,6 +284,12 @@
       },
       draggable() {
         return this.allowEditing && !this.selected && !this.descendentSelected;
+      },
+      draggableEffectAllowed() {
+        if (this.allowEditing) {
+          return this.canEdit ? EffectAllowed.COPY_OR_MOVE : EffectAllowed.COPY;
+        }
+        return EffectAllowed.NONE;
       },
       copying() {
         return this.node && this.node[COPYING_FLAG];

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -48,7 +48,7 @@
                     class="draggable-background"
                     :style="{
                       height: '40px',
-                      backgroundColor: itemProps.isDraggingOver
+                      backgroundColor: itemProps.isDraggingOver && itemProps.isDropAllowed
                         ? $vuetify.theme.draggableDropZone
                         : 'transparent'
                     }"
@@ -351,8 +351,13 @@
           this.getChildren();
         }
       },
-      dragEnter() {
-        if (!this.draggableExpanded && this.showExpansion && !this.expanded) {
+      dragEnter(e) {
+        if (
+          e.dataTransfer.dropEffect !== DropEffect.NONE &&
+          !this.draggableExpanded &&
+          this.showExpansion &&
+          !this.expanded
+        ) {
           this.draggableExpanded = true;
           this.debouncedLoad();
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -2,6 +2,7 @@
 
   <DraggableCollection
     :draggableSize="draggableSize"
+    :draggableMetadata="node"
     :beforeStyle="false"
     :afterStyle="false"
   >
@@ -14,6 +15,7 @@
       <LoadingText v-if="root && loading" class="loading-text" absolute />
       <DraggableItem
         :draggableSize="draggableSize"
+        :draggableMetadata="node"
         :beforeStyle="false"
         :afterStyle="false"
         @draggableDragEnter="dragEnter"
@@ -38,7 +40,10 @@
                 data-test="item"
                 @click="click"
               >
-                <DraggableHandle :draggable="draggable">
+                <DraggableHandle
+                  :draggable="draggable"
+                  :draggableMetadata="node"
+                >
                   <VLayout
                     row
                     align-center

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -3,8 +3,6 @@
   <DraggableCollection
     :draggableSize="draggableSize"
     :draggableMetadata="node"
-    :beforeStyle="false"
-    :afterStyle="false"
   >
     <VLayout
       class="tree-container"
@@ -16,8 +14,6 @@
       <DraggableItem
         :draggableSize="draggableSize"
         :draggableMetadata="node"
-        :beforeStyle="false"
-        :afterStyle="false"
         @draggableDragEnter="dragEnter"
         @draggableDragLeave="dragLeave"
       >
@@ -383,7 +379,6 @@
 
   .tree-container:not(.is-root) {
     position: relative;
-    padding: 3px 0;
     transition: height ease 0.2s;
 
     &::before,

--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -64,3 +64,13 @@ export const modes = {
   UPLOAD: 'UPLOAD',
   VIEW_ONLY: 'VIEW_ONLY',
 };
+
+export const DraggableUniverses = {
+  CONTENT_NODES: 'contentNodes',
+};
+
+export const DraggableRegions = {
+  TREE: 'tree',
+  TOPIC_VIEW: 'topicView',
+  CLIPBOARD: 'clipboard',
+};

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -142,17 +142,23 @@
       :style="{height}"
     >
       <VFadeTransition mode="out-in">
-        <NodePanel
-          ref="nodepanel"
-          :key="topicId"
-          class="node-panel panel"
-          :parentId="topicId"
-          :selected="selected"
-          @select="selected = [...selected, $event]"
-          @deselect="selected = selected.filter(id => id !== $event)"
-          @scroll="scroll"
+        <DraggableRegion
+          :draggableUniverse="draggableUniverse"
+          :draggableId="draggableId"
+          :draggableMetadata="node"
           @draggableDrop="handleDragDrop"
-        />
+        >
+          <NodePanel
+            ref="nodepanel"
+            :key="topicId"
+            class="node-panel panel"
+            :parentId="topicId"
+            :selected="selected"
+            @select="selected = [...selected, $event]"
+            @deselect="selected = selected.filter(id => id !== $event)"
+            @scroll="scroll"
+          />
+        </DraggableRegion>
       </VFadeTransition>
       <ResourceDrawer
         ref="resourcepanel"
@@ -205,7 +211,7 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
-  import { RouterNames, viewModes, DraggableRegions } from '../constants';
+  import { RouterNames, viewModes, DraggableRegions, DraggableUniverses } from '../constants';
   import ResourceDrawer from '../components/ResourceDrawer';
   import ContentNodeOptions from '../components/ContentNodeOptions';
   import MoveModal from '../components/move/MoveModal';
@@ -221,6 +227,7 @@
   import { DraggableTypes } from 'shared/mixins/draggable/constants';
   import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
   import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
+  import DraggableRegion from 'shared/views/draggable/DraggableRegion';
 
   export default {
     name: 'CurrentTopicView',
@@ -233,6 +240,7 @@
       Breadcrumbs,
       Checkbox,
       MoveModal,
+      DraggableRegion,
     },
     mixins: [titleMixin],
     props: {
@@ -330,6 +338,12 @@
       },
       selectionText() {
         return this.$tr('selectionCount', this.getTopicAndResourceCounts(this.selected));
+      },
+      draggableId() {
+        return DraggableRegions.TOPIC_VIEW;
+      },
+      draggableUniverse() {
+        return DraggableUniverses.CONTENT_NODES;
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -146,6 +146,7 @@
           :draggableUniverse="draggableUniverse"
           :draggableId="draggableId"
           :draggableMetadata="node"
+          :dropEffect="draggableDropEffect"
           @draggableDrop="handleDragDrop"
         >
           <NodePanel
@@ -224,7 +225,7 @@
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import { titleMixin } from 'shared/mixins';
   import { COPYING_FLAG, RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
-  import { DraggableTypes } from 'shared/mixins/draggable/constants';
+  import { DraggableTypes, DropEffect } from 'shared/mixins/draggable/constants';
   import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
   import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
   import DraggableRegion from 'shared/views/draggable/DraggableRegion';
@@ -279,6 +280,7 @@
         'getTopicAndResourceCounts',
         'getContentNodeChildren',
       ]),
+      ...mapGetters('draggable', ['activeDraggableRegionId']),
       selected: {
         get() {
           return this.selectedNodeIds;
@@ -344,6 +346,11 @@
       },
       draggableUniverse() {
         return DraggableUniverses.CONTENT_NODES;
+      },
+      draggableDropEffect() {
+        return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
+          ? DropEffect.COPY
+          : DropEffect.MOVE;
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -424,7 +424,6 @@
        * @public
        */
       handleDropToClipboard(drop) {
-        drop.stopPropagation();
         const sourceIds = drop.data.sources.map(source => source.metadata.id).filter(Boolean);
         if (sourceIds.length) {
           this.copyToClipboard(sourceIds);
@@ -436,8 +435,6 @@
        * @public
        */
       handleDragDrop(drop) {
-        // Drop has been handled, this clears the data and stops propagation
-        drop.stopPropagation();
         const { data } = drop;
         const { identity, section, relative } = data.target;
         const { region } = new DraggableIdentityHelper(identity);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -446,9 +446,10 @@
 
         let position = RELATIVE_TREE_POSITIONS.LAST_CHILD;
 
-        // If the target is not an item, or if target is in the tree, then we'll assume we're
-        // positioning in the parent, otherwise we'll determine a relative position. The tree allows
-        // dropping on a topic to insert there. The topic view does not
+        // Specifically when the target is an item in the tree, or if it's not an item
+        // and not in the tree, we'll position as a child of the target, and otherwise we'll
+        // determine a relative position. The tree allows dropping on a topic to insert there.
+        // The topic view does not
         if (isTargetItem === isTargetTree) {
           // Safety check
           const kind = identity.metadata.kind;
@@ -462,6 +463,8 @@
               ? RELATIVE_TREE_POSITIONS.FIRST_CHILD
               : RELATIVE_TREE_POSITIONS.LAST_CHILD;
         } else {
+          // Relative would be filled for DragEffect.SORT containers, so we'll use it if
+          // it's present otherwise fallback to hovered section
           const mask = relative > DraggableFlags.NONE ? relative : section;
           position =
             mask & DraggableFlags.TOP

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -413,6 +413,17 @@
           },
         });
       },
+      /**
+       * TODO: This shouldn't really be public. This is being called from TreeView
+       * to avoid duplication, and to avoid duplicating strings for now
+       * @public
+       */
+      handleDropToClipboard(data) {
+        const sourceIds = data.sources.map(source => source.metadata.id).filter(Boolean);
+        if (sourceIds.length) {
+          this.copyToClipboard(sourceIds);
+        }
+      },
       moveNodes(target) {
         return this.moveContentNodes({ id__in: this.selected, parent: target }).then(() => {
           this.clearSelections();

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -348,6 +348,10 @@
         return DraggableUniverses.CONTENT_NODES;
       },
       draggableDropEffect() {
+        if (!this.canEdit) {
+          return DropEffect.NONE;
+        }
+
         return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
           ? DropEffect.COPY
           : DropEffect.MOVE;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -26,6 +26,7 @@
     v-else
     draggableUniverse="contentNodes"
     :draggableMetadata="node"
+    @draggableDrop="$emit('draggableDrop', $event)"
   >
     <div class="node-list" @scroll="$emit('scroll', $event)">
       <VList class="py-0">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -22,36 +22,28 @@
       {{ $tr('emptyTopicText') }}
     </VFlex>
   </VLayout>
-  <DraggableRegion
-    v-else
-    :draggableUniverse="draggableUniverse"
-    :draggableId="draggableId"
-    :draggableMetadata="node"
-    @draggableDrop="$emit('draggableDrop', $event)"
-  >
-    <div class="node-list" @scroll="$emit('scroll', $event)">
-      <VList class="py-0">
-        <template
-          v-for="child in children"
-        >
-          <ContentNodeEditListItem
-            :key="child.id"
-            :nodeId="child.id"
-            :compact="isCompactViewMode"
-            :comfortable="isComfortableViewMode"
-            :select="selected.indexOf(child.id) >= 0"
-            :previewing="$route.params.detailNodeId === child.id"
-            :hasSelection="selected.length > 0"
-            @select="$emit('select', child.id)"
-            @deselect="$emit('deselect', child.id)"
-            @infoClick="goToNodeDetail(child.id)"
-            @topicChevronClick="goToTopic(child.id)"
-            @dblclick.native="onNodeDoubleClick(child)"
-          />
-        </template>
-      </VList>
-    </div>
-  </DraggableRegion>
+  <div v-else class="node-list" @scroll="$emit('scroll', $event)">
+    <VList class="py-0">
+      <template
+        v-for="child in children"
+      >
+        <ContentNodeEditListItem
+          :key="child.id"
+          :nodeId="child.id"
+          :compact="isCompactViewMode"
+          :comfortable="isComfortableViewMode"
+          :select="selected.indexOf(child.id) >= 0"
+          :previewing="$route.params.detailNodeId === child.id"
+          :hasSelection="selected.length > 0"
+          @select="$emit('select', child.id)"
+          @deselect="$emit('deselect', child.id)"
+          @infoClick="goToNodeDetail(child.id)"
+          @topicChevronClick="goToTopic(child.id)"
+          @dblclick.native="onNodeDoubleClick(child)"
+        />
+      </template>
+    </VList>
+  </div>
 
 </template>
 
@@ -59,18 +51,16 @@
 
   import { mapActions, mapGetters } from 'vuex';
 
-  import { RouterNames, DraggableRegions, DraggableUniverses } from '../constants';
+  import { RouterNames } from '../constants';
   import ContentNodeEditListItem from '../components/ContentNodeEditListItem';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import LoadingText from 'shared/views/LoadingText';
-  import DraggableRegion from 'shared/views/draggable/DraggableRegion';
   import { COPYING_FLAG } from 'shared/data/constants';
 
   export default {
     name: 'NodePanel',
     components: {
       ContentNodeEditListItem,
-      DraggableRegion,
       LoadingText,
     },
     props: {
@@ -102,12 +92,6 @@
       },
       isRoot() {
         return this.rootId === this.parentId;
-      },
-      draggableId() {
-        return DraggableRegions.TOPIC_VIEW;
-      },
-      draggableUniverse() {
-        return DraggableUniverses.CONTENT_NODES;
       },
     },
     created() {
@@ -177,17 +161,6 @@
     padding: 0;
     padding-bottom: 88px;
     background-color: var(--v-backgroundColor-base);
-
-    &::before,
-    &::after {
-      display: block;
-      width: 100%;
-      height: 0;
-      overflow: hidden;
-      content: ' ';
-      background: var(--v-draggableDropZone-base);
-      transition: height ease 0.2s;
-    }
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -25,6 +25,7 @@
   <DraggableRegion
     v-else
     draggableUniverse="contentNodes"
+    :draggableMetadata="node"
   >
     <div class="node-list" @scroll="$emit('scroll', $event)">
       <VList class="py-0">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -24,7 +24,8 @@
   </VLayout>
   <DraggableRegion
     v-else
-    draggableUniverse="contentNodes"
+    :draggableUniverse="draggableUniverse"
+    :draggableId="draggableId"
     :draggableMetadata="node"
     @draggableDrop="$emit('draggableDrop', $event)"
   >
@@ -58,7 +59,7 @@
 
   import { mapActions, mapGetters } from 'vuex';
 
-  import { RouterNames } from '../constants';
+  import { RouterNames, DraggableRegions, DraggableUniverses } from '../constants';
   import ContentNodeEditListItem from '../components/ContentNodeEditListItem';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import LoadingText from 'shared/views/LoadingText';
@@ -101,6 +102,12 @@
       },
       isRoot() {
         return this.rootId === this.parentId;
+      },
+      draggableId() {
+        return DraggableRegions.TOPIC_VIEW;
+      },
+      draggableUniverse() {
+        return DraggableUniverses.CONTENT_NODES;
       },
     },
     created() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -332,7 +332,7 @@
         return DraggableRegions.CLIPBOARD;
       },
       dropEffect() {
-        return this.canEdit ? DropEffect.COPY : DropEffect.NONE;
+        return DropEffect.COPY;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -332,7 +332,7 @@
         return DraggableRegions.CLIPBOARD;
       },
       dropEffect() {
-        return DropEffect.COPY;
+        return this.canEdit ? DropEffect.COPY : DropEffect.NONE;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -246,7 +246,7 @@
       ...mapGetters('contentNode', ['getContentNode']),
       ...mapGetters('currentChannel', ['currentChannel', 'canEdit', 'canManage', 'rootId']),
       ...mapState('draggable', ['activeDraggableUniverse', 'clientX', 'clientY']),
-      ...mapState('draggable/handles', ['activeDraggable']),
+      ...mapGetters('draggable', ['deepestActiveDraggable']),
       rootNode() {
         return this.getContentNode(this.rootId);
       },
@@ -329,15 +329,9 @@
         return this.$route.name !== RouterNames.STAGING_TREE_VIEW;
       },
       draggingData() {
-        if (this.activeDraggableUniverse === 'contentNodes' && this.activeDraggable) {
-          const { itemId, collectionId, regionId, ancestors } = this.activeDraggable;
-          const ancestor = [itemId, collectionId, regionId]
-            .map(id => (id ? ancestors.find(a => a.id === id) : null))
-            .filter(Boolean)
-            .shift();
-          return ancestor ? ancestor.metadata : null;
-        }
-        return null;
+        return this.activeDraggableUniverse === 'contentNodes' && this.deepestActiveDraggable
+          ? this.deepestActiveDraggable.metadata
+          : null;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -152,8 +152,9 @@
     >
       <template #activator>
         <DraggableRegion
-          draggableUniverse="contentNodes"
-          dropEffect="copy"
+          :draggableUniverse="draggableUniverse"
+          :draggableId="draggableId"
+          :dropEffect="dropEffect"
           @draggableDrop="$emit('dropToClipboard', $event)"
         >
           <template #default="draggableProps">
@@ -202,7 +203,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { DraggableRegions, DraggableUniverses, RouterNames } from '../../constants';
   import PublishModal from '../../components/publish/PublishModal';
   import ProgressModal from '../progress/ProgressModal';
   import SyncResourcesModal from '../sync/SyncResourcesModal';
@@ -216,6 +217,7 @@
   import { RouterNames as ChannelRouterNames } from 'frontend/channelList/constants';
   import { titleMixin } from 'shared/mixins';
   import DraggableRegion from 'shared/views/draggable/DraggableRegion';
+  import { DropEffect } from 'shared/mixins/draggable/constants';
 
   export default {
     name: 'TreeViewBase',
@@ -329,9 +331,19 @@
         return this.$route.name !== RouterNames.STAGING_TREE_VIEW;
       },
       draggingData() {
-        return this.activeDraggableUniverse === 'contentNodes' && this.deepestActiveDraggable
+        return this.activeDraggableUniverse === DraggableUniverses.CONTENT_NODES &&
+          this.deepestActiveDraggable
           ? this.deepestActiveDraggable.metadata
           : null;
+      },
+      draggableUniverse() {
+        return DraggableUniverses.CONTENT_NODES;
+      },
+      draggableId() {
+        return DraggableRegions.CLIPBOARD;
+      },
+      dropEffect() {
+        return DropEffect.COPY;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <TreeViewBase>
+  <TreeViewBase @dropToClipboard="handleDropToClipboard">
     <template v-if="hasStagingTree" #extension>
       <Banner
         :value="true"
@@ -65,7 +65,9 @@
           />
         </div>
       </VToolbar>
-      <DraggableRegion draggableUniverse="contentNodes">
+      <DraggableRegion
+        draggableUniverse="contentNodes"
+      >
         <div class="pl-3 my-5">
           <LoadingText v-if="loading" />
           <StudioTree
@@ -285,6 +287,12 @@
       },
       onHierarchyScroll(e) {
         this.listElevated = e.target.scrollTop > 0;
+      },
+      handleDropToClipboard(data) {
+        // TODO: Not ideal, but avoids headaches with strings/translations
+        if (this.$refs.topicview) {
+          this.$refs.topicview.handleDropToClipboard(data);
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -55,7 +55,7 @@
             <VToolbar
               :color="isDropAllowed
                 ? $vuetify.theme.draggableDropZone
-                : $vuetify.theme.backgroundColor"
+                : 'transparent'"
               class="py-1 hierarchy-toolbar tree-prepend"
               absolute
               dense

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -26,6 +26,7 @@
       :draggableUniverse="draggableUniverse"
       :draggableId="draggableId"
       :draggableMetadata="rootContentNode"
+      :dropEffect="draggableDropEffect"
       @draggableDrop="handleDragDrop"
     >
       <ResizableNavigationDrawer
@@ -47,6 +48,7 @@
       >
         <DraggableCollection
           :draggableId="draggablePrependId"
+          :dropEffect="draggableDropEffect"
           @draggableDrop="handleRegionDrop"
         >
           <template #default="{ isDropAllowed }">
@@ -89,6 +91,7 @@
             :treeId="rootId"
             :nodeId="rootId"
             :selectedNodeId="nodeId"
+            :dropEffect="draggableDropEffect"
             :onNodeClick="onTreeNodeClick"
             :allowEditing="true"
             :root="true"
@@ -97,6 +100,7 @@
         </div>
         <DraggableCollection
           :draggableId="draggableAppendId"
+          :dropEffect="draggableDropEffect"
           @draggableDrop="handleRegionDrop"
         >
           <VSpacer class="tree-append" />
@@ -145,6 +149,7 @@
   import DraggableCollection from 'shared/views/draggable/DraggableCollection';
   import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
   import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
+  import { DropEffect } from 'shared/mixins/draggable/constants';
 
   const DEFAULT_HIERARCHY_MAXWIDTH = 500;
   const NODEPANEL_MINWIDTH = 350;
@@ -189,6 +194,7 @@
     computed: {
       ...mapGetters('currentChannel', ['currentChannel', 'hasStagingTree', 'stagingId', 'rootId']),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeAncestors']),
+      ...mapGetters('draggable', ['activeDraggableRegionId']),
       rootContentNode() {
         return this.getContentNode(this.rootId);
       },
@@ -245,6 +251,11 @@
       },
       draggableUniverse() {
         return DraggableUniverses.CONTENT_NODES;
+      },
+      draggableDropEffect() {
+        return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
+          ? DropEffect.COPY
+          : DropEffect.MOVE;
       },
       draggablePrependId() {
         return `${this.draggableId}_prepend`;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -428,7 +428,7 @@
   .tree-append {
     min-height: 48px;
 
-    &.dragging-over.in-draggable-universe {
+    &.dragging-over.in-draggable-universe.drop-allowed {
       background-color: var(--v-draggableDropZone-base);
     }
   }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -192,7 +192,13 @@
       };
     },
     computed: {
-      ...mapGetters('currentChannel', ['currentChannel', 'hasStagingTree', 'stagingId', 'rootId']),
+      ...mapGetters('currentChannel', [
+        'currentChannel',
+        'hasStagingTree',
+        'stagingId',
+        'rootId',
+        'canEdit',
+      ]),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeAncestors']),
       ...mapGetters('draggable', ['activeDraggableRegionId']),
       rootContentNode() {
@@ -253,6 +259,9 @@
         return DraggableUniverses.CONTENT_NODES;
       },
       draggableDropEffect() {
+        if (!this.canEdit) {
+          return DropEffect.NONE;
+        }
         return this.activeDraggableRegionId === DraggableRegions.CLIPBOARD
           ? DropEffect.COPY
           : DropEffect.MOVE;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -66,7 +66,10 @@
         </div>
       </VToolbar>
       <DraggableRegion
-        draggableUniverse="contentNodes"
+        :draggableUniverse="draggableUniverse"
+        :draggableId="draggableId"
+        :draggableMetadata="{ id: nodeId }"
+        @draggableDrop="handleDragDrop"
       >
         <div class="pl-3 my-5">
           <LoadingText v-if="loading" />
@@ -112,7 +115,7 @@
 <script>
 
   import { mapActions, mapGetters, mapMutations } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouterNames, DraggableRegions, DraggableUniverses } from '../../constants';
   import StudioTree from '../../components/StudioTree/StudioTree';
   import CurrentTopicView from '../CurrentTopicView';
   import TreeViewBase from './TreeViewBase';
@@ -213,6 +216,12 @@
           },
         };
       },
+      draggableId() {
+        return DraggableRegions.TREE;
+      },
+      draggableUniverse() {
+        return DraggableUniverses.CONTENT_NODES;
+      },
     },
     watch: {
       // Makes a HEAD request to see if the content node exists every time the route changes
@@ -292,6 +301,12 @@
         // TODO: Not ideal, but avoids headaches with strings/translations
         if (this.$refs.topicview) {
           this.$refs.topicview.handleDropToClipboard(data);
+        }
+      },
+      handleDragDrop(data) {
+        // TODO: Not ideal, but avoids headaches with strings/translations
+        if (this.$refs.topicview) {
+          this.$refs.topicview.handleDragDrop(data);
         }
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -324,14 +324,29 @@ export function copyContentNode(
   });
 }
 
-export function copyContentNodes(context, { id__in, target }) {
-  return Promise.all(id__in.map(id => context.dispatch('copyContentNode', { id, target })));
+export function copyContentNodes(
+  context,
+  { id__in, target, position = RELATIVE_TREE_POSITIONS.LAST_CHILD }
+) {
+  return Promise.all(
+    id__in.map(id => context.dispatch('copyContentNode', { id, target, position }))
+  );
 }
 
+const PARENT_POSITIONS = [RELATIVE_TREE_POSITIONS.FIRST_CHILD, RELATIVE_TREE_POSITIONS.LAST_CHILD];
 export function moveContentNodes(
   context,
-  { id__in, parent: target, position = RELATIVE_TREE_POSITIONS.LAST_CHILD }
+  { id__in, parent, target = null, position = RELATIVE_TREE_POSITIONS.LAST_CHILD }
 ) {
+  // Make sure use of parent vs target matches position param
+  if (parent && !(PARENT_POSITIONS.indexOf(position) >= 0)) {
+    return Promise.reject(new Error('Invalid position for parent move'));
+  }
+
+  if (!target) {
+    target = parent;
+  }
+
   return Promise.all(
     id__in.map(id => {
       return ContentNode.move(id, target, position).then(node => {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -328,10 +328,13 @@ export function copyContentNodes(context, { id__in, target }) {
   return Promise.all(id__in.map(id => context.dispatch('copyContentNode', { id, target })));
 }
 
-export function moveContentNodes(context, { id__in, parent: target }) {
+export function moveContentNodes(
+  context,
+  { id__in, parent: target, position = RELATIVE_TREE_POSITIONS.LAST_CHILD }
+) {
   return Promise.all(
     id__in.map(id => {
-      return ContentNode.move(id, target, RELATIVE_TREE_POSITIONS.LAST_CHILD).then(node => {
+      return ContentNode.move(id, target, position).then(node => {
         context.commit('UPDATE_CONTENTNODE', node);
         return id;
       });

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/base.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/base.js
@@ -1,5 +1,6 @@
 import { mapState } from 'vuex';
 import uuidv4 from 'uuid/v4';
+import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
 
 export default {
   props: {
@@ -12,6 +13,10 @@ export default {
         return uuidv4();
       },
     },
+    draggableType: {
+      type: String,
+      default: null,
+    },
     draggableMetadata: {
       type: Object,
       default: () => ({}),
@@ -20,11 +25,41 @@ export default {
   computed: {
     ...mapState('draggable', ['activeDraggableUniverse', 'draggableDirection']),
     /**
-     * To be overridden returning draggable type specific active ID
+     * @abstract
+     * @function
+     * @name activeDraggableId
      * @return {string|null}
      */
-    activeDraggableId() {
-      return null;
+
+    draggableIdentity() {
+      return {
+        id: this.draggableId,
+        type: this.draggableType,
+        universe: this.draggableUniverse,
+        ancestors: this.draggableAncestors,
+        metadata: this.draggableMetadata,
+      };
+    },
+    draggableIdentityHelper() {
+      return new DraggableIdentityHelper(this.draggableIdentity);
+    },
+    draggableRegionId() {
+      const { region } = this.draggableIdentityHelper;
+      return region ? region.id : null;
+    },
+    draggableCollectionId() {
+      const { collection } = this.draggableIdentityHelper;
+      return collection ? collection.id : null;
+    },
+    draggableItemId() {
+      const { item } = this.draggableIdentityHelper;
+      return item ? item.id : null;
+    },
+    isActiveDraggable() {
+      return this.activeDraggableId === this.draggableId;
+    },
+    isInActiveDraggableUniverse() {
+      return this.activeDraggableUniverse === this.draggableUniverse;
     },
   },
   methods: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/base.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/base.js
@@ -12,6 +12,10 @@ export default {
         return uuidv4();
       },
     },
+    draggableMetadata: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   computed: {
     ...mapState('draggable', ['activeDraggableUniverse', 'draggableDirection']),

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
@@ -14,12 +14,11 @@ export default {
     },
   },
   computed: {
-    ...mapState('draggable/collections', ['hoverDraggableSection']),
+    ...mapState('draggable/collections', ['hoverDraggableSection', 'hoverDraggableTarget']),
     ...mapGetters('draggable/collections', [
       'activeDraggableId',
       'hoverDraggableId',
-      'draggingTargetSection',
-      'isHoverDraggableAncestor',
+      // 'isHoverDraggableAncestor',
     ]),
   },
   methods: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
@@ -15,11 +15,7 @@ export default {
   },
   computed: {
     ...mapState('draggable/collections', ['hoverDraggableSection', 'hoverDraggableTarget']),
-    ...mapGetters('draggable/collections', [
-      'activeDraggableId',
-      'hoverDraggableId',
-      // 'isHoverDraggableAncestor',
-    ]),
+    ...mapGetters('draggable/collections', ['activeDraggableId', 'hoverDraggableId']),
   },
   methods: {
     ...mapActions('draggable/collections', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
@@ -6,17 +6,12 @@ export default {
   mixins: [containerMixin],
   inject: {
     draggableUniverse: { default: null },
-    draggableRegionId: { default: null },
+    draggableAncestors: { default: () => [] },
   },
-  provide() {
-    return {
-      draggableCollectionId: this.draggableId,
-    };
-  },
-  data() {
-    return {
-      draggableType: DraggableTypes.COLLECTION,
-    };
+  props: {
+    draggableType: {
+      default: DraggableTypes.COLLECTION,
+    },
   },
   computed: {
     ...mapState('draggable/collections', ['hoverDraggableSection']),
@@ -24,10 +19,8 @@ export default {
       'activeDraggableId',
       'hoverDraggableId',
       'draggingTargetSection',
+      'isHoverDraggableAncestor',
     ]),
-    hasDescendantHoverDraggable() {
-      return this.hoverDraggableId === this.draggableId && this.hoverDraggableItemId;
-    },
   },
   methods: {
     ...mapActions('draggable/collections', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/collection.js
@@ -14,8 +14,12 @@ export default {
     },
   },
   computed: {
-    ...mapState('draggable/collections', ['hoverDraggableSection', 'hoverDraggableTarget']),
-    ...mapGetters('draggable/collections', ['activeDraggableId', 'hoverDraggableId']),
+    ...mapState('draggable/collections', ['hoverDraggableSection']),
+    ...mapGetters('draggable/collections', [
+      'activeDraggableId',
+      'hoverDraggableId',
+      'hoverDraggableTarget',
+    ]),
   },
   methods: {
     ...mapActions('draggable/collections', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/constants.js
@@ -5,3 +5,24 @@ export const DraggableTypes = {
   COLLECTION: 'collection',
   REGION: 'region',
 };
+
+const { ITEM, COLLECTION, REGION, CONTAINER } = DraggableTypes;
+
+export const DraggableContainerTypes = { ITEM, COLLECTION, REGION, CONTAINER };
+
+export const DraggableSearchOrder = [ITEM, COLLECTION, REGION, CONTAINER];
+
+/** @see https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect */
+export const DropEffect = {
+  COPY: 'copy',
+  MOVE: 'move',
+  NONE: 'none',
+};
+
+/** @see https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/effectAllowed */
+export const EffectAllowed = {
+  COPY: 'copy',
+  MOVE: 'move',
+  COPY_OR_MOVE: 'copyMove',
+  NONE: 'none',
+};

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/constants.js
@@ -26,3 +26,12 @@ export const EffectAllowed = {
   COPY_OR_MOVE: 'copyMove',
   NONE: 'none',
 };
+
+/**
+ * Not related to `DropEffect` nor `EffectAllowed`, this is unique to Draggable,
+ * and used to determine how the containers respond when hovered, and what data is required.
+ */
+export const DragEffect = {
+  DEFAULT: 'default',
+  SORT: 'sort',
+};

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -114,14 +114,14 @@ export default {
     },
     beforeStyles() {
       if (this.beforeStyle) {
-        return this.beforeStyle(this.size);
+        return this.beforeStyle(this.size, this.hoverDraggableSize);
       }
 
       return null;
     },
     afterStyles() {
       if (this.afterStyle) {
-        return this.afterStyle(this.size);
+        return this.afterStyle(this.size, this.hoverDraggableSize);
       }
 
       return null;
@@ -150,7 +150,8 @@ export default {
      */
     isActiveDraggable(isActive) {
       if (isActive) {
-        this.setActiveDraggableSize({ size: this.draggableSize || this.$el.offsetHeight });
+        const size = this.draggableSize === null ? this.$el.offsetHeight : this.draggableSize;
+        this.setActiveDraggableSize({ size });
       }
     },
     activeDraggableId(id) {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -14,17 +14,12 @@ import {
 export default {
   mixins: [baseMixin],
   provide() {
-    const { draggableId, draggableType, draggableUniverse } = this;
+    const { draggableId, draggableUniverse } = this;
 
     // Provide list of ancestors, and be sure to make a copy to avoid rewriting above the tree
     const draggableAncestors = (this.draggableAncestors || []).slice();
     if (draggableId) {
-      draggableAncestors.push({
-        id: draggableId,
-        type: draggableType,
-        universe: draggableUniverse,
-        metadata: this.draggableMetadata,
-      });
+      draggableAncestors.push(this.draggableIdentity);
     }
 
     return {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -18,6 +18,7 @@ export default {
       draggableAncestors.push({
         id: draggableId,
         type: draggableType,
+        metadata: this.draggableMetadata,
       });
     }
 
@@ -78,6 +79,7 @@ export default {
       'hoverDraggableCollectionId',
       'hoverDraggableItemId',
       'lowermostHoverDraggable',
+      'getDraggableDropData',
     ]),
     draggableIdentity() {
       return {
@@ -85,6 +87,7 @@ export default {
         type: this.draggableType,
         universe: this.draggableUniverse,
         ancestors: this.draggableAncestors,
+        metadata: this.draggableMetadata,
       };
     },
     /**
@@ -248,6 +251,7 @@ export default {
      * @param {DragEvent} e
      */
     emitDraggableDragOver(e) {
+      e.preventDefault();
       if (!this.draggableDragEntered) {
         return this.emitDraggableDragEnter(e);
       }
@@ -273,9 +277,14 @@ export default {
       }
     },
     emitDraggableDrop(e) {
-      if (this.isDropAllowed) {
+      e.preventDefault();
+      const data = this.getDraggableDropData();
+
+      if (this.isDropAllowed && data) {
         this.emitDraggableDragOver(e);
-        this.$emit('draggableDrop', e);
+        data.event = e;
+        this.$emit('draggableDrop', data);
+        this.$nextTick(() => this.emitDraggableDragLeave(e));
       }
     },
     /**
@@ -360,6 +369,7 @@ export default {
           [eventKey('dragenter')]: this.emitDraggableDragEnter,
           [eventKey('dragover')]: this.emitDraggableDragOver,
           [eventKey('dragleave')]: this.emitDraggableDragLeave,
+          [eventKey('drop')]: this.emitDraggableDrop,
         },
       },
       this.draggableScopedSlotProps()

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -348,6 +348,7 @@ export default {
       [`draggable-${this.draggableType}`]: true,
       'in-draggable-universe': this.isInActiveDraggableUniverse,
       'dragging-over': this.isDraggingOver,
+      'drop-allowed': this.dropAllowed,
       'dragging-over-top':
         dropCondition && Boolean(this.hoverDraggableSection & DraggableFlags.TOP),
       'dragging-over-bottom':

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -48,7 +48,7 @@ export default {
     },
     dropEffect: {
       type: String,
-      default: DropEffect.COPY,
+      default: DropEffect.NONE,
       validator: objectValuesValidator(DropEffect),
     },
     dragEffect: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -101,12 +101,6 @@ export default {
      * @name hoverDraggableTarget
      * @return {number|null}
      */
-    /**
-     * @abstract
-     * @function
-     * @name isHoverDraggableAncestor
-     * @return {Function<bool>}
-     */
     hasDescendantHoverDraggable() {
       return this.isHoverDraggableAncestor(this.draggableIdentity);
     },

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -283,12 +283,19 @@ export default {
      * @returns {Object<Boolean|String>}
      */
     draggableScopedSlotProps() {
-      const { isInActiveDraggableUniverse, isDraggingOver, isActiveDraggable, dropEffect } = this;
+      const {
+        isInActiveDraggableUniverse,
+        isDraggingOver,
+        isActiveDraggable,
+        activeDropEffect,
+      } = this;
       return {
         isInActiveDraggableUniverse,
         isDraggingOver,
         isActiveDraggable,
-        dropEffect,
+        dropEffect: activeDropEffect,
+        isDropAllowed:
+          isInActiveDraggableUniverse && isDraggingOver && activeDropEffect !== DropEffect.NONE,
       };
     },
     /**

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -1,15 +1,13 @@
 import { mapActions, mapGetters } from 'vuex';
 import baseMixin from './base';
-import { DraggableTypes } from './constants';
+import { objectValuesValidator } from './utils';
+import { DraggableTypes, EffectAllowed } from './constants';
 import { animationThrottle, extendSlot } from 'shared/utils/helpers';
 
 export default {
   mixins: [baseMixin],
   inject: {
     draggableUniverse: { default: null },
-    draggableRegionId: { default: null },
-    draggableCollectionId: { default: null },
-    draggableItemId: { default: null },
     draggableAncestors: { default: () => [] },
   },
   props: {
@@ -23,35 +21,20 @@ export default {
       type: Boolean,
       default: false,
     },
+    draggableType: {
+      type: String,
+      default: DraggableTypes.HANDLE,
+    },
     effectAllowed: {
       type: String,
-      default: 'copyMove',
-      /** @see https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/effectAllowed */
-      validator(val) {
-        return Boolean(['copy', 'move', 'copyMove', 'none'].find(effect => effect === val));
-      },
+      default: EffectAllowed.COPY_OR_MOVE,
+      validator: objectValuesValidator(EffectAllowed),
     },
-  },
-  data() {
-    return {
-      draggableType: DraggableTypes.HANDLE,
-    };
   },
   computed: {
     ...mapGetters('draggable/handles', ['activeDraggableId']),
     isDragging() {
       return this.draggableId === this.activeDraggableId;
-    },
-    draggableIdentity() {
-      return {
-        id: this.draggableId,
-        universe: this.draggableUniverse,
-        regionId: this.draggableRegionId,
-        collectionId: this.draggableCollectionId,
-        itemId: this.draggableItemId,
-        ancestors: this.draggableAncestors,
-        metadata: this.metadata,
-      };
     },
   },
   watch: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -13,9 +13,7 @@ export default {
   props: {
     draggable: {
       type: Boolean,
-      default() {
-        return !!(this.draggableUniverse && this.draggableRegionId);
-      },
+      default: null,
     },
     grouped: {
       type: Boolean,
@@ -35,6 +33,11 @@ export default {
     ...mapGetters('draggable/handles', ['activeDraggableId']),
     isDragging() {
       return this.draggableId === this.activeDraggableId;
+    },
+    isDraggingAllowed() {
+      return this.draggable !== null
+        ? this.draggable
+        : Boolean(this.draggableRegionId && this.draggableUniverse);
     },
   },
   watch: {
@@ -60,7 +63,7 @@ export default {
      */
     emitDraggableDragStart(e) {
       // If draggability(TM) isn't enabled then we shouldn't trigger any dragging events!
-      if (!this.draggable) {
+      if (!this.isDraggingAllowed) {
         e.preventDefault();
         return;
       }
@@ -127,7 +130,7 @@ export default {
           'is-dragging': isDragging,
         },
         attrs: {
-          draggable: String(this.draggable),
+          draggable: String(this.isDraggingAllowed),
           'aria-grabbed': String(isDragging),
         },
         on: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -50,6 +50,7 @@ export default {
         collectionId: this.draggableCollectionId,
         itemId: this.draggableItemId,
         ancestors: this.draggableAncestors,
+        metadata: this.metadata,
       };
     },
   },

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -90,7 +90,9 @@ export default {
       e.dataTransfer.setData('draggableIdentity', JSON.stringify(this.draggableIdentity));
       e.dataTransfer.effectAllowed = this.effectAllowed;
 
+      const { clientX, clientY } = e;
       this.throttledUpdateDraggableDirection.cancel();
+      this.$emit('draggableDragStart', { x: clientX, y: clientY });
       this.emitDraggableDrag(e);
       this.throttledUpdateDraggableDirection.flush();
       this.setActiveDraggable(this.draggableIdentity);
@@ -111,17 +113,24 @@ export default {
         y: clientY,
       });
     },
-    emitDraggableDragEnd() {
-      this.throttledUpdateDraggableDirection.cancel();
-      this.resetDraggableDirection();
-      this.$nextTick(() => this.resetActiveDraggable());
+    emitDraggableDragEnd(e) {
+      const { clientX, clientY } = e;
+      this.emitDraggableDrag(e);
+      this.throttledUpdateDraggableDirection.flush();
+      this.$emit('draggableDragEnd', { x: clientX, y: clientY });
+
+      this.$nextTick(() => {
+        this.resetDraggableDirection();
+        this.resetActiveDraggable();
+      });
     },
     extendSlot,
   },
   created() {
-    this.throttledUpdateDraggableDirection = animationThrottle(args =>
-      this.updateDraggableDirection(args)
-    );
+    this.throttledUpdateDraggableDirection = animationThrottle(args => {
+      this.updateDraggableDirection(args);
+      this.$emit('draggableDrag', args);
+    });
   },
   render() {
     const { isDragging, draggable } = this;

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/handle.js
@@ -85,11 +85,11 @@ export default {
      * @param {DragEvent} e
      */
     emitDraggableDrag(e) {
-      const { clientX, clientY } = e;
+      let { clientX, clientY } = e;
 
-      // Firefox has given 0,0 values
+      // Firefox gives 0,0 values :(
       if (!clientX && !clientY) {
-        return;
+        clientX = clientY = null;
       }
 
       this.throttledUpdateDraggableDirection({

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
@@ -6,13 +6,7 @@ export default {
   mixins: [containerMixin],
   inject: {
     draggableUniverse: { default: null },
-    draggableRegionId: { default: null },
-    draggableCollectionId: { default: null },
-  },
-  provide() {
-    return {
-      draggableItemId: this.draggableId,
-    };
+    draggableAncestors: { default: () => [] },
   },
   props: {
     /**
@@ -24,11 +18,9 @@ export default {
       default: true,
       required: false,
     },
-  },
-  data() {
-    return {
-      draggableType: DraggableTypes.ITEM,
-    };
+    draggableType: {
+      default: DraggableTypes.ITEM,
+    },
   },
   computed: {
     ...mapState('draggable/items', ['hoverDraggableSection']),
@@ -36,6 +28,7 @@ export default {
       'activeDraggableId',
       'hoverDraggableId',
       'draggingTargetSection',
+      'isHoverDraggableAncestor',
     ]),
   },
   methods: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
@@ -23,12 +23,11 @@ export default {
     },
   },
   computed: {
-    ...mapState('draggable/items', ['hoverDraggableSection']),
+    ...mapState('draggable/items', ['hoverDraggableSection', 'hoverDraggableTarget']),
     ...mapGetters('draggable/items', [
       'activeDraggableId',
       'hoverDraggableId',
-      'draggingTargetSection',
-      'isHoverDraggableAncestor',
+      // 'isHoverDraggableAncestor',
     ]),
   },
   methods: {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
@@ -24,11 +24,7 @@ export default {
   },
   computed: {
     ...mapState('draggable/items', ['hoverDraggableSection', 'hoverDraggableTarget']),
-    ...mapGetters('draggable/items', [
-      'activeDraggableId',
-      'hoverDraggableId',
-      // 'isHoverDraggableAncestor',
-    ]),
+    ...mapGetters('draggable/items', ['activeDraggableId', 'hoverDraggableId']),
   },
   methods: {
     ...mapActions('draggable/items', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/item.js
@@ -23,8 +23,12 @@ export default {
     },
   },
   computed: {
-    ...mapState('draggable/items', ['hoverDraggableSection', 'hoverDraggableTarget']),
-    ...mapGetters('draggable/items', ['activeDraggableId', 'hoverDraggableId']),
+    ...mapState('draggable/items', ['hoverDraggableSection']),
+    ...mapGetters('draggable/items', [
+      'activeDraggableId',
+      'hoverDraggableId',
+      'hoverDraggableTarget',
+    ]),
   },
   methods: {
     ...mapActions('draggable/items', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/region.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/region.js
@@ -14,13 +14,8 @@ export default {
     },
   },
   computed: {
-    ...mapState('draggable/regions', ['hoverDraggableSection']),
-    ...mapGetters('draggable/regions', [
-      'activeDraggableId',
-      'hoverDraggableId',
-      'draggingTargetSection',
-      'isHoverDraggableAncestor',
-    ]),
+    ...mapState('draggable/regions', ['hoverDraggableSection', 'hoverDraggableTarget']),
+    ...mapGetters('draggable/regions', ['activeDraggableId', 'hoverDraggableId']),
   },
   methods: {
     ...mapActions('draggable/regions', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/region.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/region.js
@@ -14,8 +14,12 @@ export default {
     },
   },
   computed: {
-    ...mapState('draggable/regions', ['hoverDraggableSection', 'hoverDraggableTarget']),
-    ...mapGetters('draggable/regions', ['activeDraggableId', 'hoverDraggableId']),
+    ...mapState('draggable/regions', ['hoverDraggableSection']),
+    ...mapGetters('draggable/regions', [
+      'activeDraggableId',
+      'hoverDraggableId',
+      'hoverDraggableTarget',
+    ]),
   },
   methods: {
     ...mapActions('draggable/regions', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/region.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/region.js
@@ -9,18 +9,9 @@ export default {
       type: String,
       required: true,
     },
-  },
-  provide() {
-    return {
-      draggableUniverse: this.draggableUniverse,
-      draggableRegionId: this.draggableId,
-      draggableCollectionId: null,
-    };
-  },
-  data() {
-    return {
-      draggableType: DraggableTypes.REGION,
-    };
+    draggableType: {
+      default: DraggableTypes.REGION,
+    },
   },
   computed: {
     ...mapState('draggable/regions', ['hoverDraggableSection']),
@@ -28,13 +19,8 @@ export default {
       'activeDraggableId',
       'hoverDraggableId',
       'draggingTargetSection',
+      'isHoverDraggableAncestor',
     ]),
-    hasDescendantHoverDraggable() {
-      return (
-        this.hoverDraggableId === this.draggableId &&
-        (this.hoverDraggableCollectionId || this.hoverDraggableItemId)
-      );
-    },
   },
   methods: {
     ...mapActions('draggable/regions', [

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/utils.js
@@ -1,0 +1,46 @@
+/**
+ * Returns a function suitable for prop validation, using an object
+ * to test against its values
+ *
+ * @param {Object} obj
+ * @return {function(*): boolean}
+ */
+export function objectValuesValidator(obj) {
+  const values = Object.values(obj);
+  return function validator(val) {
+    return Boolean(values.find(v => v === val));
+  };
+}
+
+export class DropEventHelper {
+  /**
+   * @param {Object} data - Drop data
+   * @param {DragEvent} [event]
+   */
+  constructor(data, event = null) {
+    this.data = data;
+    this.event = event;
+    this._stopped = false;
+    this._cleared = false;
+  }
+
+  get stopped() {
+    return this._stopped;
+  }
+
+  get cleared() {
+    return this._cleared;
+  }
+
+  stopPropagation() {
+    if (this.event) {
+      this.event.stopPropagation();
+    }
+
+    this._stopped = true;
+  }
+
+  clear() {
+    this._cleared = true;
+  }
+}

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/utils.js
@@ -20,27 +20,5 @@ export class DropEventHelper {
   constructor(data, event = null) {
     this.data = data;
     this.event = event;
-    this._stopped = false;
-    this._cleared = false;
-  }
-
-  get stopped() {
-    return this._stopped;
-  }
-
-  get cleared() {
-    return this._cleared;
-  }
-
-  stopPropagation() {
-    if (this.event) {
-      this.event.stopPropagation();
-    }
-
-    this._stopped = true;
-  }
-
-  clear() {
-    this._cleared = true;
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
@@ -1,0 +1,86 @@
+<template>
+
+  <section class="list-group" :class="{ open }">
+    <VLayout
+      tag="header"
+      class="list-group-header"
+      align-center
+      @click="open = !open"
+    >
+      <VFlex v-if="prependIcon" shrink class="icon-container">
+        <Icon>{{ prependIcon }}</Icon>
+      </VFlex>
+      <div class="header-content grow">
+        <slot name="header"></slot>
+      </div>
+      <VFlex v-if="appendIcon" shrink class="icon-container">
+        <Icon>{{ appendIcon }}</Icon>
+      </VFlex>
+    </VLayout>
+    <VExpandTransition>
+      <div v-if="open" class="list-group-content">
+        <slot></slot>
+      </div>
+    </VExpandTransition>
+  </section>
+
+</template>
+
+<script>
+
+  export default {
+    name: 'LazyListGroup',
+    props: {
+      value: {
+        type: Boolean,
+        default: false,
+      },
+      appendIcon: {
+        type: String,
+        default: null,
+      },
+      prependIcon: {
+        type: String,
+        default: null,
+      },
+    },
+    computed: {
+      open: {
+        get() {
+          return this.value;
+        },
+        set(open) {
+          this.$emit('input', open);
+        },
+      },
+    },
+  };
+
+</script>
+
+<style lang="less" scoped>
+
+  .list-group {
+    box-sizing: border-box;
+    max-width: 100%;
+  }
+
+  .list-group-header {
+    cursor: pointer;
+  }
+
+  .list-group.open > .list-group-header .v-icon {
+    transform: rotate(-180deg);
+  }
+
+  .icon-container {
+    padding: 0 16px;
+  }
+
+  .header-content,
+  .list-group-header,
+  .list-group-content {
+    max-width: 100%;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/draggable/DraggablePlaceholder.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/draggable/DraggablePlaceholder.vue
@@ -9,7 +9,7 @@
       top: `${clientY + 8}px`,
     }"
   >
-    <slot :metadata="draggingData"></slot>
+    <slot v-bind="draggingData"></slot>
   </VCard>
 
 </template>

--- a/contentcuration/contentcuration/frontend/shared/vuetify/theme.js
+++ b/contentcuration/contentcuration/frontend/shared/vuetify/theme.js
@@ -23,7 +23,8 @@ export default function theme() {
       html5: '#ff8f00',
       slideshow: '#4ece90',
       channelHighlightDefault: colors.grey.lighten3,
-      draggableDropZone: '#cccccc',
+      draggableDropZone: '#dddddd',
+      draggableDropOverlay: '#996189',
     },
     themeTokens()
   );

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/index.js
@@ -8,6 +8,23 @@ import draggableModule from './module';
  *   2. Vue component mixins `shared/mixins/draggable`
  *   3. Vue components `shared/views/draggable`
  *
+ * The draggable components are split up into two categories, containers and handles. The two
+ * categories align with the native HTML5 drag and drop event handling. Containers handle events
+ * associated with a drag entering, hovering, leaving, and dropping on an element. Handles take care
+ * of responding to the user dragging it.
+ *
+ * | Draggable Type | Category    | Purpose                                                 |
+ * | -------------- | ----------- | ------------------------------------------------------- |
+ * | Region         | Container   | Top level container, defines universe for all draggable |
+ * |                |             | components inside                                       |
+ * | -------------- | ----------- | ------------------------------------------------------- |
+ * | Collection     | Container   | Grouping container, can recurse                         |
+ * | -------------- | ----------- | ------------------------------------------------------- |
+ * | Item           | Container   | Individual item container                               |
+ * | -------------- | ----------- | ------------------------------------------------------- |
+ * | Handle         | Handle      | Draggable handle to initiate dragging                   |
+ * | -------------- | ----------- | --------------------------------------------------------|
+ *
  * Draggable structure, flat:
  *   Region
  *     > Collection

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
@@ -130,7 +130,7 @@ export function setDraggableDropped(context, identity) {
       ? context.state.draggableContainerDrops[destination.key]
       : destination.key;
 
-    return context.state.draggableContainerDrops[key];
+    return cloneDeep(context.state.draggableContainerDrops[key]);
   }
 
   // We can add grouped handles to this sources array
@@ -139,17 +139,19 @@ export function setDraggableDropped(context, identity) {
     `${identity.type}s`
   ];
   const target = {
-    identity,
+    identity: cloneDeep(identity),
     section: hoverDraggableSection,
     relative: hoverDraggableTarget,
   };
 
   // Map all ancestors to this identity's key so we can easily clean this up
-  const dropData = identity.ancestors.reduce((dropData, ancestor) => {
-    const { key } = new DraggableIdentityHelper(ancestor);
-    dropData[key] = destination.key;
-    return dropData;
-  }, {});
+  const dropData = {};
+  if (identity.ancestors) {
+    identity.ancestors.forEach(ancestor => {
+      const { key } = new DraggableIdentityHelper(ancestor);
+      dropData[key] = destination.key;
+    });
+  }
 
   const selfData = (dropData[destination.key] = {
     ...target,
@@ -157,7 +159,7 @@ export function setDraggableDropped(context, identity) {
     sources,
   });
   context.commit('ADD_DRAGGABLE_CONTAINER_DROPS', dropData);
-  return selfData;
+  return cloneDeep(selfData);
 }
 
 export function clearDraggableDropped(context, identity) {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
@@ -55,6 +55,11 @@ export function removeGroupedDraggableHandle(context, identity) {
  * the user actually changes mouse direction
  */
 export function updateDraggableDirection(context, { x, y }) {
+  // Firefox could report 0,0 values which we transform to nulls
+  if (x === null || y === null) {
+    return;
+  }
+
   const { clientX, clientY } = context.state;
 
   if (clientX !== x || clientY !== y) {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
@@ -144,15 +144,13 @@ export function setDraggableDropped(context, identity) {
     relative: hoverDraggableTarget,
   };
 
-  // Build drop data for every ancestor, and when those receive drop events, will
-  // grab their data from here
+  // Map all ancestors to this identity's key so we can easily clean this up
   const dropData = identity.ancestors.reduce((dropData, ancestor) => {
     const { key } = new DraggableIdentityHelper(ancestor);
     dropData[key] = destination.key;
     return dropData;
   }, {});
 
-  // Construct the data we'll return, and expand `target` as that matches ancestor structure
   const selfData = (dropData[destination.key] = {
     ...target,
     target,

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
@@ -1,52 +1,51 @@
+import cloneDeep from 'lodash/cloneDeep';
 import { DraggableFlags } from './constants';
 import { DraggableIdentityHelper } from './utils';
 
+const rootDispatch = { root: true };
+
 export function setActiveDraggable(context, identity) {
   context.commit('SET_ACTIVE_DRAGGABLE_UNIVERSE', identity.universe);
-  const opts = { root: true };
-  const helper = new DraggableIdentityHelper(identity);
+  const { region, collection, item } = new DraggableIdentityHelper(identity);
 
   // This gets triggered when picking up a handle, so we'll trigger activation
   // of the ancestor draggable elements
-  if (helper.region) {
-    context.dispatch('draggable/regions/setActiveDraggable', helper.region, opts);
+  if (region) {
+    context.dispatch('draggable/regions/setActiveDraggable', region, rootDispatch);
   }
-  if (helper.collection) {
-    context.dispatch('draggable/collections/setActiveDraggable', helper.collection, opts);
+  if (collection) {
+    context.dispatch('draggable/collections/setActiveDraggable', collection, rootDispatch);
   }
-  if (helper.item) {
-    context.dispatch('draggable/items/setActiveDraggable', helper.item, opts);
+  if (item) {
+    context.dispatch('draggable/items/setActiveDraggable', item, rootDispatch);
   }
 }
 
 export function resetActiveDraggable(context) {
   context.commit('RESET_ACTIVE_DRAGGABLE_UNIVERSE');
 
-  const opts = { root: true };
-  context.dispatch('draggable/regions/resetActiveDraggable', {}, opts);
-  context.dispatch('draggable/collections/resetActiveDraggable', {}, opts);
-  context.dispatch('draggable/items/resetActiveDraggable', {}, opts);
+  context.dispatch('draggable/regions/resetActiveDraggable', {}, rootDispatch);
+  context.dispatch('draggable/collections/resetActiveDraggable', {}, rootDispatch);
+  context.dispatch('draggable/items/resetActiveDraggable', {}, rootDispatch);
 }
 
 /**
  * @param context
- * @param {{id, regionId, collectionId, itemId}} payload
+ * @param {DraggableIdentity} identity
  */
-export function addGroupedDraggableHandle(context, payload) {
-  const { id, universe } = payload;
-  if (!context.getters.isGroupedDraggableHandle({ id, universe })) {
-    context.commit('ADD_GROUPED_HANDLE', payload);
+export function addGroupedDraggableHandle(context, identity) {
+  if (!context.getters.isGroupedDraggableHandle(identity)) {
+    context.commit('ADD_GROUPED_HANDLE', identity);
   }
 }
 
 /**
  * @param context
- * @param {{id, regionId, collectionId, itemId}} payload
+ * @param {DraggableIdentity} identity
  */
-export function removeGroupedDraggableHandle(context, payload) {
-  const { id, universe } = payload;
-  if (context.getters.isGroupedDraggableHandle({ id, universe })) {
-    context.commit('REMOVE_GROUPED_HANDLE', payload);
+export function removeGroupedDraggableHandle(context, identity) {
+  if (context.getters.isGroupedDraggableHandle(identity)) {
+    context.commit('REMOVE_GROUPED_HANDLE', identity);
   }
 }
 
@@ -95,4 +94,74 @@ export function updateDraggableDirection(context, { x, y }) {
 export function resetDraggableDirection(context) {
   context.commit('RESET_DRAGGABLE_DIRECTION');
   context.commit('UPDATE_MOUSE_POSITION', { x: null, y: null });
+}
+
+/**
+ *
+ * @param context
+ * @param identity
+ * @return {{
+ *  sources: DraggableIdentity[],
+ *  identity: DraggableIdentity,
+ *  section: Number,
+ *  relative: Number,
+ *  target: {
+ *    identity: DraggableIdentity,
+ *    section: Number,
+ *    relative: Number
+ *  }}|null}
+ */
+export function setDraggableDropped(context, identity) {
+  // In the future, we could add handles to other types like collections and regions,
+  // which this would support
+  const source = context.getters.deepestActiveDraggable;
+  const destination = new DraggableIdentityHelper(identity);
+
+  // Can't drop on ourselves
+  if (!source || destination.is(source)) {
+    return null;
+  }
+
+  if (destination.key in context.state.draggableContainerDrops) {
+    return context.state.draggableContainerDrops[destination.key];
+  }
+
+  // We can add grouped handles to this sources array
+  const sources = [source].map(cloneDeep);
+
+  const positioning = type => ({
+    section: context.rootState.draggable[`${type}s`].hoverDraggableSection,
+    relative: context.rootGetters[`draggable/${type}s/draggingTargetSection`],
+  });
+  const target = {
+    identity,
+    ...positioning(identity.type),
+  };
+
+  // Build drop data for every ancestor, and when those receive drop events, will
+  // grab their data from here
+  const dropData = destination.ancestorsInOrder.reduce((dropData, ancestor) => {
+    const { key } = new DraggableIdentityHelper(ancestor);
+    dropData[key] = {
+      identity: cloneDeep(ancestor),
+      sources,
+      target: cloneDeep(target),
+      ...positioning(ancestor.type),
+    };
+    return dropData;
+  }, {});
+
+  // Construct the data we'll return, and expand `target` as that matches ancestor structure
+  const selfData = (dropData[destination.key] = {
+    ...target,
+    target,
+    sources,
+  });
+  context.commit('ADD_DRAGGABLE_CONTAINER_DROPS', dropData);
+  return selfData;
+}
+
+export function clearDraggableDropped(context, identity) {
+  const { key } = new DraggableIdentityHelper(identity);
+  context.commit('REMOVE_DRAGGABLE_CONTAINER_DROPS', [key]);
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/constants.js
@@ -18,12 +18,27 @@ export const DraggableFlags = {
 
 /**
  * Structure and defaults for draggable identity
+ * @interface
  */
-export const DraggableIdentityDefaults = {
+export const DraggableIdentity = {
+  /**
+   * @var {String|null}
+   */
   id: null,
-  itemId: null,
-  collectionId: null,
-  regionId: null,
+  /**
+   * @var {String|null}
+   */
+  type: null,
+  /**
+   * @var {String|null}
+   */
+  universe: null,
+  /**
+   * @var {DraggableIdentity[]|null}
+   */
   ancestors: null,
+  /**
+   * @var {mixed|null}
+   */
   metadata: null,
 };

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/getters.js
@@ -1,20 +1,18 @@
 import { DraggableTypes } from 'shared/mixins/draggable/constants';
 
-export function lowermostHoverDraggable(state, getters) {
-  let id = null,
-    type = null;
+const DRAGGABLE_SEARCH = [DraggableTypes.ITEM, DraggableTypes.COLLECTION, DraggableTypes.REGION];
 
-  if (getters.hoverDraggableItemId) {
-    id = getters.hoverDraggableItemId;
-    type = DraggableTypes.ITEM;
-  } else if (getters.hoverDraggableCollectionId) {
-    id = getters.hoverDraggableCollectionId;
-    type = DraggableTypes.COLLECTION;
-  } else if (getters.hoverDraggableRegionId) {
-    id = getters.hoverDraggableRegionId;
-    type = DraggableTypes.REGION;
-  }
+function submoduleStateType(rootState, name) {
+  return DRAGGABLE_SEARCH.find(type => Boolean(rootState.draggable[`${type}s`][`${name}`]));
+}
 
+function submoduleGetterType(rootGetters, name) {
+  return DRAGGABLE_SEARCH.find(type => Boolean(rootGetters[`draggable/${type}s/${name}`]));
+}
+
+export function lowermostHoverDraggable(state, getters, rootState, rootGetters) {
+  const type = submoduleGetterType(rootGetters, 'hoverDraggableId');
+  const id = type ? rootGetters[`draggable/${type}s/hoverDraggableId`] : null;
   return { id, type };
 }
 
@@ -31,12 +29,8 @@ export function hoverDraggableItemId(state, getters, rootState, rootGetters) {
 }
 
 export function activeDraggableSize(state, getters, rootState, rootGetters) {
-  const submodule = ['items', 'collections', 'regions'].find(submodule => {
-    const activeDraggableId = rootGetters[`draggable/${submodule}/activeDraggableId`];
-    return Boolean(activeDraggableId);
-  });
-
-  return (submodule ? rootState.draggable[submodule].activeDraggableSize : 0) || 0;
+  const type = submoduleGetterType(rootGetters, 'activeDraggableId');
+  return (type ? rootState.draggable[`${type}s`].activeDraggableSize : 0) || 0;
 }
 
 export function isGroupedDraggableHandle(state) {
@@ -44,5 +38,32 @@ export function isGroupedDraggableHandle(state) {
     return (
       universe in state.groupedDraggableHandles && id in state.groupedDraggableHandles[universe]
     );
+  };
+}
+
+export function getDraggableDropData(state, getters, rootState, rootGetters) {
+  return function(includeGrouped = false) {
+    const sourceType = submoduleStateType(rootState, 'activeDraggable');
+    const { type: targetType } = getters.lowermostHoverDraggable;
+
+    if (!sourceType || !targetType) {
+      return null;
+    }
+
+    const sourceItem = rootState.draggable[`${sourceType}s`].activeDraggable;
+    const sources = [sourceItem];
+
+    if (includeGrouped) {
+      // TODO
+    }
+
+    const targetState = rootState.draggable[`${targetType}s`];
+
+    return {
+      sources,
+      target: targetState.hoverDraggable,
+      section: targetState.hoverDraggableSection,
+      relative: rootGetters[`draggable/${targetType}s/draggingTargetSection`],
+    };
   };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/getters.js
@@ -26,6 +26,18 @@ export function isHoverDraggableAncestor(state, getters, rootState, rootGetters)
   };
 }
 
+export function activeDraggableRegionId(state, getters, rootState, rootGetters) {
+  return rootGetters['draggable/regions/activeDraggableId'];
+}
+
+export function activeDraggableCollectionId(state, getters, rootState, rootGetters) {
+  return rootGetters['draggable/collections/activeDraggableId'];
+}
+
+export function activeDraggableItemId(state, getters, rootState, rootGetters) {
+  return rootGetters['draggable/items/activeDraggableId'];
+}
+
 export function hoverDraggableRegionId(state, getters, rootState, rootGetters) {
   return rootGetters['draggable/regions/hoverDraggableId'];
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/index.js
@@ -14,6 +14,7 @@ export default {
       draggableDirection: DraggableFlags.NONE,
       activeDraggableUniverse: null,
       groupedDraggableHandles: {},
+      draggableContainerDrops: {},
     };
   },
   getters,

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/mutations.js
@@ -1,25 +1,23 @@
 import Vue from 'vue';
 import { DraggableFlags } from './constants';
+import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
 
-export function SET_ACTIVE_DRAGGABLE_UNIVERSE(state, id) {
-  state.activeDraggableUniverse = id;
+export function SET_ACTIVE_DRAGGABLE_UNIVERSE(state, universe) {
+  state.activeDraggableUniverse = universe;
 }
 
 export function RESET_ACTIVE_DRAGGABLE_UNIVERSE(state) {
   state.activeDraggableUniverse = null;
 }
 
-export function ADD_GROUPED_HANDLE(state, payload) {
-  const { id, universe } = payload;
-  const universeGroup = state.groupedDraggableHandles[universe] || {};
-  Vue.set(universeGroup, id, payload);
-  Vue.set(state.groupedDraggableHandles, universe, universeGroup);
+export function ADD_GROUPED_HANDLE(state, identity) {
+  const { key } = new DraggableIdentityHelper(identity);
+  Vue.set(state.groupedDraggableHandles, key, identity);
 }
 
-export function REMOVE_GROUPED_HANDLE(state, { id, universe }) {
-  const universeGroup = state.groupedDraggableHandles[universe] || {};
-  Vue.delete(universeGroup, id);
-  Vue.set(state.groupedDraggableHandles, universe, universeGroup);
+export function REMOVE_GROUPED_HANDLE(state, identity) {
+  const { key } = new DraggableIdentityHelper(identity);
+  Vue.delete(state.groupedDraggableHandles, key);
 }
 
 export function UPDATE_MOUSE_POSITION(state, { x, y }) {
@@ -33,4 +31,16 @@ export function UPDATE_DRAGGABLE_DIRECTION(state, dirFlag) {
 
 export function RESET_DRAGGABLE_DIRECTION(state) {
   state.draggableDirection = DraggableFlags.NONE;
+}
+
+export function ADD_DRAGGABLE_CONTAINER_DROPS(state, data) {
+  for (let key in data) {
+    Vue.set(state.draggableContainerDrops, key, data[key]);
+  }
+}
+
+export function REMOVE_DRAGGABLE_CONTAINER_DROPS(state, keys) {
+  for (let key of keys) {
+    Vue.delete(state.draggableContainerDrops, key);
+  }
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/actions.js
@@ -16,10 +16,12 @@ export function setHoverDraggable(context, identity) {
   // Make sure we've not trying set the same draggable, or the active draggable as the
   // hover draggable
   const { id, universe } = identity;
+  const { activeDraggableUniverse } = context.rootState.draggable;
+
   if (
     context.getters.hoverDraggableId !== id &&
     context.getters.activeDraggableId !== id &&
-    context.getters.isInActiveDraggableUniverse(universe) &&
+    universe === activeDraggableUniverse &&
     !context.getters.isHoverDraggableAncestor(identity)
   ) {
     context.commit('SET_LAST_HOVER_DRAGGABLE', context.state.hoverDraggable);

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/actions.js
@@ -1,6 +1,4 @@
 import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
-import { bitMaskToObject } from 'shared/vuex/draggablePlugin/module/utils';
-import { DragEffect } from 'shared/mixins/draggable/constants';
 
 export function setActiveDraggable(context, identity) {
   context.commit('SET_ACTIVE_DRAGGABLE', identity);
@@ -31,7 +29,7 @@ export function setHoverDraggable(context, identity) {
   }
 }
 
-export function updateHoverDraggable(context, { id, minX, maxX, minY, maxY, dragEffect = null }) {
+export function updateHoverDraggable(context, { id, minX, maxX, minY, maxY }) {
   if (id !== context.getters.hoverDraggableId) {
     return;
   }
@@ -58,63 +56,6 @@ export function updateHoverDraggable(context, { id, minX, maxX, minY, maxY, drag
 
     context.commit('SET_HOVER_DRAGGABLE_SECTION', section);
   }
-
-  // If drop effect is sort, then the targeting logic is useful for determine intended
-  // location, eg before or after, which can depend on mouse momentum
-  if (dragEffect === DragEffect.SORT) {
-    return context.dispatch('updateHoverDraggableTarget');
-  }
-}
-
-/**
- * Determines the section of which we should register potential placement of
- * the current draggable items.
- */
-export function updateHoverDraggableTarget(context) {
-  let section = DraggableFlags.NONE;
-  const { lastHoverDraggableId, hoverDraggableSection, lastHoverDraggableSection } = context.state;
-  const { draggableDirection } = context.rootState.draggable;
-
-  // If no section is being hovered over, so no target section should be displayed
-  if (hoverDraggableSection === DraggableFlags.NONE) {
-    context.commit('SET_HOVER_DRAGGABLE_TARGET', section);
-    return;
-  }
-
-  // Get all booleans for hover section and direction flags
-  const hoverSection = bitMaskToObject(hoverDraggableSection);
-  const direction = bitMaskToObject(draggableDirection);
-
-  // When the user has dragged from outside of the universe, or is dragging from the area of the
-  // item that has just started dragging.
-  if (!lastHoverDraggableId) {
-    // If it's an entrance, we want to target the same section that the user
-    // has entered through dragging
-    section ^= hoverSection.top ? DraggableFlags.TOP : DraggableFlags.BOTTOM;
-    section ^= hoverSection.left ? DraggableFlags.LEFT : DraggableFlags.RIGHT;
-  } else {
-    // We'll use the last hover section to determine if the user has changed directions
-    // within a dropzone and therefore to retarget appropriately when they cross the
-    // boundary of a section
-    const lastHoverSection = bitMaskToObject(lastHoverDraggableSection);
-
-    if (lastHoverSection.bottom || (!lastHoverSection.any && hoverSection.bottom && direction.up)) {
-      section ^= DraggableFlags.TOP;
-    } else if (
-      lastHoverSection.top ||
-      (!lastHoverSection.any && hoverSection.top && direction.down)
-    ) {
-      section ^= DraggableFlags.BOTTOM;
-    }
-
-    if (lastHoverSection.right || (hoverSection.right && direction.left)) {
-      section ^= DraggableFlags.LEFT;
-    } else if (lastHoverSection.left || (hoverSection.left && direction.right)) {
-      section ^= DraggableFlags.RIGHT;
-    }
-  }
-
-  context.commit('SET_HOVER_DRAGGABLE_TARGET', section);
 }
 
 export function resetHoverDraggable(context, { id = null }) {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/actions.js
@@ -59,6 +59,8 @@ export function updateHoverDraggable(context, { id, minX, maxX, minY, maxY, drag
     context.commit('SET_HOVER_DRAGGABLE_SECTION', section);
   }
 
+  // If drop effect is sort, then the targeting logic is useful for determine intended
+  // location, eg before or after, which can depend on mouse momentum
   if (dragEffect === DragEffect.SORT) {
     return context.dispatch('updateHoverDraggableTarget');
   }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
@@ -1,5 +1,4 @@
-import { DraggableFlags } from '../constants';
-import { bitMaskToObject, DraggableIdentityHelper } from '../utils';
+import { DraggableIdentityHelper } from '../utils';
 
 /**
  * @return {String|null}
@@ -15,14 +14,13 @@ export function hoverDraggableId(state) {
   return state.hoverDraggable.id;
 }
 
-export function isHoverDraggableAncestor(state) {
+export function isHoverDraggableAncestor(state, getters) {
   /**
    * @param {Object} identity
    * @return {Boolean}
    */
   return function({ id, type }) {
-    const helper = new DraggableIdentityHelper(state.hoverDraggable);
-    return Boolean(helper.findClosestAncestor({ id, type }));
+    return Boolean(getters.getHoverAncestor({ id, type }));
   };
 }
 
@@ -33,54 +31,4 @@ export function getHoverAncestor(state) {
   return function(match) {
     return new DraggableIdentityHelper(state.hoverDraggable).findClosestAncestor(match);
   };
-}
-
-/**
- * Determines the section of which we should register potential placement of
- * the current draggable items.
- */
-export function draggingTargetSection(state, getters, rootState) {
-  let section = DraggableFlags.NONE;
-  const { lastHoverDraggableId, hoverDraggableSection, lastHoverDraggableSection } = state;
-  const { draggableDirection } = rootState.draggable;
-
-  // If no section is being hovered over, so no target section should be displayed
-  if (hoverDraggableSection === DraggableFlags.NONE) {
-    return section;
-  }
-
-  // Get all booleans for hover section and direction flags
-  const hoverSection = bitMaskToObject(hoverDraggableSection);
-  const direction = bitMaskToObject(draggableDirection);
-
-  // When the user has dragged from outside of the universe, or is dragging from the area of the
-  // item that has just started dragging.
-  if (!lastHoverDraggableId) {
-    // If it's an entrance, we want to target the same section that the user
-    // has entered through dragging
-    section ^= hoverSection.top ? DraggableFlags.TOP : DraggableFlags.BOTTOM;
-    section ^= hoverSection.left ? DraggableFlags.LEFT : DraggableFlags.RIGHT;
-  } else {
-    // We'll use the last hover section to determine if the user has changed directions
-    // within a dropzone and therefore to retarget appropriately when they cross the
-    // boundary of a section
-    const lastHoverSection = bitMaskToObject(lastHoverDraggableSection);
-
-    if (lastHoverSection.bottom || (!lastHoverSection.any && hoverSection.bottom && direction.up)) {
-      section ^= DraggableFlags.TOP;
-    } else if (
-      lastHoverSection.top ||
-      (!lastHoverSection.any && hoverSection.top && direction.down)
-    ) {
-      section ^= DraggableFlags.BOTTOM;
-    }
-
-    if (lastHoverSection.right || (hoverSection.right && direction.left)) {
-      section ^= DraggableFlags.LEFT;
-    } else if (lastHoverSection.left || (hoverSection.left && direction.right)) {
-      section ^= DraggableFlags.RIGHT;
-    }
-  }
-
-  return section;
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
@@ -1,4 +1,5 @@
-import { DraggableIdentityHelper } from '../utils';
+import { bitMaskToObject, DraggableIdentityHelper } from '../utils';
+import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
 
 /**
  * @return {String|null}
@@ -31,4 +32,54 @@ export function getHoverAncestor(state) {
   return function(match) {
     return new DraggableIdentityHelper(state.hoverDraggable).findClosestAncestor(match);
   };
+}
+
+/**
+ * Determines the section of which we should register potential placement of
+ * the current draggable items.
+ */
+export function hoverDraggableTarget(state, getters, rootState) {
+  let section = DraggableFlags.NONE;
+  const { lastHoverDraggableId, hoverDraggableSection, lastHoverDraggableSection } = state;
+  const { draggableDirection } = rootState.draggable;
+
+  // If no section is being hovered over, so no target section should be displayed
+  if (hoverDraggableSection === DraggableFlags.NONE) {
+    return section;
+  }
+
+  // Get all booleans for hover section and direction flags
+  const hoverSection = bitMaskToObject(hoverDraggableSection);
+  const direction = bitMaskToObject(draggableDirection);
+
+  // When the user has dragged from outside of the universe, or is dragging from the area of the
+  // item that has just started dragging.
+  if (!lastHoverDraggableId) {
+    // If it's an entrance, we want to target the same section that the user
+    // has entered through dragging
+    section ^= hoverSection.top ? DraggableFlags.TOP : DraggableFlags.BOTTOM;
+    section ^= hoverSection.left ? DraggableFlags.LEFT : DraggableFlags.RIGHT;
+  } else {
+    // We'll use the last hover section to determine if the user has changed directions
+    // within a dropzone and therefore to retarget appropriately when they cross the
+    // boundary of a section
+    const lastHoverSection = bitMaskToObject(lastHoverDraggableSection);
+
+    if (lastHoverSection.bottom || (!lastHoverSection.any && hoverSection.bottom && direction.up)) {
+      section ^= DraggableFlags.TOP;
+    } else if (
+      lastHoverSection.top ||
+      (!lastHoverSection.any && hoverSection.top && direction.down)
+    ) {
+      section ^= DraggableFlags.BOTTOM;
+    }
+
+    if (lastHoverSection.right || (hoverSection.right && direction.left)) {
+      section ^= DraggableFlags.LEFT;
+    } else if (lastHoverSection.left || (hoverSection.left && direction.right)) {
+      section ^= DraggableFlags.RIGHT;
+    }
+  }
+
+  return section;
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/getters.js
@@ -1,15 +1,5 @@
 import { DraggableFlags } from '../constants';
-import { bitMaskToObject } from '../utils';
-
-export function isInActiveDraggableUniverse(state, getters, rootState) {
-  /**
-   * @param {string} id
-   * @return {Boolean}
-   */
-  return function(universe) {
-    return universe === rootState.draggable.activeDraggableUniverse;
-  };
-}
+import { bitMaskToObject, DraggableIdentityHelper } from '../utils';
 
 /**
  * @return {String|null}
@@ -30,9 +20,18 @@ export function isHoverDraggableAncestor(state) {
    * @param {Object} identity
    * @return {Boolean}
    */
-  return function(identity) {
-    const ancestors = state.hoverDraggable.ancestors || [];
-    return Boolean(ancestors.find(a => a.id === identity.id && a.type === identity.type));
+  return function({ id, type }) {
+    const helper = new DraggableIdentityHelper(state.hoverDraggable);
+    return Boolean(helper.findClosestAncestor({ id, type }));
+  };
+}
+
+export function getHoverAncestor(state) {
+  /**
+   * @param {Object} match - An object with which it will test for match with ancestor
+   */
+  return function(match) {
+    return new DraggableIdentityHelper(state.hoverDraggable).findClosestAncestor(match);
   };
 }
 

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
@@ -15,8 +15,12 @@ export default function draggableSubmodule(draggableType) {
         activeDraggableSize: null,
         hoverDraggable: defaultIdentityClone(),
         lastHoverDraggable: defaultIdentityClone(),
+        // The section of the draggable that is currently hovered
         hoverDraggableSection: DraggableFlags.NONE,
+        // The last section that was hovered
         lastHoverDraggableSection: DraggableFlags.NONE,
+        // The mouse direction based target, for sorting
+        hoverDraggableTarget: DraggableFlags.NONE,
       };
     },
     getters,

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
@@ -19,8 +19,6 @@ export default function draggableSubmodule(draggableType) {
         hoverDraggableSection: DraggableFlags.NONE,
         // The last section that was hovered
         lastHoverDraggableSection: DraggableFlags.NONE,
-        // The mouse direction based target, for sorting
-        hoverDraggableTarget: DraggableFlags.NONE,
       };
     },
     getters,

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/index.js
@@ -1,9 +1,9 @@
-import { DraggableFlags, DraggableIdentityDefaults } from '../constants';
+import { DraggableFlags, DraggableIdentity } from '../constants';
 import * as getters from './getters';
 import * as mutations from './mutations';
 import * as actions from './actions';
 
-const defaultIdentityClone = () => Object.assign({}, DraggableIdentityDefaults);
+const defaultIdentityClone = () => Object.assign({}, DraggableIdentity);
 
 export default function draggableSubmodule(draggableType) {
   return {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/mutations.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { DraggableFlags, DraggableIdentityDefaults } from '../constants';
+import { DraggableFlags, DraggableIdentity } from '../constants';
 
 /**
  * @param {Vuex.State} state
@@ -8,7 +8,7 @@ import { DraggableFlags, DraggableIdentityDefaults } from '../constants';
  */
 function setIdentity(state, name, obj = null) {
   if (!obj) {
-    obj = DraggableIdentityDefaults;
+    obj = DraggableIdentity;
   }
 
   Object.keys(obj).forEach(key => {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/submodule/mutations.js
@@ -59,3 +59,11 @@ export function RESET_HOVER_DRAGGABLE_SECTION(state) {
 export function RESET_LAST_HOVER_DRAGGABLE_SECTION(state) {
   state.lastHoverDraggableSection = DraggableFlags.NONE;
 }
+
+export function SET_HOVER_DRAGGABLE_TARGET(state, sectionMask) {
+  state.hoverDraggableTarget = sectionMask;
+}
+
+export function RESET_HOVER_DRAGGABLE_TARGET(state) {
+  state.hoverDraggableTarget = DraggableFlags.NONE;
+}


### PR DESCRIPTION
## Description
The primary additions of this PR connect drop events with the appropriate copy and move operations for the related content nodes. Also, a bunch of cleanup and refinement of the draggable code as well.

- Consolidates and cleans up handling of draggable identity data structure
- Adds region to clipboard FAB and bounce animation when dragging over
- Adds draggable components to clipboard
- Adds clipboard overlay when dragging over to copy
- Adds constants for draggable universes and custom region IDs
- Adds constants for drop effect and effect allowed
- Adds container prop for distinguishing between default handling, and sort effect handling to optimize data gathering
- Adds generation of drop data
- Attaches drop event handlers to all regions

#### Issue Addressed (if applicable)
https://github.com/learningequality/studio/issues/2513

## Steps to Test

- [ ] *Sort nodes in topic view*
- [ ] *Drag nodes to and from the topic view and the tree side bar*
- [ ] *Drag nodes in between other nodes in tree side bar*
- [ ] *Drag nodes to and from open clipboard*
- [ ] *Drag nodes to clipboard FAB*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?

