### PR TITLE
make options icon always visible in channel view

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -341,15 +341,6 @@
     .updated .v-icon {
       vertical-align: middle;
     }
-
-    &__action {
-      opacity: 0;
-      transition: opacity ease 0.3s;
-
-      .content-list-item.hover & {
-        opacity: 1;
-      }
-    }
   }
 
   .thumbnail-col {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -444,7 +444,7 @@
     padding-left: 14px;
     cursor: pointer;
 
-    &:hover .topic-menu {
+    .topic-menu {
       display: block;
     }
   }


### PR DESCRIPTION
## Description 

This PR makes the "options" and "open topic" icons always visible in the channel view, rather than having them become visible on hover. 

#### Issue Addressed (if applicable)

Addresses #2400 (Do not hide context menu icons on listed content nodes)

#### Before/After Screenshots (if applicable)

<img width="1437" alt="Screen Shot 2020-11-09 at 9 15 14 AM" src="https://user-images.githubusercontent.com/17235236/98552368-5ef72680-226c-11eb-8ead-ca8cfe263a2d.png">

## Steps to Test

- [x] Log in 
- [x] Navigate to Channels, and click on "Published Channel" which will show the channel editor 
- [x] Ensure that the icons are visible 

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I edited the CSS to remove the hover state in the Content Node List Item and the Studio Tree.

## Comments

Based on the files that I changed, I am not sure if this might affect the visibility of icons in other views. The Notion discussions indicates that we are trying to ensure that all of the icons are visible, so I think if does affect more files than just this view, that would actually be a positive. 
