### PR TITLE
Update arguments passed to checkSavingProgress so saving indicator shows

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/SavingIndicator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/SavingIndicator.vue
@@ -68,7 +68,9 @@
         this.checkSavingProgress({
           contentNodeIds: this.nodeIds,
           fileIds: files.map(f => f.id).filter(Boolean),
-          assessmentIds: assessmentItems.map(ai => ai.id).filter(Boolean),
+          assessmentIds: assessmentItems
+            .map(ai => [ai.contentnode, ai.assessment_id])
+            .filter(Boolean),
         }).then(hasChanges => (this.hasChanges = hasChanges));
       }, CHECK_SAVE_INTERVAL);
     },


### PR DESCRIPTION
## Description

This PR updates the argument that is passed to checkSavingProgress() in the SavingIndicator, so that it correctly resolves and displays when data is updated in the questions tab. 

#### Issue Addressed

Addresses #2419 
 
#### Before/After Screenshots

![saving-indicator](https://user-images.githubusercontent.com/17235236/98727585-20de2d80-2366-11eb-82e1-21c659f03ebf.gif)


## Steps to Test

- [ ] In Published Channel Editor, navigate to Sample Exercise and click edit 
- [ ] In the Questions Tab, make edits to any of the questions. The saving indicator should display on the bottom bar

#### At a high level, how did you implement this?

I updated the argument that was passed to checkSavingProgress() that included both the contentnode and the assessment_id, per the AssessmentItem in resources.js and some help from @jayoshih.
