### PR TITLE
Update obsolete mastery model type field in the development server setup

### DIFF
--- a/contentcuration/contentcuration/utils/db_tools.py
+++ b/contentcuration/contentcuration/utils/db_tools.py
@@ -152,7 +152,7 @@ all_questions = (question_1, question_2, question_3, question_4)
 
 def create_exercise(title, parent, license_id, description="", user=None, empty=False):
     mastery_model = {
-        "mastery_model": exercises.M_OF_N,
+        "type": exercises.M_OF_N,
         "randomize": False,
         "m": 3,
         "n": 5,
@@ -417,7 +417,7 @@ class TreeBuilder(object):
 
     def generate_exercise(self, parent_id):
         mastery_model = {
-            "mastery_model": exercises.M_OF_N,
+            "type": exercises.M_OF_N,
             "randomize": False,
             "m": 3,
             "n": 5,


### PR DESCRIPTION
## Description

At some point, we've started using `type` field instead of `mastery_model` to save the mastery model type on exercise content nodes. However, the obsolete `mastery_mode` was still in use in the development server setup script, which caused error messages to be displayed for the sample exercise in the channel editor and in the edit modal.

## Steps to Test

- [ ] *Clear IndexedDB*
- [ ] *Run `yarn run devsetup`*
- [ ] *Check that there are no errors displayed for "Sample Exercise" of "Published Channel" in the channel editor and in the edit modal*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
