### PR TITLE
Stop repeating policy modals on Firefox

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -84,6 +84,17 @@ export const policyDates = {
   [policies.COMMUNITY_STANDARDS]: new Date('2020-08-30'),
 };
 
+export function createPolicyKey(policyName, policyDate) {
+  const policyYear = policyDate.getUTCFullYear();
+  const policyMonth = policyDate.getUTCMonth() + 1;
+  const policyDay = policyDate.getUTCDate();
+  return `${policyName}_${policyYear}_${policyMonth}_${policyDay}`;
+}
+
+export const policyKeys = Object.entries(policyDates).map(([key, value]) => {
+  return createPolicyKey(key, value);
+});
+
 // Filter constants
 export const filterTypes = {
   BOOLEAN: 'BOOLEAN',

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -79,9 +79,9 @@ export const policies = {
 };
 export const requiredPolicies = [policies.PRIVACY, policies.TERMS_OF_SERVICE];
 export const policyDates = {
-  [policies.PRIVACY]: new Date(2018, 4, 25),
-  [policies.TERMS_OF_SERVICE]: new Date(2020, 8, 30),
-  [policies.COMMUNITY_STANDARDS]: new Date(2020, 8, 30),
+  [policies.PRIVACY]: new Date('2018-04-25'),
+  [policies.TERMS_OF_SERVICE]: new Date('2020-08-30'),
+  [policies.COMMUNITY_STANDARDS]: new Date('2020-08-30'),
 };
 
 // Filter constants

--- a/contentcuration/contentcuration/frontend/shared/vuex/policies/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/policies/index.js
@@ -1,58 +1,9 @@
-import findKey from 'lodash/findKey';
-import sortBy from 'lodash/sortBy';
-import transform from 'lodash/transform';
-import { policyDates } from 'shared/constants';
+import { policyDates, policyKeys, createPolicyKey } from 'shared/constants';
 import client from 'shared/client';
-
-function _parseDateFormat(dateString) {
-  const [date, time] = dateString.split(' ');
-  const [day, month, year] = date.split('/');
-  return date && new Date(`${month}/${day}/${year} ${time}`);
-}
-
-function _parsePolicyDate(policyName, key) {
-  let out = new Date(policyName.replace(`${key}_`, '').replaceAll('_', '-'));
-  return out;
-}
 
 export default {
   namespaced: true,
   getters: {
-    // getPolicies takes an object of accepted policies from the user.
-    // returns an object with all the policies, and when the user has
-    // last signed them.
-    getPolicies() {
-      return acceptedPolicies => {
-        const sortedPolicies = {};
-        sortBy(Object.keys(acceptedPolicies), key =>
-          _parsePolicyDate(
-            key,
-            key
-              .split('_')
-              .slice(-3)
-              .join('_')
-          )
-        )
-          .reverse()
-          .forEach(key => {
-            sortedPolicies[key] = acceptedPolicies[key];
-          });
-        return transform(
-          policyDates,
-          (result, latest, key) => {
-            const lastPolicyKey = findKey(sortedPolicies, (v, k) => k.startsWith(key));
-            const lastPolicy = sortedPolicies[lastPolicyKey];
-
-            result[key] = {
-              latest,
-              signedOn: (lastPolicy && _parseDateFormat(lastPolicy)) || null,
-              lastSignedPolicy: (lastPolicyKey && _parsePolicyDate(lastPolicyKey, key)) || null,
-            };
-          },
-          {}
-        );
-      };
-    },
     getPolicyAcceptedData() {
       return policyName => {
         // what should the format be?
@@ -73,30 +24,21 @@ export default {
 
         // Get policy string
         const policyDate = policyDates[policyName];
-        const policyYear = policyDate.getUTCFullYear();
-        const policyMonth = policyDate.getUTCMonth() + 1;
-        const policyDay = policyDate.getUTCDate();
-        const policyStr = `${policyName}_${policyYear}_${policyMonth}_${policyDay}`;
-        return { [policyStr]: dateStr };
+        return { [createPolicyKey(policyName, policyDate)]: dateStr };
       };
     },
     // returns a list of policy constants (e.g. policies.PRIVACY)
     // that have not been signed by the user.
-    getNonAcceptedPolicies(state, getters) {
+    getNonAcceptedPolicies() {
       return policies => {
-        const policiesList = getters.getPolicies(policies);
-        return Object.entries(policiesList)
-          .map(([key, value]) => {
-            // if they never signed anything, or the last thing
-            // they signed isn't equal to the latest policy
-            if (
-              !value.lastSignedPolicy ||
-              value.latest.getTime() != value.lastSignedPolicy.getTime()
-            ) {
-              return key;
-            }
-          })
-          .filter(Boolean); // remove any undefined in the list
+        return policyKeys
+          .filter(key => !policies[key])
+          .map(key =>
+            key
+              .split('_')
+              .slice(0, -3)
+              .join('_')
+          );
       };
     },
   },

--- a/contentcuration/contentcuration/frontend/shared/vuex/policies/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/policies/index.js
@@ -11,7 +11,8 @@ function _parseDateFormat(dateString) {
 }
 
 function _parsePolicyDate(policyName, key) {
-  return new Date(policyName.replace(`${key}_`, '').replaceAll('_', '-'));
+  let out = new Date(policyName.replace(`${key}_`, '').replaceAll('_', '-'));
+  return out;
 }
 
 export default {
@@ -54,20 +55,27 @@ export default {
     },
     getPolicyAcceptedData() {
       return policyName => {
+        // what should the format be?
+        // {policy_name}_{year}_{month}_{day}
         // Get current date string
         const date = new Date();
-        const day = ('0' + date.getDate()).slice(-2);
-        const month = ('0' + (date.getMonth() + 1)).slice(-2);
-        const year = String(date.getFullYear()).slice(-2);
-        const hour = ('0' + (date.getHours() + 1)).slice(-2);
-        const minute = ('0' + (date.getMinutes() + 1)).slice(-2);
+        // this data is what we send to the server,
+        // and converting it to a string makes it lose
+        // timezone data. Ensure that we standardize on
+        // UTC before sending that to the server.
+        // part of the fix for issue #2508 and #2317.
+        const day = ('0' + date.getUTCDate()).slice(-2);
+        const month = ('0' + (date.getUTCMonth() + 1)).slice(-2);
+        const year = String(date.getUTCFullYear()).slice(-2);
+        const hour = ('0' + (date.getUTCHours() + 1)).slice(-2);
+        const minute = ('0' + (date.getUTCMinutes() + 1)).slice(-2);
         const dateStr = `${day}/${month}/${year} ${hour}:${minute}`;
 
         // Get policy string
         const policyDate = policyDates[policyName];
-        const policyYear = policyDate.getFullYear();
-        const policyMonth = policyDate.getMonth() + 1;
-        const policyDay = policyDate.getDate();
+        const policyYear = policyDate.getUTCFullYear();
+        const policyMonth = policyDate.getUTCMonth() + 1;
+        const policyDay = policyDate.getUTCDate();
         const policyStr = `${policyName}_${policyYear}_${policyMonth}_${policyDay}`;
         return { [policyStr]: dateStr };
       };

--- a/contentcuration/contentcuration/frontend/shared/vuex/policies/index.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/policies/index.spec.js
@@ -12,32 +12,6 @@ describe('policies store', () => {
     window.user = {};
     store = storeFactory();
   });
-  describe('getPolicies getter', () => {
-    it('should leave last signed policy information null for unsigned policies', () => {
-      const myPolicies = store.getters['policies/getPolicies']({});
-      expect(myPolicies[policies.TERMS_OF_SERVICE]).toEqual({
-        latest: policyDates[policies.TERMS_OF_SERVICE],
-        signedOn: null,
-        lastSignedPolicy: null,
-      });
-    });
-    it('should get the last signed policy version', () => {
-      const myPolicies = store.getters['policies/getPolicies']({
-        [`${policies.TERMS_OF_SERVICE}_2000_1_1`]: '01/01/2000 12:12',
-        [`${policies.TERMS_OF_SERVICE}_2001_1_1`]: '01/01/2001 12:12',
-        [`${policies.TERMS_OF_SERVICE}_2002_1_1`]: '01/01/2002 12:12',
-      });
-      expect(myPolicies[policies.TERMS_OF_SERVICE].lastSignedPolicy).toEqual(new Date(2002, 0, 1));
-    });
-    it('should get the last signed policy date', () => {
-      const myPolicies = store.getters['policies/getPolicies']({
-        [`${policies.TERMS_OF_SERVICE}_2000_1_1`]: '01/01/2000 12:12',
-        [`${policies.TERMS_OF_SERVICE}_2001_1_1`]: '01/01/2001 12:12',
-        [`${policies.TERMS_OF_SERVICE}_2002_1_1`]: '01/01/2002 12:12',
-      });
-      expect(myPolicies[policies.TERMS_OF_SERVICE].signedOn).toEqual(new Date(2002, 0, 1, 12, 12));
-    });
-  });
   describe('getNonAcceptedPolicies getter', () => {
     it('should return empty array if all policies have been accepted', () => {
       const allPolicies = transform(


### PR DESCRIPTION
Fixes #2508 and #2317.

Firefox automatically converts dates to the local timezone. This isn't a problem when we work with Date objects. However when we send data to the backend for saving, we lose this timezone data and and the date saved will not be equal to the policy modal date created in `constants.js`.

This change makes sure we use UTC dates during the conversion. We also change the dates for the policies in `constants.js` by standardizing on parsing strings when creating these dates.