### PR TITLE
Disallow dropping nodes into themselves, ignore drag and drops less than 100ms, and deselect after dragging out

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -200,6 +200,12 @@
         });
       },
     },
+    beforeDestroy() {
+      // Unselect before removing
+      if (this.selected) {
+        this.selected = false;
+      }
+    },
     $trs: {
       optionsTooltip: 'Options',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -15,7 +15,7 @@
       <DraggableItem
         :draggableSize="draggableSize"
         :draggableMetadata="node"
-        :dropEffect="dropEffect"
+        :dropEffect="activeDropEffect"
         @draggableDragEnter="dragEnter"
         @draggableDragLeave="dragLeave"
       >
@@ -254,6 +254,7 @@
     computed: {
       ...mapGetters('currentChannel', ['canEdit']),
       ...mapState('draggable', ['activeDraggableUniverse']),
+      ...mapGetters('draggable', ['deepestActiveDraggable']),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeChildren', 'nodeExpanded']),
       node() {
         return this.getContentNode(this.nodeId);
@@ -296,6 +297,11 @@
       },
       taskId() {
         return this.node && this.node[TASK_ID];
+      },
+      activeDropEffect() {
+        // Don't allow dropping into itself
+        const { metadata } = this.deepestActiveDraggable || {};
+        return metadata && metadata.id !== this.nodeId ? this.dropEffect : DropEffect.NONE;
       },
     },
     watch: {
@@ -360,7 +366,8 @@
       },
       dragEnter(e) {
         if (
-          e.dataTransfer.dropEffect !== DropEffect.NONE &&
+          e.dataTransfer.effectAllowed !== DropEffect.NONE &&
+          this.activeDropEffect !== DropEffect.NONE &&
           !this.draggableExpanded &&
           this.showExpansion &&
           !this.expanded

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -227,7 +227,6 @@
   import { COPYING_FLAG, RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
   import { DraggableTypes, DropEffect } from 'shared/mixins/draggable/constants';
   import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
-  import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
   import DraggableRegion from 'shared/views/draggable/DraggableRegion';
 
   export default {
@@ -449,7 +448,7 @@
        * @public
        */
       handleDropToClipboard(drop) {
-        const sourceIds = drop.data.sources.map(source => source.metadata.id).filter(Boolean);
+        const sourceIds = drop.sources.map(source => source.metadata.id).filter(Boolean);
         if (sourceIds.length) {
           this.copyToClipboard(sourceIds);
         }
@@ -462,8 +461,8 @@
       handleDragDrop(drop) {
         const { data } = drop;
         const { identity, section, relative } = data.target;
-        const { region } = new DraggableIdentityHelper(identity);
-        const isTargetTree = region && region.id === DraggableRegions.TREE;
+        const isTargetTree =
+          drop.target && drop.target.region && drop.target.region.id === DraggableRegions.TREE;
 
         let position = RELATIVE_TREE_POSITIONS.LAST_CHILD;
 
@@ -495,7 +494,7 @@
         };
 
         // All sources should be from the same region
-        const { region: sourceRegion } = new DraggableIdentityHelper(data.sources[0]);
+        const sourceRegion = drop.sources[0].region;
         return sourceRegion && sourceRegion.id === DraggableRegions.CLIPBOARD
           ? this.copyContentNodes(payload)
           : this.moveContentNodes(payload);

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -78,6 +78,7 @@ export default {
       'activeDraggableSize',
       'deepestHoverDraggable',
       'isHoverDraggableAncestor',
+      'getDraggableDropData',
     ]),
     /**
      * @abstract
@@ -115,7 +116,7 @@ export default {
       return (
         this.effectAllowed !== DropEffect.NONE &&
         this.activeDropEffect !== DropEffect.NONE &&
-        effectAllowed.match(this.activeDropEffect)
+        Boolean(effectAllowed.match(this.activeDropEffect))
       );
     },
     beforeStyles() {
@@ -142,6 +143,9 @@ export default {
       return this.isActiveDraggable
         ? this.activeDraggableSize || this.hoverDraggableSize
         : Math.min(this.hoverDraggableSize, this.activeDraggableSize);
+    },
+    dropData() {
+      return this.getDraggableDropData(this.draggableIdentity);
     },
   },
   watch: {
@@ -284,10 +288,13 @@ export default {
       }
 
       this.setDraggableDropped(this.draggableIdentity)
-        .then(data => {
-          if (data) {
-            const drop = new DropEventHelper(data, e);
-            this.$emit('draggableDrop', drop);
+        .then(() => {
+          if (this.dropData) {
+            const drop = new DropEventHelper(this.dropData, e);
+
+            if (drop.isValid()) {
+              this.$emit('draggableDrop', drop);
+            }
           }
         })
         .then(() => this.$nextTick())

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -115,9 +115,7 @@ export default {
       return (
         this.effectAllowed !== DropEffect.NONE &&
         this.activeDropEffect !== DropEffect.NONE &&
-        (this.dragEffect === DragEffect.SORT
-          ? effectAllowed.match(DropEffect.MOVE)
-          : effectAllowed.match(this.activeDropEffect))
+        effectAllowed.match(this.activeDropEffect)
       );
     },
     beforeStyles() {

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/container.js
@@ -67,6 +67,7 @@ export default {
   },
   data() {
     return {
+      effectAllowed: null,
       draggableDragEntered: false,
       hoverDraggableSize: this.draggableSize,
       debouncedEmitDraggableDragLeave: () => {},
@@ -110,7 +111,14 @@ export default {
       return this.isInActiveDraggableUniverse ? this.dropEffect : DropEffect.NONE;
     },
     isDropAllowed() {
-      return this.activeDropEffect !== DropEffect.NONE;
+      const effectAllowed = (this.effectAllowed || DropEffect.NONE).toLowerCase();
+      return (
+        this.effectAllowed !== DropEffect.NONE &&
+        this.activeDropEffect !== DropEffect.NONE &&
+        (this.dragEffect === DragEffect.SORT
+          ? effectAllowed.match(DropEffect.MOVE)
+          : effectAllowed.match(this.activeDropEffect))
+      );
     },
     beforeStyles() {
       if (this.beforeStyle) {
@@ -211,7 +219,7 @@ export default {
         return;
       }
       let dropEffect = this.activeDropEffect;
-      if (e.target === this.$el && e.dataTransfer.dropEffect !== dropEffect) {
+      if (!this.hasDescendantHoverDraggable && e.dataTransfer.dropEffect !== dropEffect) {
         e.dataTransfer.dropEffect = dropEffect;
       }
     },
@@ -221,6 +229,7 @@ export default {
     emitDraggableDragEnter(e) {
       e.preventDefault();
       let entered = false;
+      this.effectAllowed = e.dataTransfer.effectAllowed;
 
       if (!this.draggableDragEntered && this.isInActiveDraggableUniverse) {
         this.throttledUpdateHoverDraggable.cancel();
@@ -321,7 +330,10 @@ export default {
     // Debounce the leave emitter since it can get fired multiple times, and there are some browser
     // inconsistencies that make relying on the drag events difficult. This helps
     this.throttledUpdateHoverDraggable = animationThrottle(args => this.updateHoverDraggable(args));
-    this.debouncedResetHoverDraggable = debounce(args => this.resetHoverDraggable(args), 500);
+    this.debouncedResetHoverDraggable = debounce(args => {
+      this.resetHoverDraggable(args);
+      this.effectAllowed = null;
+    }, 500);
   },
   render() {
     // Add event key modifier if we're supposed to use capturing
@@ -348,7 +360,7 @@ export default {
       [`draggable-${this.draggableType}`]: true,
       'in-draggable-universe': this.isInActiveDraggableUniverse,
       'dragging-over': this.isDraggingOver,
-      'drop-allowed': this.dropAllowed,
+      'drop-allowed': this.isDropAllowed,
       'dragging-over-top':
         dropCondition && Boolean(this.hoverDraggableSection & DraggableFlags.TOP),
       'dragging-over-bottom':

--- a/contentcuration/contentcuration/frontend/shared/mixins/draggable/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins/draggable/utils.js
@@ -1,3 +1,5 @@
+import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
+
 /**
  * Returns a function suitable for prop validation, using an object
  * to test against its values
@@ -20,5 +22,20 @@ export class DropEventHelper {
   constructor(data, event = null) {
     this.data = data;
     this.event = event;
+  }
+
+  get target() {
+    return new DraggableIdentityHelper(this.data.target.identity);
+  }
+
+  get sources() {
+    const { target } = this;
+    return this.data.sources
+      .filter(source => !target.is(source))
+      .map(source => new DraggableIdentityHelper(source));
+  }
+
+  isValid() {
+    return this.sources.length > 0;
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/views/draggable/DraggablePlaceholder.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/draggable/DraggablePlaceholder.vue
@@ -48,6 +48,7 @@
   .drag-placeholder {
     position: absolute;
     z-index: 24;
+    transition: none !important;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/__tests__/utils.spec.js
@@ -1,0 +1,66 @@
+import { DraggableIdentityHelper } from '../utils';
+
+const testIdentity = {
+  id: 'item1',
+  type: 'item',
+  universe: 'testing',
+  metadata: 'abc',
+  ancestors: [
+    {
+      id: 'collection1',
+      type: 'collection',
+      universe: 'testing',
+      metadata: null,
+      ancestors: [
+        {
+          id: 'region1',
+          type: 'region',
+          universe: 'testing',
+          metadata: null,
+          ancestors: [],
+        },
+      ],
+    },
+    {
+      id: 'region1',
+      type: 'region',
+      universe: 'testing',
+      metadata: null,
+      ancestors: [],
+    },
+  ],
+};
+
+describe('DraggableIdentityHelper', () => {
+  it('should Proxy to identity', () => {
+    const helper = new DraggableIdentityHelper(testIdentity);
+    expect(helper.id).toEqual(testIdentity.id);
+    expect(helper.type).toEqual(testIdentity.type);
+    expect(helper.universe).toEqual(testIdentity.universe);
+    expect(helper.ancestors).toEqual(testIdentity.ancestors);
+    expect(helper.metadata).toEqual(testIdentity.metadata);
+  });
+
+  describe('get region()', () => {
+    it('should return the region ancestor', () => {
+      const helper = new DraggableIdentityHelper(testIdentity);
+      expect(helper.region).toBeTruthy();
+      expect(helper.region.id).toEqual('region1');
+    });
+  });
+
+  describe('get collection()', () => {
+    it('should return the collection ancestor', () => {
+      const helper = new DraggableIdentityHelper(testIdentity);
+      expect(helper.collection).toBeTruthy();
+      expect(helper.collection.id).toEqual('collection1');
+    });
+  });
+
+  describe('get item()', () => {
+    it('should return the item ancestor', () => {
+      const helper = new DraggableIdentityHelper(testIdentity);
+      expect(helper.item).toBeFalsy();
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/actions.js
@@ -109,19 +109,8 @@ export function resetDraggableDirection(context) {
 }
 
 /**
- *
  * @param context
  * @param identity
- * @return {{
- *  sources: DraggableIdentity[],
- *  identity: DraggableIdentity,
- *  section: Number,
- *  relative: Number,
- *  target: {
- *    identity: DraggableIdentity,
- *    section: Number,
- *    relative: Number
- *  }}|null}
  */
 export function setDraggableDropped(context, identity) {
   const now = new Date().getTime();
@@ -129,7 +118,7 @@ export function setDraggableDropped(context, identity) {
 
   // Ensure accidental drag and drops do not do anything
   if (now - dragStart < MinimumDragTime) {
-    return null;
+    return;
   }
 
   // In the future, we could add handles to other types like collections and regions,
@@ -137,19 +126,8 @@ export function setDraggableDropped(context, identity) {
   const source = context.getters.deepestActiveDraggable;
   const destination = new DraggableIdentityHelper(identity);
 
-  // Can't drop on ourselves
-  if (!source || destination.is(source)) {
-    return null;
-  }
-
-  if (destination.key in context.state.draggableContainerDrops) {
-    // Ancestors will map to the string of the actual data, instead of duplicating,
-    // as prepared in code below
-    const key = isString(context.state.draggableContainerDrops[destination.key])
-      ? context.state.draggableContainerDrops[destination.key]
-      : destination.key;
-
-    return cloneDeep(context.state.draggableContainerDrops[key]);
+  if (!source || destination.key in context.state.draggableContainerDrops) {
+    return;
   }
 
   // We can add grouped handles to this sources array
@@ -172,13 +150,12 @@ export function setDraggableDropped(context, identity) {
     });
   }
 
-  const selfData = (dropData[destination.key] = {
+  dropData[destination.key] = {
     ...target,
     target,
     sources,
-  });
+  };
   context.commit('ADD_DRAGGABLE_CONTAINER_DROPS', dropData);
-  return cloneDeep(selfData);
 }
 
 export function clearDraggableDropped(context, identity) {

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/constants.js
@@ -42,3 +42,8 @@ export const DraggableIdentity = {
    */
   metadata: null,
 };
+
+/**
+ * @type {number} milliseconds
+ */
+export const MinimumDragTime = 100;

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/getters.js
@@ -1,3 +1,4 @@
+import isString from 'lodash/isString';
 import { DraggableSearchOrder, DraggableTypes } from 'shared/mixins/draggable/constants';
 import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
 
@@ -63,5 +64,30 @@ export function isGroupedDraggableHandle(state) {
     }
 
     return false;
+  };
+}
+
+export function getDraggableDropData(state) {
+  /**
+   * @param {DraggableIdentity} identity
+   * @return {{
+   *  sources: DraggableIdentity[],
+   *  identity: DraggableIdentity,
+   *  section: Number,
+   *  relative: Number,
+   *  target: {
+   *    identity: DraggableIdentity,
+   *    section: Number,
+   *    relative: Number
+   *  }}|undefined}
+   */
+  return function(identity) {
+    // Ancestors will map to the string of the actual data, instead of duplicating,
+    // as prepared in code below
+    const destination = new DraggableIdentityHelper(identity);
+    const key = isString(state.draggableContainerDrops[destination.key])
+      ? state.draggableContainerDrops[destination.key]
+      : destination.key;
+    return state.draggableContainerDrops[key];
   };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/index.js
@@ -11,6 +11,7 @@ export default {
     return {
       clientX: null,
       clientY: null,
+      dragStartTime: null,
       draggableDirection: DraggableFlags.NONE,
       activeDraggableUniverse: null,
       groupedDraggableHandles: {},

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/mutations.js
@@ -2,6 +2,14 @@ import Vue from 'vue';
 import { DraggableFlags } from './constants';
 import { DraggableIdentityHelper } from 'shared/vuex/draggablePlugin/module/utils';
 
+export function SET_DRAG_START_TIME(state, time) {
+  state.dragStartTime = time;
+}
+
+export function RESET_DRAG_START_TIME(state) {
+  state.dragStartTime = null;
+}
+
 export function SET_ACTIVE_DRAGGABLE_UNIVERSE(state, universe) {
   state.activeDraggableUniverse = universe;
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/draggablePlugin/module/utils.js
@@ -1,6 +1,6 @@
 import isMatch from 'lodash/isMatch';
 import { DraggableFlags } from './constants';
-import { DraggableSearchOrder, DraggableTypes } from 'shared/mixins/draggable/constants';
+import { DraggableTypes } from 'shared/mixins/draggable/constants';
 
 /**
  * Helper with getters to grab different draggable ancestor types based
@@ -12,20 +12,27 @@ export class DraggableIdentityHelper {
    */
   constructor(identity) {
     this._identity = identity;
-    this._ancestors = (identity.ancestors || []).slice().reverse();
+    this.ancestorsOrdered = (identity.ancestors || []).slice().reverse();
   }
 
-  is({ id, type, universe }) {
-    return isMatch(this._identity, { id, type, universe });
+  get id() {
+    return this._identity.id;
   }
 
-  findClosestAncestor(matcher) {
-    const { id, type } = this._identity;
-    return this._ancestors.find(a => isMatch(a, matcher) && !isMatch(a, { id, type }));
+  get type() {
+    return this._identity.type;
   }
 
-  get ancestorsInOrder() {
-    return DraggableSearchOrder.map(type => this.findClosestAncestor({ type })).filter(Boolean);
+  get universe() {
+    return this._identity.universe;
+  }
+
+  get ancestors() {
+    return this._identity.ancestors;
+  }
+
+  get metadata() {
+    return this._identity.metadata;
   }
 
   get key() {
@@ -43,6 +50,29 @@ export class DraggableIdentityHelper {
 
   get item() {
     return this.findClosestAncestor({ type: DraggableTypes.ITEM });
+  }
+
+  /**
+   * Whether this identity matches the one passed in
+   *
+   * @param {String} id
+   * @param {String} type
+   * @param {String} universe
+   * @return {Boolean}
+   */
+  is({ id, type, universe }) {
+    return isMatch(this._identity, { id, type, universe });
+  }
+
+  /**
+   * Finds the closest ancestor that matches the `matcher` obj passed in
+   *
+   * @param {Object} matcher
+   * @return {DraggableIdentity|null}
+   */
+  findClosestAncestor(matcher) {
+    const { id, type } = this._identity;
+    return this.ancestorsOrdered.find(a => isMatch(a, matcher) && !isMatch(a, { id, type }));
   }
 }
 


### PR DESCRIPTION
## Description
Addresses a variety of issues with drag and drop issues.

#### Issue Addressed (if applicable)
https://github.com/learningequality/studio/issues/2552
https://github.com/learningequality/studio/issues/2570
https://github.com/learningequality/studio/issues/2562
https://github.com/learningequality/studio/issues/2484

## Steps to Test

- [ ] *Verify issues above are addressed*

## Implementation Notes (optional)

#### At a high level, how did you implement this?
- Further enhances coordination of the drag event's drop effect and effect allowed to ensure proper handling upon drop
- Prevents dropping a topic into itself in the hierarchy tree
- Adds a minimum drag time of 100ms to avoid accidental drag and drops
- Emits deselection when content node list item is destroyed by dragging to new location
- Removes CSS transition from floating placeholder, which speeds up its movement