### PR TITLE
Use GOOGLE_APPLICATION_CREDENTIALS as the auth mechanism for connecting to sheets

### DIFF
--- a/contentcuration/contentcuration/utils/google_drive.py
+++ b/contentcuration/contentcuration/utils/google_drive.py
@@ -1,5 +1,5 @@
-import gspread
 import google.auth
+import gspread
 
 
 def colnum_string(n):
@@ -24,6 +24,7 @@ class GoogleClient():
 
     def __init__(self, *args, **kwargs):
         credentials = get_credentials()
+
         self.client = gspread.authorize(credentials)
 
     def get(self, spreadsheet_id):

--- a/contentcuration/contentcuration/utils/google_drive.py
+++ b/contentcuration/contentcuration/utils/google_drive.py
@@ -1,8 +1,5 @@
 import gspread
-import httplib2
-from apiclient import discovery
-from django.conf import settings
-from oauth2client.service_account import ServiceAccountCredentials
+import google.auth
 
 
 def colnum_string(n):
@@ -18,8 +15,9 @@ def colnum_string(n):
 
 
 def get_credentials():
-    scope = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
-    return ServiceAccountCredentials.from_json_keyfile_name(settings.GOOGLE_AUTH_JSON, scope)
+    scopes = ['https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive']
+    credentials, _project = google.auth.default(scopes=scopes)
+    return credentials
 
 
 class GoogleClient():
@@ -27,8 +25,6 @@ class GoogleClient():
     def __init__(self, *args, **kwargs):
         credentials = get_credentials()
         self.client = gspread.authorize(credentials)
-        http = credentials.authorize(httplib2.Http())
-        self.service = discovery.build('drive', 'v3', http=http, cache_discovery=False)
 
     def get(self, spreadsheet_id):
         """ get: returns spreadsheet matching id

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ google-cloud-storage
 django-s3-storage==0.12.4
 requests>=2.20.0
 google-cloud-core
-gspread==3.0.1
+gspread==3.6.0
 google-api-python-client
 django-db-readonly==0.5.0
 oauth2client

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,8 @@ future==0.18.2            # via -r requirements.in
 google-api-core[grpc]==1.16.0  # via google-cloud-core, google-cloud-kms, google-cloud-logging
 google-api-python-client==1.7.11  # via -r requirements.in
 google-auth-httplib2==0.0.3  # via google-api-python-client
-google-auth==1.11.2       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-storage
+google-auth-oauthlib==0.4.2  # via gspread
+google-auth==1.23.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-auth-oauthlib, google-cloud-storage, gspread
 google-cloud-core==1.3.0  # via -r requirements.in, google-cloud-logging, google-cloud-storage
 google-cloud-error-reporting==0.33.0  # via -r requirements.in
 google-cloud-kms==0.2.1   # via -r requirements.in
@@ -46,7 +47,7 @@ google-resumable-media==0.5.0  # via google-cloud-storage
 googleapis-common-protos[grpc]==1.51.0  # via google-api-core, grpc-google-iam-v1
 grpc-google-iam-v1==0.11.4  # via google-cloud-kms
 grpcio==1.27.2            # via google-api-core, googleapis-common-protos, grpc-google-iam-v1
-gspread==3.0.1            # via -r requirements.in
+gspread==3.6.0            # via -r requirements.in
 gunicorn==19.6.0          # via -r requirements.in
 html5lib==1.1             # via -r requirements.in
 httplib2==0.18.0          # via django-postmark, google-api-python-client, google-auth-httplib2, oauth2client
@@ -58,6 +59,7 @@ le-utils==0.1.24          # via -r requirements.in
 minio==3.0.3              # via -r requirements.in
 newrelic==5.6.0.135       # via -r requirements.in
 oauth2client==4.1.3       # via -r requirements.in
+oauthlib==3.1.0           # via requests-oauthlib
 pathlib==1.0.1            # via -r requirements.in
 pillow==8.0.1             # via -r requirements.in
 progressbar2==3.38.0      # via -r requirements.in
@@ -73,7 +75,8 @@ python-utils==2.4.0       # via progressbar2
 pytz==2019.3              # via celery, django, django-postmark, google-api-core, minio
 raven==6.10.0             # via -r requirements.in
 redis==2.10.5             # via -r requirements.in, django-redis
-requests==2.22.0          # via -r requirements.in, google-api-core, gspread
+requests-oauthlib==1.3.0  # via google-auth-oauthlib
+requests==2.22.0          # via -r requirements.in, google-api-core, gspread, requests-oauthlib
 rsa==4.0                  # via google-auth, oauth2client
 s3transfer==0.3.3         # via boto3
 sentry-sdk==0.14.1        # via -r requirements.in


### PR DESCRIPTION

## Description

We now use google's application default credentials mechanism for authenticating with google sheets. This allows us to be more flexible in terms of how we authenticate in production and local testing.


Local testing can now use the `GOOGLE_APPLICATION_CREDENTIALS` env var to point to a service account json file, or can use `gcloud auth activate-service-account` to activate the service account login once and not have to worry about the service account key location.

