### PR TITLE
Load search results on first entry

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -163,6 +163,9 @@
       this.showSavedSearches = false;
       next();
     },
+    mounted() {
+      this.fetch();
+    },
     methods: {
       ...mapActions('importFromChannels', ['fetchResourceSearchResults', 'createSearch']),
       fetch() {


### PR DESCRIPTION
Looks like the duplicate calls has been fixed with debouncing, so it's okay to add fetching results on mounted back to the search results list

Fixes https://github.com/learningequality/studio/issues/2593