### PR TITLE
update terms of service and privacy policy dates

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -79,8 +79,8 @@ export const policies = {
 };
 export const requiredPolicies = [policies.PRIVACY, policies.TERMS_OF_SERVICE];
 export const policyDates = {
-  [policies.PRIVACY]: new Date('2018-04-25'),
-  [policies.TERMS_OF_SERVICE]: new Date('2020-08-30'),
+  [policies.PRIVACY]: new Date('2018-05-25'),
+  [policies.TERMS_OF_SERVICE]: new Date('2020-12-10'),
   [policies.COMMUNITY_STANDARDS]: new Date('2020-08-30'),
 };
 


### PR DESCRIPTION
## Description

PR adjusts the dates for terms of service and privacy policy.

#### Issue Addressed (if applicable)

Addresses #2558 

#### Before/After Screenshots (if applicable)

(Dates are adjusted to May 25, 2018 and December 10, 2020, but I'm in PST, so dates are reflective of my timezone)

![Screen Shot 2020-11-23 at 1 24 56 PM](https://user-images.githubusercontent.com/13563002/100019655-41a97880-2d93-11eb-9113-d699034f8ed3.png)
![Screen Shot 2020-11-23 at 1 25 08 PM](https://user-images.githubusercontent.com/13563002/100019657-42420f00-2d93-11eb-9d9a-2d70b23ff5cd.png)

## Steps to Test

- [ ] Log in. The "Terms of Service" modal should appear. Check the date and click "accept".
- [ ] The "Policies" modal should then appear. Check the date.

OR
- [ ] Go to Settings > About Studio > Terms of Service. Check the date.
- [ ] Go to Settings > About Studio > Privacy Policy. Check the date.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Changed the dates in `constants.js`

#### Does this introduce any tech-debt items?


## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?

## Comments
As seen in the screenshots, the dates are adjusted to May 25, 2018 and December 10, 2020, but I'm in PST, so dates are reflective of my timezone (PST). Is this an issue?

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
