### PR TITLE
move sentry request to the end of the script tag

### DIFF
--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -114,11 +114,6 @@
         <script>
           {% if current_user %}
           var user = JSON.parse({{ current_user | safe }});
-          {%  if not debug %}
-          if (user && user.id) {
-            Sentry.setUser({ id: user.id, email: user.email });
-          }
-          {% endif %}
           {% endif %}
           {% if user_preferences %}
           var user_preferences = JSON.parse({{ user_preferences | safe }});
@@ -126,6 +121,11 @@
           var csrftoken = '{{ csrf_token }}';
           var betaMode = "{{ BETA_MODE }}" === "True";
           var storageBaseUrl = "{{ STORAGE_HOST }}/{{ STORAGE_BASE_URL }}";
+          {%  if not debug %}
+          if (user && user.id) {
+            Sentry.setUser({ id: user.id, email: user.email });
+          }
+          {% endif %}
         </script>
       {% endblock head %}
 


### PR DESCRIPTION
## Description

Ensure JS code involving sentry requests are the last thing to execute in the tag script to avoid blockers break the code in the script

#### Issue Addressed (if applicable)

Addresses #2549 

## Steps to Test
Blocking sentry with adblock or other tools (PiHole in the reported issue),  does not allow the user create a channel, because var user_preferences is never parsed when `Sentry.setUser` fails

With this pr, all the js code is parsed before executing the  `Sentry.setUser` call


