### PR TITLE
makes update banner hidden for view-only channels

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <TreeViewBase @dropToClipboard="handleDropToClipboard">
-    <template v-if="hasStagingTree" #extension>
+    <template v-if="hasStagingTree && canManage" #extension>
       <Banner
         :value="true"
         border
@@ -197,6 +197,7 @@
         'stagingId',
         'rootId',
         'canEdit',
+        'canManage',
       ]),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeAncestors']),
       ...mapGetters('draggable', ['activeDraggableRegionId']),


### PR DESCRIPTION
## Description

Hides the "updates banner" for users who only have "view-only" access to that channel; only users who are editors are able to see the "updates banner".

#### Issue Addressed (if applicable)

Addresses #2538 

#### Screenshots
Screenshot for user with editing privileges:
![Screen Shot 2020-11-24 at 8 28 45 PM](https://user-images.githubusercontent.com/13563002/100186241-8966f780-2e9a-11eb-9a72-fac65e6e773e.png)

Screenshot for user with view-only privileges:
![Screen Shot 2020-11-24 at 8 30 13 PM](https://user-images.githubusercontent.com/13563002/100186245-8a982480-2e9a-11eb-90fd-a35e126305f9.png)

## Steps to Test

- [ ] With a Ricecooker channel (of which you have editing access), make a change to that channel via Ricecooker.
- [ ] Check to see that the "updates banner" is visible.
- [ ] Share the channel with another user, but give that user "view-only" access.
- [ ] Log in as that user, and check that the "updates banner" is no longer available for that user.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Added `canManage` getter to the component, and added that to the v-if directive in the template.

#### Does this introduce any tech-debt items?

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?

## Comments

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
