### PR TITLE
Only request updates if existing changes have been pushed

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -607,7 +607,16 @@ class Resource extends mix(APIResource, IndexedDBResource) {
       if (!objs.length) {
         return this.requestCollection(params);
       }
-      this.requestCollection(params);
+      // Only fetch new updates if we've finished syncing the changes table
+      db[CHANGES_TABLE].where('table')
+        .equals(this.tableName)
+        .limit(1)
+        .toArray()
+        .then(pendingChanges => {
+          if (pendingChanges.length === 0) {
+            this.requestCollection(params);
+          }
+        });
       return objs;
     });
   }


### PR DESCRIPTION
## Description

This is a reimplementation of a fix @rtibbles made that somehow got lost.  It makes sure we avoid checking for new updates if there are pending changes in the changes table that still need to be pushed.

#### Issue Addressed

This might address quite a few syncing related bugs!