### PR TITLE
Filter channelsetlist by user

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
@@ -3,7 +3,7 @@ import { ChannelSet } from 'shared/data/resources';
 import storeFactory from 'shared/vuex/baseStore';
 
 jest.mock('shared/vuex/connectionPlugin');
-const userId = 'testId';
+const userId = 1;
 
 describe('channelSet actions', () => {
   let store;
@@ -11,6 +11,7 @@ describe('channelSet actions', () => {
   const channelSetDatum = {
     name: 'test',
     channels: { '11111111111111111111111111111111': true },
+    editors: 1,
   };
   beforeEach(() => {
     return ChannelSet.put(channelSetDatum).then(newId => {
@@ -30,7 +31,7 @@ describe('channelSet actions', () => {
     it('should call ChannelSet.where', () => {
       const whereSpy = jest.spyOn(ChannelSet, 'where');
       return store.dispatch('channelSet/loadChannelSetList').then(() => {
-        expect(whereSpy).toHaveBeenCalledWith();
+        expect(whereSpy).toHaveBeenCalledWith({ editors: 1 });
         whereSpy.mockRestore();
       });
     });

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
@@ -11,7 +11,7 @@ describe('channelSet actions', () => {
   const channelSetDatum = {
     name: 'test',
     channels: { '11111111111111111111111111111111': true },
-    editors: 1,
+    edit: true,
   };
   beforeEach(() => {
     return ChannelSet.put(channelSetDatum).then(newId => {
@@ -31,7 +31,7 @@ describe('channelSet actions', () => {
     it('should call ChannelSet.where', () => {
       const whereSpy = jest.spyOn(ChannelSet, 'where');
       return store.dispatch('channelSet/loadChannelSetList').then(() => {
-        expect(whereSpy).toHaveBeenCalledWith({ editors: 1 });
+        expect(whereSpy).toHaveBeenCalledWith({ edit: true });
         whereSpy.mockRestore();
       });
     });

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/actions.js
@@ -3,7 +3,7 @@ import { ChannelSet } from 'shared/data/resources';
 
 /* CHANNEL SET ACTIONS */
 export function loadChannelSetList(context) {
-  return ChannelSet.where({ editors: context.rootGetters.currentUserId }).then(channelSets => {
+  return ChannelSet.where({ edit: true }).then(channelSets => {
     context.commit('SET_CHANNELSET_LIST', channelSets);
     return channelSets;
   });

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/actions.js
@@ -3,7 +3,7 @@ import { ChannelSet } from 'shared/data/resources';
 
 /* CHANNEL SET ACTIONS */
 export function loadChannelSetList(context) {
-  return ChannelSet.where().then(channelSets => {
+  return ChannelSet.where({ editors: context.rootGetters.currentUserId }).then(channelSets => {
     context.commit('SET_CHANNELSET_LIST', channelSets);
     return channelSets;
   });

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -993,7 +993,9 @@ class ChannelSet(models.Model):
     def filter_edit_queryset(cls, queryset, user):
         if user.is_anonymous():
             return queryset.none()
-        return queryset.filter(editors=user)
+        user_id = not user.is_anonymous() and user.id
+        edit = Exists(User.channel_sets.through.objects.filter(user_id=user_id, channelset_id=OuterRef("id")))
+        return queryset.annotate(edit=edit).filter(edit=True)
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -1,5 +1,6 @@
 from django.db.models import CharField
 from django.db.models import Q
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 
@@ -7,6 +8,7 @@ from contentcuration.models import Channel
 from contentcuration.models import ChannelSet
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
+from contentcuration.viewsets.base import FilterSet
 from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.common import NotNullMapArrayAgg
 from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
@@ -50,11 +52,22 @@ class ChannelSetSerializer(BulkModelSerializer):
         list_serializer_class = BulkListSerializer
 
 
+class ChannelSetFilter(FilterSet):
+
+    class Meta:
+        model = ChannelSet
+        fields = (
+            "editors",
+        )
+
+
 class ChannelSetViewSet(ValuesViewset):
     queryset = ChannelSet.objects.all()
     serializer_class = ChannelSetSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = ChannelSetFilter
     permission_classes = [IsAuthenticated]
-    values = ("id", "name", "description", "channels", "secret_token__token")
+    values = ("id", "name", "description", "channels", "secret_token__token", "editors")
 
     field_map = {"secret_token": "secret_token__token"}
 

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -81,7 +81,7 @@ class ChannelSetViewSet(ValuesViewset):
         queryset = super(ChannelSetViewSet, self).get_queryset()
         user_id = not self.request.user.is_anonymous() and self.request.user.id
         edit = Exists(User.channel_sets.through.objects.filter(user_id=user_id, channelset_id=OuterRef("id")))
-        return queryset.annotate(edit=edit).filter(edit=True)
+        return queryset.annotate(edit=edit)
 
     def annotate_queryset(self, queryset):
         return queryset.annotate(


### PR DESCRIPTION
*What does this PR do? Briefly describe in 1-2 sentences*

This PR filters the ChannelSetList (aka "Collections") so that only the current user's Collections are displayed.

#### Issue Addressed (if applicable)

Addresses #2542 - Admins can see all Channelsets/Collections, even if they do not have edit access to them

## Steps to Test

- [ ] Sign in as Admin and ensure you have at least one collection
- [ ] Create a second test account that is also an Admin and sign in. You should not see the other Admin collections.
- [ ] Create a collection. You should see it displayed
- [ ] Sign in as the original Admin. You should only see your collections still

#### At a high level, how did you implement this?

I created a FilterSet on the backend for ChannelSetList and passed a parameter in the front end .where() query and updated tests for this change.

