### PR TITLE
Update ‘page_size’ query param when it is updated on the the Administration User/Channel tables

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/mixins.js
+++ b/contentcuration/contentcuration/frontend/administration/mixins.js
@@ -4,6 +4,7 @@ import findKey from 'lodash/findKey';
 import intersection from 'lodash/intersection';
 import transform from 'lodash/transform';
 import omit from 'lodash/omit';
+import pickBy from 'lodash/pickBy';
 
 function _getBooleanVal(value) {
   return typeof value === 'string' ? value === 'true' : value;
@@ -131,14 +132,24 @@ export const tableMixin = {
         return params;
       },
       set(pagination) {
+        // Removes null pagination parameters from the URL
+        const newQuery = pickBy(
+          {
+            ...this.$route.query,
+            page_size: pagination.rowsPerPage,
+            ...omit(pagination, ['rowsPerPage', 'totalItems']),
+          },
+          value => {
+            return value !== null;
+          }
+        );
+
+        // TODO prevent 'ordering' from being set since it's not used
+        delete newQuery.ordering;
         this.$router
           .replace({
             ...this.$route,
-            query: {
-              ...this.$route.query,
-              page_size: pagination.rowsPerPage,
-              ...omit(pagination, ['rowsPerPage', 'totalItems']),
-            },
+            query: newQuery,
           })
           .catch(error => {
             if (error && error.name != 'NavigationDuplicated') {

--- a/contentcuration/contentcuration/frontend/administration/mixins.js
+++ b/contentcuration/contentcuration/frontend/administration/mixins.js
@@ -144,8 +144,6 @@ export const tableMixin = {
           }
         );
 
-        // TODO prevent 'ordering' from being set since it's not used
-        delete newQuery.ordering;
         this.$router
           .replace({
             ...this.$route,

--- a/contentcuration/contentcuration/frontend/administration/mixins.js
+++ b/contentcuration/contentcuration/frontend/administration/mixins.js
@@ -137,7 +137,7 @@ export const tableMixin = {
             query: {
               ...this.$route.query,
               page_size: pagination.rowsPerPage,
-              ...omit(pagination, ['rowsPerPage']),
+              ...omit(pagination, ['rowsPerPage', 'totalItems']),
             },
           })
           .catch(error => {

--- a/contentcuration/contentcuration/frontend/administration/mixins.js
+++ b/contentcuration/contentcuration/frontend/administration/mixins.js
@@ -3,6 +3,7 @@ import difference from 'lodash/difference';
 import findKey from 'lodash/findKey';
 import intersection from 'lodash/intersection';
 import transform from 'lodash/transform';
+import omit from 'lodash/omit';
 
 function _getBooleanVal(value) {
   return typeof value === 'string' ? value === 'true' : value;
@@ -135,7 +136,8 @@ export const tableMixin = {
             ...this.$route,
             query: {
               ...this.$route.query,
-              ...pagination,
+              page_size: pagination.rowsPerPage,
+              ...omit(pagination, ['rowsPerPage']),
             },
           })
           .catch(error => {


### PR DESCRIPTION
**Please remove any unused sections**

## Description

1. Adds a missing line in `administration/mixins.js` to update the `page_size` query param when the two-way binded `pagination` object and it's `rowsPerPage` field change.
1. Removes `rowsPerPage`, and `totalItems` from being added to the URL query paramas, since they are not necessary
1. Removes `sortBy` and `descending` query params from URL when they are `null`

#### Issue Addressed (if applicable)

Fixes #2362 

