### PR TITLE
Fix concurrent copying

### DIFF
--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -410,33 +410,18 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
                 )
             return [node_copy]
 
-    def _parse_filter_kwargs(self, contentnode, contentnode__in):
-        filter_kwargs = {}
-        if contentnode is not None:
-            filter_kwargs["contentnode"] = contentnode
-        elif contentnode__in is not None:
-            filter_kwargs["contentnode__in"] = contentnode__in
-        else:
-            raise ValueError("Must specify one of contentnode or contentnode__in")
-
-        return filter_kwargs
-
-    def _copy_tags(self, source_copy_id_map, contentnode, contentnode__in):
+    def _copy_tags(self, source_copy_id_map):
         from contentcuration.models import ContentTag
 
-        filter_kwargs = self._parse_filter_kwargs(contentnode, contentnode__in)
-
         node_tags_mappings = list(
-            self.model.tags.through.objects.filter(**filter_kwargs)
+            self.model.tags.through.objects.filter(
+                contentnode_id__in=source_copy_id_map.keys()
+            )
         )
-        if contentnode is not None:
-            tags_to_copy = ContentTag.objects.filter(
-                tagged_content=contentnode, channel__isnull=False
-            )
-        elif contentnode__in is not None:
-            tags_to_copy = ContentTag.objects.filter(
-                tagged_content__in=contentnode__in, channel__isnull=False
-            )
+
+        tags_to_copy = ContentTag.objects.filter(
+            tagged_content__in=source_copy_id_map.keys(), channel__isnull=False
+        )
 
         # Get a lookup of all existing null channel tags so we don't duplicate
         existing_tags_lookup = {
@@ -474,13 +459,13 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
 
         self.model.tags.through.objects.bulk_create(mappings_to_create)
 
-    def _copy_assessment_items(self, source_copy_id_map, contentnode, contentnode__in):
+    def _copy_assessment_items(self, source_copy_id_map):
         from contentcuration.models import File
         from contentcuration.models import AssessmentItem
 
-        filter_kwargs = self._parse_filter_kwargs(contentnode, contentnode__in)
-
-        node_assessmentitems = list(AssessmentItem.objects.filter(**filter_kwargs))
+        node_assessmentitems = list(
+            AssessmentItem.objects.filter(contentnode_id__in=source_copy_id_map.keys())
+        )
         node_assessmentitem_files = list(
             File.objects.filter(assessment_item__in=node_assessmentitems)
         )
@@ -515,12 +500,12 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
 
         File.objects.bulk_create(node_assessmentitem_files)
 
-    def _copy_files(self, source_copy_id_map, contentnode, contentnode__in):
+    def _copy_files(self, source_copy_id_map):
         from contentcuration.models import File
 
-        filter_kwargs = self._parse_filter_kwargs(contentnode, contentnode__in)
-
-        node_files = list(File.objects.filter(**filter_kwargs))
+        node_files = list(
+            File.objects.filter(contentnode_id__in=source_copy_id_map.keys())
+        )
 
         for file in node_files:
             file.id = None
@@ -528,14 +513,12 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
 
         File.objects.bulk_create(node_files)
 
-    def _copy_associated_objects(
-        self, source_copy_id_map, contentnode=None, contentnode__in=None
-    ):
-        self._copy_files(source_copy_id_map, contentnode, contentnode__in)
+    def _copy_associated_objects(self, source_copy_id_map):
+        self._copy_files(source_copy_id_map)
 
-        self._copy_assessment_items(source_copy_id_map, contentnode, contentnode__in)
+        self._copy_assessment_items(source_copy_id_map)
 
-        self._copy_tags(source_copy_id_map, contentnode, contentnode__in)
+        self._copy_tags(source_copy_id_map)
 
     def _shallow_copy(
         self,
@@ -557,9 +540,7 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
             self.insert_node(node_copy, target, position=position, save=False)
             node_copy.save(force_insert=True)
 
-        self._copy_associated_objects(
-            {node.id: node_copy.id}, contentnode=node,
-        )
+        self._copy_associated_objects({node.id: node_copy.id})
         increment_progress(1)
         return node_copy
 
@@ -607,7 +588,7 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
         if target:
             self.filter(pk=target.pk).update(changed=True)
 
-        self._copy_associated_objects(source_copy_id_map, contentnode__in=nodes_to_copy)
+        self._copy_associated_objects(source_copy_id_map)
 
         increment_progress(len(nodes_to_copy))
 


### PR DESCRIPTION
## Description

* Simplifies the copying of associated objects (files, assessment items, tags)
* Uses the generated dict of source_id to copy_id as the source of truth about which associated objects to copy
* Avoids an issue that resulted from previous dependence on a queryset generated from MPTT's `get_descendants` method that occured during concurrent copying when the lft and rght values for the descendants queries were no longer current

#### Issue Addressed (if applicable)

Fixes #2556

#### Before/After Screenshots (if applicable)
Copy operation after (see issue for before):
![copyconcurrent](https://user-images.githubusercontent.com/1680573/100945426-0d7e3800-34b6-11eb-8a69-39611bdcc701.gif)

## Steps to Test

- Have two topics with content in them side by side
- Select both the topics on the main channel edit page
- Press the 'Make a copy' button
- Observe that both the topics complete their copy operation
