### PR TITLE
withChangeTracker bugfix - call hideCallback in snackbar if it exists

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/snackbar/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/snackbar/index.js
@@ -19,7 +19,10 @@ export default {
     },
   },
   actions: {
-    showSnackbar({ commit }, { text, duration, actionText, actionCallback }) {
+    showSnackbar({ commit, state }, { text, duration, actionText, actionCallback }) {
+      if (state.options.hideCallback) {
+        state.options.hideCallback();
+      }
       return new Promise(hideCallback => {
         commit('CORE_CREATE_SNACKBAR', {
           text,


### PR DESCRIPTION
## Description

Addressing issues noted in #2338 where locks would be generated and properly instantiated with an `expiry` of `0` - but - in some cases the lock's expiry would not be set to a proper time in the future. If `expiry` is always 0 then the lock is forever locked.

#### Issue Addressed (if applicable)

Fixes #2338 

However - it doesn't apply the specific changes noted there. Per @bjester the issue lied in unresolved snackbar promises causing the bug occurring.

## Steps to Test

The following steps should first be done on the latest `develop` branch to replicate it please. 

Then - repeat the following steps again after checking out this branch.

- Clear your IndexedDB altogether so you are starting fresh.
- Open Dev Tools -> Application -> IndexedDB -> KolibriStudio

> In the DevTools - you'll see at the top of the table of entries a "Refresh" icon - additionally, when IndexedDB notices something changed, it lets you know with a little yellow warning icon up top on the right side so you can click refresh to see the latest changes.

> Additionally, you will want to check the `__changesForSyncing` table regularly. Basically - after about 10-15 seconds of inactivity after doing the following steps you should see this table cleared.

- Go to a channel and perform several of the following actions in quick succession:

> My assessment of the bug is that the only way to replicate the issue is to do these things in quick succession. Be sure to do the same thing quickly in a row - as in - copy a node, copy another, copy another, delete one, delete another, etc

- Copy one or more nodes to Clipboard
- Duplicate one or more nodes
- Delete one or more nodes.

- FINAL STEP! After 20 or so seconds, check the `__changeLocks` table and see if any of the entries' `expiry` value is `0`. If you see one or more that is `0` then I hope you're replicating the bug and not testing the fix :) 

## Implementation Notes (optional)

Note: This is an updated implementation from the original. 

@bjester was a great help noticing that the snackbar promises were the root of the issue and helped me find the solution to ensure that we call hideCallback in `showSnackbar` so that promises don't go unresolved.