### PR TITLE
Make sure changes are merged in order

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -171,7 +171,7 @@ function syncChanges() {
             return syncableChanges
               .offset(i)
               .limit(SYNC_BUFFER)
-              .toArray()
+              .sortBy('rev')
               .then(changes => {
                 // Continue to merge on to the existing changes we have merged
                 changesToSync = mergeAllChanges(changes, finalRecursion, changesToSync);


### PR DESCRIPTION
## Description
We squash changes a couple times before them to the sync endpoint, but the function that does the merging wasn't always getting changes passed in the right order.

#### Issue Addressed (if applicable)

I'm optimistic that this will fix issue [#2572](https://github.com/learningequality/studio/issues/2572), and it might help fix quite a few other issues too.

## Steps to Test

- [ ] Make a new assessment item
- [ ] Create like 15 questions in a row.  For the question I like to quickly smash my fingers all across the keyboard, but I always end each question with a single character of punctiation.
- [ ] Go back to the channel editor and open the assessment item in the details sidebar.
- [ ] Make sure every question has punctuation!

## Checklist

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
