### PR TITLE
Navigate out of active views when deleting topics or resources

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -69,7 +69,7 @@
     },
     computed: {
       ...mapGetters('currentChannel', ['canEdit', 'trashId']),
-      ...mapGetters('contentNode', ['getContentNode', 'getContentNodeChildren']),
+      ...mapGetters('contentNode', ['getContentNode', 'getContentNodeDescendants']),
       node() {
         return this.getContentNode(this.nodeId);
       },
@@ -133,7 +133,7 @@
         // of the deleted topic
         if (
           nodeId === this.nodeId ||
-          this.getContentNodeChildren(this.nodeId).find(({ id }) => id === nodeId)
+          this.getContentNodeDescendants(this.nodeId).find(({ id }) => id === nodeId)
         ) {
           const parentId = this.getContentNode(this.nodeId).parent;
           return () => this.$router.replace({ params: { nodeId: parentId } });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -516,8 +516,16 @@
         });
       },
       removeNodes: withChangeTracker(function(id__in, changeTracker) {
+        let nextRoute;
+        // If the NodePanel for one of the deleted nodes is open, close it
+        if (id__in.includes(this.$route.params.detailNodeId)) {
+          nextRoute = { params: { detailNodeId: null } };
+        }
         return this.moveContentNodes({ id__in, parent: this.trashId }).then(() => {
           this.clearSelections();
+          if (nextRoute) {
+            this.$router.replace(nextRoute);
+          }
           return this.showSnackbar({
             text: this.$tr('removedItems', { count: id__in.length }),
             actionText: this.$tr('undo'),


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Adds an extra function to the callback of `removeNode(s)` in `ContentNodeOptions` and `CurrentTopicView` to do an appropriate navigation to a "higher" position in the hierarchy if the user removes the currently-viewed topic, or an ancestor of that topic.

#### Issue Addressed (if applicable)

Fixes #2581 (3 different scenarios)

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

Test the three scenarios in #2581. The main thing is that if you are viewing a topic or a resource detail panel, then the UI cleans itself up after removing that topic/resource from the tree.

Test the removal operation on all of these widgets

![CleanShot 2020-12-07 at 11 14 16@2x](https://user-images.githubusercontent.com/10248067/101394868-fbb5df80-387d-11eb-8f64-cb5d29218bed.png)

Don't forget the bulk deletion widget

![image](https://user-images.githubusercontent.com/10248067/101394950-1d16cb80-387e-11eb-8c61-afee7eb820af.png)

