### PR TITLE
Ensure window.Urls has correct language code & browser lang is respected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ endtoendtest:
 
 collectstatic:
 	python contentcuration/manage.py collectstatic --noinput
-	python contentcuration/manage.py collectstatic_js_reverse
 
 migrate:
 	python contentcuration/manage.py migrate || true
@@ -98,7 +97,7 @@ i18n-download-translations:
 	node node_modules/kolibri-tools/lib/i18n/intl_code_gen.js
 	python node_modules/kolibri-tools/lib/i18n/crowdin.py convert-files
 
-i18n-download: i18n-download-translations 
+i18n-download: i18n-download-translations
 
 i18n-update:
 	echo "WARNING: i18n-update has been renamed to i18n-download"

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -194,6 +194,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'readonly.context_processors.readonly',
                 'contentcuration.context_processors.site_variables',
+                'contentcuration.context_processors.url_tag',
             ],
         },
     },

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -171,6 +171,10 @@
 
     <app></app>
 
+    {% block i18n %}
+      {{ I18N_URLS }}
+    {% endblock %}
+
     <!-- Site content gets injected here -->
     {% block content %}{% endblock content %}
     <!-- prevent more than 1 bundle per page -->

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -78,12 +78,6 @@
         {% block title %}{% trans 'Kolibri Studio' %}{% endblock title %}
       </title>
 
-        {% if not debug %}
-            <script src={% static 'django_js_reverse/js/reverse.js' %}></script>
-        {% else %}
-            <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
-        {% endif %}
-
         <!-- fullstory integration, only on develop until we add an opt-in option. -->
         {% if request.get_host == 'develop.studio.learningequality.org' %}
         <script>


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Imports and modifies logic here: https://github.com/learningequality/kolibri/blob/release-v0.14.x/kolibri/core/kolibri_plugin.py#L36 and inserts it into the context processor which exposes a dict w/ `I18N_URLS` key returning the properly generated and minified JS code that sets `window.Urls` to the currently used i18n lang code.

Also helps ensure that browser language code is respected. 

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues/2627

## Steps to Test

Set your browser's language to a non-English language of your choice.

Navigate the site's sections:

- Sign in page
- Channel's listings
- Channel edit
- Settings
- Profile

You should never have your URL default back to `en` as you navigate.