### PR TITLE
Ensure changes are merged in order, log an error if not.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -131,7 +131,16 @@ export default function mergeAllChanges(changes, flatten = false, changesToSync 
     changesToSync = Object.fromEntries(Object.keys(INDEXEDDB_RESOURCES).map(key => [key, {}]));
     changesToSync['unmergeableChanges'] = {};
   }
+  let lastRev;
   for (let change of changes) {
+    // Ensure changes are merged in order
+    if (lastRev) {
+      if (change.rev <= lastRev) {
+        console.error('Changes are getting merged out of order:', changes);
+      }
+    }
+    lastRev = change.rev;
+
     // Ignore changes initiated by non-Resource registered tables
     if (changesToSync[change.table]) {
       if (mergeableChanges.has(change.type)) {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -246,7 +246,7 @@ class IndexedDBResource {
         // Get any relevant changes that would be overwritten by this bulkPut
         return db[CHANGES_TABLE].where('[table+key]')
           .anyOf(itemData.map(datum => [this.tableName, this.getIdValue(datum)]))
-          .toArray(changes => {
+          .sortBy('rev', changes => {
             changes = mergeAllChanges(changes, true);
             const collectedChanges = collectChanges(changes)[this.tableName] || {};
             for (let changeType of Object.keys(collectedChanges)) {


### PR DESCRIPTION
## Description
Following #2629 and #2630, this PR further ensures that changes are getting merged in order, at least for changes that have a `rev`.  If they aren't in order, it logs an error, but doesn't currently do anything to prevent stale changes from overriding new ones.

#### Does this introduce any tech-debt items?

- If possible, it could be nice to gracefully handle these errors by passing on changes unmerged, or by sorting them and starting over.
- This needs tests.

## Checklist
- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
