### PR TITLE
Add `tab=questions|details` query param to Exercise Detail URLs

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -38,20 +38,20 @@
         <slot name="actions"></slot>
       </VLayout>
       <Tabs v-if="isExercise" slider-color="primary">
-        <VTab class="px-2" @click="tab = 'questions'">
+        <VTab class="px-2" :to="{ query: { tab: 'questions' } }" exact>
           {{ $tr('questions') }}
           <Icon v-if="invalidQuestions" color="red" small class="mx-2">
             error
           </Icon>
         </VTab>
-        <VTab class="px-2" @click="tab = 'details'">
+        <VTab class="px-2" :to="{ query: { tab: 'details' } }" exact>
           {{ $tr('details') }}
           <Icon v-if="invalidDetails" color="red" small class="mx-2">
             error
           </Icon>
         </VTab>
       </Tabs>
-      <VTabsItems v-model="tab">
+      <VTabsItems :value="tab" @change="tab = $event">
         <VTabItem value="questions">
           <Banner
             :value="!assessmentItems.length"
@@ -360,7 +360,6 @@
     data() {
       return {
         loading: false,
-        tab: 'details',
         showAnswers: false,
       };
     },
@@ -377,6 +376,27 @@
       },
       files() {
         return sortBy(this.getContentNodeFiles(this.nodeId), f => f.preset.order);
+      },
+      tab: {
+        set(value) {
+          if (!this.isExercise) {
+            return;
+          }
+          // If viewing an exercise, we need to synchronize the the route's
+          // query params with the 'tab' value
+          const newRoute = { query: { tab: value } };
+          if (!this.$route.query.tab) {
+            this.$router.replace(newRoute);
+          } else {
+            this.$router.push(newRoute);
+          }
+        },
+        get() {
+          if (!this.isExercise) {
+            return 'details';
+          }
+          return this.$route.query.tab || 'questions';
+        },
       },
       defaultText() {
         return '-';


### PR DESCRIPTION
## Description

This makes `?tab=details` and `?tab=questions` valid query parameters when viewing the details of an Exercise node. This lets the change between the two tabs be tracked in the browser history (including more convenient back/forward browser button behavior).

#### Issue Addressed (if applicable)

Addresses #*PR# HERE*

Fixes #2399

#### Before/After Screenshots (if applicable)

video of me browsing the topic, sometimes using the UI buttons, sometimes using the mouse forward/backward buttons.

![CleanShot 2020-12-07 at 17 42 53](https://user-images.githubusercontent.com/10248067/101427740-4b170280-38b4-11eb-847a-ad114dd78548.gif)


## Implementation notes

From `ResourcePanel.vue`, I removed the `tab` from `data` and made it a more complex computed prop that would

1. Always return `details` if the node is not an exercise
1. Return the value of `?tab` if it is an exercise
1. Synchronize the value of `?tab` if `this.tab` changes (i.e. in the mounted/watch hooks).
1. Convert the `VTabs` to use `router-links`, which link directly to URLs with the correct value of `?tab`