### PR TITLE
New channel modal toggle tabs

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -154,7 +154,7 @@ const router = new VueRouter({
     },
     {
       name: ChannelRouterNames.CHANNEL_EDIT,
-      path: '/:nodeId/:detailNodeId?/channel/:channelId/edit',
+      path: '/:nodeId/:detailNodeId?/channel/:channelId/:tab',
       component: ChannelModal,
       props: true,
       beforeEnter: (to, from, next) => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -319,6 +319,7 @@
           params: {
             ...this.$route.params,
             channelId: this.currentChannel.id,
+            tab: 'edit',
           },
         };
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -333,9 +333,9 @@
           name: ChannelRouterNames.CHANNEL_EDIT,
           params: {
             channelId: this.currentChannel.id,
+            tab: 'share',
           },
           query: {
-            sharing: true,
             last: this.$route.name,
           },
         };

--- a/contentcuration/contentcuration/frontend/channelList/router.js
+++ b/contentcuration/contentcuration/frontend/channelList/router.js
@@ -38,7 +38,7 @@ const router = new VueRouter({
     },
     {
       name: RouterNames.CHANNEL_EDIT,
-      path: '/:channelId/edit',
+      path: '/:channelId/:tab',
       component: ChannelModal,
       props: true,
     },

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -292,6 +292,7 @@
           },
           params: {
             channelId: this.channelId,
+            tab: 'edit',
           },
         };
       },

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -8,11 +8,11 @@
     <ToolBar v-if="!isNew" class="tabs" color="white">
       <Tabs v-model="currentTab" slider-color="primary" height="64px">
         <!-- Details tab -->
-        <VTab href="#edit" class="px-3" @click="currentTab = 'edit'">
+        <VTab href="#edit" class="px-3" data-test="details-tab" @click="currentTab = 'edit'">
           {{ $tr('editTab') }}
         </VTab>
         <!-- Share tab -->
-        <VTab href="#share" class="px-3" @click="currentTab = 'share'">
+        <VTab href="#share" class="px-3" data-test="share-tab" @click="currentTab = 'share'">
           {{ $tr('shareTab') }}
         </VTab>
       </Tabs>
@@ -24,9 +24,9 @@
       style="margin: 0;"
       height="5"
     />
-    <VCardText v-else>
+    <VCardText>
       <VTabsItems v-model="currentTab">
-        <VTabItem value="edit">
+        <VTabItem value="edit" data-test="edit-content">
           <Banner fluid :value="isRicecooker" color="secondary lighten-1">
             {{ $tr('APIText') }}
           </Banner>
@@ -78,7 +78,7 @@
             </VForm>
           </VContainer>
         </VTabItem>
-        <VTabItem value="share">
+        <VTabItem value="share" data-test="share-content">
           <VCard flat class="pa-5">
             <ChannelSharing :channelId="channelId" />
           </VCard>
@@ -137,6 +137,9 @@
       channelId: {
         type: String,
       },
+      tab: {
+        type: String,
+      },
     },
     data() {
       return {
@@ -162,22 +165,24 @@
       },
       currentTab: {
         get() {
-          const tab = this.$route.params.tab;
+          const tab = this.tab;
           return tab;
         },
         set(value) {
           // Only navigate if we're changing locations
-          if (value !== this.currentTab) {
-            this.$router.replace({
-              ...this.$route,
-              query: {
-                ...this.$route.query,
-              },
-              params: {
-                ...this.$route.params,
-                tab: value,
-              },
-            });
+          if (value !== this.tab) {
+            this.$router
+              .replace({
+                ...this.$route,
+                query: {
+                  ...this.$route.query,
+                },
+                params: {
+                  ...this.$route.params,
+                  tab: value,
+                },
+              })
+              .catch(() => {});
           }
         },
       },

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -5,14 +5,18 @@
     :header="isNew ? $tr('creatingHeader') : header"
     @input="onDialogInput"
   >
-    <template v-if="!isNew" #tabs>
-      <VTab href="#edit" class="px-3" @click="currentTab = 'edit'">
-        {{ $tr('editTab') }}
-      </VTab>
-      <VTab href="#share" class="px-3" @click="currentTab = 'share'">
-        {{ $tr('shareTab') }}
-      </VTab>
-    </template>
+    <ToolBar v-if="!isNew" class="tabs" color="white">
+      <Tabs v-model="currentTab" slider-color="primary" height="64px">
+        <!-- Details tab -->
+        <VTab href="#edit" class="px-3" @click="currentTab = 'edit'">
+          {{ $tr('editTab') }}
+        </VTab>
+        <!-- Share tab -->
+        <VTab href="#share" class="px-3" @click="currentTab = 'share'">
+          {{ $tr('shareTab') }}
+        </VTab>
+      </Tabs>
+    </ToolBar>
     <VProgressLinear
       v-if="loading"
       indeterminate
@@ -113,6 +117,8 @@
   import ContentDefaults from 'shared/views/form/ContentDefaults';
   import FullscreenModal from 'shared/views/FullscreenModal';
   import Banner from 'shared/views/Banner';
+  import Tabs from 'shared/views/Tabs';
+  import ToolBar from 'shared/views/ToolBar';
 
   export default {
     name: 'ChannelModal',
@@ -124,6 +130,8 @@
       MessageDialog,
       FullscreenModal,
       Banner,
+      Tabs,
+      ToolBar,
     },
     props: {
       channelId: {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -154,9 +154,9 @@
       },
       currentTab: {
         get() {
-          const sharing = this.$route.query.sharing;
+          const tab = this.$route.params.tab;
           // On load, sharing counts as string, so just process as if a string
-          return sharing && String(sharing) === 'true' ? 'share' : 'edit';
+          return tab;
         },
         set(value) {
           // Only navigate if we're changing locations
@@ -165,7 +165,10 @@
               ...this.$route,
               query: {
                 ...this.$route.query,
-                sharing: value === 'share',
+              },
+              params: {
+                ...this.$route.params,
+                tab: value,
               },
             });
           }

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -165,7 +165,7 @@
       },
       currentTab: {
         get() {
-          const tab = this.tab;
+          const tab = this.tab === 'share' ? 'share' : 'edit';
           return tab;
         },
         set(value) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -163,7 +163,6 @@
       currentTab: {
         get() {
           const tab = this.$route.params.tab;
-          // On load, sharing counts as string, so just process as if a string
           return tab;
         },
         set(value) {
@@ -276,9 +275,6 @@
               this.header = this.channel.name;
             });
           }
-        } else {
-          // Go back to Details tab to show validation errors
-          this.currentTab = 'edit';
         }
       },
       onDialogInput(value) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/__tests__/channelModal.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/__tests__/channelModal.spec.js
@@ -20,12 +20,14 @@ const router = new VueRouter({
 
 const store = storeFactory();
 const channelId = '11111111111111111111111111111111';
+let tab = 'share';
 
 function makeWrapper() {
   router.push({
     name: TESTROUTE,
     params: {
       channelId,
+      tab,
     },
   });
   return mount(ChannelModal, {
@@ -33,17 +35,18 @@ function makeWrapper() {
     store,
     propsData: {
       channelId,
+      tab,
     },
     computed: {
       channel() {
         return {
           name: 'test',
           deleted: false,
-          edit: true,
           id: channelId,
           content_defaults: {},
           editors: [],
           viewers: [],
+          isNew: false,
         };
       },
     },
@@ -64,10 +67,15 @@ describe('channelModal', () => {
     wrapper.find('[data-test="close"]').trigger('click');
     expect(cancelChanges).toHaveBeenCalled();
   });
-  it('setting currentTab should set router query params', () => {
-    wrapper.vm.currentTab = 'share';
-    expect(wrapper.vm.$route.query.sharing).toBe(true);
-    wrapper.vm.currentTab = 'edit';
-    expect(wrapper.vm.$route.query.sharing).toBe(false);
+  it('when the current tab is share, the share content should display in the modal', async () => {
+    expect(wrapper.vm.tab).toBe('share');
+    expect(wrapper.find('[data-test="share-content"]').isVisible()).toBe(true);
+    expect(wrapper.find('[data-test="edit-content"]').isVisible()).toBe(false);
+  });
+  it('when the current tab is edit, the edit content should display in the modal', async () => {
+    await wrapper.setProps({ tab: 'edit' });
+    expect(wrapper.vm.tab).toBe('edit');
+    expect(wrapper.find('[data-test="edit-content"]').isVisible()).toBe(true);
+    expect(wrapper.find('[data-test="share-content"]').isVisible()).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

Updates routing to use a `/:tab` value that can be either 'edit' or 'share' rather than the query `sharing=true` in the share and detail modal. Also makes sure the tab indicator aligns with 'share' correctly on open. Replaces [PR2547](https://github.com/learningequality/studio/pull/2547).

#### Issue Addressed (if applicable)

Addresses #2004 

#### Before/After Screenshots (if applicable)
![toggle-tabs](https://user-images.githubusercontent.com/17235236/101518411-e27d6380-394f-11eb-954b-1b06209047d1.gif)

## Steps to Test

Option 1:
- [ ] Click into channel
- [ ] Access modal from "Edit Channel Details" or "Share Channel"

Option 2:
- [ ] Access modal from the channel list view through the options drop-down menu


