### PR TITLE
Solve problems when sorting by mapped fields in the admin tables

### DIFF
--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -65,15 +65,21 @@ class CachedListPagination(PageNumberPagination):
 
 
 def get_order_queryset(request, queryset, field_map):
+    """
+    Function used to extract the field the queryset must be ordered by,
+    and apply it correctly to the queryset
+    """
     order = request.GET.get("sortBy", "")
-    if order:
+    if not order:
+        # frontend sends sometimes an 'ordering' parameter instead of sortBy (unknown reason)
+        order = request.GET.get("ordering", "undefined")
+
+    if request.GET.get("descending", "true") == "false" and order != "undefined":
         if order in field_map and type(field_map[order]) is str:
             order = field_map[order]
-        if request.GET.get("descending", "true") == "false":
-            order = "-" + order
+        order = "-" + order
+        queryset = queryset.order_by(order)
     else:
-        # frontend sends sometimes an 'ordering' parameter with unknown reason
-        order = request.GET.get("ordering", "undefined")
-    queryset = queryset.order_by() if order == "undefined" else queryset.order_by(order)
+        queryset = queryset.order_by()
 
     return (order, queryset)

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -72,14 +72,16 @@ def get_order_queryset(request, queryset, field_map):
     order = request.GET.get("sortBy", "")
     if not order:
         # frontend sends sometimes an 'ordering' parameter instead of sortBy (unknown reason)
+        # this 'ordering' param is sometimes null and others undefined
         order = request.GET.get("ordering", "undefined")
+        order = "undefined" if order == "null" else order
+
+    if order in field_map and type(field_map[order]) is str:
+        order = field_map[order]
 
     if request.GET.get("descending", "true") == "false" and order != "undefined":
-        if order in field_map and type(field_map[order]) is str:
-            order = field_map[order]
         order = "-" + order
-        queryset = queryset.order_by(order)
-    else:
-        queryset = queryset.order_by()
+
+    queryset = queryset.order_by() if order == "undefined" else queryset.order_by(order)
 
     return (order, queryset)

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -62,3 +62,18 @@ class CachedListPagination(PageNumberPagination):
                 "results": data,
             }
         )
+
+
+def get_order_queryset(request, queryset, field_map):
+    order = request.GET.get("sortBy", "")
+    if order:
+        if order in field_map and type(field_map[order]) is str:
+            order = field_map[order]
+        if request.GET.get("descending", "true") == "false":
+            order = "-" + order
+    else:
+        # frontend sends sometimes an 'ordering' parameter with unknown reason
+        order = request.GET.get("ordering", "undefined")
+    queryset = queryset.order_by() if order == "undefined" else queryset.order_by(order)
+
+    return (order, queryset)

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -32,6 +32,7 @@ from contentcuration.models import SecretToken
 from contentcuration.models import User
 from contentcuration.tasks import create_async_task
 from contentcuration.utils.pagination import CachedListPagination
+from contentcuration.utils.pagination import get_order_queryset
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ReadOnlyValuesViewset
@@ -602,16 +603,7 @@ class AdminChannelViewSet(ChannelViewSet):
     ordering = ("name",)
 
     def paginate_queryset(self, queryset):
-        order = self.request.GET.get("sortBy", "")
-        if order:
-            if order in self.field_map and type(self.field_map[order]) is str:
-                order = self.field_map[order]
-            if self.request.GET.get("descending", "true") == "false":
-                order = "-" + order
-        else:
-            # frontend sends sometimes an 'ordering' parameter with unknown reason
-            order = self.request.GET.get("ordering", "undefined")
-        queryset = queryset.order_by() if order == "undefined" else queryset.order_by(order)
+        order, queryset = get_order_queryset(self.request, queryset, self.field_map)
         page_results = self.paginator.paginate_queryset(
             queryset, self.request, view=self
         )

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -24,6 +24,7 @@ from rest_framework.serializers import ValidationError
 
 from contentcuration.models import Channel
 from contentcuration.models import User
+from contentcuration.utils.pagination import get_order_queryset
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ReadOnlyValuesViewset
@@ -338,20 +339,15 @@ class AdminUserViewSet(UserViewSet):
     ordering = ("last_name",)
 
     def paginate_queryset(self, queryset):
-
+        order, queryset = get_order_queryset(self.request, queryset, self.field_map)
         page_results = self.paginator.paginate_queryset(
             queryset, self.request, view=self
         )
         ids = [result["id"] for result in page_results]
-        order = self.request.GET.get("sortBy", "")
-        if order:
-            if self.request.GET.get("descending", "true") == "false":
-                order = "-" + order
-        else:
-            order = self.request.GET.get("ordering", "null")
+
         self.values = self.base_values
         queryset = User.objects.filter(id__in=ids).values(*(self.values))
-        if order != "null":
+        if order != "undefined":
             queryset = queryset.order_by(order)
         return queryset.annotate(**self.annotations)
 


### PR DESCRIPTION

## Description

* Does a correct sorting of the queryset if a mapped field is used in the Admin Channel and users section
* Deal with the erratic behaviour of the `ordering` parameter provided by the `request` object: sometimes is "`_undefined_`" , others replaces `sortBy` and others repeates `sortBy` value

#### Issue Addressed (if applicable)

Closes #2544 

## Steps to Test

Play with the admin section of Studio, sorting columns both in the Channels and Users sections

#