### PR TITLE
Make sure channel deletion endpoint gets called

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -126,7 +126,7 @@
               <VListTileTitle>{{ $tr('openTrash') }}</VListTileTitle>
             </VListTile>
             <VListTile v-if="canEdit" @click="showDeleteModal = true">
-              <VListTileTitle>{{ $tr('deleteChannel') }}</VListTileTitle>
+              <VListTileTitle class="red--text">{{ $tr('deleteChannel') }}</VListTileTitle>
             </VListTile>
           </VList>
         </VMenu>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -126,7 +126,9 @@
               <VListTileTitle>{{ $tr('openTrash') }}</VListTileTitle>
             </VListTile>
             <VListTile v-if="canEdit" @click="showDeleteModal = true">
-              <VListTileTitle class="red--text">{{ $tr('deleteChannel') }}</VListTileTitle>
+              <VListTileTitle class="red--text">
+                {{ $tr('deleteChannel') }}
+              </VListTileTitle>
             </VListTile>
           </VList>
         </VMenu>

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -776,9 +776,9 @@ export const Channel = new Resource({
 
   softDelete(id) {
     // Call endpoint directly in case we need to navigate to new page
-    return client.put(this.modelUrl(id), { deleted: true }).then(() => {
-      return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
-        return this.table.update(id, { deleted: true });
+    return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
+      return this.table.update(id, { deleted: true }).then(() => {
+        return client.put(this.modelUrl(id), { deleted: true });
       });
     });
   },

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -778,7 +778,7 @@ export const Channel = new Resource({
     // Call endpoint directly in case we need to navigate to new page
     return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
       return this.table.update(id, { deleted: true }).then(() => {
-        return client.put(this.modelUrl(id), { deleted: true });
+        return client.patch(this.modelUrl(id), { deleted: true });
       });
     });
   },

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -773,6 +773,15 @@ export const Channel = new Resource({
       assessment_items,
     });
   },
+
+  softDelete(id) {
+    // Call endpoint directly in case we need to navigate to new page
+    return client.put(this.modelUrl(id), { deleted: true }).then(() => {
+      return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
+        return this.table.update(id, { deleted: true });
+      });
+    });
+  },
 });
 
 export const ContentNodePrerequisite = new IndexedDBResource({

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
@@ -144,14 +144,17 @@ describe('channel actions', () => {
     });
   });
   describe('deleteChannel action', () => {
-    it('should call Channel.update', () => {
-      const updateSpy = jest.spyOn(Channel, 'update');
+    beforeEach(() => {
+      Channel.softDelete = jest.fn().mockReturnValue(Promise.resolve());
+    });
+    it('should call Channel.softDelete', () => {
+      const updateSpy = jest.spyOn(Channel, 'softDelete');
       store.commit('channel/ADD_CHANNEL', {
         id,
         name: 'test',
       });
       return store.dispatch('channel/deleteChannel', id).then(() => {
-        expect(updateSpy).toHaveBeenCalledWith(id, { deleted: true });
+        expect(updateSpy).toHaveBeenCalledWith(id);
       });
     });
     it('should remove the channel from vuex state', () => {

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -2,6 +2,7 @@ import pickBy from 'lodash/pickBy';
 import { NOVALUE } from 'shared/constants';
 import { Channel, Invitation, ChannelUser } from 'shared/data/resources';
 import client from 'shared/client';
+import { debouncedSyncChanges } from 'shared/data/serverSync';
 
 /* CHANNEL LIST ACTIONS */
 export function loadChannelList(context, payload = {}) {
@@ -206,7 +207,7 @@ export function bookmarkChannel(context, { id, bookmark }) {
 }
 
 export function deleteChannel(context, channelId) {
-  return Channel.update(channelId, { deleted: true }).then(() => {
+  return Channel.softDelete(channelId).then(() => {
     context.commit('REMOVE_CHANNEL', { id: channelId });
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -2,7 +2,6 @@ import pickBy from 'lodash/pickBy';
 import { NOVALUE } from 'shared/constants';
 import { Channel, Invitation, ChannelUser } from 'shared/data/resources';
 import client from 'shared/client';
-import { debouncedSyncChanges } from 'shared/data/serverSync';
 
 /* CHANNEL LIST ACTIONS */
 export function loadChannelList(context, payload = {}) {


### PR DESCRIPTION
## Description

Fixes https://github.com/learningequality/studio/issues/2622

Calls channel detail endpoint directly to make sure changes get sent before page navigation

## Steps to Test

- [ ] Open a channel
- [ ] Click the options menu in the top right corner
- [ ] Delete the channel
- [ ] Verify channel is no longer listed in main channel list (and after indexeddb deletion)

## Checklist

- [ ] Is the code clean and well-commented?