### PR TITLE
Use the latest state when merging and handling changes before syncing

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/mergeChanges.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/mergeChanges.spec.js
@@ -1,0 +1,103 @@
+import mergeAllChanges from 'shared/data/mergeChanges';
+
+describe('Merge all changes', () => {
+  const initialQuestionValue = '';
+  const finalQuestionValue = 'What is the correct answer?';
+
+  // merging will mutate `rev`, so we generate fresh test data from a function
+  const updateChanges = () => [
+    {
+      table: 'assessmentitem',
+      key: ['contentnode_1', 'assessment_x'],
+      type: 2,
+      mods: {
+        question: 'What',
+      },
+      oldObj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: initialQuestionValue,
+      },
+      obj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: 'What',
+      },
+      rev: 1,
+    },
+    {
+      table: 'assessmentitem',
+      key: ['contentnode_1', 'assessment_x'],
+      type: 2,
+      mods: {
+        question: 'What is',
+      },
+      oldObj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: 'What',
+      },
+      obj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: 'What is',
+      },
+      rev: 2,
+    },
+    {
+      table: 'assessmentitem',
+      key: ['contentnode_1', 'assessment_x'],
+      type: 2,
+      mods: {
+        question: finalQuestionValue,
+      },
+      oldObj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: 'What is',
+      },
+      obj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: finalQuestionValue,
+      },
+      rev: 3,
+    },
+  ];
+  describe('merging updates', () => {
+    it('should retain the most recent update for a property', () => {
+      const mergedChanges = mergeAllChanges(updateChanges(), true);
+      expect(mergedChanges.length).toBe(1);
+
+      const mergedChange = mergedChanges[0];
+      expect(mergedChange.obj.question).toBe(finalQuestionValue);
+      expect(mergedChange.mods.question).toBe(finalQuestionValue);
+      expect(mergedChange.oldObj.question).toBe(initialQuestionValue);
+    });
+  });
+  describe('merging create and update', () => {
+    const createChange = () => ({
+      table: 'assessmentitem',
+      key: ['contentnode_1', 'assessment_x'],
+      type: 1,
+      obj: {
+        assessment_id: 'assessment_x',
+        contentnode: 'contentnode_1',
+        question: initialQuestionValue,
+      },
+      rev: 0,
+    });
+
+    it('should retain the most recent update for a property', () => {
+      const createAndUpdateChanges = [createChange(), ...updateChanges()];
+      const mergedChanges = mergeAllChanges(createAndUpdateChanges, true);
+      expect(mergedChanges.length).toBe(1);
+
+      const mergedChange = mergedChanges[0];
+      expect(mergedChange.type).toBe(1);
+      expect(mergedChange.obj.question).toBe(finalQuestionValue);
+      expect(mergedChange.mods).toBeUndefined();
+      expect(mergedChange.oldObj).toBeUndefined();
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -65,6 +65,7 @@ function combineUpdateAndUpdate(oldChange, newChange) {
         delete oldChange.mods[subPath];
       });
   });
+  oldChange.obj = newChange.obj;
   return oldChange;
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -308,7 +308,7 @@ if (process.env.NODE_ENV !== 'production') {
   window.pollUnsyncedChanges = pollUnsyncedChanges;
 }
 
-function handleChanges(changes) {
+async function handleChanges(changes) {
   changes.map(applyResourceListener);
   const syncableChanges = changes.filter(isSyncableChange).map(change => {
     // Filter out the rev property as we want that to be assigned during the bulkPut
@@ -322,7 +322,7 @@ function handleChanges(changes) {
 
   if (syncableChanges.length) {
     // Flatten any changes before we store them in the changes table
-    db[CHANGES_TABLE].bulkPut(mergeAllChanges(syncableChanges, true));
+    await db[CHANGES_TABLE].bulkPut(mergeAllChanges(syncableChanges, true));
   }
 
   // If we detect locks were removed, or changes were written to the changes table


### PR DESCRIPTION
## Description

This PR fixes two sync related issues:
- Sometimes syncing was getting kicked off before changes had finished getting added to the changes table
- The function that merges updates was not passing along the latest state

It also adds some basic tests for the merging functionality.

This is a followup on #2629, #2630 and #2638.

#### Issue Addressed
This should fix a number of assessment item related bugs, and possibly other bugs where updates were happening somewhat rapidly in succession.

## Steps to Test

- [x] Run the included tests! :partying_face: 

## Comments

Special thanks to @rtibbles for helping me see just what was going on and teaching me all about the sync code!