### PR TITLE
Fix clipboard move action visibility

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
@@ -7,7 +7,7 @@
     :style="{ 'border-left-color': channelColor }"
   >
     <template #header>
-      <VListTile class="py-2" inactive>
+      <VListTile class="channel-tile py-2" inactive>
         <VListTileAction class="select-col">
           <Checkbox
             ref="checkbox"
@@ -27,8 +27,8 @@
           />
         </div>
         <VListTileContent>
-          <VListTileTitle class="text-truncate">
-            <h4 class="notranslate">
+          <VListTileTitle>
+            <h4 class="notranslate text-truncate">
               {{ channel.name }}
             </h4>
           </VListTileTitle>
@@ -117,9 +117,16 @@
   }
 
   .channel-item,
-  .v-list__tile {
+  .channel-tile,
+  .v-list__tile__title,
+  .v-list__tile__title > h4,
+  /deep/ .channel-tile > .v-list__tile {
     width: 100%;
     max-width: 100%;
+  }
+
+  /deep/ .channel-tile > .v-list__tile {
+    padding-right: 0;
   }
 
   .select-col {
@@ -128,10 +135,6 @@
 
   .v-list__tile__title {
     height: auto;
-  }
-
-  /deep/ .v-list__group__header .v-list__tile {
-    padding-left: 11px;
   }
 
   .text-truncate {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -51,7 +51,7 @@
                         {{ getTitle(contentNode) }}
                       </VListTileTitle>
                     </VListTileContent>
-                    <VListTileAction style="min-width: unset;" class="px-3">
+                    <VListTileAction style="min-width: unset;" class="pl-3 pr-1">
                       <div class="badge caption font-weight-bold">
                         {{ contentNode.resource_count }}
                       </div>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -196,10 +196,10 @@
     },
     computed: {
       ...mapGetters(['clipboardRootId']),
+      ...mapGetters('currentChannel', ['canEdit']),
       ...mapGetters('clipboard', [
         'channels',
         'selectedNodeIds',
-        'selectedChannels',
         'getCopyTrees',
         'getMoveTrees',
         'legacyNodesSelected',
@@ -209,9 +209,6 @@
         getRealContentNodes: 'getContentNodes',
       }),
       ...mapState('draggable/regions', ['activeDraggableId']),
-      canEdit() {
-        return !this.selectedChannels.find(channel => !channel.edit);
-      },
       selected() {
         return Boolean(this.selectionState & SelectionFlags.ALL_DESCENDANTS);
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
@@ -382,7 +382,7 @@ export function moveClipboardNodes(context, { legacyTrees, newTrees, target }) {
   }
   if (newTrees.length) {
     for (let copyNode of newTrees) {
-      promises.append(
+      promises.push(
         context.dispatch(
           'contentNode/copyContentNode',
           {

--- a/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
@@ -8,7 +8,7 @@
       <div v-if="prependIcon" class="icon-container">
         <Icon>{{ prependIcon }}</Icon>
       </div>
-      <div class="header-content" :class="{'has-icon': appendIcon || prependIcon}">
+      <div class="header-content" :class="{ 'has-icon': appendIcon || prependIcon }">
         <slot name="header"></slot>
       </div>
       <div v-if="appendIcon" class="icon-container">
@@ -79,6 +79,7 @@
 </script>
 
 <style lang="less" scoped>
+
   @icon-padding: 16px;
   @icon-width: 25px;
   @header-width: calc(2 * @icon-padding + @icon-width);
@@ -89,8 +90,8 @@
   }
 
   .list-group-header {
-    cursor: pointer;
     white-space: nowrap;
+    cursor: pointer;
   }
 
   .header-content,
@@ -102,12 +103,12 @@
   .header-content,
   .icon-container {
     display: inline-block;
-    vertical-align: middle;
     white-space: normal;
+    vertical-align: middle;
   }
 
   .header-content.has-icon {
-    width: calc(100% ~"-" @header-width);
+    width: calc(100% ~'-' @header-width);
   }
 
   .list-group.open > .list-group-header .v-icon {
@@ -116,8 +117,8 @@
 
   .icon-container {
     box-sizing: border-box;
-    padding: 0 @icon-padding;
     width: @icon-width;
+    padding: 0 @icon-padding;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
@@ -1,24 +1,26 @@
 <template>
 
   <section class="list-group" :class="{ open }">
-    <VLayout
-      tag="header"
+    <header
       class="list-group-header"
-      align-center
       @click="open = !open"
     >
-      <VFlex v-if="prependIcon" shrink class="icon-container">
+      <div v-if="prependIcon" class="icon-container">
         <Icon>{{ prependIcon }}</Icon>
-      </VFlex>
-      <div class="grow header-content">
+      </div>
+      <div class="header-content" :class="{'has-icon': appendIcon || prependIcon}">
         <slot name="header"></slot>
       </div>
-      <VFlex v-if="appendIcon" shrink class="icon-container">
+      <div v-if="appendIcon" class="icon-container">
         <Icon>{{ appendIcon }}</Icon>
-      </VFlex>
-    </VLayout>
+      </div>
+    </header>
     <VExpandTransition>
-      <div v-if="open" class="list-group-content">
+      <div
+        v-if="hasOpened"
+        v-show="showContent"
+        class="list-group-content"
+      >
         <slot></slot>
       </div>
     </VExpandTransition>
@@ -44,6 +46,12 @@
         default: null,
       },
     },
+    data() {
+      return {
+        hasOpened: false,
+        showContent: false,
+      };
+    },
     computed: {
       open: {
         get() {
@@ -54,11 +62,26 @@
         },
       },
     },
+    watch: {
+      value(open) {
+        if (open) {
+          this.hasOpened = true;
+        }
+
+        // Delay show to next tick after open
+        this.$nextTick(() => {
+          this.showContent = open;
+        });
+      },
+    },
   };
 
 </script>
 
 <style lang="less" scoped>
+  @icon-padding: 16px;
+  @icon-width: 25px;
+  @header-width: calc(2 * @icon-padding + @icon-width);
 
   .list-group {
     box-sizing: border-box;
@@ -67,6 +90,24 @@
 
   .list-group-header {
     cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .header-content,
+  .list-group-header,
+  .list-group-content {
+    width: 100%;
+  }
+
+  .header-content,
+  .icon-container {
+    display: inline-block;
+    vertical-align: middle;
+    white-space: normal;
+  }
+
+  .header-content.has-icon {
+    width: calc(100% ~"-" @header-width);
   }
 
   .list-group.open > .list-group-header .v-icon {
@@ -74,13 +115,9 @@
   }
 
   .icon-container {
-    padding: 0 16px;
-  }
-
-  .header-content,
-  .list-group-header,
-  .list-group-content {
-    max-width: 100%;
+    box-sizing: border-box;
+    padding: 0 @icon-padding;
+    width: @icon-width;
   }
 
 </style>


### PR DESCRIPTION
## Description
- Fixes conditionals hiding move button on clipboard so it shows when current channel is editable
- Fixes channel title overflow on clipboard
- Other tweaks and fixes

#### Issue Addressed (if applicable)

https://github.com/learningequality/studio/issues/2564

#### Before/After Screenshots (if applicable)

| Before | After |
| --- | --- |
| ![Screenshot from 2020-12-08 15-33-19](https://user-images.githubusercontent.com/819838/101554263-216ce280-396b-11eb-91d4-2160574ae174.png) | ![Screenshot from 2020-12-08 15-33-47](https://user-images.githubusercontent.com/819838/101554278-26ca2d00-396b-11eb-939c-a0d0ca22d54f.png) |


## Steps to Test

- [ ] *Copy items to clipboard*
- [ ] *Open editable channel*
- [ ] *Select clipboard items*
- [ ] *Click move button*
- [ ] *Select move target and complete*


## Checklist

- [ ] Is the code clean and well-commented?
- [X] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
