### PR TITLE
Add guard to `TreeView` `created` hook, to prevent data over-fetching

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -282,10 +282,15 @@
       },
     },
     created() {
-      Promise.all([
-        this.loadContentNodes({ parent__in: [this.nodeId, this.rootId] }),
-        this.loadAncestors({ id: this.nodeId }),
-      ]).then(() => {
+      let childrenPromise;
+      // If viewing the root-level node, don't request anything, since the NodePanel.created
+      // hook will make a redundant request
+      if (this.nodeId === this.rootId) {
+        childrenPromise = Promise.resolve();
+      } else {
+        childrenPromise = this.loadContentNodes({ parent: this.rootId });
+      }
+      Promise.all([childrenPromise, this.loadAncestors({ id: this.nodeId })]).then(() => {
         this.loading = false;
         this.jumpToLocation();
       });


### PR DESCRIPTION
## Description

This adds a guard to the `TreeView`'s `created` hook to prevent it (along with the `NodePanel`s `created` hook) from doing two types of overfetching:

1. At a channel's root node, `TreeView` and `NodePanel` will collectively request the root node twice
1. At a channels' non-root node `Treeview` and `NodePanel` will collectively request the root node once, and the current node twice

Here I'm using a shorthand of "request the node" to mean "make a call to `/api/contentnode` with the query param of `parent=node`".

After this fix:

1. At a channel's root node, `TreeView` will not request the root node. And `NodePanel` will request the root node once.
1. At a channels' non-root node `Treeview` will request the root node once. And `NodePanel` will request the current node once.

#### Issue Addressed (if applicable)

Fixes #2316 

#### Before/After Screenshots (if applicable)

Before:

Notice that the same IDs are repeated multiple times in the request URL

![CleanShot 2020-12-08 at 16 39 23@2x](https://user-images.githubusercontent.com/10248067/101558967-ecfe2400-3974-11eb-8179-28190f1d3c35.png)
![CleanShot 2020-12-08 at 16 37 01@2x](https://user-images.githubusercontent.com/10248067/101558978-eff91480-3974-11eb-9b1e-1e64d16b68cf.png)


After:

Notice that the ID do not overlap between requests URLs

![CleanShot 2020-12-08 at 16 34 53@2x](https://user-images.githubusercontent.com/10248067/101558994-f5565f00-3974-11eb-9bbe-979d1d849b58.png)
![CleanShot 2020-12-08 at 16 34 12@2x](https://user-images.githubusercontent.com/10248067/101558999-f9827c80-3974-11eb-95be-0320433c5918.png)


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I added a guard to `TreeView` to ask for a smaller amount of data, with the knowledge that `NodePanel` will be rendered in the UI tree and make a complementary data request. This ensures that the current behavior of always request the root node + the current node is retained, but done in a way that we are not overfetching duplicate copies of these nodes.

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*

I don't know enough about the architecture to know if this is hacky. It's possible that a smarter solution would have just removed all calls to `loadContentNodes` from `TreeView` and deferred it to `NodePanel`

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
