### PR TITLE
Remove order parameter admin view

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/vuex/channelAdmin/actions.js
+++ b/contentcuration/contentcuration/frontend/administration/vuex/channelAdmin/actions.js
@@ -4,7 +4,6 @@ import client from 'shared/client';
 export function loadChannels({ commit }, params) {
   params.deleted = Boolean(params.deleted) && params.deleted.toString() === 'true';
   params.page_size = params.page_size || 25;
-  params.ordering = `${params.descending ? '-' : ''}${params.sortBy}` || '';
 
   return client.get(window.Urls.admin_channels_list(), { params }).then(response => {
     commit('SET_PAGE_DATA', response.data);

--- a/contentcuration/contentcuration/frontend/administration/vuex/userAdmin/actions.js
+++ b/contentcuration/contentcuration/frontend/administration/vuex/userAdmin/actions.js
@@ -23,7 +23,6 @@ export function loadUserDetails(context, id) {
 
 export function loadUsers({ commit }, params) {
   params.page_size = params.page_size || 100;
-  params.ordering = `${params.descending ? '-' : ''}${params.sortBy}` || '';
   return client.get(window.Urls.admin_users_list(), { params }).then(response => {
     response.data.results = map(response.data.results, u => {
       return { ...u, id: u.id.toString() };

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -71,10 +71,7 @@ def get_order_queryset(request, queryset, field_map):
     """
     order = request.GET.get("sortBy", "")
     if not order:
-        # frontend sends sometimes an 'ordering' parameter instead of sortBy (unknown reason)
-        # this 'ordering' param is sometimes null and others undefined
-        order = request.GET.get("ordering", "undefined")
-        order = "undefined" if order == "null" else order
+        order = "undefined"
 
     if order in field_map and type(field_map[order]) is str:
         order = field_map[order]

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -17,7 +17,6 @@ from le_utils.constants import roles
 from rest_framework import serializers
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import ValidationError
-from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
@@ -568,7 +567,6 @@ class AdminChannelViewSet(ChannelViewSet):
     filter_class = AdminChannelFilter
     filter_backends = (
         DjangoFilterBackend,
-        OrderingFilter,
     )
     field_map = {
         "published": "main_tree__published",
@@ -591,16 +589,6 @@ class AdminChannelViewSet(ChannelViewSet):
         "demo_server_url",
     )
     values = base_values
-    ordering_fields = (
-        "name",
-        "id",
-        "modified",
-        "created",
-        "primary_token",
-        "source_url",
-        "demo_server_url",
-    )
-    ordering = ("name",)
 
     def paginate_queryset(self, queryset):
         order, queryset = get_order_queryset(self.request, queryset, self.field_map)

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -15,7 +15,6 @@ from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
-from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
@@ -311,7 +310,6 @@ class AdminUserViewSet(UserViewSet):
     filter_class = AdminUserFilter
     filter_backends = (
         DjangoFilterBackend,
-        OrderingFilter,
     )
     base_values = (
         "id",
@@ -326,17 +324,6 @@ class AdminUserViewSet(UserViewSet):
         "is_active",
     )
     values = base_values
-    ordering_fields = (
-        "name",
-        "last_name",
-        "email",
-        "disk_space",
-        "edit_count",
-        "view_count",
-        "date_joined",
-        "last_login",
-    )
-    ordering = ("last_name",)
 
     def paginate_queryset(self, queryset):
         order, queryset = get_order_queryset(self.request, queryset, self.field_map)


### PR DESCRIPTION
## Description

This PR removes the 'ordering' param from being set in the front end, and the backend code that filters this param, because it is not used for the tables in `/administration`. It duplicates information that already exists in `sortBy` and `descending`.

#### Issue Addressed (if applicable)

Addresses issues discussed in [PR 2617](https://github.com/learningequality/studio/pull/2617)

#### Before/After Screenshots (if applicable)

Before - information duplicated: 
<img width="1141" alt="Screen Shot 2020-12-08 at 6 15 18 PM" src="https://user-images.githubusercontent.com/17235236/101651075-a9ee9000-3a0a-11eb-84fc-d0a148ab5c77.png">

After - ordering not passed in URL params:
![no-ordering](https://user-images.githubusercontent.com/17235236/101651106-b377f800-3a0a-11eb-94fe-5e8ece58e39d.gif)

## Steps to Test

- [ ] Navigate to the `/administration` page
- [ ] Test the sortBy feature by toggling ascending and descending on various table columns. This should work with no issues on both Channels and Users

## Comments

I did not see any issues with removing this and I find both the front end and the back end seem to be working as expected with manual testing. It is possible that there are issues with this approach that I did not foresee, so any feedback, especially regarding the backend, would be appreciate.
