### PR TITLE
Fixes external link issues and sometimes incorrect imported channel name 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VList>
-    <VListTile :to="viewLink" target="_blank">
+    <VListTile :href="viewLink" target="_blank">
       <VListTileTitle>{{ $tr('goToOriginalLocation') }}</VListTileTitle>
     </VListTile>
     <VListTile v-if="!legacyNode(nodeId)" @click="duplicateNode()">
@@ -57,13 +57,15 @@
         return this.node.channel_id;
       },
       viewLink() {
-        return {
+        const channelURI = window.Urls.channel(this.channelId);
+        const sourceNode = this.$router.resolve({
           name: RouterNames.TREE_VIEW,
           params: {
             nodeId: this.node.parent,
             detailNodeId: this.node.id,
           },
-        };
+        });
+        return `${channelURI}${sourceNode.href}`;
       },
       canEdit() {
         return this.getChannel(this.channelId) && this.getChannel(this.channelId).edit;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -208,6 +208,7 @@
                 :text="importedChannelName"
                 :href="importedChannelLink"
                 truncate
+                notranslate
                 target="_blank"
               />
             </DetailsRow>
@@ -237,6 +238,7 @@
                 :text="importedChannelName"
                 :href="importedChannelLink"
                 truncate
+                notranslate
                 target="_blank"
               />
             </DetailsRow>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -203,11 +203,10 @@
             <div class="section-header">
               {{ $tr('resources') }}
             </div>
-            <DetailsRow v-if="isImported" :label="$tr('originalChannel')">
+            <DetailsRow v-if="isImported && importedChannelLink" :label="$tr('originalChannel')">
               <ActionLink
-                v-if="importedChannelLink"
-                :text="node.original_channel_name"
-                :to="importedChannelLink"
+                :text="importedChannelName"
+                :href="importedChannelLink"
                 truncate
                 target="_blank"
               />
@@ -233,7 +232,7 @@
             <div class="section-header">
               {{ $tr('source') }}
             </div>
-            <DetailsRow v-if="isImported" :label="$tr('originalChannel')">
+            <DetailsRow v-if="isImported && importedChannelLink" :label="$tr('originalChannel')">
               <ActionLink
                 :text="importedChannelName"
                 :href="importedChannelLink"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -208,8 +208,8 @@
                 v-if="importedChannelLink"
                 :text="node.original_channel_name"
                 :to="importedChannelLink"
+                truncate
                 target="_blank"
-                text-truncate
               />
             </DetailsRow>
             <DetailsRow :label="$tr('totalResources')">
@@ -237,6 +237,7 @@
               <ActionLink
                 :text="importedChannelName"
                 :href="importedChannelLink"
+                truncate
                 target="_blank"
               />
             </DetailsRow>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -209,6 +209,7 @@
                 :text="node.original_channel_name"
                 :to="importedChannelLink"
                 target="_blank"
+                text-truncate
               />
             </DetailsRow>
             <DetailsRow :label="$tr('totalResources')">

--- a/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
@@ -13,6 +13,8 @@
     <slot>
       <span
         :class="{ 'text-truncate': truncate }"
+        :title="text"
+        class="notranslate"
         style="text-decoration: underline;"
       >
         {{ text }}

--- a/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
@@ -3,6 +3,7 @@
   <VBtn
     :style="{ color: $vuetify.theme.primary }"
     :target="target"
+    :class="{ 'has-text-truncate': textTruncate }"
     v-bind="$attrs"
     flat
     exact
@@ -10,7 +11,10 @@
     @click.stop="$emit('click')"
   >
     <slot>
-      <span style="text-decoration: underline;">
+      <span
+        :class="{ 'text-truncate': textTruncate }"
+        style="text-decoration: underline;"
+      >
         {{ text }}
       </span>
       <Icon v-if="target === '_blank'" small class="mx-1 rtl-flip">
@@ -32,6 +36,10 @@
         type: String,
         required: false,
       },
+      textTruncate: {
+        type: Boolean,
+        default: false,
+      },
     },
   };
 
@@ -46,6 +54,11 @@
     margin: 0;
     font-weight: normal;
     text-transform: none;
+  }
+
+  .v-btn.has-text-truncate {
+    width: 100%;
+    min-width: 0;
   }
 
   .v-icon {

--- a/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
@@ -12,9 +12,8 @@
   >
     <slot>
       <span
-        :class="{ 'text-truncate': truncate }"
+        :class="{ 'text-truncate': truncate, notranslate }"
         :title="text"
-        class="notranslate"
         style="text-decoration: underline;"
       >
         {{ text }}
@@ -39,6 +38,10 @@
         required: false,
       },
       truncate: {
+        type: Boolean,
+        default: false,
+      },
+      notranslate: {
         type: Boolean,
         default: false,
       },

--- a/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ActionLink.vue
@@ -3,7 +3,7 @@
   <VBtn
     :style="{ color: $vuetify.theme.primary }"
     :target="target"
-    :class="{ 'has-text-truncate': textTruncate }"
+    :class="{ truncate }"
     v-bind="$attrs"
     flat
     exact
@@ -12,7 +12,7 @@
   >
     <slot>
       <span
-        :class="{ 'text-truncate': textTruncate }"
+        :class="{ 'text-truncate': truncate }"
         style="text-decoration: underline;"
       >
         {{ text }}
@@ -36,7 +36,7 @@
         type: String,
         required: false,
       },
-      textTruncate: {
+      truncate: {
         type: Boolean,
         default: false,
       },
@@ -56,7 +56,7 @@
     text-transform: none;
   }
 
-  .v-btn.has-text-truncate {
+  .v-btn.truncate {
     width: 100%;
     min-width: 0;
   }


### PR DESCRIPTION
## Description
- Fixes imported channel name by coalescing with current channel name
- Fixes broken link to original location for imported topics
- Fixes broken link to clipboard original location
- Truncates external link text to original location in node details (see screenshots)
- Adds title to external link and `notranslate` class


#### Issue Addressed (if applicable)
https://github.com/learningequality/studio/issues/2659
https://github.com/learningequality/studio/issues/2660
https://github.com/learningequality/studio/issues/2589

#### Before/After Screenshots (if applicable)
| Before | After coalesce fix | After truncate |
| --- | --- | --- |
| ![Screenshot from 2020-12-09 14-35-48](https://user-images.githubusercontent.com/819838/101705014-dde1a980-3a3a-11eb-8971-b2162292dc7e.png) | ![Screenshot from 2020-12-09 14-37-59](https://user-images.githubusercontent.com/819838/101705024-e3d78a80-3a3a-11eb-98b6-f843854fc67c.png) | ![Screenshot from 2020-12-09 14-36-44](https://user-images.githubusercontent.com/819838/101705034-e89c3e80-3a3a-11eb-92d9-293a7e551718.png) |



## Steps to Test
- [ ] Open a channel
- [ ] Click ADD and add a new topic
- [ ] Add a resource to the topic
- [ ] Copy the topic to the clipboard
- [ ] Open another channel
- [ ] Click ADD and then Import from another channel
- [ ] Import the added topic from the first channel
- [ ] Complete import, wait until it's finished
- [ ] Refresh
- [ ] View imported topic details and verify channel import name
- [ ] Verify channel import name
- [ ] Verify original location link works correctly
- [ ] Open the clipboard
- [ ] Find the new topic on the clipboard
- [ ] Right click and Go to original location
- [ ] Verify the link works correctly

