### PR TITLE
Pass selected trash nodes into `MoveModal` `moveNodeIds` prop

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -169,6 +169,11 @@
         type: Array,
         default: () => [],
       },
+      // Set to true to modify behavior for TrashModal
+      movingFromTrash: {
+        type: Boolean,
+        default: false,
+      },
     },
     data() {
       return {
@@ -198,6 +203,10 @@
         return this.$tr('moveItems', this.getTopicAndResourceCounts(this.moveNodeIds));
       },
       currentLocationId() {
+        // If opening modal from inside TrashModal, begin navigation at root node
+        if (this.movingFromTrash) {
+          return this.currentChannel.root_id;
+        }
         const contentNode = this.getContentNode(this.moveNodeIds[0]);
         return contentNode && contentNode.parent;
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -112,7 +112,14 @@
         </VBtn>
       </template>
     </MessageDialog>
-    <MoveModal v-if="moveModalOpen" ref="moveModal" v-model="moveModalOpen" @target="moveNodes" />
+    <MoveModal
+      v-if="moveModalOpen"
+      ref="moveModal"
+      v-model="moveModalOpen"
+      :moveNodeIds="selected"
+      :movingFromTrash="true"
+      @target="moveNodes"
+    />
   </FullscreenModal>
 
 </template>


### PR DESCRIPTION

## Description

1. Passes `TrashModal.selected` into its child `MoveModal`'s `moveNodeIds` prop to get the proper header in that latter modal.
1. Adds a `moveFromTrash` prop to `MoveModal` so it begins at the channel root node (was starting at some place related to the route's `nodeId`, so would either be invalid move destination or otherwise unpredictable).

#### Issue Addressed (if applicable)

Fixes #2559

#### Before/After Screenshots (if applicable)

**After**

Notice that the message before pressing "Restore" is consistent with the header

From selection screen:

![image](https://user-images.githubusercontent.com/10248067/101706700-85141000-3a3e-11eb-871c-00149b6c488d.png)

From move modal:
![image](https://user-images.githubusercontent.com/10248067/101706739-9e1cc100-3a3e-11eb-81d5-297db254f925.png)


## Steps to Test

1. Move some stuff to the trash
1. Restore from trash
1. Confirm correct header and navigation experience within Move Modal

