### PR TITLE
Ensure `rev` is only set on changes when it needs to be

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/mergeChanges.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/mergeChanges.spec.js
@@ -64,17 +64,22 @@ describe('Merge all changes', () => {
       rev: 3,
     },
   ];
-  describe('merging updates', () => {
-    it('should retain the most recent update for a property', () => {
-      const mergedChanges = mergeAllChanges(updateChanges(), true);
-      expect(mergedChanges.length).toBe(1);
 
-      const mergedChange = mergedChanges[0];
+  describe('merging updates', () => {
+    const mergedChanges = mergeAllChanges(updateChanges(), true);
+    it('should return only one change', () => {
+      expect(mergedChanges.length).toBe(1);
+    });
+    const mergedChange = mergedChanges[0];
+    it('should retain the most recent update for a property', () => {
       expect(mergedChange.obj.question).toBe(finalQuestionValue);
       expect(mergedChange.mods.question).toBe(finalQuestionValue);
+    });
+    it("should keep record of the first change's initial value", () => {
       expect(mergedChange.oldObj.question).toBe(initialQuestionValue);
     });
   });
+
   describe('merging create and update', () => {
     const createChange = () => ({
       table: 'assessmentitem',
@@ -88,14 +93,18 @@ describe('Merge all changes', () => {
       rev: 0,
     });
 
-    it('should retain the most recent update for a property', () => {
-      const createAndUpdateChanges = [createChange(), ...updateChanges()];
-      const mergedChanges = mergeAllChanges(createAndUpdateChanges, true);
-      expect(mergedChanges.length).toBe(1);
+    const createAndUpdateChanges = [createChange(), ...updateChanges()];
+    const mergedChanges = mergeAllChanges(createAndUpdateChanges, true);
 
-      const mergedChange = mergedChanges[0];
-      expect(mergedChange.type).toBe(1);
+    it('should return only one change', () => {
+      expect(mergedChanges.length).toBe(1);
+    });
+    const mergedChange = mergedChanges[0];
+    it('should retain the most recent update for a property', () => {
       expect(mergedChange.obj.question).toBe(finalQuestionValue);
+    });
+    it('should result in a change of type `created`', () => {
+      expect(mergedChange.type).toBe(1);
       expect(mergedChange.mods).toBeUndefined();
       expect(mergedChange.oldObj).toBeUndefined();
     });

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/mergeChanges.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/mergeChanges.spec.js
@@ -109,4 +109,17 @@ describe('Merge all changes', () => {
       expect(mergedChange.oldObj).toBeUndefined();
     });
   });
+
+  describe('failure to merge changes with order issues', () => {
+    it('should refuse to merge changes without `rev` set', () => {
+      const changesMissingRev = updateChanges();
+      delete changesMissingRev[0].rev;
+      expect(() => mergeAllChanges(changesMissingRev, true)).toThrow(Error);
+    });
+    it('should refuse to merge out of order changes', () => {
+      const disorderedChanges = updateChanges();
+      disorderedChanges[0].rev = 5e1000;
+      expect(() => mergeAllChanges(disorderedChanges, true)).toThrow(Error);
+    });
+  });
 });

--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -135,10 +135,12 @@ export default function mergeAllChanges(changes, flatten = false, changesToSync 
   let lastRev;
   for (let change of changes) {
     // Ensure changes are merged in order
-    if (lastRev) {
-      if (change.rev <= lastRev) {
-        console.error('Changes are getting merged out of order:', changes);
-      }
+    if (!('rev' in change) || typeof(change.rev) === 'undefined') {
+      console.error("This change has no `rev`:", change);
+      throw new Error('Cannot determine the correct order for a change with no `rev`.')
+    } else if (change.rev <= lastRev) {
+      console.error("These changes aren't ordered by `rev`:", changes);
+      throw new Error('Cannot merge changes unless they are ordered by `rev`.');
     }
     lastRev = change.rev;
 

--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -135,9 +135,9 @@ export default function mergeAllChanges(changes, flatten = false, changesToSync 
   let lastRev;
   for (let change of changes) {
     // Ensure changes are merged in order
-    if (!('rev' in change) || typeof(change.rev) === 'undefined') {
-      console.error("This change has no `rev`:", change);
-      throw new Error('Cannot determine the correct order for a change with no `rev`.')
+    if (!('rev' in change) || typeof change.rev === 'undefined') {
+      console.error('This change has no `rev`:', change);
+      throw new Error('Cannot determine the correct order for a change with no `rev`.');
     } else if (change.rev <= lastRev) {
       console.error("These changes aren't ordered by `rev`:", changes);
       throw new Error('Cannot merge changes unless they are ordered by `rev`.');


### PR DESCRIPTION
## Description
This fixes an issue where some changes weren't getting added to the changes table, which meant that they were never getting synced. With this PR:
- `rev` must be set for changes passed to `mergeAllChanges`, and the changes must be in order, otherwise errors will be thrown
- `rev` will be filtered out on changes committed to the changes table

I also organized the unit tests for `mergeAllChanges`, and added some test cases to make sure `mergeAllChanges` throws exceptions when confronted with disordered changes or changes with no `rev` set.

## Implementation Notes

#### At a high level, how did you implement this?

When the changes passed to it didn't have `rev` set, the `mergeAllChanges` function was returning a squashed change with `rev: undefined`, which meant it couldn't be inserted into the changes table, which has `rev` as an auto-incrementing primary key.

With this PR, all changes passed into `mergeAllChanges` must have `rev` set, and `rev` is explicitly filtered out after changes are merged, but right before trying to changes into the changes table.


## Checklist

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
