### PR TITLE
Allow same origin iframe

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -38,7 +38,7 @@
     <iframe
       v-else-if="isHTML"
       :src="htmlPath"
-      sandbox="allow-scripts"
+      sandbox="allow-scripts allow-same-origin"
       @load="loading = false"
     ></iframe>
     <embed v-else-if="isPDF" :src="src" :type="file.mimetype" @load="loading = false">


### PR DESCRIPTION
This patch fixes part of the problem described in https://github.com/learningequality/studio/issues/2523 - some SCORM content wants to access the Scorm API and can't because of cross-origin issues. The content is loaded from the same origin in any case.



## Description

It allows cross-origin from the Studio channel preview iframe.

#### Issue Addressed (if applicable)

Addresses #2523 (in part)

#### Before/After Screenshots (if applicable)

Before:
![imagen](https://user-images.githubusercontent.com/199755/101772075-a66e0e00-3ac9-11eb-945b-a99cada6ab69.png)

After:
![imagen](https://user-images.githubusercontent.com/199755/101772085-ac63ef00-3ac9-11eb-85ff-a0bf93df14b5.png)

## Steps to Test

Try loading https://studio.learningequality.org/channels/de932aff604b570b8c5c61037c88c319/view/15dcece/c29d589 - then inspect the iframe tag and add "allow-same-origin" to the sandbox attribute. Then right click on the iframe and choose "reload frame". Content will load.

#### At a high level, how did you implement this?

Just tested it locally

#### Does this introduce any tech-debt items?

No.

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin @kollivier  (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina radinamatic (documentation)
