### PR TITLE
remove autofilled title value from contentNode

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -103,7 +103,6 @@
         let nodeData = {
           parent: this.nodeId,
           kind: 'topic',
-          title: this.$tr('topicDefaultTitle', { title: this.node.title }),
         };
         this.createContentNode(nodeData).then(newId => {
           this.$router.push({
@@ -195,7 +194,6 @@
     },
 
     $trs: {
-      topicDefaultTitle: '{title} topic',
       newSubtopic: 'New topic',
       editTopicDetails: 'Edit topic details',
       editDetails: 'Edit details',

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -169,7 +169,6 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     tags: {},
     extra_fields: {},
     [NEW_OBJECT]: true,
-    complete: false,
     changed: true,
     language: session.preferences ? session.preferences.language : session.currentLanguage,
     parent,
@@ -178,6 +177,11 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     ...payload,
   };
 
+  contentNodeData.complete = isNodeComplete({
+    nodeDetails: contentNodeData,
+    assessmentItems: [],
+    files: [],
+  });
   return ContentNode.put(contentNodeData).then(id => {
     context.commit('ADD_CONTENTNODE', {
       id,


### PR DESCRIPTION
Addresses #2565 

#### Before/After Screenshots (if applicable)

Before: 
![subtopic-1](https://user-images.githubusercontent.com/17235236/101835295-90803d80-3b09-11eb-99b5-8b45292029db.gif)

After: 
![subtopic-2](https://user-images.githubusercontent.com/17235236/101840730-a80ff400-3b12-11eb-9775-c3b215cb3aec.gif)


## Steps to Test

- [ ] Open a channel and create a subtopic using the options menu in the side panel. 
- [ ] Form should open without a title autofilled and if required field are completed, should save without error.

