### PR TITLE
Don't try to delete a channel that has not been committed to the DB yet.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -108,7 +108,7 @@
 <script>
 
   import Vue from 'vue';
-  import { mapActions, mapGetters, mapState } from 'vuex';
+  import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
   import ChannelThumbnail from './ChannelThumbnail';
   import ChannelSharing from './ChannelSharing';
   import { NEW_OBJECT, ErrorTypes } from 'shared/constants';
@@ -265,7 +265,8 @@
       this.header = this.channel.name; // Get channel name when user enters modal
     },
     methods: {
-      ...mapActions('channel', ['updateChannel', 'loadChannel', 'deleteChannel', 'commitChannel']),
+      ...mapActions('channel', ['updateChannel', 'loadChannel', 'commitChannel']),
+      ...mapMutations('channel', ['REMOVE_CHANNEL']),
       saveChannel() {
         if (this.$refs.detailsform.validate()) {
           this.changed = false;
@@ -306,7 +307,7 @@
         this.changed = false;
         this.showUnsavedDialog = false;
         if (this.isNew) {
-          return this.deleteChannel(this.channelId).then(this.close);
+          this.REMOVE_CHANNEL(this.channel);
         }
         this.close();
       },


### PR DESCRIPTION
## Description

* When closing the new channel modal, we would try to soft delete the channel
* We had not committed this channel to the backend, so this would fail
* Hence you could not close the modal
* This fixes that by just removing it from the Vuex state where it has been stored

#### Issue Addressed (if applicable)

Fixes #2676


## Steps to Test

- Click new channel
- Type something in the title
- Press the 'X' to leave
- Press 'exit anyway'
- Confirm the channel does not appear in 'my channels'
