### PR TITLE
Update `window.title` value for pages in `channelList` SPA

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/router.js
+++ b/contentcuration/contentcuration/frontend/channelList/router.js
@@ -6,7 +6,6 @@ import CatalogList from './views/Channel/CatalogList';
 import { RouterNames } from './constants';
 import CatalogFAQ from './views/Channel/CatalogFAQ';
 import { ChannelListTypes } from 'shared/constants';
-import { updateTabTitle } from 'shared/i18n';
 import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
 import ChannelModal from 'shared/views/channel/ChannelModal';
 
@@ -75,11 +74,6 @@ const router = new VueRouter({
       redirect: { name: RouterNames.CHANNELS_EDITABLE },
     },
   ],
-});
-
-router.beforeEach((to, from, next) => {
-  next();
-  updateTabTitle();
 });
 
 export default router;

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -225,7 +225,9 @@
         }
         // Title changes for other routes are handled by other components, since
         // we can access $tr messages only from within the component.
-        this.updateTabTitle(title);
+        if (title) {
+          this.updateTabTitle(title);
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -93,7 +93,7 @@
   import ChannelInvitation from './Channel/ChannelInvitation';
   import ChannelListAppError from './ChannelListAppError';
   import { ChannelListTypes } from 'shared/constants';
-  import { constantsTranslationMixin } from 'shared/mixins';
+  import { constantsTranslationMixin, routerMixin } from 'shared/mixins';
   import GlobalSnackbar from 'shared/views/GlobalSnackbar';
   import KolibriLogo from 'shared/views/KolibriLogo';
   import AppBar from 'shared/views/AppBar';
@@ -117,7 +117,7 @@
       PolicyUpdates,
       OfflineText,
     },
-    mixins: [constantsTranslationMixin],
+    mixins: [constantsTranslationMixin, routerMixin],
     computed: {
       ...mapState({
         offline: state => !state.connection.online,
@@ -183,6 +183,10 @@
           this.$store.dispatch('errors/clearError');
         }
       },
+      '$route.name': {
+        handler: 'updateTitleForPage',
+        immediate: true,
+      },
     },
     created() {
       if (this.loggedIn) {
@@ -203,6 +207,25 @@
       ...mapActions('channelList', ['loadInvitationList']),
       getChannelLink(listType) {
         return { name: ListTypeToRouteMapping[listType] };
+      },
+      updateTitleForPage() {
+        // Updates the tab title every time the top-level route changes
+        let title;
+        const routeName = this.$route.name;
+        if (routeName === RouterNames.CHANNEL_SETS) {
+          title = this.$tr('channelSets');
+        } else if (routeName === RouterNames.CATALOG_ITEMS) {
+          title = this.translateConstant('public');
+        } else if (routeName === RouterNames.CHANNELS_VIEW_ONLY) {
+          title = this.translateConstant('view');
+        } else if (routeName === RouterNames.CHANNELS_STARRED) {
+          title = this.translateConstant('bookmark');
+        } else if (routeName === RouterNames.CHANNELS_EDITABLE) {
+          title = this.translateConstant('edit');
+        }
+        // Title changes for other routes are handled by other components, since
+        // we can access $tr messages only from within the component.
+        this.updateTabTitle(title);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -158,7 +158,7 @@
   import ChannelSelectionList from './ChannelSelectionList';
   import ChannelItem from './ChannelItem';
   import { NEW_OBJECT, ChannelListTypes, ErrorTypes } from 'shared/constants';
-  import { constantsTranslationMixin } from 'shared/mixins';
+  import { constantsTranslationMixin, routerMixin } from 'shared/mixins';
   import CopyToken from 'shared/views/CopyToken';
   import MessageDialog from 'shared/views/MessageDialog';
   import FullscreenModal from 'shared/views/FullscreenModal';
@@ -176,7 +176,7 @@
       Tabs,
       LoadingText,
     },
-    mixins: [constantsTranslationMixin],
+    mixins: [constantsTranslationMixin, routerMixin],
     props: {
       channelSetId: {
         type: String,
@@ -245,6 +245,9 @@
     beforeMount() {
       return this.verifyChannelSet(this.channelSetId);
     },
+    mounted() {
+      this.updateTitleForPage();
+    },
     methods: {
       ...mapActions('channel', ['loadChannelList']),
       ...mapActions('channelSet', [
@@ -261,6 +264,14 @@
           return;
         }
         this.dialog = value;
+      },
+      updateTitleForPage() {
+        if (this.isNew) {
+          this.updateTabTitle(this.$tr('creatingChannelSet'));
+        } else {
+          // TODO improve the title, since it omits "collection"
+          this.updateTabTitle(this.name);
+        }
       },
       saveChannels() {
         const oldChannels = this.channelSet.channels;

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -253,6 +253,11 @@
         },
       },
     },
+    watch: {
+      '$route.params.tab'() {
+        this.updateTitleForPage();
+      },
+    },
     // NOTE: Placing verification in beforeMount is tailored for this component's use in
     // channelList. In channelEdit, if a channel does not exist, this component
     // will never be rendered.
@@ -287,7 +292,11 @@
         }
       },
       updateTitleForPage() {
-        this.updateTabTitle(this.channel.name);
+        if (this.$route.params.tab === 'edit') {
+          this.updateTabTitle(`${this.$tr('editTab')} - ${this.channel.name}`);
+        } else {
+          this.updateTabTitle(`${this.$tr('shareTab')} - ${this.channel.name}`);
+        }
       },
       onDialogInput(value) {
         if (!value) {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -116,6 +116,7 @@
   import LanguageDropdown from 'shared/views/LanguageDropdown';
   import ContentDefaults from 'shared/views/form/ContentDefaults';
   import FullscreenModal from 'shared/views/FullscreenModal';
+  import { routerMixin } from 'shared/mixins';
   import Banner from 'shared/views/Banner';
   import Tabs from 'shared/views/Tabs';
   import ToolBar from 'shared/views/ToolBar';
@@ -133,6 +134,7 @@
       Tabs,
       ToolBar,
     },
+    mixins: [routerMixin],
     props: {
       channelId: {
         type: String,
@@ -258,11 +260,13 @@
       const channelId = this.$route.params.channelId;
       return this.verifyChannel(channelId).then(() => {
         this.header = this.channel.name; // Get channel name when user enters modal
+        this.updateTitleForPage();
       });
     },
     mounted() {
       // Set expiry to 1ms
       this.header = this.channel.name; // Get channel name when user enters modal
+      this.updateTitleForPage();
     },
     methods: {
       ...mapActions('channel', ['updateChannel', 'loadChannel', 'deleteChannel', 'commitChannel']),
@@ -281,6 +285,9 @@
             });
           }
         }
+      },
+      updateTitleForPage() {
+        this.updateTabTitle(this.channel.name);
       },
       onDialogInput(value) {
         if (!value) {

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -147,7 +147,10 @@
         return this.thumbnailSrc && !this.compact;
       },
       kindTitle() {
-        return this.translateConstant(this.kind);
+        if (this.kind) {
+          return this.translateConstant(this.kind);
+        }
+        return '';
       },
     },
     $trs: {


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Uses the `updateTabTitle` function to update the tab titles on pages in the `channelList` SPA.

This is accomplished in various ways depending on the page, so basically:

1. We mirror the tab name (e.g. "Starred", "Content catalog") for the highest-level pages
1. We put the channel or channelset name for detail-level pages.

#### Issue Addressed (if applicable)

This is one step towards #2537. Later PRs will fix the issue in other SPAs.



## Steps to Test

- Go to every possible page in the `channelList` SPA. You should see a tab title that is not just "Kolibri Studio"

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are users' storage used being recalculated properly on any changes to their main tree files?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
