### PR TITLE
Misc fixes to serializers' handling of attempted updates to missing content

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_assessmentitem.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_assessmentitem.py
@@ -263,6 +263,28 @@ class SyncTestCase(StudioAPITestCase):
             new_question,
         )
 
+    def test_attempt_update_missing_assessmentitem(self):
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event([
+                            self.channel.main_tree.get_descendants()
+                                .filter(kind_id=content_kinds.EXERCISE)
+                                .first()
+                                .id,
+                            uuid.uuid4().hex
+                        ],
+                    ASSESSMENTITEM,
+                    {"question": "but why is it missing in the first place?"},
+                )
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertEqual(response.data.get("errors")[0].get("error")[0], "Not found")
+
     def test_update_assessmentitem_with_file(self):
 
         assessmentitem = models.AssessmentItem.objects.create(

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -186,8 +186,7 @@ class AssessmentItemSerializer(BulkModelSerializer):
             instance = super(AssessmentItemSerializer, self).update(
                 instance, validated_data
             )
-            validated_data["assessment_id"] = instance.assessment_id
-            validated_data["contentnode_id"] = instance.contentnode_id
+            self.set_id_values(instance, validated_data)
             self.set_files([instance], [validated_data])
             return instance
 

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -110,18 +110,17 @@ class AssessmentItemSerializer(BulkModelSerializer):
             # have had these fields modified.
             md_fields_modified = set(
                 [
-                    (ai["contentnode_id"], ai["assessment_id"])
-                    for ai in all_validated_data
+                    self.id_value_lookup(ai) for ai in all_validated_data
                     if "question" in ai or "hints" in ai or "answers" in ai
                 ]
             )
         else:
             # If this is a create operation, just check if these fields are not null.
             md_fields_modified = set(
-                [(ai.contentnode.id, ai.assessment_id) for ai in all_objects if ai.question or ai.hints or ai.answers]
+                [self.id_value_lookup(ai) for ai in all_objects if ai.question or ai.hints or ai.answers]
             )
 
-        all_objects = [ai for ai in all_objects if (ai.contentnode.id, ai.assessment_id) in md_fields_modified]
+        all_objects = [ai for ai in all_objects if self.id_value_lookup(ai) in md_fields_modified]
 
         for file in File.objects.filter(assessment_item__in=all_objects):
             if file.assessment_item_id not in current_files_by_aitem:

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -74,7 +74,11 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
         else:
             # Could alternatively have coerced the list of values to a string
             # but this seemed more explicit in terms of the intended format.
-            return tuple(self.get_value(data, attr) for attr in id_attr)
+            id_values = (self.get_value(data, attr) for attr in id_attr)
+
+            # For the combined index, use any related objects' primary key
+            combined_index = (idx.pk if hasattr(idx, 'pk') else idx for idx in id_values)
+            return tuple(combined_index)
 
     def set_id_values(self, data, obj):
         """

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -65,8 +65,7 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
         """
         Method to get the value for an id to use in lookup dicts
         In the case of a simple id, this is just the str of the value
-        In the case of a combined index, we make a stringified array
-        representation of the values.
+        In the case of a combined index, we make a tuple of the values.
         """
         id_attr = self.id_attr()
 
@@ -75,9 +74,7 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
         else:
             # Could alternatively have coerced the list of values to a string
             # but this seemed more explicit in terms of the intended format.
-            return "[{}]".format(
-                ",".join((str(self.get_value(data, attr)) for attr in id_attr))
-            )
+            return tuple(self.get_value(data, attr) for attr in id_attr)
 
     def set_id_values(self, data, obj):
         """
@@ -105,10 +102,9 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
 
     def remove_id_values(self, obj):
         """
-        Remove the id value(s) from obj
-        Return obj for consistency, even though this method has side
-        effects.
+        Return a copy of obj with its id value(s) removed.
         """
+        obj = obj.copy()
         id_attr = self.id_attr()
 
         if isinstance(id_attr, str):
@@ -721,7 +717,7 @@ class BulkUpdateMixin(UpdateModelMixin):
                 errors = [
                     dict(error=ValidationError("Not found").detail, **change)
                     for change in changes
-                    if change["key"] in serializer.missing_keys
+                    if tuple(change["key"]) in serializer.missing_keys
                 ]
         else:
             valid_data = []

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -304,9 +304,8 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
                     self.changes.extend(self.child.changes)
 
         if len(all_validated_data_by_id) != len(updated_keys):
-            self.missing_keys = updated_keys.difference(
-                set(all_validated_data_by_id.keys())
-            )
+            self.missing_keys = set(all_validated_data_by_id.keys())\
+                .difference(updated_keys)
 
         bulk_update(updated_objects, update_fields=properties_to_update)
 


### PR DESCRIPTION
## Description
If the front-end tries to update an assessment item that's missing from the back-end, this PR makes sure that a useful error is returned, instead of a confusing one.

This us a followup on https://github.com/learningequality/studio/pull/2655.
#### Issue Addressed

This will make https://github.com/learningequality/studio/issues/2679 and https://github.com/learningequality/studio/issues/2603 less severe by adding proper error handling for attempts to update missing items.

## Steps to Test

- [x] run the included test

## Implementation Notes

#### At a high level, how did you implement this?
- Added a unit test for attempts to update missing assessment items
- Stopped `remove_id_values` from mutating changes unexpectedly
- Used `id_value_lookup` method for consistent keying of assessment items
- Changed `id_value_lookup` to use a tuple instead of a string, for simpler conversion from front-end `change["key"]` array representation.
- Fixed calculation of `missing_keys` to generate errors for missing items.
