### PR TITLE
Display informative "tab titles" for Administration and Settings SPAs

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelDetails.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelDetails.vue
@@ -107,7 +107,7 @@
       next(vm => {
         if (vm.channel) {
           // Modal has already been opened
-          vm.updateTabTitle(vm.channel.name);
+          vm.updateTitleForPage();
         }
       });
     },
@@ -116,6 +116,9 @@
     },
     methods: {
       ...mapActions('channel', ['loadChannel', 'loadChannelDetails']),
+      updateTitleForPage() {
+        this.updateTabTitle(`${this.channel.name} - Channels - Administration`);
+      },
       load() {
         this.loading = true;
         const channelPromise = this.loadChannel(this.channelId);
@@ -129,7 +132,7 @@
               return;
             }
             // Need to add here in case user is refreshing page
-            this.updateTabTitle(channel.name);
+            this.updateTitleForPage();
 
             this.details = details;
             this.loading = false;

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
@@ -102,6 +102,7 @@
   import { RouterNames, rowsPerPageItems } from '../../constants';
   import ChannelItem from './ChannelItem';
   import { channelExportMixin } from 'shared/views/channel/mixins';
+  import { routerMixin } from 'shared/mixins';
   import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
@@ -126,7 +127,7 @@
       LanguageDropdown,
       IconButton,
     },
-    mixins: [tableMixin, filterMixin, channelExportMixin],
+    mixins: [tableMixin, filterMixin, channelExportMixin, routerMixin],
     data() {
       return {
         selected: [],
@@ -199,6 +200,9 @@
       'channels.length'() {
         this.selected = [];
       },
+    },
+    mounted() {
+      this.updateTabTitle('Channels - Administration');
     },
     methods: {
       ...mapActions('channelAdmin', ['loadChannels', 'getAdminChannelListDetails']),

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
@@ -20,7 +20,7 @@
           @deleted="dialog = false"
         />
       </VLayout>
-      <h1>{{ user.name }}</h1>
+      <h1>{{ userFullName }}</h1>
 
       <!-- Basic information -->
       <h2 class="mb-2 mt-4">
@@ -214,6 +214,14 @@
       user() {
         return this.getUser(this.userId);
       },
+      userFullName() {
+        // Return full name if `user.name` is not being returned in getter
+        if (this.user.name) {
+          return this.user.name;
+        } else {
+          return this.user.first_name + ' ' + this.user.last_name;
+        }
+      },
       storageUsed() {
         return (this.details.used_space / this.user.disk_space) * 100;
       },
@@ -266,7 +274,7 @@
       next(vm => {
         if (vm.user) {
           // Modal has already been opened
-          vm.updateTabTitle(vm.user.name);
+          vm.updateTitleForPage();
         }
       });
     },
@@ -275,6 +283,9 @@
     },
     methods: {
       ...mapActions('userAdmin', ['loadUser', 'loadUserDetails']),
+      updateTitleForPage() {
+        this.updateTabTitle(`${this.userFullName} - Users - Administration`);
+      },
       load() {
         const userPromise = this.loadUser(this.userId);
         this.loading = true;
@@ -285,7 +296,7 @@
               this.$router.replace(this.backLink);
               return;
             }
-            this.updateTabTitle(user.name);
+            this.updateTitleForPage();
             this.details = details;
             this.loading = false;
           })

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -93,6 +93,7 @@
   import { tableMixin, generateFilterMixin } from '../../mixins';
   import EmailUsersDialog from './EmailUsersDialog';
   import UserItem from './UserItem';
+  import { routerMixin } from 'shared/mixins';
   import IconButton from 'shared/views/IconButton';
   import Checkbox from 'shared/views/form/Checkbox';
   import CountryField from 'shared/views/form/CountryField';
@@ -115,7 +116,7 @@
       UserItem,
       CountryField,
     },
-    mixins: [tableMixin, filterMixin],
+    mixins: [tableMixin, filterMixin, routerMixin],
     data() {
       return {
         selected: [],
@@ -186,6 +187,9 @@
       'users.length'() {
         this.selected = [];
       },
+    },
+    mounted() {
+      this.updateTabTitle('Users - Administration');
     },
     methods: {
       ...mapActions('userAdmin', ['loadUsers']),

--- a/contentcuration/contentcuration/frontend/settings/pages/SettingsIndex.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/SettingsIndex.vue
@@ -38,12 +38,14 @@
   import { RouterNames } from '../constants';
   import GlobalSnackbar from 'shared/views/GlobalSnackbar';
   import AppBar from 'shared/views/AppBar';
+  import { routerMixin } from 'shared/mixins';
   import OfflineText from 'shared/views/OfflineText';
   import PolicyUpdates from 'shared/views/policies/PolicyUpdates';
 
   export default {
     name: 'SettingsIndex',
     components: { GlobalSnackbar, AppBar, OfflineText, PolicyUpdates },
+    mixins: [routerMixin],
     computed: {
       ...mapState({
         offline: state => !state.connection.online,
@@ -52,11 +54,32 @@
         return RouterNames;
       },
     },
+    watch: {
+      '$route.name': {
+        handler: 'updateTitleForPage',
+        immediate: true,
+      },
+    },
     created() {
       this.fetchDeferredUserData();
     },
     methods: {
       ...mapActions('settings', ['fetchDeferredUserData']),
+      updateTitleForPage() {
+        // Updates the tab title every time the top-level route changes
+        let title;
+        const routeName = this.$route.name;
+        if (routeName === RouterNames.ACCOUNT) {
+          title = this.$tr('accountLabel');
+        } else if (routeName === RouterNames.STORAGE) {
+          title = this.$tr('storageLabel');
+        } else if (routeName === RouterNames.USING_STUDIO) {
+          title = this.$tr('usingStudioLabel');
+        }
+        // TODO combine this `{firstItem} - {secondItem}` into a single message to support
+        // RTL languages
+        this.updateTabTitle(`${title} - ${this.$tr('settingsTitle')}`);
+      },
     },
     $trs: {
       settingsTitle: 'Settings',


### PR DESCRIPTION
**Please remove any unused sections**

## Description

1. Uses the `updateTabTitle` mixin to update `window.title` (aka "tab title") for pages under the Administration and Settings SPA. The naming convention used is that suggested in https://github.com/learningequality/studio/issues/2537#issuecomment-742825262. E.g. something of the form `Detail Page - Main Page - SPA name - Kolibri Studio`.
1. Fixed a bug for `UserDetail` page where the user's full name would not display if going directly to the URL

#### Issue Addressed (if applicable)

Part of #2537

#### Before/After Screenshots (if applicable)

GIFs show me navigating through the Settings and Administration pages (view the tab title)

![CleanShot 2020-12-14 at 16 44 32](https://user-images.githubusercontent.com/10248067/102153766-cb95b000-3e2c-11eb-961f-4466e6f08bf9.gif)

![CleanShot 2020-12-14 at 16 43 46](https://user-images.githubusercontent.com/10248067/102153769-cd5f7380-3e2c-11eb-9037-3ce2c7208d3c.gif)


## Implementation Notes (optional)

#### At a high level, how did you implement this?

I continue (from #2681) to wrap `updateTabTitle` in a component method called `updateTitleForPage` that is called late in the component lifecycle to update `window.title`

#### Does this introduce any tech-debt items?

The strategy I used in the Settings SPA to simply interpolate `${pageTitle} - ${$tr('settingsTitle')` will not work in RTL languages. This interpolated version will need to be combined into a single message like `{firstItem} - {secondItem}` so it can be properly internationalized in a future version.

