### PR TITLE
Copy to parent of copied node with last-child position

### DIFF
--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -567,9 +567,18 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
 
         source_copy_id_map = {}
 
+        parent_id = None
+        # If the position is *-child then parent is target
+        # but if it is not - then our parent is the same as the target's parent
+        if target:
+            if position in ["last-child", "first-child"]:
+                parent_id = target.id
+            else:
+                parent_id = target.parent_id
+
         data = self._recurse_to_create_tree(
             node,
-            target.id if target else None,
+            parent_id,
             source_channel_id,
             nodes_by_parent,
             source_copy_id_map,

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -266,9 +266,31 @@ class NodeOperationsTestCase(BaseTestCase):
                 self.assertEqual(last_rght + 1, new_node.lft)
             last_rght = new_node.rght
 
-    def test_duplicate_nodes_position_right(self):
+    def test_duplicate_nodes_position_right_shallow(self):
         """
         Ensures that when we copy nodes to the right, they are inserted at the next position
+        Testing with shallow batch_size of 1
+        """
+        new_channel = testdata.channel()
+
+        # simulate a clean, right-after-publish state to ensure only new channel is marked as change
+        self.channel.main_tree.changed = False
+        self.channel.main_tree.title = "Some other name"
+        self.channel.main_tree.save()
+        self.channel.main_tree.refresh_from_db()
+
+        self.channel.main_tree.copy_to(
+            new_channel.main_tree.get_children()[0], position="right", batch_size=1
+        )
+
+        self.assertEqual(
+            new_channel.main_tree.get_children()[1].title, self.channel.main_tree.title
+        )
+
+    def test_duplicate_nodes_position_right_mixed(self):
+        """
+        Ensures that when we copy nodes to the right, they are inserted at the next position
+        Testing with a mixed/medium batch size of 1000
         """
         new_channel = testdata.channel()
 
@@ -280,6 +302,27 @@ class NodeOperationsTestCase(BaseTestCase):
 
         self.channel.main_tree.copy_to(
             new_channel.main_tree.get_children()[0], position="right", batch_size=1000
+        )
+
+        self.assertEqual(
+            new_channel.main_tree.get_children()[1].title, self.channel.main_tree.title
+        )
+
+    def test_duplicate_nodes_position_right_deep(self):
+        """
+        Ensures that when we copy nodes to the right, they are inserted at the next position
+        Testing with deep batch_size of 10,000
+        """
+        new_channel = testdata.channel()
+
+        # simulate a clean, right-after-publish state to ensure only new channel is marked as change
+        self.channel.main_tree.changed = False
+        self.channel.main_tree.title = "Some other name"
+        self.channel.main_tree.save()
+        self.channel.main_tree.refresh_from_db()
+
+        self.channel.main_tree.copy_to(
+            new_channel.main_tree.get_children()[0], position="right", batch_size=10000
         )
 
         self.assertEqual(


### PR DESCRIPTION
## Description

Copying was trying to use the node which was being copied as the `target` - which ought to have been the `parent` of the node being copied (because they should end up direct children of the same parent).

The position was `right` which caused issues in `resolveParent()` where it resolves the `target` immediately if the position is `last-child` or `first-child`. I changed the calls to use the default `last-child` position and to pass the node's parent ID as the `target` - which results in nodes being copied successfully into the same topic as the node they're a copy of.

#### Issue Addressed (if applicable)

Fixes #2686 

## Steps to Test

- Copy a Topic folder. It should appear in a "loading" state at the bottom of the list of content nodes you are viewing. 
- Once the copy is completed (not loading anymore) - navigate to the topic node you selected to copy from and verify that the bug shown in #2686 is no longer occurring.
- Return and you should see your original node and it's copy there.

Try copying two ways:

- Select multiple nodes' (topics and content items) checkboxes and click the icon for "Make a copy".
- Click one content node's context menu (three vertical dots) and select "Make a copy". Do this for Topic and a non-topic.

