### PR TITLE
Update tab titles for pages in `channelEdit` SPA

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -442,7 +442,7 @@
         });
       },
       updateTitleForPage() {
-        this.updateTabTitle(this.$store.getters.appendChannelNameToString(this.modalTitle));
+        this.updateTabTitle(this.$store.getters.appendChannelName(this.modalTitle));
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -177,7 +177,7 @@
   import EditList from './EditList';
   import EditView from './EditView';
   import SavingIndicator from './SavingIndicator';
-  import { fileSizeMixin } from 'shared/mixins';
+  import { fileSizeMixin, routerMixin } from 'shared/mixins';
   import FileStorage from 'shared/views/files/FileStorage';
   import MessageDialog from 'shared/views/MessageDialog';
   import ResizableNavigationDrawer from 'shared/views/ResizableNavigationDrawer';
@@ -208,7 +208,7 @@
       ToolBar,
       BottomBar,
     },
-    mixins: [fileSizeMixin],
+    mixins: [fileSizeMixin, routerMixin],
     props: {
       detailNodeIds: {
         type: String,
@@ -328,6 +328,7 @@
           }
           return Promise.all(promises)
             .then(() => {
+              vm.updateTitleForPage();
               vm.loading = false;
             })
             .catch(() => {
@@ -439,6 +440,9 @@
             });
           });
         });
+      },
+      updateTitleForPage() {
+        this.updateTabTitle(this.$store.getters.appendChannelNameToString(this.modalTitle));
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/editModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/editModal.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import { modes } from '../../../constants';
 import EditModal from '../EditModal';
 import EditList from '../EditList';
-import { localStore, mockFunctions, generateNode, DEFAULT_TOPIC, DEFAULT_TOPIC2 } from './data.js';
+import { localStore, mockFunctions, generateNode, DEFAULT_TOPIC, DEFAULT_TOPIC2 } from './data';
 import Uploader from 'shared/views/files/Uploader';
 
 const testNodes = [DEFAULT_TOPIC, DEFAULT_TOPIC2];

--- a/contentcuration/contentcuration/frontend/channelEdit/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/getters.js
@@ -9,3 +9,18 @@ export function isComfortableViewMode(state) {
   const { viewMode } = state.viewModeOverrides.slice().pop() || state;
   return viewMode === viewModes.COMFORTABLE;
 }
+
+// Convenience function to format strings like "Page Name - Channel Name"
+// for tab titles
+export function appendChannelName(state, getters) {
+  return function(string) {
+    // Fallback if current channel isn't available yet
+    const channel = getters['currentChannel/currentChannel'];
+
+    if (channel) {
+      return `${string} - ${channel.name}`;
+    } else {
+      return string;
+    }
+  };
+}

--- a/contentcuration/contentcuration/frontend/channelEdit/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/getters.js
@@ -18,9 +18,9 @@ export function appendChannelName(state, getters) {
     const channel = getters['currentChannel/currentChannel'];
 
     if (channel) {
-      return `${string} - ${channel.name}`;
-    } else {
-      return string;
+      return string ? `${string} - ${channel.name}` : channel.name;
     }
+
+    return string || '';
   };
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
@@ -14,14 +14,14 @@
   import { mapActions } from 'vuex';
   import { RouterNames, TabNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
-  import { routerMixin } from 'shared/mixins';
+  import { routerMixin, titleMixin } from 'shared/mixins';
 
   export default {
     name: 'AddNextStepsPage',
     components: {
       AddRelatedResourcesModal,
     },
-    mixins: [routerMixin],
+    mixins: [routerMixin, titleMixin],
     props: {
       targetNodeId: {
         type: String,
@@ -60,7 +60,7 @@
         let title = this.$tr('toolbarTitle');
         const node = this.$store.getters['contentNode/getContentNode'](this.targetNodeId);
         if (node) {
-          title = title + ` - ${node.title}`;
+          title = title + ` - ${this.getTitle(node)}`;
         }
         this.updateTabTitle(this.$store.getters.appendChannelName(title));
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
@@ -12,20 +12,24 @@
 <script>
 
   import { mapActions } from 'vuex';
-
   import { RouterNames, TabNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
+  import { routerMixin } from 'shared/mixins';
 
   export default {
     name: 'AddNextStepsPage',
     components: {
       AddRelatedResourcesModal,
     },
+    mixins: [routerMixin],
     props: {
       targetNodeId: {
         type: String,
         required: true,
       },
+    },
+    mounted() {
+      this.updateTitleForPage();
     },
     methods: {
       ...mapActions('contentNode', ['addNextStepToNode']),
@@ -51,6 +55,14 @@
             tab: TabNames.RELATED,
           },
         });
+      },
+      updateTitleForPage() {
+        let title = this.$tr('toolbarTitle');
+        const node = this.$store.getters['contentNode/getContentNode'](this.targetNodeId);
+        if (node) {
+          title = title + ` - ${node.title}`;
+        }
+        this.updateTabTitle(this.$store.getters.appendChannelName(title));
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
@@ -14,14 +14,14 @@
   import { mapActions } from 'vuex';
   import { RouterNames, TabNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
-  import { routerMixin } from 'shared/mixins';
+  import { routerMixin, titleMixin } from 'shared/mixins';
 
   export default {
     name: 'AddPreviousStepsPage',
     components: {
       AddRelatedResourcesModal,
     },
-    mixins: [routerMixin],
+    mixins: [routerMixin, titleMixin],
     props: {
       targetNodeId: {
         type: String,
@@ -60,7 +60,7 @@
         let title = this.$tr('toolbarTitle');
         const node = this.$store.getters['contentNode/getContentNode'](this.targetNodeId);
         if (node) {
-          title = title + ` - ${node.title}`;
+          title = title + ` - ${this.getTitle(node)}`;
         }
         this.updateTabTitle(this.$store.getters.appendChannelName(title));
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
@@ -12,20 +12,24 @@
 <script>
 
   import { mapActions } from 'vuex';
-
   import { RouterNames, TabNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
+  import { routerMixin } from 'shared/mixins';
 
   export default {
     name: 'AddPreviousStepsPage',
     components: {
       AddRelatedResourcesModal,
     },
+    mixins: [routerMixin],
     props: {
       targetNodeId: {
         type: String,
         required: true,
       },
+    },
+    mounted() {
+      this.updateTitleForPage();
     },
     methods: {
       ...mapActions('contentNode', ['addPreviousStepToNode']),
@@ -51,6 +55,14 @@
             tab: TabNames.RELATED,
           },
         });
+      },
+      updateTitleForPage() {
+        let title = this.$tr('toolbarTitle');
+        const node = this.$store.getters['contentNode/getContentNode'](this.targetNodeId);
+        if (node) {
+          title = title + ` - ${node.title}`;
+        }
+        this.updateTabTitle(this.$store.getters.appendChannelName(title));
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -19,6 +19,7 @@ const ROOT_ID = 'channel-root-tree';
 const GETTERS = {
   global: {
     isCompactViewMode: jest.fn(),
+    appendChannelName: () => () => jest.fn(),
   },
   currentChannel: {
     rootId: () => ROOT_ID,

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -271,7 +271,7 @@
   import ResourceDrawer from '../../components/ResourceDrawer';
   import Diff from './Diff';
   import DiffTable from './DiffTable';
-  import { fileSizeMixin, titleMixin } from 'shared/mixins';
+  import { fileSizeMixin, titleMixin, routerMixin } from 'shared/mixins';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import BottomBar from 'shared/views/BottomBar';
   import Breadcrumbs from 'shared/views/Breadcrumbs';
@@ -299,7 +299,7 @@
       MainNavigationDrawer,
       OfflineText,
     },
-    mixins: [fileSizeMixin, titleMixin],
+    mixins: [fileSizeMixin, titleMixin, routerMixin],
     props: {
       nodeId: {
         type: String,
@@ -439,6 +439,9 @@
         .catch(error => {
           throw new Error(error);
         });
+    },
+    mounted() {
+      this.updateTabTitle(this.$store.getters.appendChannelName(this.$tr('deployChannel')));
     },
     methods: {
       ...mapActions(['showSnackbar', 'addViewModeOverride', 'removeViewModeOverride']),

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -78,6 +78,7 @@
   import sumBy from 'lodash/sumBy';
   import { RouterNames } from '../../constants';
   import ResourceDrawer from '../../components/ResourceDrawer';
+  import { routerMixin } from 'shared/mixins';
   import FullscreenModal from 'shared/views/FullscreenModal';
 
   const IMPORT_ROUTES = [
@@ -101,6 +102,7 @@
   export default {
     name: 'ImportFromChannelsModal',
     components: { FullscreenModal, ResourceDrawer },
+    mixins: [routerMixin],
     data() {
       return {
         previewNode: null,
@@ -170,6 +172,9 @@
       this.$store.dispatch('clearSnackbar');
       next();
     },
+    mounted() {
+      this.updateTitleForPage();
+    },
     methods: {
       ...mapActions('contentNode', ['copyContentNodes']),
       ...mapMutations('importFromChannels', {
@@ -218,6 +223,17 @@
       // it prevents the close button from getting clicked on the route change
       goBackToBrowse() {
         this.$router.push(this.backToBrowseRoute);
+      },
+      updateTitleForPage() {
+        // NOTE: Tab title for ReviewSelectionPage is handled in that component
+        if (
+          [
+            RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+            RouterNames.IMPORT_FROM_CHANNELS_SEARCH,
+          ].includes(this.$route.name)
+        ) {
+          this.updateTabTitle(this.$store.getters.appendChannelName(this.$tr('importTitle')));
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
@@ -53,7 +53,7 @@
   import ImportFromChannelsModal from './ImportFromChannelsModal';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
-  import { titleMixin } from 'shared/mixins';
+  import { titleMixin, routerMixin } from 'shared/mixins';
 
   export default {
     name: 'ReviewSelectionsPage',
@@ -61,9 +61,12 @@
       ContentNodeIcon,
       ImportFromChannelsModal,
     },
-    mixins: [titleMixin],
+    mixins: [titleMixin, routerMixin],
     computed: {
       ...mapState('importFromChannels', ['selected']),
+    },
+    mounted() {
+      this.updateTitleForPage();
     },
     methods: {
       ...mapMutations('importFromChannels', { deselectNode: 'DESELECT_NODE' }),
@@ -75,6 +78,11 @@
           return undefined;
         }
         return node.resource_count;
+      },
+      updateTitleForPage() {
+        this.updateTabTitle(
+          this.$store.getters.appendChannelName(this.$tr('reviewSelectionHeader'))
+        );
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -135,7 +135,7 @@
   import MessageDialog from 'shared/views/MessageDialog';
   import LoadingText from 'shared/views/LoadingText';
   import FullscreenModal from 'shared/views/FullscreenModal';
-  import { titleMixin } from 'shared/mixins';
+  import { titleMixin, routerMixin } from 'shared/mixins';
 
   export default {
     name: 'TrashModal',
@@ -148,7 +148,7 @@
       FullscreenModal,
       MoveModal,
     },
-    mixins: [titleMixin],
+    mixins: [titleMixin, routerMixin],
     props: {
       nodeId: {
         type: String,
@@ -217,6 +217,9 @@
         this.loading = false;
         return;
       }
+      this.updateTabTitle(
+        this.$store.getters.appendChannelNameToString(this.$tr('trashModalTitle'))
+      );
       this.loadChildren({ parent: this.trashId }).then(() => {
         this.loading = false;
       });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -217,9 +217,7 @@
         this.loading = false;
         return;
       }
-      this.updateTabTitle(
-        this.$store.getters.appendChannelNameToString(this.$tr('trashModalTitle'))
-      );
+      this.updateTabTitle(this.$store.getters.appendChannelName(this.$tr('trashModalTitle')));
       this.loadChildren({ parent: this.trashId }).then(() => {
         this.loading = false;
       });

--- a/contentcuration/contentcuration/frontend/shared/views/errors/PageNotFoundError.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/PageNotFoundError.vue
@@ -20,17 +20,22 @@
 <script>
 
   import AppError from './AppError';
+  import { routerMixin } from 'shared/mixins';
 
   export default {
     name: 'PageNotFoundError',
     components: {
       AppError,
     },
+    mixins: [routerMixin],
     props: {
       backHomeLink: {
         type: Object,
         required: true,
       },
+    },
+    mounted() {
+      this.updateTabTitle(this.$store.getters.appendChannelName(this.$tr('pageNotFoundHeader')));
     },
     $trs: {
       pageNotFoundHeader: 'Page not found',


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Adds tab titles to all pages in the Channel Edit SPA. Tries to follow this pattern

`Page/Node Title - Channel Name - Kolibri Studio`.

#### Issue Addressed (if applicable)

Fixes #2537 

#### Before/After Screenshots (if applicable)



## Steps to Test

Visit all the pages in Channel Edit SPA, the title should update with an informative message

