### PR TITLE
Multiple changes in node details calculation

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1,6 +1,5 @@
 from future import standard_library
 standard_library.install_aliases()
-from builtins import zip
 from builtins import filter
 from builtins import str
 from builtins import range
@@ -38,6 +37,7 @@ from django.db.models import Q
 from django.db.models import Sum
 from django.db.models import Subquery
 from django.db.models import Value
+from django.db.models.expressions import RawSQL
 from django.db.models.query_utils import DeferredAttribute
 from django.dispatch import receiver
 from django.utils import timezone
@@ -64,6 +64,10 @@ from contentcuration.db.models.manager import CustomContentNodeTreeManager
 from contentcuration.statistics import record_channel_stats
 from contentcuration.utils.cache import delete_public_channel_cache_keys
 from contentcuration.utils.parser import load_json_string
+from contentcuration.viewsets.common import SQArrayAgg
+from contentcuration.viewsets.common import SQCount
+from contentcuration.viewsets.common import SQRelatedArrayAgg
+from contentcuration.viewsets.common import SQSum
 
 
 EDIT_ACCESS = "edit"
@@ -1381,102 +1385,227 @@ class ContentNode(MPTTModel, models.Model):
         else:
             return cls.objects.filter(title=title)
 
-    def get_details(self):
+    def get_details(self, channel_id=None):
         """
         Returns information about the node and its children, including total size, languages, files, etc.
 
         :return: A dictionary with detailed statistics and information about the node.
         """
-        descendants = self.get_descendants().prefetch_related('children', 'files', 'tags') \
-            .select_related('license', 'language')
-        channel = self.get_channel()
+        node = ContentNode.objects.filter(pk=self.id).order_by()
+
+        descendants = (
+            self.get_descendants()
+            .prefetch_related("children", "files", "tags")
+            .select_related("license", "language")
+            .values("id")
+        )
+
+        if channel_id:
+            channel = Channel.objects.filter(id=channel_id)[0]
+        else:
+            channel = self.get_channel()
 
         # Get resources
         resources = descendants.exclude(kind=content_kinds.TOPIC)
+        nodes = With(
+            File.objects.filter(contentnode_id__in=Subquery(resources.values("id")))
+            .values("checksum", "file_size")
+            .order_by(),
+            name="nodes",
+        )
+        file_query = (
+            nodes.queryset().with_cte(nodes).values("checksum", "file_size").distinct()
+        )
+        l_nodes = With(
+            File.objects.filter(contentnode_id__in=Subquery(resources.values("id")))
+            .values("language_id", "preset_id")
+            .order_by(),
+            name="l_nodes",
+        )
+        accessible_languages_query = (
+            l_nodes.queryset()
+            .filter(preset_id=format_presets.VIDEO_SUBTITLE)
+            .with_cte(l_nodes)
+            .values("language__native_name")
+            .distinct()
+        )
+        tags_query = str(
+            ContentTag.objects.filter(
+                tagged_content__pk__in=descendants.values_list("pk", flat=True)
+            )
+            .values("tag_name")
+            .annotate(count=Count("tag_name"))
+            .query
+        ).replace("topic", "'topic'")
+        kind_count_query = str(
+            resources.values("kind_id").annotate(count=Count("kind_id")).query
+        ).replace("topic", "'topic'")
 
-        # Get all copyright holders, authors, aggregators, and providers and split into lists
-        creators = resources.values_list('copyright_holder', 'author', 'aggregator', 'provider')
-        split_lst = list(zip(*creators))
-        copyright_holders = list(filter(bool, set(split_lst[0]))) if len(split_lst) > 0 else []
-        authors = list(filter(bool, set(split_lst[1]))) if len(split_lst) > 1 else []
-        aggregators = list(filter(bool, set(split_lst[2]))) if len(split_lst) > 2 else []
-        providers = list(filter(bool, set(split_lst[3]))) if len(split_lst) > 3 else []
+        node = node.annotate(
+            resource_count=SQCount(resources, field="id"),
+            resource_size=SQSum(file_query, field="file_size"),
+            copyright_holders=SQArrayAgg(
+                resources.distinct("copyright_holder").order_by("copyright_holder"),
+                field="copyright_holder",
+            ),
+            authors=SQArrayAgg(
+                resources.distinct("author").order_by("author"), field="author"
+            ),
+            aggregators=SQArrayAgg(
+                resources.distinct("aggregator").order_by("aggregator"),
+                field="aggregator",
+            ),
+            providers=SQArrayAgg(
+                resources.distinct("provider").order_by("provider"), field="provider"
+            ),
+            languages=SQRelatedArrayAgg(
+                descendants.exclude(language=None)
+                .distinct("language__native_name")
+                .order_by(),
+                field="language__native_name",
+                fieldname="native_name",
+            ),
+            accessible_languages=SQRelatedArrayAgg(
+                accessible_languages_query,
+                field="language__native_name",
+                fieldname="native_name",
+            ),
+            licenses=SQRelatedArrayAgg(
+                resources.exclude(license=None)
+                .distinct("license__license_name")
+                .order_by("license__license_name"),
+                field="license__license_name",
+                fieldname="license_name",
+            ),
+            kind_count=RawSQL(
+                "SELECT json_agg(row_to_json (x)) FROM ({}) as x".format(
+                    kind_count_query
+                ),
+                (),
+            ),
+            tags_list=RawSQL(
+                "SELECT json_agg(row_to_json (x)) FROM ({}) as x".format(tags_query), ()
+            ),
+            coach_content=SQCount(
+                resources.filter(role_visibility=roles.COACH), field="id"
+            ),
+            exercises=SQCount(
+                resources.filter(kind_id=content_kinds.EXERCISE), field="id"
+            ),
+        )
 
         # Get sample pathway by getting longest path
         # Using resources.aggregate adds a lot of time, use values that have already been fetched
-        max_level = max(resources.values_list('level', flat=True).distinct() or [0])
-        deepest_node = resources.filter(level=max_level).first()
-        pathway = list(deepest_node.get_ancestors()
-                       .exclude(parent=None)
-                       .values('title', 'node_id', 'kind_id')
-                       ) if deepest_node else []
-        sample_nodes = [
-            {
-                "node_id": n.node_id,
-                "title": n.title,
-                "description": n.description,
-                "thumbnail": n.get_thumbnail(),
-                "kind": n.kind_id,
-            } for n in deepest_node.get_siblings(include_self=True)[0:4]
-        ] if deepest_node else []
+        max_level = max(
+            resources.values_list("level", flat=True).order_by().distinct() or [0]
+        )
+        m_nodes = With(
+            resources.values("id", "level", "tree_id", "lft").order_by(),
+            name="m_nodes",
+        )
+        depeest_node_record = (
+            m_nodes.queryset()
+            .with_cte(m_nodes)
+            .filter(level=max_level)
+            .values("id")
+            .order_by("tree_id", "lft")
+            .first()
+        )
+        if depeest_node_record:
+            deepest_node = ContentNode.objects.get(pk=depeest_node_record["id"])
+        pathway = (
+            list(
+                deepest_node.get_ancestors()
+                .order_by()
+                .exclude(parent=None)
+                .values("title", "node_id", "kind_id")
+                .order_by()
+            )
+            if depeest_node_record
+            else []
+        )
+        sample_nodes = (
+            [
+                {
+                    "node_id": n.node_id,
+                    "title": n.title,
+                    "description": n.description,
+                    "thumbnail": n.get_thumbnail(),
+                    "kind": n.kind_id,
+                }
+                for n in deepest_node.get_siblings(include_self=True)[0:4]
+            ]
+            if depeest_node_record
+            else []
+        )
 
         # Get list of channels nodes were originally imported from (omitting the current channel)
         channel_id = channel and channel.id
-        originals = resources.values("original_channel_id") \
-            .annotate(count=Count("original_channel_id")) \
+        originals = (
+            resources.values("original_channel_id")
+            .annotate(count=Count("original_channel_id"))
             .order_by("original_channel_id")
-        originals = {c['original_channel_id']: c['count'] for c in originals}
-        original_channels = Channel.objects.exclude(pk=channel_id) \
+        )
+        originals = {c["original_channel_id"]: c["count"] for c in originals}
+        original_channels = (
+            Channel.objects.exclude(pk=channel_id)
             .filter(pk__in=[k for k, v in list(originals.items())], deleted=False)
-        original_channels = [{
-            "id": c.id,
-            "name": "{}{}".format(c.name, _(" (Original)") if channel_id == c.id else ""),
-            "thumbnail": c.get_thumbnail(),
-            "count": originals[c.id]
-        } for c in original_channels]
+            .order_by()
+        )
+        original_channels = [
+            {
+                "id": c.id,
+                "name": "{}{}".format(
+                    c.name, _(" (Original)") if channel_id == c.id else ""
+                ),
+                "thumbnail": c.get_thumbnail(),
+                "count": originals[c.id],
+            }
+            for c in original_channels
+        ]
 
-        # Get tags from channel
-        tags = list(ContentTag.objects.filter(tagged_content__pk__in=descendants.values_list('pk', flat=True))
-                    .values('tag_name')
-                    .annotate(count=Count('tag_name'))
-                    .order_by('tag_name'))
-
-        # Get resource variables
-        resource_count = resources.count() or 0
-        resource_size = resources.values('files__checksum', 'files__file_size').distinct().aggregate(
-            resource_size=Sum('files__file_size'))['resource_size'] or 0
-
-        languages = list(set(descendants.exclude(language=None).values_list('language__native_name', flat=True)))
-        accessible_languages = resources.filter(files__preset_id=format_presets.VIDEO_SUBTITLE) \
-            .values_list('files__language_id', flat=True)
-        accessible_languages = list(
-            Language.objects.filter(id__in=accessible_languages).distinct().values_list('native_name', flat=True))
-
-        licenses = list(set(resources.exclude(license=None).values_list('license__license_name', flat=True)))
-        kind_count = list(resources.values('kind_id').annotate(count=Count('kind_id')).order_by('kind_id'))
-
-        # Add "For Educators" booleans
+        node = (
+            node.order_by()
+            .values(
+                "id",
+                "resource_count",
+                "resource_size",
+                "copyright_holders",
+                "authors",
+                "aggregators",
+                "providers",
+                "languages",
+                "accessible_languages",
+                "coach_content",
+                "licenses",
+                "tags_list",
+                "kind_count",
+                "exercises",
+            )
+            .first()
+        )
         for_educators = {
-            "coach_content": resources.filter(role_visibility=roles.COACH).count(),
-            "exercises": resources.filter(kind_id=content_kinds.EXERCISE).count(),
+            "coach_content": node["coach_content"],
+            "exercises": node["exercises"],
         }
-
         # Serialize data
         data = {
-            "last_update": pytz.utc.localize(datetime.now()).strftime(settings.DATE_TIME_FORMAT),
+            "last_update": pytz.utc.localize(datetime.now()).strftime(
+                settings.DATE_TIME_FORMAT
+            ),
             "created": self.created.strftime(settings.DATE_TIME_FORMAT),
-            "resource_count": resource_count,
-            "resource_size": resource_size,
+            "resource_count": node.get("resource_count", 0),
+            "resource_size": node.get("resource_size", 0),
             "includes": for_educators,
-            "kind_count": kind_count,
-            "languages": languages,
-            "accessible_languages": accessible_languages,
-            "licenses": licenses,
-            "tags": tags,
-            "copyright_holders": copyright_holders,
-            "authors": authors,
-            "aggregators": aggregators,
-            "providers": providers,
+            "kind_count": node.get("kind_count", []),
+            "languages": node.get("languages", ""),
+            "accessible_languages": node.get("accessible_languages", ""),
+            "licenses": node.get("licenses", ""),
+            "tags": node.get("tags_list", []),
+            "copyright_holders": node["copyright_holders"],
+            "authors": node["authors"],
+            "aggregators": node["aggregators"],
+            "providers": node["providers"],
             "sample_pathway": pathway,
             "original_channels": original_channels,
             "sample_nodes": sample_nodes,

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -64,10 +64,6 @@ from contentcuration.db.models.manager import CustomContentNodeTreeManager
 from contentcuration.statistics import record_channel_stats
 from contentcuration.utils.cache import delete_public_channel_cache_keys
 from contentcuration.utils.parser import load_json_string
-from contentcuration.viewsets.common import SQArrayAgg
-from contentcuration.viewsets.common import SQCount
-from contentcuration.viewsets.common import SQRelatedArrayAgg
-from contentcuration.viewsets.common import SQSum
 
 
 EDIT_ACCESS = "edit"
@@ -1391,6 +1387,11 @@ class ContentNode(MPTTModel, models.Model):
 
         :return: A dictionary with detailed statistics and information about the node.
         """
+        from contentcuration.viewsets.common import SQArrayAgg
+        from contentcuration.viewsets.common import SQCount
+        from contentcuration.viewsets.common import SQRelatedArrayAgg
+        from contentcuration.viewsets.common import SQSum
+
         node = ContentNode.objects.filter(pk=self.id).order_by()
 
         descendants = (

--- a/contentcuration/contentcuration/views/nodes.py
+++ b/contentcuration/contentcuration/views/nodes.py
@@ -60,7 +60,7 @@ def get_channel_details(request, channel_id):
             request.user.can_view_node(node)
     except PermissionDenied:
         return HttpResponseNotFound("No topic found for {}".format(channel_id))
-    data = get_node_details_cached(node)
+    data = get_node_details_cached(node, channel_id=channel_id)
     return HttpResponse(json.dumps(data))
 
 
@@ -75,9 +75,8 @@ def get_node_details(request, node_id):
     return HttpResponse(json.dumps(data))
 
 
-def get_node_details_cached(node):
+def get_node_details_cached(node, channel_id=None):
     cached_data = cache.get("details_{}".format(node.node_id))
-
     if cached_data:
         descendants = (
             node.get_descendants()
@@ -105,4 +104,4 @@ def get_node_details_cached(node):
                 getnodedetails_task.apply_async((node.pk,))
         return json.loads(cached_data)
 
-    return node.get_details()
+    return node.get_details(channel_id=channel_id)

--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -93,6 +93,11 @@ class SQArrayAgg(AggregateSubquery):
     output_field = ArrayField(CharField())
 
 
+class SQRelatedArrayAgg(SQArrayAgg):
+    # For cases where fields are in a related table, for example language__native_name
+    template = "(SELECT ARRAY_AGG(%(fieldname)s::text) FROM (%(subquery)s) AS %(field)s__sum)"
+
+
 dot_path_regex = re.compile(r"^([^.]+)\.(.+)$")
 
 


### PR DESCRIPTION
## Description

Optimize the database queries to create an object with the channel details

#### Issue Addressed (if applicable)

Closes #2272 

#### Before/After Screenshots (if applicable)
_(Caching of channels details disabled in all cases)_

Before (after filtering the data catalog to see channels in Spanish and excluding KA):
![Old-without-KA-2021-01-03_19-26](https://user-images.githubusercontent.com/1008178/103522353-8c321080-4e7a-11eb-99d7-4a1dffc16695.png)

After (with the same channels):
![New-without-KA-2021-01-03_19-16](https://user-images.githubusercontent.com/1008178/103522419-a4099480-4e7a-11eb-8bae-dadda930cc4d.png)

Before, including KA: interrupted after waiting for more than 18 minutes
![Old_KA-2021-01-03_19-45](https://user-images.githubusercontent.com/1008178/103522469-b552a100-4e7a-11eb-9d6c-c6e72455251e.png)
After including KA:
![New-with-KA-2021-01-03_19-16](https://user-images.githubusercontent.com/1008178/103522494-be437280-4e7a-11eb-96dd-ba0a02669150.png)



#### At a high level, how did you implement this?

- Modify the function parameters to include available information (channel id) instead of calculating it again 
- Modifying and optimizing every query used to fetch the tree node data
  - using cte when it improves the times
  - inserting all what is possible in annotations to reduce the number of queries. 
  - sorting is removed whenever it's possible
  - retrieved fileds are reduced to be only those that are used in the code.


## Steps to Test

Open the content library, filter by Spanish language, click on the "￼Download a summary of selected channels" link and donwload the csv file.


## Implementation Notes (optional)

In #2272 there are comments about the need to reduce the number of requests to donwload the csv or pdf file. However, looking at the above screenshots it's clear the bottleneck is in the calculation of the data for the channel. Calculation of channel properties involving the contentcuration_file table are taken most of the time needed in this task, as it's a O(2<sup>n</sup>)  calculation.
With small channels the time reduction with this PR is between 20% and 50% , with channels as KA we pass from a situation where it just didn't work to have it in about 2 minutes.

In the case where channels details are cached and its calculation is not needed, reducing the number of requests will clearly improve the performance of this task in 3 or 4 seconds, but when calculations are needed, having multiple threads in the server will have a positive impact, so I think it's not worth to do the change to request several channels at once.

Also, if we can get rid of the random resources shown in the channel info when a pdf is required, calculating all the data in a single query is possible. That would allow also, calculating multiple channels details in one single query. So, how important is to show those samples with screenshots in the pdf, taking into account that they are not used when downloading the information in a csv format?

Finally, in every code part where we have to deal with the File model we have performance problems (size calculations mainly but also,as in this case, fetching languages for subtitles). I think we should consider seriouly removing this huuuge table and inserting its information as a jsonb data in the Node model.