### PR TITLE
Fixed menu and thumbnail icon alignment

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemToolbar.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemToolbar.vue
@@ -28,10 +28,7 @@
       v-if="displayMenu"
       class="toolbar-item"
     >
-      <VMenu
-        bottom
-        left
-      >
+      <Menu bottom>
         <template slot="activator" slot-scope="{ on }">
           <VBtn
             icon
@@ -54,7 +51,7 @@
             <VListTileTitle>{{ config[action].label }}</VListTileTitle>
           </VListTile>
         </VList>
-      </VMenu>
+      </Menu>
     </VFlex>
   </VLayout>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -73,7 +73,7 @@
                   </template>
 
                   <VListTileAction class="action-col option-col" :aria-hidden="!hover">
-                    <VMenu offset-y left>
+                    <Menu>
                       <template #activator="{ on }">
                         <VBtn
                           small
@@ -88,7 +88,7 @@
                       </template>
 
                       <ContentNodeOptions :nodeId="nodeId" :ancestorId="ancestorId" />
-                    </VMenu>
+                    </Menu>
                   </VListTileAction>
                 </VListTile>
               </DraggableHandle>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
@@ -1,12 +1,12 @@
 <template>
 
-  <VMenu v-model="value" :position-x="positionX" :position-y="positionY" absolute offset-y>
+  <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute>
     <VCard>
       <slot>
         <ContentNodeOptions :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />
       </slot>
     </VCard>
-  </VMenu>
+  </Menu>
 
 </template>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -48,7 +48,7 @@
 
         <template #actions-end>
           <VListTileAction :aria-hidden="!active" class="action-icon px-1">
-            <VMenu v-model="activated" offset-y left>
+            <Menu v-model="activated">
               <template #activator="{ on }">
                 <IconButton
                   icon="optionsVertical"
@@ -60,7 +60,7 @@
                 />
               </template>
               <ContentNodeOptions v-if="!copying" :nodeId="nodeId" />
-            </VMenu>
+            </Menu>
           </VListTileAction>
         </template>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -113,7 +113,6 @@
                       :aria-hidden="hover"
                       data-test="btn-chevron"
                       icon="chevronRight"
-                      rtl-flip
                       :text="$tr('openTopic')"
                       size="small"
                       @click="$emit('topicChevronClick')"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -120,10 +120,8 @@
                         size="15"
                         width="2"
                       />
-                      <VMenu
+                      <Menu
                         v-else
-                        offset-y
-                        right
                         data-test="editMenu"
                       >
                         <template #activator="{ on }">
@@ -135,7 +133,7 @@
                           />
                         </template>
                         <ContentNodeOptions :nodeId="nodeId" />
-                      </VMenu>
+                      </Menu>
                     </VFlex>
                     <ContentNodeContextMenu
                       v-if="allowEditing && !copying"

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -111,7 +111,7 @@
                   <template v-if="isTopic(child)" #actions-end>
                     <VListTileAction>
                       <IconButton
-                        color="primary"
+                        :color="$themeTokens.primary"
                         icon="info"
                         :text="$tr('viewDetails')"
                         data-test="btn-info"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -11,7 +11,7 @@
             <VFlex class="font-weight-bold text-truncate" shrink :class="getTitleClass(item)">
               {{ getTitle(item) }}
             </VFlex>
-            <VMenu v-if="item.displayNodeOptions" offset-y right>
+            <Menu v-if="item.displayNodeOptions">
               <template #activator="{ on }">
                 <IconButton
                   icon="dropdown"
@@ -20,7 +20,7 @@
                 />
               </template>
               <ContentNodeOptions v-if="node" :nodeId="topicId" />
-            </VMenu>
+            </Menu>
           </VLayout>
           <span v-else class="grey--text" :class="getTitleClass(item)">
             {{ getTitle(item) }}
@@ -87,7 +87,7 @@
       </VFadeTransition>
 
       <VToolbarItems>
-        <VMenu offset-y left class="pa-1">
+        <Menu class="pa-1">
           <template #activator="{ on }">
             <IconButton
               icon="list"
@@ -105,9 +105,9 @@
               <VListTileTitle>{{ $tr(mode) }}</VListTileTitle>
             </VListTile>
           </VList>
-        </VMenu>
+        </Menu>
 
-        <VMenu v-if="canEdit" offset-y>
+        <Menu v-if="canEdit">
           <template #activator="{ on }">
             <VBtn color="primary" class="ml-2" style="height: 32px;" v-on="on">
               {{ $tr('addButton') }}
@@ -130,7 +130,7 @@
               <VListTileTitle>{{ $tr('importFromChannels') }}</VListTileTitle>
             </VListTile>
           </VList>
-        </VMenu>
+        </Menu>
       </VToolbarItems>
     </ToolBar>
 
@@ -177,7 +177,7 @@
             :text="$tr('editButton')"
             @click="editNodes([detailNodeId])"
           />
-          <VMenu offset-y left>
+          <Menu>
             <template #activator="{ on }">
               <IconButton
                 size="small"
@@ -192,7 +192,7 @@
               hideEditLink
               @removed="closePanel"
             />
-          </VMenu>
+          </Menu>
         </template>
         <template v-else #actions>
           <IconButton

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -73,13 +73,13 @@
 
     <!-- Created after -->
     <!-- Box styling throws menu alignment off, so nudge accordingly -->
-    <VMenu
+    <Menu
       v-model="showDatePicker"
       :close-on-content-click="false"
-      offset-y
       full-width
       :nudge-bottom="4"
-      :nudge-left="12"
+      :nudge-left="$isRtl ? 0 : 12"
+      :nudge-right="$isRtl ? 12 : 0"
     >
       <template #activator="{ on }">
         <VTextField
@@ -102,7 +102,7 @@
         min="2017-01-01"
         @input="showDatePicker = false"
       />
-    </VMenu>
+    </Menu>
   </VNavigationDrawer>
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -80,7 +80,7 @@
         </span>
       </template>
       <VToolbarItems>
-        <VMenu v-if="showChannelMenu" offset-y>
+        <Menu v-if="showChannelMenu">
           <template #activator="{ on }">
             <VBtn flat icon v-on="on">
               <Icon>more_horiz</Icon>
@@ -131,7 +131,7 @@
               </VListTileTitle>
             </VListTile>
           </VList>
-        </VMenu>
+        </Menu>
       </VToolbarItems>
       <template #extension>
         <slot name="extension"></slot>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -39,8 +39,10 @@
         class="tree-drawer"
         :maxWidth="drawer.maxWidth"
         :minWidth="200"
-        style="z-index: 4;"
-        :style="{ backgroundColor: $vuetify.theme.backgroundColor }"
+        :style="{
+          backgroundColor: $vuetify.theme.backgroundColor,
+          zIndex: hideHierarchyDrawer? 8 : 4,
+        }"
         :app="hasTopics"
         :hide-overlay="drawer.hideOverlay"
         @scroll="onHierarchyScroll"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -41,7 +41,7 @@
         :minWidth="200"
         :style="{
           backgroundColor: $vuetify.theme.backgroundColor,
-          zIndex: hideHierarchyDrawer? 8 : 4,
+          zIndex: hideHierarchyDrawer ? 8 : 4,
         }"
         :app="hasTopics"
         :hide-overlay="drawer.hideOverlay"

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -76,7 +76,7 @@
               <VBtn flat data-test="cancel" class="ma-0" @click="setSelection(false)">
                 {{ $tr('cancelButton') }}
               </VBtn>
-              <VMenu offset-y top>
+              <Menu top>
                 <template v-slot:activator="{ on }">
                   <VBtn color="primary" class="ma-0 mx-2" v-on="on">
                     {{ $tr('downloadButton') }}
@@ -93,7 +93,7 @@
                     <VListTileTitle>{{ $tr('downloadCSV') }}</VListTileTitle>
                   </VListTile>
                 </VList>
-              </VMenu>
+              </Menu>
             </VLayout>
           </VFlex>
         </VLayout>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -122,7 +122,7 @@
             @mouseenter.native="hideHighlight = true"
             @mouseleave.native="hideHighlight = false"
           />
-          <VMenu v-if="showOptions" offset-y>
+          <Menu v-if="showOptions">
             <template v-slot:activator="{ on }">
               <VBtn
                 icon
@@ -194,7 +194,7 @@
                 <VListTileTitle>{{ $tr('deleteChannel') }}</VListTileTitle>
               </VListTile>
             </VList>
-          </VMenu>
+          </Menu>
         </VFlex>
       </VLayout>
     </VCardActions>

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetItem.vue
@@ -13,7 +13,7 @@
       {{ $formatNumber(channelCount) }}
     </td>
     <td class="text-xs-right">
-      <VMenu offset-y>
+      <Menu>
         <template v-slot:activator="{ on }">
           <VBtn flat block v-on="on">
             {{ $tr('options') }}
@@ -34,7 +34,7 @@
             <VListTileTitle>{{ $tr('delete') }}</VListTileTitle>
           </VListTile>
         </VList>
-      </VMenu>
+      </Menu>
       <MessageDialog
         v-model="deleteDialog"
         :header="$tr('deleteChannelSetTitle')"

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -16,6 +16,7 @@ import './styles/vuetify.css';
 import 'shared/styles/main.less';
 import Base from 'shared/Base.vue';
 import ActionLink from 'shared/views/ActionLink';
+import Menu from 'shared/views/Menu';
 import { initializeDB, resetDB } from 'shared/data';
 import { CURRENT_USER } from 'shared/data/constants';
 import { Session } from 'shared/data/resources';
@@ -43,6 +44,7 @@ Vue.use(KThemePlugin);
 
 // Register global components
 Vue.component('ActionLink', ActionLink);
+Vue.component('Menu', Menu);
 
 function initiateServiceWorker() {
   // Second conditional must be removed if you are doing dev work on the service

--- a/contentcuration/contentcuration/frontend/shared/views/AppBar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/AppBar.vue
@@ -27,7 +27,7 @@
       <VSpacer />
       <VToolbarItems>
         <template v-if="loggedIn">
-          <VMenu offsetY>
+          <Menu>
             <template #activator="{ on }">
               <VBtn flat style="text-transform: none;" v-on="on">
                 <Icon>person</Icon>
@@ -72,7 +72,7 @@
                 <VListTileTitle v-text="$tr('logOut')" />
               </VListTile>
             </VList>
-          </VMenu>
+          </Menu>
         </template>
         <VBtn v-else href="/accounts" flat>
           {{ $tr('logIn') }}

--- a/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
@@ -13,7 +13,7 @@
     </template>
     <!-- Overflow menu -->
     <VBreadcrumbsItem v-if="breadcrumbStartingIndex > 0" tag="div">
-      <VMenu offset-y bottom>
+      <Menu bottom>
         <template #activator="{ on }">
           <VBtn icon flat class="ma-0" v-on="on">
             <Icon medium>
@@ -30,7 +30,7 @@
             </VListTile>
           </VList>
         </VCard>
-      </VMenu>
+      </Menu>
     </VBreadcrumbsItem>
 
     <!-- Visible breadcrumbs -->

--- a/contentcuration/contentcuration/frontend/shared/views/ContextMenu.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContextMenu.vue
@@ -11,11 +11,11 @@
       @contextmenu.prevent="showMenu"
     >
       <slot></slot>
-      <VMenu v-model="show" :position-x="x" :position-y="y" absolute offset-y>
+      <Menu v-model="show" :position-x="x" :position-y="y" absolute>
         <VCard>
           <slot name="menu"></slot>
         </VCard>
-      </VMenu>
+      </Menu>
     </div>
   </div>
 

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/MarkdownImageField.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/MarkdownImageField.vue
@@ -6,7 +6,7 @@
     v-mouse-move="resizeMouseMove"
     :class="[imgClass, draggingResizer ? 'dragging' : '', resizing ? 'resizing' : '']"
   >
-    <VMenu offset-y z-index="203" class="ignore-md">
+    <Menu z-index="203" class="ignore-md">
       <template #activator="{ on }">
         <VBtn
           v-show="!resizing && editing"
@@ -36,7 +36,7 @@
           <VListTileTitle>{{ $tr('removeImageOption') }}</VListTileTitle>
         </VListTile>
       </VList>
-    </VMenu>
+    </Menu>
     <img
       ref="image"
       :src="image.src"

--- a/contentcuration/contentcuration/frontend/shared/views/Menu.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Menu.vue
@@ -1,0 +1,32 @@
+<script>
+
+  import { VMenu } from 'vuetify/lib/components/VMenu';
+
+  export default {
+    name: 'Menu',
+    extends: VMenu,
+    props: {
+      left: {
+        type: Boolean,
+        default() {
+          return this.$isRTL;
+        },
+      },
+      right: {
+        type: Boolean,
+        default() {
+          return !this.$isRTL;
+        },
+      },
+      offsetY: {
+        type: Boolean,
+        default: true,
+      },
+    },
+  };
+
+</script>
+
+<style lang="less" scoped>
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/Menu.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Menu.vue
@@ -6,6 +6,7 @@
     name: 'Menu',
     extends: VMenu,
     props: {
+      /* eslint-disable kolibri/vue-no-unused-properties */
       left: {
         type: Boolean,
         default() {
@@ -22,6 +23,7 @@
         type: Boolean,
         default: true,
       },
+      /* eslint-enable kolibri/vue-no-unused-properties */
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/views/ResizableNavigationDrawer.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ResizableNavigationDrawer.vue
@@ -104,7 +104,7 @@
     methods: {
       // @public
       getWidth() {
-        return `${this.width}px`;
+        return this.width;
       },
       resize(e) {
         document.body.style.cursor = 'col-resize';

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelDetailsModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelDetailsModal.vue
@@ -11,7 +11,7 @@
     <VCardText v-else-if="channel">
       <VLayout class="mb-3">
         <VSpacer v-if="$vuetify.breakpoint.smAndUp" />
-        <VMenu offset-y>
+        <Menu>
           <template v-slot:activator="{ on }">
             <VBtn color="primary" dark :block="$vuetify.breakpoint.xsOnly" v-on="on">
               {{ $tr('downloadButton') }}
@@ -27,7 +27,7 @@
               <VListTileTitle>{{ $tr('downloadCSV') }}</VListTileTitle>
             </VListTile>
           </VList>
-        </VMenu>
+        </Menu>
       </VLayout>
       <Details
         v-if="channel && details"

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
@@ -28,7 +28,7 @@
             </em>
           </td>
           <td class="text-xs-right">
-            <VMenu v-if="item.id !== user.id && (item.pending || viewOnly)" offset-y>
+            <Menu v-if="item.id !== user.id && (item.pending || viewOnly)">
               <template v-slot:activator="{ on }">
                 <VBtn flat v-on="on">
                   {{ $tr('optionsDropdown') }}
@@ -64,7 +64,7 @@
                   </VListTile>
                 </template>
               </VList>
-            </VMenu>
+            </Menu>
           </td>
         </tr>
       </template>

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -225,6 +225,10 @@
       left: 21%;
       display: block;
       width: 55%;
+
+      [dir='rtl'] & {
+        left: -10px;
+      }
     }
 
     text {


### PR DESCRIPTION
Fixes https://github.com/learningequality/studio/issues/1836

As for the other items described in the issue:

- I was unable to reproduce the exercise answers overlapping, so I opened [an issue](https://github.com/learningequality/studio/issues/2706) so we can keep an eye on it
- I opened [a separate issue](https://github.com/learningequality/studio/issues/2705) for the pdf numbers as it seems like it might be tricky to resolve soon
- It looks like Firefox automatically localizes the numbers, so I'm not sure if there's anything we can do about it on Chrome. Opened [an issue](https://github.com/learningequality/studio/issues/2707) for it anyways just in case