### PR TITLE
Re add gcs key for signing

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -381,6 +381,12 @@ AWS_AUTO_CREATE_BUCKET = False
 AWS_S3_FILE_OVERWRITE = True
 AWS_S3_BUCKET_AUTH = False
 
+# the path to the service account json key to use for authentication to GCS. If not set,
+# defaults to what's inferred from the environment. See
+# https://cloud.google.com/docs/authentication/production
+# for how these credentials are inferred automatically.
+GCS_STORAGE_SERVICE_ACCOUNT_KEY_PATH = os.getenv("GOOGLE_CLOUD_STORAGE_SERVICE_ACCOUNT_CREDENTIALS")
+
 # GOOGLE DRIVE SETTINGS
 GOOGLE_AUTH_JSON = "credentials/client_secret.json"
 GOOGLE_STORAGE_REQUEST_SHEET = "16X6zcFK8FS5t5tFaGpnxbWnWTXP88h4ccpSpPbyLeA8"

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -9,6 +9,7 @@ STUDIO_BUCKET_NAME=$4
 COMMIT_SHA=$5
 PROJECT_ID=$6
 DATABASE_INSTANCE_NAME=$7
+DATABASE_REGION=$8
 
 K8S_DIR=$(dirname $0)
 
@@ -30,5 +31,9 @@ helm upgrade --install \
      --set cloudsql-proxy.credentials.username=$(get_secret postgres-username) \
      --set cloudsql-proxy.credentials.password=$(get_secret postgres-password) \
      --set cloudsql-proxy.credentials.dbname=$(get_secret postgres-dbname) \
+     --set cloudsql-proxy.cloudsql.instances[0].instance=$DATABASE_INSTANCE_NAME \
+     --set cloudsql-proxy.cloudsql.instances[0].project=$PROJECT_ID \
+     --set cloudsql-proxy.cloudsql.instances[0].region=$DATABASE_REGION \
+     --set cloudsql-proxy.cloudsql.instances[0].port=5432 \
      --set newRelic.licenseKey=$(get_secret newrelic-license-key) \
      $RELEASE_NAME $K8S_DIR

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -23,6 +23,7 @@ helm upgrade --install \
      --set studioApp.imageName=$STUDIO_APP_IMAGE_NAME \
      --set studioNginx.imageName=$STUDIO_NGINX_IMAGE_NAME \
      --set studioApp.gcs.bucketName=$STUDIO_BUCKET_NAME \
+     --set studioApp.gcs.signedUploadServiceAccountKey=$(get_secret studio-gcs-service-account-key) \
      --set settings=contentcuration.production_settings \
      --set sentry.dsnKey=$(get_secret sentry-dsn-key) \
      --set redis.password=$(get_secret redis-password) \

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 RELEASE_NAME=$1
 STUDIO_APP_IMAGE_NAME=$2
@@ -23,7 +23,7 @@ helm upgrade --install \
      --set studioApp.imageName=$STUDIO_APP_IMAGE_NAME \
      --set studioNginx.imageName=$STUDIO_NGINX_IMAGE_NAME \
      --set studioApp.gcs.bucketName=$STUDIO_BUCKET_NAME \
-     --set studioApp.gcs.signedUploadServiceAccountKey=$(get_secret studio-gcs-service-account-key) \
+     --set studioApp.gcs.signedUploadServiceAccountKeyBase64Encoded=$(get_secret studio-gcs-service-account-key | base64 -w 0) \
      --set settings=contentcuration.production_settings \
      --set sentry.dsnKey=$(get_secret sentry-dsn-key) \
      --set redis.password=$(get_secret redis-password) \

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -23,7 +23,7 @@ helm upgrade --install \
      --set studioApp.imageName=$STUDIO_APP_IMAGE_NAME \
      --set studioNginx.imageName=$STUDIO_NGINX_IMAGE_NAME \
      --set studioApp.gcs.bucketName=$STUDIO_BUCKET_NAME \
-     --set studioApp.gcs.signedUploadServiceAccountKeyBase64Encoded=$(get_secret studio-gcs-service-account-key | base64 -w 0) \
+     --set studioApp.gcs.writerServiceAccountKeyBase64Encoded=$(get_secret studio-gcs-service-account-key | base64 -w 0) \
      --set settings=contentcuration.production_settings \
      --set sentry.dsnKey=$(get_secret sentry-dsn-key) \
      --set redis.password=$(get_secret redis-password) \

--- a/k8s/helm-deploy.sh
+++ b/k8s/helm-deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xeuo pipefail
+set -euo pipefail
 
 RELEASE_NAME=$1
 STUDIO_APP_IMAGE_NAME=$2

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -68,6 +68,10 @@ spec:
             memory: 2Gi
           limits:
             memory: 2Gi
+        volumeMounts:
+          - mountPath: /var/secrets
+            name: gcs-upload-signing-key
+            readOnly: true
       - name: nginx-proxy
         image: {{ .Values.studioNginx.imageName }}
         env:
@@ -89,6 +93,12 @@ spec:
       volumes:
         - emptyDir: {}
           name: staticfiles
+        - name: gcs-upload-signing-key
+          secret:
+            secretName: {{ template "studio.fullname" . }}
+            items:
+            - key: gcs-signed-upload-service-account-key
+              path: gcs-signed-uploads.key.json
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -53,6 +53,8 @@ spec:
           value: "true"
         - name: DATA_DB_HOST
           value: {{ template "cloudsql-proxy.fullname" . }}
+        - name: GOOGLE_SIGNED_UPLOADS_SERVICE_ACCOUNT_CREDENTIALS
+          value: /var/secrets/gcs-signed-uploads.key.json
         ports:
         - containerPort: {{ .Values.studioApp.appPort }}
         readinessProbe:

--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -53,8 +53,8 @@ spec:
           value: "true"
         - name: DATA_DB_HOST
           value: {{ template "cloudsql-proxy.fullname" . }}
-        - name: GOOGLE_SIGNED_UPLOADS_SERVICE_ACCOUNT_CREDENTIALS
-          value: /var/secrets/gcs-signed-uploads.key.json
+        - name: GOOGLE_CLOUD_STORAGE_SERVICE_ACCOUNT_CREDENTIALS
+          value: /var/secrets/gcs-writer-service-account-key.json
         ports:
         - containerPort: {{ .Values.studioApp.appPort }}
         readinessProbe:
@@ -72,7 +72,7 @@ spec:
             memory: 2Gi
         volumeMounts:
           - mountPath: /var/secrets
-            name: gcs-upload-signing-key
+            name: gcs-writer-service-account-key
             readOnly: true
       - name: nginx-proxy
         image: {{ .Values.studioNginx.imageName }}
@@ -95,12 +95,12 @@ spec:
       volumes:
         - emptyDir: {}
           name: staticfiles
-        - name: gcs-upload-signing-key
+        - name: gcs-writer-service-account-key
           secret:
             secretName: {{ template "studio.fullname" . }}
             items:
-            - key: gcs-signed-upload-service-account-key
-              path: gcs-signed-uploads.key.json
+            - key: gcs-writer-service-account-key
+              path: gcs-writer-service-account-key.json
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -14,5 +14,5 @@ data:
   postgres-password: {{ index .Values "cloudsql-proxy" "credentials" "password" | b64enc }}
   postgres-database: {{ index .Values "cloudsql-proxy" "credentials" "dbname" | b64enc }}
   sentry-dsn-key: {{ .Values.sentry.dsnKey | b64enc }}
-  gcs-signed-upload-service-account-key: {{ .Values.studioApp.gcs.signedUploadServiceAccountKeyBase64Encoded }}
+  gcs-writer-service-account-key: {{ .Values.studioApp.gcs.writerServiceAccountKeyBase64Encoded }}
   newrelic-license-key: {{ .Values.newRelic.licenseKey | b64enc }}

--- a/k8s/templates/studio-secrets.yaml
+++ b/k8s/templates/studio-secrets.yaml
@@ -14,4 +14,5 @@ data:
   postgres-password: {{ index .Values "cloudsql-proxy" "credentials" "password" | b64enc }}
   postgres-database: {{ index .Values "cloudsql-proxy" "credentials" "dbname" | b64enc }}
   sentry-dsn-key: {{ .Values.sentry.dsnKey | b64enc }}
+  gcs-signed-upload-service-account-key: {{ .Values.studioApp.gcs.signedUploadServiceAccountKeyBase64Encoded }}
   newrelic-license-key: {{ .Values.newRelic.licenseKey | b64enc }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -20,6 +20,7 @@ studioApp:
   appPort: 8081
   gcs:
     bucketName: develop-studio-content
+    signedUploadServiceAccountKey: "REPLACEME"
   pgbouncer:
     replicas: 3
     pool_size: 10

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -20,7 +20,7 @@ studioApp:
   appPort: 8081
   gcs:
     bucketName: develop-studio-content
-    signedUploadServiceAccountKey: "REPLACEME"
+    signedUploadServiceAccountKeyBase64Encoded: "REPLACEME"
   pgbouncer:
     replicas: 3
     pool_size: 10

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -40,9 +40,9 @@ cloudsql-proxy:
   enabled: true
   cloudsql:
     instances:
-      - instance: "develop"
-        project: "contentworkshop-159920"
-        region: "us-central1"
+      - instance: "REPLACEME"
+        project: "REPLACEME"
+        region: "REPLACEME"
         port: 5432
   credentials:
     username: ""

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -20,7 +20,7 @@ studioApp:
   appPort: 8081
   gcs:
     bucketName: develop-studio-content
-    signedUploadServiceAccountKeyBase64Encoded: "REPLACEME"
+    writerServiceAccountKeyBase64Encoded: "REPLACEME"
   pgbouncer:
     replicas: 3
     pool_size: 10


### PR DESCRIPTION
This re-adds GCS keys to use for interacting with GCS. Fixes #2703.

Previously we depended on GCP's Application Default Credentials (ADC) to authenticate to GCP APIs. This is simpler for the majority of cases and makes administration simpler. However for signing we need access to an actual keyfile.

This adds a change where any GCS interaction reads from a keyfile specified by an env var, if defined. Falls back to ADC if the env var isn't defined.