### PR TITLE
add missing arg to helm-deploy.sh in cloudbuild.yaml

### DIFF
--- a/cloudbuild-production.yaml
+++ b/cloudbuild-production.yaml
@@ -81,6 +81,7 @@ steps:
       $COMMIT_SHA
       $PROJECT_ID
       $_DATABASE_INSTANCE_NAME
+      us-central1
 
 
 substitutions:


### PR DESCRIPTION
I forgot to add the new DB location arg for helm-deploy.sh in cloudbuild-production.yaml, so new deploys aren't working. This adds that back.