### PR TITLE
In "Import from channels" workflow, clear selections when exiting

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -106,6 +106,7 @@
     data() {
       return {
         previewNode: null,
+        showSnackbar: true,
       };
     },
     provide: {
@@ -165,7 +166,9 @@
     },
     watch: {
       selectedResourcesCount(newVal, oldVal) {
-        this.showResourcesSnackbar(newVal, oldVal);
+        if (this.showSnackbar) {
+          this.showResourcesSnackbar(newVal, oldVal);
+        }
       },
     },
     beforeRouteUpdate(to, from, next) {
@@ -211,6 +214,9 @@
           id__in: nodeIds,
           target: this.$route.params.destNodeId,
         }).then(() => {
+          // When exiting, do not show snackbar when clearing selections
+          this.showSnackbar = false;
+          this.$store.commit('importFromChannels/CLEAR_NODES');
           this.$router.push({
             name: RouterNames.TREE_VIEW,
             params: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -127,7 +127,7 @@
       if (to.name === RouterNames.TREE_VIEW) {
         this.$store.commit('importFromChannels/CLEAR_NODES');
       }
-      next()
+      next();
     },
     mounted() {
       this.searchTerm = this.$route.params.searchTerm || '';

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -134,7 +134,6 @@
       }),
       handleBackToBrowse() {
         this.$router.push(this.backToBrowseRoute);
-        this.clearNodes();
       },
       handleSearchTerm() {
         if (this.searchIsValid) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -122,6 +122,13 @@
         );
       },
     },
+    beforeRouteLeave(to, from, next) {
+      // Clear selections if going back to TreeView
+      if (to.name === RouterNames.TREE_VIEW) {
+        this.$store.commit('importFromChannels/CLEAR_NODES');
+      }
+      next()
+    },
     mounted() {
       this.searchTerm = this.$route.params.searchTerm || '';
     },


### PR DESCRIPTION
**Please remove any unused sections**

## Description

1. Fix issue where selections would be cleared when going from Search to Browse
2. Clear selections when going backwards from SearchOrBrowsePage to TreeView
3. Clear selections when going forward from ReviewSelectionsPage to TreeView

#### Issue Addressed (if applicable)

Fixes #2573

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are users' storage used being recalculated properly on any changes to their main tree files?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
