### PR TITLE
Copy task tweaks

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -149,6 +149,7 @@
 
 <script>
 
+  import { mapActions } from 'vuex';
   import ContentNodeValidator from '../ContentNodeValidator';
   import ContentNodeChangedIcon from '../ContentNodeChangedIcon';
   import TaskProgress from '../../views/progress/TaskProgress';
@@ -252,6 +253,7 @@
       copying(isCopying, wasCopying) {
         if (wasCopying && !isCopying) {
           this.highlight = true;
+          this.deleteTask({ task_id: this.taskId });
           setTimeout(() => {
             this.highlight = false;
           }, 2500);
@@ -259,6 +261,7 @@
       },
     },
     methods: {
+      ...mapActions('task', ['deleteTask']),
       handleTileClick(e) {
         // Ensures that clicking an icon button is not treated the same as clicking the card
         if (e.target.tagName !== 'svg' && !this.copying) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/TaskProgress.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/TaskProgress.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VProgressCircular
-    :indeterminate="!task"
+    :indeterminate="!task || !progress"
     :progress="progress"
     :color="progressBarColor"
     v-bind="$attrs"


### PR DESCRIPTION
## Description

* Deletes copying tasks when they are complete
* Doesn't show determinate loader until non-zero progress is registered

#### Issue Addressed (if applicable)

Fixes #2709

## Steps to Test

- Copy content
- Verify that the progress loader doesn't appear until after some progress has been achieved
- Verify that the task gets deleted after completion
