### PR TITLE
Reinstates move as an async task

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1455,6 +1455,14 @@ export const Clipboard = new Resource({
   },
 });
 
+function deleteMoveTasks(change) {
+  if (change.obj.status === 'SUCCESS' || change.obj.status === 'FAILED') {
+    if (change.obj.task_type === 'move-nodes') {
+      Task.delete(change.key);
+    }
+  }
+}
+
 export const Task = new Resource({
   tableName: TABLE_NAMES.TASK,
   urlName: 'task',
@@ -1467,6 +1475,7 @@ export const Task = new Resource({
           applyChanges(changes);
         }
       }
+      deleteMoveTasks(change);
     },
     [CHANGE_TYPES.UPDATED]: function(change) {
       if (change.mods.status === 'SUCCESS') {
@@ -1475,6 +1484,7 @@ export const Task = new Resource({
           applyChanges(changes);
         }
       }
+      deleteMoveTasks(change);
     },
   },
 });

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -84,7 +84,7 @@ def move_nodes_task(
                 if "deadlock detected" in e.args[0]:
                     pass
                 else:
-                    report_exception(e)
+                    raise
     except Exception as e:
         report_exception(e)
 


### PR DESCRIPTION
## Description

Long running sync operations and deadlocks seem to be occurring in a small number of situations, and seem to be self reinforcing.

To deal with this, move operations are put back into an async task, with some limited handling for error to revert the front end state.

#### Issue Addressed (if applicable)

Fixes #2739 
Fixes #2740


To test, move a node. Verify that it is moved and that the move persists after refresh. Further, confirm that the tasks returned from the tasks API does not contain a residual move task afterwards.