### PR TITLE
Pass appropriate options to move

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -75,7 +75,7 @@
       ...mapActions(['showSnackbar']),
       ...mapActions('clipboard', ['copy', 'deleteClipboardNode', 'moveClipboardNodes']),
       calculateMoveNodes() {
-        const trees = this.getMoveTrees(this.clipboardRootId);
+        const trees = this.getMoveTrees(this.nodeId, this.ancestorId, true);
 
         this.legacyTrees = trees.legacyTrees;
 


### PR DESCRIPTION
## Description

Fixes the clipboard item's context menu action for moving nodes. The action was not using the node's context for determining what nodes to move. In this scenario, we also want to ignore the current selection state, for which there was existing support for.

#### Issue Addressed (if applicable)

Resolves https://github.com/learningequality/studio/issues/2721

## Steps to Test

- [ ] *Add nodes to clipboard*
- [ ] *Use 3 dot menu to move them*
- [ ] *Complete move operation*
- [ ] *Verify moved nodes*

## Comments
There are a couple other unresolved issues I will look into:
- The move modal doesn't show accurate topic and resource amounts when moving from the clipboard
- The context menu is left open after move