### PR TITLE
Make sure we recalculate user storage on updates

### DIFF
--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -48,6 +48,13 @@ class FileSerializer(BulkModelSerializer):
         queryset=AssessmentItem.objects.all(), required=False
     )
 
+    def update(self, instance, validated_data):
+        from contentcuration.utils.user import calculate_user_storage
+        results = super(FileSerializer, self).update(instance, validated_data)
+        if instance.uploaded_by_id:
+            calculate_user_storage(instance.uploaded_by_id)
+        return results
+
     class Meta:
         model = File
         fields = (

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -13,6 +13,7 @@ from contentcuration.models import File
 from contentcuration.models import generate_object_storage_name
 from contentcuration.models import generate_storage_url
 from contentcuration.utils.storage_common import get_presigned_upload_url
+from contentcuration.utils.user import calculate_user_storage
 from contentcuration.viewsets.base import BulkDeleteMixin
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
@@ -49,7 +50,6 @@ class FileSerializer(BulkModelSerializer):
     )
 
     def update(self, instance, validated_data):
-        from contentcuration.utils.user import calculate_user_storage
         results = super(FileSerializer, self).update(instance, validated_data)
         if instance.uploaded_by_id:
             calculate_user_storage(instance.uploaded_by_id)


### PR DESCRIPTION
When I upload new files, it isn't updating the user storage because the serializer update code doesn't call the File.save() method. This just calculates on the update function