### PR TITLE
Run sync before publishing a channel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/publish/PublishModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/publish/PublishModal.vue
@@ -101,6 +101,7 @@
   import Languages from 'shared/leUtils/Languages';
   import { fileSizeMixin } from 'shared/mixins';
   import HelpTooltip from 'shared/views/HelpTooltip';
+  import { forceServerSync } from 'shared/data/serverSync';
 
   export default {
     name: 'PublishModal',
@@ -123,6 +124,7 @@
       };
     },
     computed: {
+      ...mapGetters(['areAllChangesSaved']),
       ...mapGetters('currentChannel', ['currentChannel', 'rootId']),
       ...mapGetters('contentNode', ['getContentNode']),
       dialog: {
@@ -162,8 +164,12 @@
         this.publishDescription = '';
         this.dialog = false;
       },
-      handlePublish() {
+      async handlePublish() {
         if (this.$refs.form.validate()) {
+          if (!this.areAllChangesSaved) {
+            await forceServerSync();
+          }
+
           this.publishChannel(this.publishDescription).then(this.close);
         }
       },

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -21,7 +21,6 @@ import Menu from 'shared/views/Menu';
 import { initializeDB, resetDB } from 'shared/data';
 import { CURRENT_USER } from 'shared/data/constants';
 import { Session } from 'shared/data/resources';
-import { forceServerSync } from 'shared/data/serverSync';
 
 // just say yes to devtools (in debug mode)
 if (process.env.NODE_ENV !== 'production') {
@@ -134,7 +133,6 @@ export default async function startApp({ store, router, index }) {
     const areAllChangesSaved = store.getters['areAllChangesSaved'];
 
     if (!logoutConfirmed && !areAllChangesSaved) {
-      forceServerSync();
       e.preventDefault();
       e.returnValue = '';
     }


### PR DESCRIPTION
## Description

1. Run sync before publishing a channel to ensure that all updates are included
2. One follow-up commit to address[ this comment from a previous sync PR](https://github.com/learningequality/studio/pull/2699#discussion_r555926270)

#### Issue Addressed (if applicable)

Closes #2536

## Steps to Test

- [ ] *Increase [`SYNC_IF_NO_CHANGES_FOR`](https://github.com/learningequality/studio/blob/develop/contentcuration/contentcuration/frontend/shared/data/serverSync.js#L26), for example to 20 seconds, so that you can test it comfortably*
- [ ] *Make a change in a channel that you can edit (add a new topic, exercise)*
- [ ] *Publish the channel*
- [ ] *Make sure that `/sync` request has been triggered before the publish request*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are users' storage used being recalculated properly on any changes to their main tree files?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
