### PR TITLE
Explicitly set complete on trash tree

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -873,6 +873,7 @@ class Channel(models.Model):
                 kind_id=content_kinds.TOPIC,
                 content_id=self.id,
                 node_id=self.id,
+                complete=True,
             )
 
         # if this change affects the public channel list, clear the channel cache

--- a/contentcuration/contentcuration/viewsets/clipboard.py
+++ b/contentcuration/contentcuration/viewsets/clipboard.py
@@ -80,6 +80,7 @@ class ClipboardSerializer(BulkModelSerializer):
             )
         except ContentNode.DoesNotExist:
             raise ValidationError("ContentNode does not exist")
+        validated_data["complete"] = True
         return super(ClipboardSerializer, self).create(validated_data)
 
     def update(self, instance, validated_data):


### PR DESCRIPTION
## Description

Sets complete explicitly on trash tree otherwise complains that nullable boolean cannot be null.

#### Issue Addressed (if applicable)

Fixes #2754
