### PR TITLE
Tweaks to the helm deployment

### DIFF
--- a/k8s/templates/studio-deployment.yaml
+++ b/k8s/templates/studio-deployment.yaml
@@ -146,3 +146,12 @@ spec:
           limits:
             cpu: 2
             memory: 8Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: full-gcp-access-scope
+                operator: In
+                values:
+                - "true"

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -17,6 +17,7 @@ studioApp:
   imageName: "REPLACEME"
   postmarkApiKey: "REPLACEME"
   releaseCommit: ""
+  replicas: 5
   appPort: 8081
   gcs:
     bucketName: develop-studio-content


### PR DESCRIPTION
- Ensure we have 5 replicas. A temporary hack to make sure every new deployment doesn't scale down the number of replicas to 1. Later one we should convince helm instead to not scale down the number of replicas when set manually.
- Add in NodeAffinity to workers that ensures they run on nodes that have full GCP access scope. Otherwise they can't access GCS.