### PR TITLE
Make node deletion an async task.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1481,6 +1481,14 @@ function deleteMoveTasks(change) {
   }
 }
 
+function deleteDeleteNodeTasks(change) {
+  if (change.obj.status === 'SUCCESS' || change.obj.status === 'FAILED') {
+    if (change.obj.task_type === 'delete-node') {
+      Task.delete(change.key);
+    }
+  }
+}
+
 export const Task = new Resource({
   tableName: TABLE_NAMES.TASK,
   urlName: 'task',
@@ -1494,6 +1502,7 @@ export const Task = new Resource({
         }
       }
       deleteMoveTasks(change);
+      deleteDeleteNodeTasks(change);
     },
     [CHANGE_TYPES.UPDATED]: function(change) {
       if (change.mods.status === 'SUCCESS') {
@@ -1503,6 +1512,7 @@ export const Task = new Resource({
         }
       }
       deleteMoveTasks(change);
+      deleteDeleteNodeTasks(change);
     },
   },
 });


### PR DESCRIPTION
## Description

Makes node deletion an async task


To Test:

* Move a node to trash
* Permanently delete the node from trash
* Verify that the node stays deleted after refresh
* Verify that no task remains in the task endpoint query once the deletion is complete