### PR TITLE
Adding dots between languages on sign-in page

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -164,7 +164,7 @@
   }
 
   .links span:not(:last-child)::after {
-    margin: 0 8px;
+    margin: 0 8px 0 12px;
     font-size: 14pt;
     color: var(--v-grey-base);
     vertical-align: middle;

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
@@ -10,8 +10,8 @@
         @click="showLanguageModal = true"
       />
       <span
-        class="selected"
-        :style="{ 'margin': '0 8px 0 12px' }"
+        class="linksSpan selected"
+        :style="{ 'margin': '0' }"
         :title="selectedLanguage.english_name"
       >
         {{ selectedLanguage.lang_name }}
@@ -24,6 +24,7 @@
         class="lang"
         :class="language.lang_direction ? 'linksRtl' : 'links'"
         appearance="basic-link"
+        :style="{ 'margin': '0 2px' }"
         @click="switchLanguage(language.id)"
       />
       <KButton
@@ -129,11 +130,20 @@
     text-align: left;
   }
 
-  .links:not(:last-child)::after,
-  span::after {
+  .links:not(:last-child)::after {
     // because it is a pseudo-element, text-decoration only works with 'display: inline-block`
     display: inline-block;
-    margin: 0 8px 0 20px;
+    margin: 0 8px 0 12px;
+    font-size: 14pt;
+    color: var(--v-grey-base);
+    text-decoration: none;
+    vertical-align: middle;
+    content: '•';
+  }
+
+  .linksSpan::after {
+    display: inline-block;
+    margin: 0 6px;
     font-size: 14pt;
     color: var(--v-grey-base);
     text-decoration: none;
@@ -143,7 +153,7 @@
 
   .linksRtl::before {
     display: inline-block;
-    margin: 0 8px 0 20px;
+    margin: 0 8px 0 12px;
     font-size: 14pt;
     color: var(--v-grey-base);
     text-decoration: none;

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
@@ -10,7 +10,7 @@
         @click="showLanguageModal = true"
       />
       <span
-        class="linksSpan selected"
+        class="dotsSpan selected"
         :style="{ 'margin': '0' }"
         :title="selectedLanguage.english_name"
       >
@@ -22,7 +22,9 @@
         :text="language.lang_name"
         :title="language.english_name"
         class="lang"
-        :class="language.lang_direction ? 'linksRtl' : 'links'"
+        :class="(!$isRTL && language.lang_direction) || ($isRTL && !language.lang_direction)
+          ? 'dotsRtl'
+          : 'dots'"
         appearance="basic-link"
         :style="{ 'margin': '0 2px' }"
         @click="switchLanguage(language.id)"
@@ -130,10 +132,10 @@
     text-align: left;
   }
 
-  .links:not(:last-child)::after {
-    // because it is a pseudo-element, text-decoration only works with 'display: inline-block`
+  .dots:not(:last-child)::after {
+    // because it is a pseudo-element, text-decoration none only works with 'display: inline-block`
     display: inline-block;
-    margin: 0 8px 0 12px;
+    margin: 0 8px;
     font-size: 14pt;
     color: var(--v-grey-base);
     text-decoration: none;
@@ -141,7 +143,7 @@
     content: '•';
   }
 
-  .linksSpan::after {
+  .dotsSpan::after {
     display: inline-block;
     margin: 0 6px;
     font-size: 14pt;
@@ -151,9 +153,9 @@
     content: '•';
   }
 
-  .linksRtl::before {
+  .dotsRtl:not(:last-child)::before {
     display: inline-block;
-    margin: 0 8px 0 12px;
+    margin: 0 8px;
     font-size: 14pt;
     color: var(--v-grey-base);
     text-decoration: none;

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
@@ -9,7 +9,11 @@
         class="globe"
         @click="showLanguageModal = true"
       />
-      <span class="selected" :title="selectedLanguage.english_name">
+      <span
+        class="selected"
+        :style="{ 'margin': '0 8px 0 12px' }"
+        :title="selectedLanguage.english_name"
+      >
         {{ selectedLanguage.lang_name }}
       </span>
       <KButton
@@ -18,10 +22,10 @@
         :text="language.lang_name"
         :title="language.english_name"
         class="lang"
+        :class="language.lang_direction ? 'linksRtl' : 'links'"
         appearance="basic-link"
         @click="switchLanguage(language.id)"
       />
-
       <KButton
         v-if="numSelectableLanguages > numVisibleLanguages + 1"
         :text="$tr('showMoreLanguagesSelector')"
@@ -123,6 +127,28 @@
 
   .ta-l {
     text-align: left;
+  }
+
+  .links:not(:last-child)::after,
+  span::after {
+    // because it is a pseudo-element, text-decoration only works with 'display: inline-block`
+    display: inline-block;
+    margin: 0 8px 0 20px;
+    font-size: 14pt;
+    color: var(--v-grey-base);
+    text-decoration: none;
+    vertical-align: middle;
+    content: '•';
+  }
+
+  .linksRtl::before {
+    display: inline-block;
+    margin: 0 8px 0 20px;
+    font-size: 14pt;
+    color: var(--v-grey-base);
+    text-decoration: none;
+    vertical-align: middle;
+    content: '•';
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
@@ -22,9 +22,7 @@
         :text="language.lang_name"
         :title="language.english_name"
         class="lang"
-        :class="(!$isRTL && language.lang_direction) || ($isRTL && !language.lang_direction)
-          ? 'dotsRtl'
-          : 'dots'"
+        :class="determineLangDirection(language.lang_direction)"
         appearance="basic-link"
         :style="{ 'margin': '0 2px' }"
         @click="switchLanguage(language.id)"
@@ -101,6 +99,11 @@
             return compareLanguages(a, b);
           })
           .slice(0, this.numVisibleLanguages);
+      },
+    },
+    methods: {
+      determineLangDirection(direction) {
+        return (!this.$isRTL && direction) || (this.$isRTL && !direction) ? 'dotsRtl' : 'dots';
       },
     },
     $trs: {


### PR DESCRIPTION
## Description

This PR adds "dots" between the languages on the sign-in page for Studio so that it matches the links for Privacy Policy, Terms of Service, and the link to LE's website.

#### Issue Addressed (if applicable)

Addresses #2725

#### Before/After Screenshots (if applicable)

|Studio RTL lang|Studio LTR lang|
|--|--|
|![Screen Shot 2021-01-19 at 8 37 29 PM](https://user-images.githubusercontent.com/13563002/105127766-5d30b700-5a96-11eb-866c-e4197f393486.png)|![Screen Shot 2021-01-19 at 8 37 49 PM](https://user-images.githubusercontent.com/13563002/105127759-5a35c680-5a96-11eb-8d18-66ea6b33a830.png)|

##### Difference between Kolibri and Studio (addressed in Kolibri learningequality/kolibri#7748)

|Currently|Kolibri|
|--|--|
|![Screen Shot 2021-01-14 at 3 04 55 PM](https://user-images.githubusercontent.com/13563002/104659916-6a0a7080-567a-11eb-9904-fa3f3fee1630.png)|![Screen Shot 2021-01-14 at 3 09 47 PM](https://user-images.githubusercontent.com/13563002/104659984-90301080-567a-11eb-900b-affe3637936f.png)|

## Steps to Test

- [ ] *Step 1*: Open Studio
- [ ] *Step 2*: Click on the different languages at the bottom to check if the dots are showing up in the correct places

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I added some CSS classes that use pseudo-elements to create the dots (similar to the way they were created in the links below in `Main.vue`), added a method to either add the dots before or after a link for the language depending on whether the page is RTL/LTR and the language itself in the links is an RTL or LTR language (`::before` is used for RTL languages, while `::after` is used for LTR languages).

#### Does this introduce any tech-debt items?

We will need to make sure these changes are also made in Kolibri, as it is the same component (`LanguageSwitcherList`) in both. There is a connected issue in Kolibri learningequality/kolibri#7748 to fix.

## Checklist

- [x] Is the code clean and well-commented?
- [x] Are all UI components LTR and RTL compliant (if applicable)?
- [x] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?




## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
