### PR TITLE
Edit modal fixes for dropdown fields and enabling tag edits for multiple nodes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -187,6 +187,7 @@
               :placeholder="getPlaceholder('author')"
               :value="author && author.toString()"
               @input.native="e => author = e.srcElement.value"
+              @input="author = $event"
               @focus="trackClick('Author')"
             >
               <template v-slot:append-outer>
@@ -207,6 +208,7 @@
               box
               :value="provider && provider.toString()"
               @input.native="e => provider = e.srcElement.value"
+              @input="provider = $event"
               @focus="trackClick('Provider')"
             >
               <template v-slot:append-outer>
@@ -227,6 +229,7 @@
               box
               :value="aggregator && aggregator.toString()"
               @input.native="e => aggregator = e.srcElement.value"
+              @input="aggregator = $event"
               @focus="trackClick('Aggregator')"
             >
               <template v-slot:append-outer>
@@ -262,7 +265,7 @@
               box
               :value="copyright_holder && copyright_holder.toString()"
               @input.native="e => copyright_holder = e.srcElement.value"
-              @input="e => copyright_holder = e"
+              @input="copyright_holder = $event"
               @focus="trackClick('Copyright holder')"
             />
           </VFlex>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -14,12 +14,13 @@
 
       <!-- Basic information section -->
       <VLayout row wrap class="section">
-        <VFlex v-if="oneSelected" xs12>
+        <VFlex xs12>
           <h1 class="subheading">
             {{ $tr('basicInfoHeader') }}
           </h1>
           <!-- Title -->
           <VTextField
+            v-if="oneSelected"
             ref="title"
             v-model="title"
             maxlength="200"
@@ -33,6 +34,7 @@
           />
           <!-- Description -->
           <VTextarea
+            v-if="oneSelected"
             ref="description"
             v-model="description"
             :label="$tr('descriptionLabel')"


### PR DESCRIPTION
## Description

- Fixes an issue that I found today where selecting either Author, Provider, or Aggregator from a dropdown did not trigger a change to the value, so it wouldn't be saved.
- Allows editing of tags when editing multiple nodes @jayoshih 

![Screenshot from 2021-01-14 15-31-40](https://user-images.githubusercontent.com/819838/104661577-a8555f00-567d-11eb-855c-ad0025e0656b.png)

Basically the same fix from @nucleogenesis in PR https://github.com/learningequality/studio/pull/2358
## Steps to Test

- [ ] *Edit node details*
- [ ] *Change author to dropdown option*
- [ ] *Observe it syncs (didn't previously)*
- [ ] *Observe it saved the value by finishing (didn't previously)*

