### PR TITLE
Separate out different categories of incomplete.

### DIFF
--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -17,65 +17,57 @@ logmodule.basicConfig(level=logmodule.INFO)
 logging = logmodule.getLogger('command')
 
 
-CHUNKSIZE = 10000
-
-
 class Command(BaseCommand):
 
-    def add_arguments(self, parser):
-        parser.add_argument("--chunksize", dest="chunksize", default=CHUNKSIZE)
-
     def handle(self, *args, **options):
-        chunksize = options["chunksize"]
-
         start = time.time()
 
         # Mark invalid titles
         titlestart = time.time()
         logging.info('Marking blank titles...')
-        count = ContentNode.objects.filter(title='').order_by().update(complete=False)
+        count = ContentNode.objects.exclude(complete=False).filter(title='').order_by().update(complete=False)
         logging.info('Marked {} invalid titles (finished in {})'.format(count, time.time() - titlestart))
 
         # Mark invalid licenses
         licensestart = time.time()
         logging.info('Marking blank licenses...')
-        count = ContentNode.objects.exclude(kind_id=content_kinds.TOPIC).filter(license__isnull=True).order_by().update(complete=False)
+        count = ContentNode.objects.exclude(complete=False, kind_id=content_kinds.TOPIC).filter(license__isnull=True).order_by().update(complete=False)
         logging.info('Marked {} invalid licenses (finished in {})'.format(count, time.time() - licensestart))
 
         licensestart = time.time()
         logging.info('Marking blank license descriptions...')
         custom_licenses = list(License.objects.filter(is_custom=True).values_list("pk", flat=True))
-        count = ContentNode.objects.exclude(kind_id=content_kinds.TOPIC)\
+        count = ContentNode.objects.exclude(complete=False, kind_id=content_kinds.TOPIC)\
             .filter(license_id__in=custom_licenses).filter(Q(license_description__isnull=True) | Q(license_description=''))\
             .order_by().update(complete=False)
         logging.info('Marked {} invalid license descriptions (finished in {})'.format(count, time.time() - licensestart))
 
+        licensestart = time.time()
+        logging.info('Marking blank copyright holders...')
+        copyright_licenses = list(License.objects.filter(copyright_holder_required=True).values_list("pk", flat=True))
+        count = ContentNode.objects.exclude(complete=False, kind_id=content_kinds.TOPIC)\
+            .filter(license_id__in=copyright_licenses).filter(Q(copyright_holder__isnull=True) | Q(copyright_holder=''))\
+            .order_by().update(complete=False)
+        logging.info('Marked {} invalid copyright holders (finished in {})'.format(count, time.time() - licensestart))
+
         # Mark invalid file resources
         resourcestart = time.time()
         logging.info('Marking file resources...')
-        i = 0
-        count = 0
         file_check_query = File.objects.filter(preset__supplementary=False, contentnode=OuterRef("id")).order_by()
         query = ContentNode.objects \
             .exclude(kind_id=content_kinds.TOPIC) \
             .exclude(kind_id=content_kinds.EXERCISE) \
+            .exclude(complete=False) \
             .order_by()
-        total = query.count()
-        node_ids = query[i:i + chunksize]
-        while i < total + chunksize:
-            nodes = ContentNode.objects.filter(pk__in=node_ids) \
-                .annotate(has_files=Exists(file_check_query)) \
-                .filter(has_files=False).order_by().values_list('id', flat=True)
-            count += ContentNode.objects.filter(pk__in=nodes).update(complete=False)
-            i += chunksize
-            node_ids = query[i:i + chunksize]
+        nodes = query \
+            .annotate(has_files=Exists(file_check_query)) \
+            .filter(has_files=False).order_by().values_list('id', flat=True)
+        count = nodes.update(complete=False)
         logging.info('Marked {} invalid file resources (finished in {})'.format(count, time.time() - resourcestart))
 
         # Mark invalid exercises
         exercisestart = time.time()
         logging.info('Marking exercises...')
-        i = 0
-        count = 0
         exercise_check_query = AssessmentItem.objects.filter(contentnode=OuterRef('id')) \
             .exclude(type=exercises.PERSEUS_QUESTION)\
             .filter(
@@ -85,25 +77,21 @@ class Command(BaseCommand):
             ).order_by()
         query = ContentNode.objects \
             .filter(kind_id=content_kinds.EXERCISE) \
+            .exclude(complete=False) \
             .order_by()
-        total = query.count()
-        node_ids = query[i:i + chunksize]
-        while node_ids:
-            nodes = ContentNode.objects.filter(pk__in=node_ids) \
-                .annotate(
-                    has_questions=Exists(AssessmentItem.objects.filter(contentnode=OuterRef("id"))),
-                    invalid_exercise=Exists(exercise_check_query)
-                ).filter(
-                    Q(has_questions=False) |
-                    Q(invalid_exercise=True) |
-                    ~Q(extra_fields__has_key='type') |
-                    Q(extra_fields__type=exercises.M_OF_N) & (
-                        ~Q(extra_fields__has_key='m') | ~Q(extra_fields__has_key='n')
-                    )
-                ).order_by().values_list('id', flat=True)
-            count += ContentNode.objects.filter(pk__in=nodes).update(complete=False)
-            i += chunksize
-            node_ids = query[i:i + chunksize]
+        nodes = query \
+            .annotate(
+                has_questions=Exists(AssessmentItem.objects.filter(contentnode=OuterRef("id"))),
+                invalid_exercise=Exists(exercise_check_query)
+            ).filter(
+                Q(has_questions=False) |
+                Q(invalid_exercise=True) |
+                ~Q(extra_fields__has_key='type') |
+                Q(extra_fields__type=exercises.M_OF_N) & (
+                    ~Q(extra_fields__has_key='m') | ~Q(extra_fields__has_key='n')
+                )
+            ).order_by().values_list('id', flat=True)
+        count = nodes.update(complete=False)
 
         logging.info('Marked {} invalid exercises (finished in {})'.format(count, time.time() - exercisestart))
 

--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -78,20 +78,27 @@ class Command(BaseCommand):
                 Q(answers='[]') |
                 (~Q(type=exercises.INPUT_QUESTION) & ~Q(answers__iregex=r'"correct":\s*true'))  # hack to check if no correct answers
             ).order_by()
-        query = ContentNode.objects \
+
+        has_questions_query = With(AssessmentItem.objects.all().values("contentnode_id").order_by(), name="t_assessmentitem")
+
+        query = has_questions_query.join(ContentNode, id=has_questions_query.col.contentnode_id, _join_type=LOUTER)\
+            .with_cte(has_questions_query) \
+            .annotate(t_contentnode_id=has_questions_query.col.contentnode_id) \
             .filter(kind_id=content_kinds.EXERCISE) \
             .exclude(complete=False) \
+            .filter(t_contentnode_id__isnull=True)\
             .order_by()
         exercisestart = time.time()
-        nodes = query \
-            .annotate(
-                has_questions=Exists(AssessmentItem.objects.filter(contentnode=OuterRef("id"))),
-            ).filter(has_questions=False).order_by()
-        count = nodes.update(complete=False)
+        count = ContentNode.objects.filter(id__in=query.order_by().values_list('id', flat=True)).update(complete=False)
 
         logging.info('Marked {} questionless exercises (finished in {})'.format(count, time.time() - exercisestart))
 
         exercisestart = time.time()
+        query = ContentNode.objects\
+            .filter(kind_id=content_kinds.EXERCISE) \
+            .exclude(complete=False) \
+            .order_by()
+
         nodes = query \
             .annotate(
                 invalid_exercise=Exists(exercise_check_query)

--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -93,12 +93,11 @@ class Command(BaseCommand):
                                         # hack to check if no correct answers
                                         (~Q(type=exercises.INPUT_QUESTION) & ~Q(answers__iregex=r'"correct":\s*true'))).order_by(), name="t_assessmentitem")
 
-        query = exercise_check_query.join(ContentNode, id=has_questions_query.col.contentnode_id, _join_type=LOUTER)\
+        query = exercise_check_query.join(ContentNode, id=has_questions_query.col.contentnode_id)\
             .with_cte(exercise_check_query) \
             .annotate(t_contentnode_id=exercise_check_query.col.contentnode_id) \
             .filter(kind_id=content_kinds.EXERCISE) \
             .exclude(complete=False) \
-            .filter(t_contentnode_id__isnull=False)\
             .order_by()
 
         count = ContentNode.objects.filter(id__in=query.order_by().values_list('id', flat=True)).update(complete=False)


### PR DESCRIPTION
## Description

Makes updates to the mark incomplete command to separate out different checks
Adds order_bys liberally to reduce scanning