### PR TITLE
Validate channel modal automatically on existing channels

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -266,6 +266,9 @@
       return this.verifyChannel(channelId).then(() => {
         this.header = this.channel.name; // Get channel name when user enters modal
         this.updateTitleForPage();
+        if (!this.isNew) {
+          this.$refs.detailsform.validate();
+        }
       });
     },
     mounted() {


### PR DESCRIPTION
Make sure channel validation gets triggered so it's clear what the error icon means if a language is missing

Fixes https://github.com/learningequality/studio/issues/2657