### PR TITLE
Set the default number of worker pods to 5

### DIFF
--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -62,7 +62,7 @@ redis:
   enabled: true
 
 studioWorkers:
-  replicas: 1
+  replicas: 5
 
 
 studioProber:


### PR DESCRIPTION
1 worker in production is not enough, and I don't want to be manually setting the scale every time we deploy :) so set the default worker scale to 5 for now until I figure out how to tell Helm not to update the replica count.