### PR TITLE
Disable PWA manifest

### DIFF
--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -12,7 +12,6 @@
     <head>
         {% block head %}
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
-        <link rel="manifest" href="{% url 'manifest' %}">
 
         <script>
             window.DEBUG = "{{DEBUG}}" === "True";


### PR DESCRIPTION
Disables the PWA manifest to avoid an issue with PWA rendering on Android.