### PR TITLE
Add helpers for Postgres advisory locks, implement in MPTT tree locking

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -45,7 +45,7 @@ Addresses #*PR# HERE*
 - [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
 - [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
 - [ ] Are there opportunities for using Google Analytics here (if applicable)?
-- [ ] If the Pipfile has been changed, is the updated Pipfile.lock file also included in this PR?
+- [ ] If any Python requirements have changed, are the updated requirements.txt files also included in this PR?
 - [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
 
 ## Comments

--- a/contentcuration/contentcuration/db/advisory_lock.py
+++ b/contentcuration/contentcuration/db/advisory_lock.py
@@ -74,6 +74,8 @@ def try_advisory_lock(key1, key2=None, shared=False):
     :raises: AdvisoryLockBusy
     """
     with execute_lock(key1, key2=key2, shared=shared, wait=False) as cursor:
+        # for `try` locks, the PG function will return True or False,
+        # representing whether the lock was acquired or not
         results = cursor.fetchone()
         if not results[0]:
             raise AdvisoryLockBusy("Unable to acquire advisory lock")

--- a/contentcuration/contentcuration/db/advisory_lock.py
+++ b/contentcuration/contentcuration/db/advisory_lock.py
@@ -75,6 +75,5 @@ def try_advisory_lock(key1, key2=None, shared=False):
     """
     with execute_lock(key1, key2=key2, shared=shared, wait=False) as cursor:
         results = cursor.fetchone()
-        print("XXX", results)
         if not results[0]:
             raise AdvisoryLockBusy("Unable to acquire advisory lock")

--- a/contentcuration/contentcuration/db/advisory_lock.py
+++ b/contentcuration/contentcuration/db/advisory_lock.py
@@ -1,0 +1,80 @@
+import logging as logger
+from contextlib import contextmanager
+
+from django.db import connection
+
+
+logging = logger.getLogger(__name__)
+
+
+class AdvisoryLockBusy(RuntimeError):
+    pass
+
+
+@contextmanager
+def execute_lock(key1, key2=None, unlock=False, session=False, shared=False, wait=True):
+    """
+    Creates or destroys an advisory lock within postgres
+
+    :param key1: An int sent to the PG lock function
+    :param key2: A 2nd int sent to the PG lock function
+    :param unlock: A bool representing whether query should use `unlock`
+    :param session: A bool indicating if this should persist outside of transaction
+    :param shared: A bool indicating if this should be shared, otherwise exclusive
+    :param wait: A bool indicating if it should use a `try` PG function
+    """
+    if not session:
+        if not connection.in_atomic_block:
+            raise NotImplementedError("Advisory lock requires transaction")
+        if unlock:
+            raise NotImplementedError("Transaction level locks unlock automatically")
+
+    keys = [key1]
+    if key2 is not None:
+        keys.append(key2)
+
+    query = "SELECT pg{_try}_advisory_{xact_}{lock}{_shared}({keys}) AS lock;".format(
+        _try="" if wait else "_try",
+        xact_="" if session else "xact_",
+        lock="unlock" if unlock else "lock",
+        _shared="_shared" if shared else "",
+        keys=", ".join(["%s" for i in range(0, 2 if key2 is not None else 1)])
+    )
+
+    log_query = "'{}' with params {}".format(query, keys)
+    logging.debug("Acquiring advisory lock: {}".format(query, log_query))
+    with connection.cursor() as c:
+        c.execute(query, keys)
+        logging.debug("Acquired advisory lock: {}".format(query, log_query))
+        yield c
+
+
+@contextmanager
+def advisory_lock(key1, key2=None, shared=False):
+    """
+    Creates a transaction level advisory lock that blocks until ready
+
+    :param key1: int
+    :param key2: int
+    :param shared: bool
+    """
+    with execute_lock(key1, key2=key2, shared=shared) as cursor:
+        # this yields the cursor, but the lock will exist until the transaction
+        # is either committed or rolled-back
+        yield cursor
+
+
+def try_advisory_lock(key1, key2=None, shared=False):
+    """
+    Creates a transaction level advisory lock that doesn't block
+
+    :param key1: int
+    :param key2: int
+    :param shared: bool
+    :raises: AdvisoryLockBusy
+    """
+    with execute_lock(key1, key2=key2, shared=shared, wait=False) as cursor:
+        results = cursor.fetchone()
+        print("XXX", results)
+        if not results[0]:
+            raise AdvisoryLockBusy("Unable to acquire advisory lock")

--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -12,6 +12,7 @@ from le_utils.constants import content_kinds
 from mptt.managers import TreeManager
 from mptt.signals import node_moved
 
+from contentcuration.db.advisory_lock import advisory_lock
 from contentcuration.db.models.query import CustomTreeQuerySet
 from contentcuration.utils.tasks import increment_progress
 from contentcuration.utils.tasks import set_total
@@ -32,6 +33,7 @@ logging = logger.getLogger(__name__)
 # The exact optimum batch size is probably highly dependent on tree
 # topology also, so these rudimentary tests are likely insufficient
 BATCH_SIZE = 100
+TREE_LOCK = 1001
 
 
 class CustomManager(Manager.from_queryset(CTEQuerySet)):
@@ -81,10 +83,12 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
         return new_id
 
     @contextlib.contextmanager
-    def _attempt_lock(self, tree_ids, values):
+    def _attempt_lock(self, tree_ids, shared_tree_ids=None):
         """
         Internal method to allow the lock_mptt method to do retries in case of deadlocks
         """
+        shared_tree_ids = shared_tree_ids or []
+
         start = time.time()
         with transaction.atomic():
             # Issue a separate lock on each tree_id
@@ -92,17 +96,12 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
             # This will mean that every process acquires locks in the same order
             # and should help to minimize deadlocks
             for tree_id in tree_ids:
-                execute_queryset_without_results(
-                    self.select_for_update()
-                    .order_by()
-                    .filter(tree_id=tree_id)
-                    .values(*values)
-                )
+                advisory_lock(TREE_LOCK, key2=tree_id, shared=tree_id in shared_tree_ids)
             yield
             log_lock_time_spent(time.time() - start)
 
     @contextlib.contextmanager
-    def lock_mptt(self, *tree_ids):
+    def lock_mptt(self, shared_tree_ids=None, *tree_ids):
         tree_ids = sorted((t for t in set(tree_ids) if t is not None))
         # If this is not inside the context of a delay context manager
         # or updates are not disabled set a lock on the tree_ids.
@@ -111,25 +110,15 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
             and self.model._mptt_updates_enabled
             and tree_ids
         ):
-            # Lock based on MPTT columns for updates on any of the tree_ids specified
-            # until the end of this transaction
-            mptt_opts = self.model._mptt_meta
-            values = (
-                mptt_opts.tree_id_attr,
-                mptt_opts.left_attr,
-                mptt_opts.right_attr,
-                mptt_opts.level_attr,
-                mptt_opts.parent_attr,
-            )
             try:
-                with self._attempt_lock(tree_ids, values):
+                with self._attempt_lock(tree_ids, shared_tree_ids=shared_tree_ids):
                     yield
             except OperationalError as e:
                 if "deadlock detected" in e.args[0]:
                     logging.error(
                         "Deadlock detected while trying to lock ContentNode trees for mptt operations, retrying"
                     )
-                    with self._attempt_lock(tree_ids, values):
+                    with self._attempt_lock(tree_ids, shared_tree_ids=shared_tree_ids):
                         yield
                 else:
                     raise
@@ -556,15 +545,15 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
         excluded_descendants,
         can_edit_source_channel,
     ):
-
-        nodes_to_copy = self._all_nodes_to_copy(node, excluded_descendants)
-
         nodes_by_parent = {}
 
-        for copy_node in nodes_to_copy:
-            if copy_node.parent_id not in nodes_by_parent:
-                nodes_by_parent[copy_node.parent_id] = []
-            nodes_by_parent[copy_node.parent_id].append(copy_node)
+        # lock mptt source tree with shared advisory lock
+        with self.lock_mptt(node.tree_id, shared_tree_ids=[node.tree_id]):
+            nodes_to_copy = self._all_nodes_to_copy(node, excluded_descendants)
+            for copy_node in nodes_to_copy:
+                if copy_node.parent_id not in nodes_by_parent:
+                    nodes_by_parent[copy_node.parent_id] = []
+                nodes_by_parent[copy_node.parent_id].append(copy_node)
 
         source_copy_id_map = {}
 

--- a/contentcuration/contentcuration/tests/db/test_advisory_lock.py
+++ b/contentcuration/contentcuration/tests/db/test_advisory_lock.py
@@ -1,0 +1,124 @@
+from multiprocessing import Pipe
+from multiprocessing import Process
+from multiprocessing import set_start_method
+from time import sleep
+
+from django.db import transaction
+from django.test.testcases import SimpleTestCase
+from mock import mock
+from mock import patch
+from pytest import mark
+from pytest import raises
+
+from contentcuration.db.advisory_lock import advisory_lock
+from contentcuration.db.advisory_lock import AdvisoryLockBusy
+from contentcuration.db.advisory_lock import execute_lock
+from contentcuration.db.advisory_lock import try_advisory_lock
+
+TEST_LOCK = 1337
+# flake8: noqa
+
+
+@mark.parametrize("key1, key2, unlock, session, shared, wait, expected_query", [
+    # transaction level
+    (1, None, False, False, False, True,  "SELECT pg_advisory_xact_lock(%s) AS lock;"),
+    (3, None, False, False, True,  True,  "SELECT pg_advisory_xact_lock_shared(%s) AS lock;"),
+    (4, None, False, False, True,  False, "SELECT pg_try_advisory_xact_lock_shared(%s) AS lock;"),
+    (5, None, False, False, False, False, "SELECT pg_try_advisory_xact_lock(%s) AS lock;"),
+    (6,    1, False, False, False, True,  "SELECT pg_advisory_xact_lock(%s, %s) AS lock;"),
+    (7,    2, False, False, True,  True,  "SELECT pg_advisory_xact_lock_shared(%s, %s) AS lock;"),
+    (8,    3, False, False, True,  False, "SELECT pg_try_advisory_xact_lock_shared(%s, %s) AS lock;"),
+    (9,    4, False, False, False, False, "SELECT pg_try_advisory_xact_lock(%s, %s) AS lock;"),
+
+    # session level
+    (10, None, False, True, False, True,  "SELECT pg_advisory_lock(%s) AS lock;"),
+    (11, None, True,  True, False, True,  "SELECT pg_advisory_unlock(%s) AS lock;"),
+    (12, None, False, True, True,  True,  "SELECT pg_advisory_lock_shared(%s) AS lock;"),
+    (13, None, True,  True, True,  True,  "SELECT pg_advisory_unlock_shared(%s) AS lock;"),
+    (14, None, False, True, False, False, "SELECT pg_try_advisory_lock(%s) AS lock;"),
+    (15, None, True,  True, False, False, "SELECT pg_try_advisory_unlock(%s) AS lock;"),
+    (16, None, False, True, True,  False, "SELECT pg_try_advisory_lock_shared(%s) AS lock;"),
+    (17, None, True,  True, True,  False, "SELECT pg_try_advisory_unlock_shared(%s) AS lock;"),
+    (18,    1, False, True, False, True,  "SELECT pg_advisory_lock(%s, %s) AS lock;"),
+    (19,    2, True,  True, False, True,  "SELECT pg_advisory_unlock(%s, %s) AS lock;"),
+    (20,    3, False, True, True,  True,  "SELECT pg_advisory_lock_shared(%s, %s) AS lock;"),
+    (21,    4, True,  True, True,  True,  "SELECT pg_advisory_unlock_shared(%s, %s) AS lock;"),
+    (22,    5, False, True, False, False, "SELECT pg_try_advisory_lock(%s, %s) AS lock;"),
+    (23,    6, True,  True, False, False, "SELECT pg_try_advisory_unlock(%s, %s) AS lock;"),
+    (24,    7, False, True, True,  False, "SELECT pg_try_advisory_lock_shared(%s, %s) AS lock;"),
+    (25,    8, True,  True, True,  False, "SELECT pg_try_advisory_unlock_shared(%s, %s) AS lock;"),
+])
+def test_execute_lock(key1, key2, unlock, session, shared, wait, expected_query):
+    with patch("contentcuration.db.advisory_lock.connection") as conn:
+        cursor = mock.Mock()
+        conn.cursor.return_value.__enter__.return_value = cursor
+        conn.in_atomic_block.return_value = not session
+        cursor.execute.return_value = True
+
+        with execute_lock(key1, key2=key2, unlock=unlock, session=session, shared=shared, wait=wait) as c:
+            assert c == cursor
+
+        expected_params = [key1]
+        if key2 is not None:
+            expected_params.append(key2)
+
+        query, params = cursor.execute.call_args_list[0][0]
+        assert query == expected_query
+        assert params == expected_params
+
+
+@mark.parametrize("unlock, in_atomic_block", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_execute_lock__not_implemented(unlock, in_atomic_block):
+    with patch("contentcuration.db.advisory_lock.connection") as conn:
+        conn.in_atomic_block = in_atomic_block
+
+        with raises(NotImplementedError):
+            with execute_lock(99, key2=99, unlock=unlock, session=False, shared=False, wait=False):
+                pass
+
+
+START_SIGNAL = 'START_SIGNAL'
+END_SIGNAL = 'END_SIGNAL'
+SLEEP_SEC = 0.1
+
+
+def wait_for(conn, signal):
+    while True:
+        msg = conn.recv()
+        if msg == signal:
+            break
+        sleep(SLEEP_SEC)
+
+
+def create_lock(conn):
+    with transaction.atomic():
+        with advisory_lock(TEST_LOCK):
+            sleep(SLEEP_SEC)
+            conn.send(START_SIGNAL)
+            wait_for(conn, END_SIGNAL)
+
+
+class AdvisoryLockDatabaseTest(SimpleTestCase):
+    # this test manages its own transactions
+    allow_database_queries = True
+
+    def test_try(self):
+        set_start_method("spawn")
+
+        parent_conn, child_conn = Pipe()
+        p = Process(target=create_lock, args=(child_conn,))
+        p.start()
+
+        try:
+            wait_for(parent_conn, START_SIGNAL)
+
+            with transaction.atomic():
+                with raises(AdvisoryLockBusy):
+                    try_advisory_lock(TEST_LOCK)
+        finally:
+            parent_conn.send(END_SIGNAL)
+            p.join(2)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -21,6 +21,7 @@ jedi>=0.9.0
 json-rpc>=1.8.1
 service_factory>=0.1.6
 pytest-pythonpath
+pytest-timeout
 pytest-watch
 rope
 autopep8<=1.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,8 @@ geventhttpclient==1.4.4   # via locust
 greenlet==0.4.16          # via gevent
 identify==1.4.11          # via pre-commit
 idna==2.8                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via pluggy, pre-commit, pytest, virtualenv
+importlib-metadata==1.5.0  # via importlib-resources, pluggy, pre-commit, pytest, virtualenv
+importlib-resources==1.5.0  # via pre-commit, virtualenv
 importmagic==0.1.7        # via -r requirements-dev.in
 inflection==0.5.0         # via drf-yasg
 ipdb==0.12.3              # via -r requirements-dev.in
@@ -89,8 +90,9 @@ pytest-cov==2.8.1         # via -r requirements-dev.in
 pytest-django==3.8.0      # via -r requirements-dev.in
 pytest-logging==2015.11.4  # via -r requirements-dev.in
 pytest-pythonpath==0.7.3  # via -r requirements-dev.in
+pytest-timeout==1.4.2     # via -r requirements-dev.in
 pytest-watch==4.2.0       # via -r requirements-dev.in
-pytest==5.3.5             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-logging, pytest-pythonpath, pytest-watch
+pytest==5.3.5             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-logging, pytest-pythonpath, pytest-timeout, pytest-watch
 python-dateutil==2.8.1    # via -c requirements.txt, faker
 python-jsonrpc-server==0.3.4  # via python-language-server
 python-language-server==0.31.8  # via -r requirements-dev.in, pyls-isort
@@ -119,7 +121,7 @@ werkzeug==1.0.1           # via flask
 wheel==0.35.1             # via pypandoc
 wrapt==1.11.2             # via astroid
 yapf==0.29.0              # via -r requirements-dev.in
-zipp==2.2.0               # via importlib-metadata
+zipp==2.2.0               # via importlib-metadata, importlib-resources
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 


### PR DESCRIPTION
## Description
PostgresSQL has several [locking functions](https://www.postgresql.org/docs/9.6/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS) that can be used for application specific [purposes](https://www.postgresql.org/docs/9.6/explicit-locking.html#ADVISORY-LOCKS). In this PR, I have added functions for creating advisory locks. MPTT tree operations that required locking have been refactored to use advisory locks.

For tree locking operations, we use two keys/integers: an integer that denotes the operation as a tree operation, and the tree ID.

#### Issue Addressed (if applicable)

Helps: https://github.com/learningequality/studio/issues/2829

## Steps to Test
See `test_advisory_lock.py` for concurrent scenarios.

## Checklist

*Delete any items that don't apply*

- [X] Is the code clean and well-commented?
- [X] Are there tests for this change?
- [X] Updated `requirements-dev.txt`
