### PR TITLE
Added automatic thumbnail generation

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
@@ -83,12 +83,12 @@
   import differenceBy from 'lodash/differenceBy';
   import { mapActions, mapGetters } from 'vuex';
   import { RouterNames } from '../../constants';
+  import ThumbnailGenerator from '../../views/files/thumbnails/ThumbnailGenerator';
   import { fileSizeMixin, fileStatusMixin } from 'shared/mixins';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
   import Checkbox from 'shared/views/form/Checkbox';
-  import {ContentKindsNames} from 'shared/leUtils/ContentKinds';
+  import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
-  import ThumbnailGenerator from '../../views/files/thumbnails/ThumbnailGenerator';
   import Uploader from 'shared/views/files/Uploader';
 
   const kindToContentDefaultKeyMap = {
@@ -127,7 +127,7 @@
       ...mapGetters('contentNode', [
         'getContentNode',
         'getContentNodeIsValid',
-        'getContentNodeThumbnailPreset'
+        'getContentNodeThumbnailPreset',
       ]),
       ...mapGetters('file', ['getContentNodeFiles', 'getFileUpload']),
       selected: {
@@ -176,14 +176,16 @@
         return this.files.filter(f => f.error);
       },
       progress() {
-        return this.uploadingFiles.reduce((sum, f) => {
-          if(f.progress === undefined) {
-            return 1 + sum;
-          } else if(f.progress) {
-            return f.progress + sum;
-          }
-          return sum
-        }, 0) / this.uploadingFiles.length;
+        return (
+          this.uploadingFiles.reduce((sum, f) => {
+            if (f.progress === undefined) {
+              return 1 + sum;
+            } else if (f.progress) {
+              return f.progress + sum;
+            }
+            return sum;
+          }, 0) / this.uploadingFiles.length
+        );
       },
       thumbnailPresetID() {
         return this.getContentNodeThumbnailPreset(this.nodeId);
@@ -193,7 +195,7 @@
       uploadingFiles(newList, oldList) {
         // Show progress spinner if there are new uploads
         const newFiles = differenceBy(newList, oldList, 'id');
-        if(newFiles.length) {
+        if (newFiles.length) {
           this.showUploadProgress = true;
         } else {
           setTimeout(() => {
@@ -202,13 +204,10 @@
         }
 
         // Trigger automatic thumbnail generation on first upload for a node
-        if(
-          this.$route.name === RouterNames.UPLOAD_FILES &&
-          !oldList.length && newList.length
-        ) {
+        if (this.$route.name === RouterNames.UPLOAD_FILES && !oldList.length && newList.length) {
           this.autoGenerateThumbnail();
         }
-      }
+      },
     },
     methods: {
       ...mapActions('contentNode', ['deleteContentNode']),
@@ -222,8 +221,7 @@
         // Check if thumbnail exists or user has turned off automatic thumbnail
         // generation for this node kind
         const contentDefaultKey = kindToContentDefaultKeyMap[this.node.kind];
-        console.log(this.node.kind, kindToContentDefaultKeyMap, this.currentChannel.content_defaults)
-        if(
+        if (
           !this.files.some(f => f.preset.thumbnail) &&
           this.currentChannel.content_defaults[contentDefaultKey]
         ) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentNodeThumbnail.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/contentNodeThumbnail.spec.js
@@ -171,7 +171,7 @@ describe('thumbnail', () => {
     });
     it('cancelling upload should revert to the original state', () => {
       const removeGenerationTracking = jest.fn();
-      wrapper.setMethods({removeGenerationTracking});
+      wrapper.setMethods({ removeGenerationTracking });
       return wrapper.vm.$nextTick().then(() => {
         wrapper.find('[data-test="cancel-upload"]').trigger('click');
         expect(removeGenerationTracking).toHaveBeenCalled();

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/thumbnailGenerator.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/thumbnailGenerator.spec.js
@@ -11,12 +11,12 @@ function makeWrapper(filePath, generationList) {
     propsData: { nodeId },
     computed: {
       filePath() {
-        return filePath
+        return filePath;
       },
       contentNodeThumbnailGenerations() {
         return generationList || [];
-      }
-    }
+      },
+    },
   });
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/thumbnailGenerator.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/thumbnailGenerator.spec.js
@@ -2,15 +2,21 @@ import { mount } from '@vue/test-utils';
 import ThumbnailGenerator from '../thumbnails/ThumbnailGenerator';
 import { factory } from '../../../store';
 
-function makeWrapper(filePath) {
+const nodeId = 'test';
+function makeWrapper(filePath, generationList) {
   const store = factory();
   return mount(ThumbnailGenerator, {
     store,
     attachToDocument: true,
-    propsData: {
-      filePath,
-      presetID: 'video_thumbnail',
-    },
+    propsData: { nodeId },
+    computed: {
+      filePath() {
+        return filePath
+      },
+      contentNodeThumbnailGenerations() {
+        return generationList || [];
+      }
+    }
   });
 }
 
@@ -37,10 +43,9 @@ describe('thumbnailGenerator', () => {
     expect(wrapper.vm.showErrorAlert).toBe(true);
   });
   it('handleGenerated should not call handleFiles if cancelled', () => {
-    let wrapper = makeWrapper('test.wut');
+    let wrapper = makeWrapper('test.wut', [nodeId]);
     const handleFiles = jest.fn(() => true);
     wrapper.setMethods({ handleFiles });
-    wrapper.setData({ cancelled: true });
     wrapper.vm.handleGenerated('');
     expect(handleFiles).not.toHaveBeenCalled();
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -328,7 +328,7 @@
         return this.node && this.node.kind;
       },
       hasPrimaryFile() {
-        return this.nodeId && this.files.find(f => !f.preset.supplementary && f.url);
+        return this.nodeId && this.files.some(f => !f.preset.supplementary && f.url);
       },
       width() {
         return THUMBNAIL_WIDTH;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ContentNodeThumbnail.vue
@@ -189,7 +189,6 @@
   import ThumbnailGenerator from './ThumbnailGenerator';
   import ThumbnailCard from './ThumbnailCard';
   import { fileSizeMixin, fileStatusMixin } from 'shared/mixins';
-  import { FormatPresetsList } from 'shared/leUtils/FormatPresets';
   import Uploader from 'shared/views/files/Uploader';
   import FileDropzone from 'shared/views/files/FileDropzone';
   import FileStatus from 'shared/views/files/FileStatus';
@@ -249,7 +248,7 @@
           return this.contentNodeThumbnailGenerations.includes(this.nodeId);
         },
         set(value) {
-          if(!value) {
+          if (!value) {
             this.removeGenerationTracking(this.nodeId);
           }
         },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
@@ -22,7 +22,6 @@
   import epubJS from 'epubjs';
   import client from 'shared/client';
   import Alert from 'shared/views/Alert';
-  import { FormatPresetsList } from 'shared/leUtils/FormatPresets';
   import { ASPECT_RATIO, THUMBNAIL_WIDTH } from 'shared/constants';
 
   // Based off of solution here: https://github.com/mozilla/pdf.js/issues/7612
@@ -54,18 +53,10 @@
       };
     },
     computed: {
-      ...mapGetters('contentNode', ['getContentNode', 'getContentNodeThumbnailPreset']),
       ...mapGetters('file', ['getContentNodeFiles']),
       ...mapState('file', ['contentNodeThumbnailGenerations']),
-      kind() {
-        const node = this.getContentNode(this.nodeId);
-        return node && node.kind;
-      },
       files() {
         return this.getContentNodeFiles(this.nodeId);
-      },
-      thumbnailPresetID() {
-        return this.getContentNodeThumbnailPreset(this.nodeId);
       },
       filePath() {
         const file = this.files.find(f => !f.preset.supplementary && f.url);
@@ -221,7 +212,7 @@
         const file = new File(byteArrays, filename, { type: 'image/png' });
 
         // Make sure thumbnail generation hasn't been cancelled elsewhere
-        if(this.contentNodeThumbnailGenerations.includes(this.nodeId)) {
+        if (this.contentNodeThumbnailGenerations.includes(this.nodeId)) {
           this.handleFiles([file]);
         }
         this.removeGenerationTracking(this.nodeId);
@@ -237,8 +228,8 @@
       },
       async generate() {
         // Check if generation is already in progress
-        if(this.contentNodeThumbnailGenerations.includes(this.nodeId)) {
-          return
+        if (this.contentNodeThumbnailGenerations.includes(this.nodeId)) {
+          return;
         }
 
         // Make sure file exists

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -7,6 +7,7 @@ import { parseNode } from './utils';
 
 import { getNodeDetailsErrors, getNodeFilesErrors } from 'shared/utils/validation';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+import { FormatPresetsList } from 'shared/leUtils/FormatPresets';
 import { NEW_OBJECT } from 'shared/constants';
 
 function sorted(nodes) {
@@ -315,4 +316,12 @@ export function nodeExpanded(state) {
   return function(id) {
     return Boolean(state.expandedNodes[id]);
   };
+}
+
+export function getContentNodeThumbnailPreset(state, getters) {
+  return function(id) {
+    const node = getters.getContentNode(id);
+    return node &&
+      FormatPresetsList.find(p => p.thumbnail && p.kind_id === (node.kind || null)).id;
+  }
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -321,7 +321,6 @@ export function nodeExpanded(state) {
 export function getContentNodeThumbnailPreset(state, getters) {
   return function(id) {
     const node = getters.getContentNode(id);
-    return node &&
-      FormatPresetsList.find(p => p.thumbnail && p.kind_id === (node.kind || null)).id;
-  }
+    return node && FormatPresetsList.find(p => p.thumbnail && p.kind_id === (node.kind || null)).id;
+  };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -159,6 +159,9 @@ export function uploadFileToStorage(
             loaded: file.size,
             total: file.size,
           });
+          setTimeout(() => {
+            context.commit('REMOVE_FILE_FROM_UPLOADS', id);
+          }, 2000);
         });
     });
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/index.js
@@ -19,6 +19,8 @@ export default {
       // A map for tracking file upload info
       // keyed by file id
       fileUploadsMap: {},
+      // A map for tracking thumbnail generations for nodes
+      contentNodeThumbnailGenerations: [],
     };
   },
   getters,

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -62,5 +62,7 @@ export function REMOVE_THUMBNAIL_GENERATION_TRACKING(state, nodeId) {
   if (!nodeId) {
     return;
   }
-  state.contentNodeThumbnailGenerations = state.contentNodeThumbnailGenerations.filter(n => n !== nodeId)
+  state.contentNodeThumbnailGenerations = state.contentNodeThumbnailGenerations.filter(
+    n => n !== nodeId
+  );
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -46,3 +46,21 @@ export function REMOVE_FILE(state, file) {
     return;
   }
 }
+
+export function REMOVE_FILE_FROM_UPLOADS(state, file) {
+  if (!file.id) {
+    return;
+  }
+  Vue.delete(state.fileUploadsMap, file.id);
+}
+
+export function TRACK_THUMBNAIL_GENERATION(state, nodeId) {
+  state.contentNodeThumbnailGenerations = state.contentNodeThumbnailGenerations.concat([nodeId]);
+}
+
+export function REMOVE_THUMBNAIL_GENERATION_TRACKING(state, nodeId) {
+  if (!nodeId) {
+    return;
+  }
+  state.contentNodeThumbnailGenerations = state.contentNodeThumbnailGenerations.filter(n => n !== nodeId)
+}


### PR DESCRIPTION
## Description

Adds automatic thumbnail generation when you upload new resources

#### Issue Addressed (if applicable)

Fixes https://github.com/learningequality/studio/issues?q=is%3Aissue+is%3Aopen+automatic

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

- [ ] *Step 1*
- [ ] *Step 2*

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I added thumbnail generation to the state as it makes it a lot easier to make sure the generating status is propagated across the edit modal components. This makes sure we don't allow the user to trigger multiple generations for the same node
