### PR TITLE
Use empty folder icon in topic tree hierarchy to reflect topics without resources

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -70,7 +70,7 @@
                       <VTooltip :disabled="!hasTitle(node)" bottom open-delay="500">
                         <template #activator="{ on }">
                           <Icon v-on="on">
-                            {{ hasContent ? "folder" : "folder_open" }}
+                            {{ node.resource_count ? "folder" : "folder_open" }}
                           </Icon>
                         </template>
                         <span>{{ getTitle(node) }}</span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7447496/105270139-20be9300-5b4a-11eb-8032-2dc1ac77ff46.png)
