### PR TITLE
Ensure that dropped connections do not disrupt task execution or signal handling.

### DIFF
--- a/contentcuration/contentcuration/tasks_test.py
+++ b/contentcuration/contentcuration/tasks_test.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
 from celery.utils.log import get_task_logger
+from django.conf import settings
+from django.db import connection
+from django.db.utils import OperationalError
 
 from contentcuration.celery import app
 from contentcuration.models import Task
@@ -49,3 +52,36 @@ def non_async_test_task(**kwargs):
     in a Task object being created or updated.
     """
     return 42
+
+
+def close_db_connection():
+    cursor = connection.cursor()
+    try:
+        cursor.execute("select pg_terminate_backend(pid) from pg_stat_activity where datname='{}';".format(settings.DATABASES["default"]["NAME"]))
+    except OperationalError:
+        pass
+
+
+@app.task(name="drop_db_connections_success")
+def drop_db_connections_success(**kwargs):
+    """
+    This is a mock task used to simulate connections being dropped during a task
+    """
+    close_db_connection()
+
+
+@app.task(name="drop_db_connections_fail")
+def drop_db_connections_fail(**kwargs):
+    """
+    This is a mock task used to simulate connections being dropped during a task
+    """
+    close_db_connection()
+    raise Exception()
+
+
+@app.task(name="query_db_task")
+def query_db_task(**kwargs):
+    """
+    This is a mock task used to simulate connections being dropped during a task
+    """
+    list(Task.objects.all())

--- a/contentcuration/contentcuration/utils/celery_signals.py
+++ b/contentcuration/contentcuration/utils/celery_signals.py
@@ -10,6 +10,7 @@ from celery.signals import task_success
 from celery.utils.log import get_task_logger
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection
+from django.db.utils import InterfaceError
 
 from contentcuration.models import Task
 
@@ -21,8 +22,11 @@ logger = get_task_logger(__name__)
 
 
 def clear_and_connect():
-    connection.close_if_unusable_or_obsolete()
-    connection.connect()
+    try:
+        connection.cursor()
+    except InterfaceError:
+        connection.close_if_unusable_or_obsolete()
+        connection.connect()
 
 
 @task_prerun.connect

--- a/contentcuration/contentcuration/utils/celery_signals.py
+++ b/contentcuration/contentcuration/utils/celery_signals.py
@@ -21,7 +21,7 @@ from contentcuration.models import Task
 logger = get_task_logger(__name__)
 
 
-def clear_and_connect():
+def check_connection():
     try:
         connection.cursor()
     except InterfaceError:
@@ -31,12 +31,12 @@ def clear_and_connect():
 
 @task_prerun.connect
 def prerun(sender, **kwargs):
-    clear_and_connect()
+    check_connection()
 
 
 @task_postrun.connect
 def postrun(sender, **kwargs):
-    clear_and_connect()
+    check_connection()
 
 
 @after_task_publish.connect
@@ -61,7 +61,7 @@ def before_start(sender, headers, body, **kwargs):
 
 @task_failure.connect
 def on_failure(sender, **kwargs):
-    clear_and_connect()
+    check_connection()
     try:
         task = Task.objects.get(task_id=sender.request.id)
         task.status = "FAILURE"
@@ -89,7 +89,7 @@ def on_failure(sender, **kwargs):
 
 @task_success.connect
 def on_success(sender, result, **kwargs):
-    clear_and_connect()
+    check_connection()
     try:
         logger.info("on_success called, process is {}".format(os.getpid()))
         task_id = sender.request.id


### PR DESCRIPTION
Adds tests to replicate InterfaceError behaviour.
Adds fixes to ensure that connection is not expired during and after task execution

Fixes #2849