### PR TITLE
Create Thumbnail Encoding Serializer to accept nested values

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -80,6 +80,26 @@ class SyncTestCase(StudioAPITestCase):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(models.Channel.objects.get(id=channel.id).name, new_name)
 
+    def test_update_channel_thumbnail_encoding(self):
+        user = testdata.user()
+        channel = models.Channel.objects.create(**self.channel_metadata)
+        channel.editors.add(user)
+        new_encoding = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQA"
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(channel.id, CHANNEL, {
+                "thumbnail_encoding.base64": new_encoding,
+                "thumbnail_encoding.orientation": 1,
+                "thumbnail_encoding.scale": 0.73602189113443,
+                "thumbnail_encoding.startX": -96.66631072431669,
+                "thumbnail_encoding.startY": -335.58116356397636,
+            })],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(models.Channel.objects.get(id=channel.id).thumbnail_encoding["base64"], new_encoding)
+
     def test_cannot_update_channel(self):
         user = testdata.user()
         channel = models.Channel.objects.create(**self.channel_metadata)

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -23,7 +23,6 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import CharField
-from rest_framework.serializers import DictField
 from rest_framework.serializers import FloatField
 from rest_framework.serializers import IntegerField
 
@@ -230,7 +229,6 @@ class ChannelFilter(BaseChannelFilter):
 
 
 class ThumbnailEncodingFieldsSerializer(JSONFieldDictSerializer):
-    type = DictField(allow_null=True)
     base64 = CharField(allow_blank=True)
     orientation = IntegerField(required=False)
     scale = FloatField(required=False)

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -22,6 +22,10 @@ from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.serializers import CharField
+from rest_framework.serializers import DictField
+from rest_framework.serializers import FloatField
+from rest_framework.serializers import IntegerField
 
 from contentcuration.decorators import cache_no_user_data
 from contentcuration.models import Channel
@@ -40,6 +44,7 @@ from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.common import CatalogPaginator
 from contentcuration.viewsets.common import ContentDefaultsSerializer
+from contentcuration.viewsets.common import JSONFieldDictSerializer
 from contentcuration.viewsets.common import SQCount
 from contentcuration.viewsets.common import SQSum
 from contentcuration.viewsets.common import UUIDInFilter
@@ -224,12 +229,22 @@ class ChannelFilter(BaseChannelFilter):
         )
 
 
+class ThumbnailEncodingFieldsSerializer(JSONFieldDictSerializer):
+    type = DictField(allow_null=True)
+    base64 = CharField(allow_blank=True)
+    orientation = IntegerField(required=False)
+    scale = FloatField(required=False)
+    startX = FloatField(required=False)
+    startY = FloatField(required=False)
+
+
 class ChannelSerializer(BulkModelSerializer):
     """
     This is a write only serializer - we leverage it to do create and update
     operations, but read operations are handled by the Viewset.
     """
 
+    thumbnail_encoding = ThumbnailEncodingFieldsSerializer(required=False)
     bookmark = serializers.BooleanField(required=False)
     content_defaults = ContentDefaultsSerializer(partial=True, required=False)
 


### PR DESCRIPTION
## Description

This PR creates a ThumbnailEncoding serializer so that the encoding fields, which are nested, can be managed on the backend.

#### Issue Addressed (if applicable)

Addresses #2774 

## Steps to Test

- [ ] Edit the Channel Thumbnail by cropping or changing the size.
- [ ] Save and navigate back to the main channel list. The image should remain cropped
