### PR TITLE
Add defensive check for node while refreshing mptt values

### DIFF
--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -180,7 +180,7 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
         }
         for node in nodes:
             # Set the values on each of the nodes
-            if node.id:
+            if node.id and node.id in values_lookup:
                 values = values_lookup[node.id]
                 for k, v in values.items():
                     setattr(node, k, v)

--- a/contentcuration/contentcuration/tests/db/models/test_manager.py
+++ b/contentcuration/contentcuration/tests/db/models/test_manager.py
@@ -1,0 +1,16 @@
+from contentcuration.db.models.manager import CustomContentNodeTreeManager
+from contentcuration.models import ContentNode
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioTestCase
+
+
+class CustomContentNodeTreeManagerTest(StudioTestCase):
+    def setUp(self):
+        super(CustomContentNodeTreeManagerTest, self).setUp()
+        self.manager = CustomContentNodeTreeManager()
+        self.manager.model = ContentNode
+
+    def test_mptt_refresh(self):
+        node_a = testdata.node({"kind_id": "topic", "title": "Node A"})
+        node_b = ContentNode(id="abc123", title="Node B")
+        self.manager._mptt_refresh(node_a, node_b)


### PR DESCRIPTION
## Description

Adds a defensive check to `mptt_refresh` when attempting to set refreshed MPTT values pulled from the DB.

#### Issue Addressed (if applicable)

Resolves: https://github.com/learningequality/studio/issues/2824

## Steps to Test
- Added test for this scenario [`db/models/test_manager.py`](https://github.com/bjester/studio/blob/mptt-refresh/contentcuration/contentcuration/tests/db/models/test_manager.py)

## Checklist

- [X] Are there tests for this change?
