### PR TITLE
Self-heal validation on edit modal load

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -321,7 +321,9 @@
           const parentTopicId = to.params.nodeId;
           const childrenNodesIds =
             to.params.detailNodeIds !== undefined ? to.params.detailNodeIds.split(',') : [];
-          const allNodesIds = [...childrenNodesIds, parentTopicId];
+          // remove duplicates - if a topic is being edited,
+          // then parent topic ID is also in children nodes IDs
+          const allNodesIds = [...new Set([...childrenNodesIds, parentTopicId])];
 
           // Nice to have TODO: Refactor EditModal to make each tab
           // responsible for fetching data that it needs

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -316,6 +316,8 @@
           vm.loading = true;
 
           let promises;
+          // Nice to have TODO: Refactor EditModal to make each tab
+          // responsible for fetching data that it needs
           if (to.params.detailNodeIds !== undefined) {
             const ids = to.params.detailNodeIds.split(',');
             promises = [
@@ -323,13 +325,13 @@
               vm.loadFiles({ contentnode__in: ids }),
               ...ids.map(nodeId => vm.loadRelatedResources(nodeId)),
               // Do not remove - there is a logic that relies heavily
-              // on assessment items being properly loaded (especially
-              // marking nodes as (in)complete)
-              // Nice to have TODO: Refactor EditModal to make each tab
-              // responsible for fetching data that it needs
+              // on assessment items and files being properly loaded
+              // (especially marking nodes as (in)complete)
               vm.loadAssessmentItems({ contentnode__in: ids }),
             ];
           } else {
+            // `nodeId` is ID of a topic - no need to load
+            // assessment items or files as topics have none
             promises = [vm.loadContentNode(to.params.nodeId)];
           }
           return Promise.all(promises)

--- a/contentcuration/contentcuration/management/commands/setup.py
+++ b/contentcuration/contentcuration/management/commands/setup.py
@@ -110,9 +110,8 @@ class Command(BaseCommand):
         audio_file = create_file("Sample Audio", format_presets.AUDIO, file_formats.MP3, user=admin)
         html5_file = create_file("Sample HTML", format_presets.HTML5_ZIP, file_formats.HTML5, user=admin)
 
-        # Populate channel 1 with content and publish
+        # Populate channel 1 with content
         generate_tree(channel1.main_tree, document_file, video_file, subtitle_file, audio_file, html5_file, user=admin, tags=tags)
-        call_command('exportchannel', channel1.pk)
 
         # Populate channel 2 with staged content
         channel2.ricecooker_version = "0.0.0"
@@ -125,6 +124,15 @@ class Command(BaseCommand):
         # Get validation to be reflected in nodes properly
         ContentNode.objects.all().update(complete=True)
         call_command('mark_incomplete')
+
+        # Mark this node as incomplete even though it is complete
+        # for testing purposes
+        node = ContentNode.objects.get(tree_id=channel1.main_tree.tree_id, title="Sample Audio")
+        node.complete = False
+        node.save()
+
+        # Publish
+        call_command('exportchannel', channel1.pk)
 
         print("\n\n\nSETUP DONE: Log in as admin to view data (email: {}, password: {})\n\n\n".format(email, password))
 


### PR DESCRIPTION
## Description

Check if nodes' `complete` attribute is correct when nodes are loaded on edit modal open. Fix it for nodes that are marked incorrectly.

## Steps to Test

- [ ] *Clear IndexedDB*
- [ ] *yarn run devsetup*
- [ ] *Go to "Published Channel" editor*
- [ ] *Navigate to Topic 1 where you can find a node that is incorrectly marked as incomplete -  "Sample Audio"*
- [ ] *Open edit modal for "Sample Audio"*
- [ ] *Check that the "Incomplete" error icon disappeared from the node's list and a request with a correct complete attribute has been sent*

#### Does this introduce any tech-debt items?

I wanted to add tests but I've found out that we skip all edit modal test cases. After removing `skip`, everything fails. This makes adding new scenarios difficult. I can see that we skip tests for more related views. I think this is our tech debt from times when we needed to do some core refactors and agreed to comment out certain tests to be able to merge asap so other folks could work on related features. I am going to raise this issue during content dev meeting and hopefully will address that soon and also add tests for this new behavior on that opportunity.

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?