### PR TITLE
Ensures nodes are loaded prior to copy, a use case for importing from search

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -44,7 +44,7 @@ describe('ContentNode methods', () => {
         return Promise.resolve(nodes.find(n => n.id === id));
       });
 
-      const excluded_descendants = 'excluded_descendants';
+      const excluded_descendants = {};
       return ContentNode.tableCopy(
         copyNode.id,
         targetNode.id,

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -1,4 +1,5 @@
 import sortBy from 'lodash/sortBy';
+import find from 'lodash/find';
 import {
   RELATIVE_TREE_POSITIONS,
   COPYING_FLAG,
@@ -12,17 +13,307 @@ import { ContentNode, ContentNodePrerequisite, uuid4 } from 'shared/data/resourc
 describe('ContentNode methods', () => {
   const mocks = [];
   afterEach(() => {
-    mocks.forEach(mock => mock.mockRestore());
+    while (mocks.length) {
+      mocks.pop().mockRestore();
+    }
     return ContentNode.table.clear();
   });
 
-  function mockContentNodeFunc(name, implementation) {
+  function mockMethod(name, implementation) {
     const mock = jest.spyOn(ContentNode, name).mockImplementation(implementation);
     mocks.push(mock);
     return mock;
   }
 
-  describe('tableCopy method', () => {
+  describe('resolveParent method', () => {
+    let node,
+      parent,
+      get,
+      nodes = [];
+    beforeEach(() => {
+      parent = { id: uuid4(), title: 'Test node parent' };
+      node = { id: uuid4(), parent: parent.id, title: 'Test node' };
+      nodes = [node, parent];
+      get = mockMethod('get', id => {
+        return Promise.resolve(find(nodes, ['id', id]));
+      });
+    });
+
+    it('should reject invalid positions', () => {
+      return expect(ContentNode.resolveParent('abc123', 'not-a-valid-position')).rejects.toThrow(
+        `"not-a-valid-position" is an invalid position`
+      );
+    });
+
+    it('should return target node when first child', async () => {
+      await expect(
+        ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.FIRST_CHILD)
+      ).resolves.toBe(node);
+      expect(get).toHaveBeenCalledWith(node.id);
+    });
+
+    it('should return target node when last child', async () => {
+      await expect(
+        ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.LAST_CHILD)
+      ).resolves.toBe(node);
+      expect(get).toHaveBeenCalledWith(node.id);
+    });
+
+    it("should return target node's parent when inserting after", async () => {
+      await expect(ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.RIGHT)).resolves.toBe(
+        parent
+      );
+      expect(get).toHaveBeenNthCalledWith(1, node.id);
+      expect(get).toHaveBeenNthCalledWith(2, parent.id);
+    });
+
+    it("should return target node's parent when inserting before", async () => {
+      await expect(ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.LEFT)).resolves.toBe(
+        parent
+      );
+      expect(get).toHaveBeenNthCalledWith(1, node.id);
+      expect(get).toHaveBeenNthCalledWith(2, parent.id);
+    });
+
+    it("should reject when the target can't be found", async () => {
+      nodes = [];
+      await expect(
+        ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.FIRST_CHILD)
+      ).rejects.toThrow(`Target ${node.id} does not exist`);
+      expect(get).toHaveBeenNthCalledWith(1, node.id);
+    });
+
+    it("should reject when the target's parent can't be found", async () => {
+      nodes = [node];
+      await expect(
+        ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.LEFT)
+      ).rejects.toThrow(`Target ${parent.id} does not exist`);
+      expect(get).toHaveBeenNthCalledWith(1, node.id);
+      expect(get).toHaveBeenNthCalledWith(2, parent.id);
+    });
+  });
+
+  describe('resolveTreeInsert method', () => {
+    let node,
+      parent,
+      lft,
+      siblings = [],
+      resolveParent,
+      treeLock,
+      get,
+      where,
+      getNewSortOrder,
+      sortBy;
+    beforeEach(() => {
+      node = { id: uuid4(), title: 'Test node' };
+      parent = {
+        id: uuid4(),
+        title: 'Test node parent',
+        root_id: uuid4(),
+      };
+      siblings = [];
+      resolveParent = mockMethod('resolveParent', () => Promise.resolve(parent));
+      treeLock = mockMethod('treeLock', (id, cb) => cb());
+      getNewSortOrder = mockMethod('getNewSortOrder', () => lft);
+      get = mockMethod('get', id => Promise.resolve(node));
+      sortBy = jest.fn(() => Promise.resolve(siblings));
+      where = mockMethod('where', () => ({ sortBy }));
+    });
+
+    it('should reject with error when attempting to set as child of itself', async () => {
+      parent.id = 'abc123';
+      await expect(
+        ContentNode.resolveTreeInsert('abc123', 'target', 'position', false, jest.fn())
+      ).rejects.toThrow('Cannot set node as child of itself');
+      expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+    });
+
+    describe('moving', () => {
+      it('should default to appending', async () => {
+        let cb = jest.fn(() => Promise.resolve('results'));
+        await expect(
+          ContentNode.resolveTreeInsert('abc123', 'target', 'position', false, cb)
+        ).resolves.toEqual('results');
+        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
+        expect(get).toHaveBeenCalledWith('abc123');
+        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(getNewSortOrder).not.toBeCalled();
+        expect(cb).toBeCalled();
+        const result = cb.mock.calls[0][0];
+        expect(result).toMatchObject({
+          node,
+          parent,
+          payload: {
+            id: 'abc123',
+            parent: parent.id,
+            lft: 1,
+            changed: true,
+          },
+          change: {
+            key: 'abc123',
+            from_key: null,
+            target: parent.id,
+            position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+            oldObj: node,
+            source: CLIENTID,
+            table: 'contentnode',
+            type: CHANGE_TYPES.MOVED,
+          },
+        });
+      });
+
+      it('should determine lft from siblings', async () => {
+        let cb = jest.fn(() => Promise.resolve('results'));
+        lft = 7;
+        siblings = Array(5)
+          .fill(1)
+          .map((_, i) => ({ id: uuid4(), title: `Sibling ${i}` }));
+        await expect(
+          ContentNode.resolveTreeInsert('abc123', 'target', 'position', false, cb)
+        ).resolves.toEqual('results');
+        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
+        expect(get).toHaveBeenCalledWith('abc123');
+        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(getNewSortOrder).toHaveBeenCalledWith('abc123', 'target', 'position', siblings);
+        expect(cb).toBeCalled();
+        const result = cb.mock.calls[0][0];
+        expect(result).toMatchObject({
+          node,
+          parent,
+          payload: {
+            id: 'abc123',
+            parent: parent.id,
+            lft,
+            changed: true,
+          },
+          change: {
+            key: 'abc123',
+            from_key: null,
+            target: 'target',
+            position: 'position',
+            oldObj: node,
+            source: CLIENTID,
+            table: 'contentnode',
+            type: CHANGE_TYPES.MOVED,
+          },
+        });
+      });
+
+      it('should reject if null lft', async () => {
+        lft = null;
+        let cb = jest.fn(() => Promise.resolve('results'));
+        siblings = Array(5)
+          .fill(1)
+          .map((_, i) => ({ id: uuid4(), title: `Sibling ${i}` }));
+        await expect(
+          ContentNode.resolveTreeInsert('abc123', 'target', 'position', false, cb)
+        ).rejects.toThrow('New lft value evaluated to null');
+        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
+        expect(get).toHaveBeenCalledWith('abc123');
+        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(getNewSortOrder).toHaveBeenCalledWith('abc123', 'target', 'position', siblings);
+        expect(cb).not.toBeCalled();
+      });
+    });
+
+    describe('copying', () => {
+      it('should default to appending', async () => {
+        let cb = jest.fn(() => Promise.resolve('results'));
+        await expect(
+          ContentNode.resolveTreeInsert('abc123', 'target', 'position', true, cb)
+        ).resolves.toEqual('results');
+        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
+        expect(get).toHaveBeenCalledWith('abc123');
+        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(getNewSortOrder).not.toBeCalled();
+        expect(cb).toBeCalled();
+        const result = cb.mock.calls[0][0];
+        expect(result).toMatchObject({
+          node,
+          parent,
+          payload: {
+            id: expect.not.stringMatching('abc123'),
+            parent: parent.id,
+            lft: 1,
+            changed: true,
+          },
+          change: {
+            key: expect.not.stringMatching('abc123'),
+            from_key: 'abc123',
+            target: parent.id,
+            position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+            oldObj: null,
+            source: CLIENTID,
+            table: 'contentnode',
+            type: CHANGE_TYPES.COPIED,
+          },
+        });
+        expect(result.payload.id).toEqual(result.change.key);
+      });
+
+      it('should determine lft from siblings', async () => {
+        let cb = jest.fn(() => Promise.resolve('results'));
+        lft = 7;
+        siblings = Array(5)
+          .fill(1)
+          .map((_, i) => ({ id: uuid4(), title: `Sibling ${i}` }));
+        await expect(
+          ContentNode.resolveTreeInsert('abc123', 'target', 'position', true, cb)
+        ).resolves.toEqual('results');
+        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
+        expect(get).toHaveBeenCalledWith('abc123');
+        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(getNewSortOrder).toHaveBeenCalledWith(null, 'target', 'position', siblings);
+        expect(cb).toBeCalled();
+        const result = cb.mock.calls[0][0];
+        expect(result).toMatchObject({
+          node,
+          parent,
+          payload: {
+            id: expect.not.stringMatching('abc123'),
+            parent: parent.id,
+            lft,
+            changed: true,
+          },
+          change: {
+            key: expect.not.stringMatching('abc123'),
+            from_key: 'abc123',
+            target: 'target',
+            position: 'position',
+            oldObj: null,
+            source: CLIENTID,
+            table: 'contentnode',
+            type: CHANGE_TYPES.COPIED,
+          },
+        });
+        expect(result.payload.id).toEqual(result.change.key);
+      });
+
+      it('should reject if null lft', async () => {
+        lft = null;
+        let cb = jest.fn(() => Promise.resolve('results'));
+        siblings = Array(5)
+          .fill(1)
+          .map((_, i) => ({ id: uuid4(), title: `Sibling ${i}` }));
+        await expect(
+          ContentNode.resolveTreeInsert('abc123', 'target', 'position', true, cb)
+        ).rejects.toThrow('New lft value evaluated to null');
+        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
+        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
+        expect(get).toHaveBeenCalledWith('abc123');
+        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(getNewSortOrder).toHaveBeenCalledWith(null, 'target', 'position', siblings);
+        expect(cb).not.toBeCalled();
+      });
+    });
+  });
+
+  describe.skip('tableCopy method', () => {
     it('should load relevant nodes', () => {
       const nodes = ['Copy node', 'Target node'].map(title => ({
         id: uuid4(),
@@ -36,11 +327,11 @@ describe('ContentNode methods', () => {
       }));
       const [copyNode, targetNode] = nodes;
 
-      let getNewParentAndSiblings = mockContentNodeFunc('getNewParentAndSiblings', () => {
+      let getNewParentAndSiblings = mockMethod('getNewParentAndSiblings', () => {
         return Promise.resolve({ parent: targetNode.id, siblings: [] });
       });
 
-      let requestModel = mockContentNodeFunc('requestModel', id => {
+      let requestModel = mockMethod('requestModel', id => {
         return Promise.resolve(nodes.find(n => n.id === id));
       });
 

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -1,7 +1,7 @@
 import Dexie from 'dexie';
 import flatten from 'lodash/flatten';
 import sortBy from 'lodash/sortBy';
-import { CHANGE_TYPES, CHANGES_TABLE, IGNORED_SOURCE } from './constants';
+import { CHANGE_TYPES, IGNORED_SOURCE } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
 

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -1,7 +1,7 @@
 import Dexie from 'dexie';
 import flatten from 'lodash/flatten';
 import sortBy from 'lodash/sortBy';
-import { CHANGE_TYPES, IGNORED_SOURCE } from './constants';
+import { CHANGE_TYPES, CHANGES_TABLE, IGNORED_SOURCE } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
 
@@ -67,6 +67,27 @@ export function collectChanges(changes) {
   return collectedChanges;
 }
 
+/**
+ * @param {{table: string, rev: Number, key: string, target: string, position: string}} changes
+ * @return {Promise[]}
+ */
+function applyMoveChanges(changes) {
+  return sortBy(changes, 'rev')
+    .map(change => {
+      const resource = INDEXEDDB_RESOURCES[change.table];
+      if (!resource || !resource.tableMove) {
+        return null;
+      }
+
+      const { key, target, position } = change;
+      return resource.resolveTreeInsert(key, target, position, false, data => {
+        data.change.source = IGNORED_SOURCE;
+        return resource.tableMove(data);
+      });
+    })
+    .filter(Boolean);
+}
+
 /*
  * Modified from https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
  */
@@ -94,17 +115,7 @@ export default function applyChanges(changes) {
         promises.push(table.bulkDelete(deleteChangesToApply.map(c => c.key)).then(() => null));
       }
       if (moveChangesToApply.length) {
-        sortBy(moveChangesToApply, 'rev').forEach(change => {
-          if (INDEXEDDB_RESOURCES[change.table] && INDEXEDDB_RESOURCES[change.table].tableMove) {
-            promises.push(
-              INDEXEDDB_RESOURCES[change.table].tableMove(
-                change.key,
-                change.target,
-                change.position
-              )
-            );
-          }
-        });
+        promises.push(...applyMoveChanges(moveChangesToApply));
       }
     });
     return Promise.all(promises).then(results => flatten(results).filter(Boolean));

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -229,7 +229,7 @@ class IndexedDBResource {
    * initiated it by setting the CLIENTID.
    */
   transaction({ mode = 'rw', source = CLIENTID } = {}, ...extraTables) {
-    const callback = extraTables.pop(-1);
+    const callback = extraTables.pop();
     return db.transaction(mode, this.tableName, ...extraTables, () => {
       Dexie.currentTransaction.source = source;
       return callback();
@@ -1178,7 +1178,7 @@ export const ContentNode = new TreeResource({
   },
 
   getAncestors(id) {
-    return this.get(id).then(node => {
+    return this.table.get(id).then(node => {
       if (node) {
         if (node.parent) {
           return this.getAncestors(node.parent).then(nodes => {
@@ -1468,7 +1468,7 @@ export const Clipboard = new Resource({
         extra_fields,
       };
 
-      return this.transaction({ mode: 'rw' }, TABLE_NAMES.CONTENTNODE, () => {
+      return this.transaction({ mode: 'rw' }, () => {
         return this.table.put(data).then(() => data);
       });
     });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -942,8 +942,8 @@ export const ContentNode = new Resource({
       }
 
       // Get source node and parent so we can reference some specifics
-      const nodePromise = this.table.get(id);
-      const parentNodePromise = this.table.get(parent);
+      const nodePromise = this.get(id);
+      const parentNodePromise = this.get(parent);
 
       // Next, we'll add the new node immediately
       return Promise.all([nodePromise, parentNodePromise]).then(([node, parentNode]) => {
@@ -1000,7 +1000,7 @@ export const ContentNode = new Resource({
       ) {
         resolve(target);
       } else {
-        this.table.get(target).then(node => {
+        this.get(target).then(node => {
           if (node) {
             resolve(node.parent);
           } else {
@@ -1126,8 +1126,7 @@ export const ContentNode = new Resource({
 
       let data = { parent, lft, changed: true };
       let oldObj = null;
-      return this.table
-        .get(id)
+      return this.get(id)
         .then(node => {
           oldObj = node;
           return this.table.update(id, data);
@@ -1145,7 +1144,7 @@ export const ContentNode = new Resource({
           }
           // Update didn't succeed, this node probably doesn't exist, do a put instead,
           // but need to add in other parent info.
-          return this.table.get(parent).then(parentNode => {
+          return this.get(parent).then(parentNode => {
             data = {
               id,
               parent,
@@ -1171,7 +1170,7 @@ export const ContentNode = new Resource({
   },
 
   getAncestors(id) {
-    return this.table.get(id).then(node => {
+    return this.get(id).then(node => {
       if (node) {
         if (node.parent) {
           return this.getAncestors(node.parent).then(nodes => {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1,4 +1,5 @@
 import Dexie from 'dexie';
+import Mutex from 'mutex-js';
 import findIndex from 'lodash/findIndex';
 import flatMap from 'lodash/flatMap';
 import get from 'lodash/get';
@@ -688,6 +689,31 @@ class Resource extends mix(APIResource, IndexedDBResource) {
   }
 }
 
+/**
+ * Tree resources mixin
+ */
+class TreeResource extends Resource {
+  constructor(...args) {
+    super(...args);
+    this._locks = {};
+  }
+
+  /**
+   * Locks a treeId so we can be sure nothing changes while we're computing a new tree position
+   *
+   * @param {Number} id
+   * @param {Function} callback
+   * @return {Promise}
+   */
+  treeLock(id, callback) {
+    if (!this._locks.has(id)) {
+      this._locks[id] = new Mutex();
+    }
+
+    return this._locks[id].lock(callback);
+  }
+}
+
 export const Session = new IndexedDBResource({
   tableName: TABLE_NAMES.SESSION,
   idField: CURRENT_USER,
@@ -801,7 +827,7 @@ export const ContentNodePrerequisite = new IndexedDBResource({
   syncable: true,
 });
 
-export const ContentNode = new Resource({
+export const ContentNode = new TreeResource({
   tableName: TABLE_NAMES.CONTENTNODE,
   urlName: 'contentnode',
   indexFields: [
@@ -891,138 +917,112 @@ export const ContentNode = new Resource({
   },
 
   /**
-   * @param {string} id The ID of the node to treeCopy
-   * @param {string} target The ID of the target node used for positioning
-   * @param {string} position The position relative to `target`
-   * @param {string} excluded_descendants a map of node_ids to exclude from the copy
-   * @return {Promise}
-   */
-  copy(id, target, position = 'last-child', excluded_descendants = null) {
-    if (!validPositions.has(position)) {
-      throw new TypeError(`${position} is not a valid position`);
-    }
-
-    if (process.env.NODE_ENV !== 'production' && !process.env.TRAVIS) {
-      /* eslint-disable no-console */
-      console.groupCollapsed(`Copying contentnode from ${id} with target ${target}`);
-      console.trace();
-      console.groupEnd();
-      /* eslint-enable */
-    }
-
-    // Ignore changes from this operation except for the
-    // explicit copy change we generate.
-    return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, CHANGES_TABLE, () => {
-      return this.tableCopy(id, target, position, excluded_descendants);
-    });
-  },
-
-  tableCopy(id, target, position, excluded_descendants) {
-    if (!validPositions.has(position)) {
-      return Promise.reject();
-    }
-
-    return this.getNewParentAndSiblings(target, position).then(({ parent, siblings }) => {
-      if (parent === id) {
-        return Promise.reject();
-      }
-      let lft = 1;
-
-      if (siblings.length) {
-        // Pass in null id as new node has not been created yet
-        lft = this.getNewSortOrder(null, target, position, siblings);
-      } else {
-        // if there are no siblings, overwrite
-        target = parent;
-        position = RELATIVE_TREE_POSITIONS.LAST_CHILD;
-      }
-
-      if (lft === null) {
-        return Promise.reject('new lft value evaluated to null');
-      }
-
-      // Get source node and parent so we can reference some specifics
-      const nodePromise = this.get(id);
-      const parentNodePromise = this.get(parent);
-
-      // Next, we'll add the new node immediately
-      return Promise.all([nodePromise, parentNodePromise]).then(([node, parentNode]) => {
-        const data = {
-          ...node,
-          published: false,
-          changed: true,
-          id: uuid4(),
-          original_source_node_id: node.original_source_node_id || node.node_id,
-          lft,
-          source_channel_id: node.channel_id,
-          source_node_id: node.node_id,
-          channel_id: parentNode.channel_id,
-          root_id: parentNode.root_id,
-          parent: parentNode.id,
-          // Set this node as copying until we get confirmation from the
-          // backend that it has finished copying
-          [COPYING_FLAG]: true,
-          // Set to null, but this should update to a task id to track the copy
-          // task once it has been initiated
-          [TASK_ID]: null,
-        };
-        // Manually put our changes into the tree changes for syncing table
-        db[CHANGES_TABLE].put({
-          key: data.id,
-          from_key: id,
-          target,
-          position,
-          excluded_descendants,
-          mods: {},
-          source: CLIENTID,
-          oldObj: null,
-          table: this.tableName,
-          type: CHANGE_TYPES.COPIED,
-        });
-        return this.table.put(data).then(() => ({
-          // Return the id along with the data for further processing
-          source_id: id,
-          ...data,
-        }));
-      });
-    });
-  },
-
-  /**
+   * Resolves target ID string into parent object, based off position, for tree inserts
+   *
    * @param {string} target
    * @param {string} position
-   * @return {Promise<string>}
+   * @return {Promise<Object>}
    */
   resolveParent(target, position) {
-    return new Promise((resolve, reject) => {
-      if (
-        position === RELATIVE_TREE_POSITIONS.FIRST_CHILD ||
-        position === RELATIVE_TREE_POSITIONS.LAST_CHILD
-      ) {
-        resolve(target);
-      } else {
-        this.get(target).then(node => {
-          if (node) {
-            resolve(node.parent);
-          } else {
-            reject(new RangeError(`Target ${target} does not exist`));
-          }
-        });
-      }
-    });
+    if (!validPositions.has(position)) {
+      return Promise.reject(new TypeError(`"${position}" is an invalid position`));
+    }
+
+    return this.get(target)
+      .then(node => {
+        if (
+          position === RELATIVE_TREE_POSITIONS.FIRST_CHILD ||
+          position === RELATIVE_TREE_POSITIONS.LAST_CHILD
+        ) {
+          return node;
+        }
+
+        target = node.parent;
+        return node ? this.get(target) : null;
+      })
+      .then(node => {
+        if (!node) {
+          throw new RangeError(`Target ${target} does not exist`);
+        }
+
+        return node;
+      });
   },
 
   /**
+   * Resolves data required for a tree insert operation and passes it to the callback, which should
+   * perform the update and return a Promise.
+   *
+   * The tree operation references a node by `id`, which will be inserted to `position` of `target`.
+   * If the node is being explicitly created (not moved), then pass `isCreate=true`. Lastly, the
+   * callback is passed the results of the resolving the tree insert, while locking the tree
+   * locally so we can ensure we have orderly operations
+   *
+   * @template {Object} ContentNode
+   * @param {string} id
    * @param {string} target
    * @param {string} position
-   * @return {Promise<{parent: string, siblings: Object[]}>}
+   * @param {Boolean} isCreate
+   * @param {Function<Promise<ContentNode>>} callback
+   * @return {Promise<ContentNode>}
    */
-  getNewParentAndSiblings(target, position) {
+  resolveTreeInsert(id, target, position, isCreate, callback) {
+    // First, resolve parent so we can determine the sort order, but also to determine
+    // the tree so we can temporarily lock it while we determine those values locally
     return this.resolveParent(target, position).then(parent => {
-      return this.table
-        .where({ parent })
-        .sortBy('lft')
-        .then(siblings => ({ parent, siblings }));
+      if (id === parent.id) {
+        throw new RangeError(`Cannot set node as child of itself`);
+      }
+
+      // Using root_id, we'll keep this locked while we handle this, so no other operations
+      // happen while we're potentially waiting for some data we need (siblings, source node)
+      return this.treeLock(parent.root_id, () => {
+        // Preload the ID we're referencing, and get siblings to determine sort order
+        return Promise.all([this.get(id), this.where({ parent: parent.id }).sortBy('lft')]).then(
+          ([node, siblings]) => {
+            let lft = 1;
+            if (siblings.length) {
+              // If we're creating, we don't need to worry about passing the ID
+              lft = this.getNewSortOrder(isCreate ? null : id, target, position, siblings);
+            } else {
+              // if there are no siblings, overwrite
+              target = parent.id;
+              position = RELATIVE_TREE_POSITIONS.LAST_CHILD;
+            }
+
+            if (lft === null) {
+              return Promise.reject(new RangeError('New lft value evaluated to null'));
+            }
+
+            // Prep the bare minimum update payload
+            const payload = {
+              id: isCreate ? uuid4() : id,
+              parent: parent.id,
+              lft,
+              changed: true,
+            };
+
+            // Prep the change data tracked in the changes table
+            const change = {
+              key: payload.id,
+              from_key: isCreate ? id : null,
+              target,
+              position,
+              oldObj: isCreate ? null : node,
+              source: CLIENTID,
+              table: this.tableName,
+              type: isCreate ? CHANGE_TYPES.COPIED : CHANGE_TYPES.MOVED,
+            };
+
+            return callback({
+              node,
+              parent,
+              payload,
+              change,
+            });
+          }
+        );
+      });
     });
   },
 
@@ -1089,85 +1089,90 @@ export const ContentNode = new Resource({
   },
 
   move(id, target, position = RELATIVE_TREE_POSITIONS.FIRST_CHILD) {
-    if (!validPositions.has(position)) {
-      throw new TypeError(`${position} is not a valid position`);
-    }
-    return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, CHANGES_TABLE, () => {
-      // Ignore changes from this operation except for the
-      // explicit move change we generate.
-      return this.tableMove(id, target, position).then(data => {
-        // TODO: Call propagate to parents (get parent from oldObj)
-        return data;
+    return this.resolveTreeInsert(id, target, position, false, data => {
+      // Ignore changes from this operation except for the explicit move change we generate.
+      return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, CHANGES_TABLE, () => {
+        return this.tableMove(data);
       });
     });
   },
 
-  tableMove(id, target, position) {
-    if (!validPositions.has(position)) {
-      return Promise.reject();
+  tableMove({ node, parent, payload, change }) {
+    return this.table
+      .update(node.id, payload)
+      .then(() => {
+        // Set old parent to changed
+        if (node.parent !== parent.id) {
+          return this.table.update(node.parent, { changed: true });
+        }
+      })
+      .then(updated => {
+        payload = { ...payload };
+        if (updated) {
+          // Update succeeded
+          return payload;
+        }
+        // Update didn't succeed, this node probably doesn't exist, do a put instead,
+        // but need to add in other parent info.
+        payload = {
+          ...payload,
+          root_id: parent.root_id,
+        };
+        return this.table.put(payload).then(() => payload);
+      })
+      .then(payload => db[CHANGES_TABLE].put(change).then(() => payload));
+  },
+
+  /**
+   * @param {string} id The ID of the node to treeCopy
+   * @param {string} target The ID of the target node used for positioning
+   * @param {string} position The position relative to `target`
+   * @param {Object|null} [excluded_descendants] a map of node_ids to exclude from the copy
+   * @return {Promise}
+   */
+  copy(id, target, position = RELATIVE_TREE_POSITIONS.LAST_CHILD, excluded_descendants = null) {
+    if (process.env.NODE_ENV !== 'production' && !process.env.TRAVIS) {
+      /* eslint-disable no-console */
+      console.groupCollapsed(`Copying contentnode from ${id} with target ${target}`);
+      console.trace();
+      console.groupEnd();
+      /* eslint-enable */
     }
-    // This implements a 'parent local' algorithm
-    // to produce locally consistent node moves
-    return this.getNewParentAndSiblings(target, position).then(({ parent, siblings }) => {
-      if (parent === id) {
-        return Promise.reject();
-      }
-      let lft = 1;
-      if (siblings.length) {
-        lft = this.getNewSortOrder(id, target, position, siblings);
-      } else {
-        // if there are no siblings, overwrite
-        target = parent;
-        position = RELATIVE_TREE_POSITIONS.LAST_CHILD;
-      }
 
-      if (lft === null) {
-        return Promise.reject('new lft value evaluated to null');
-      }
+    return this.resolveTreeInsert(id, target, position, true, data => {
+      data.change.exclude_descendants = excluded_descendants;
 
-      let data = { parent, lft, changed: true };
-      let oldObj = null;
-      return this.get(id)
-        .then(node => {
-          oldObj = node;
-          return this.table.update(id, data);
-        })
-        .then(() => {
-          // Set old parent to changed
-          if (oldObj.parent !== parent) {
-            return this.table.update(oldObj.parent, { changed: true });
-          }
-        })
-        .then(updated => {
-          if (updated) {
-            // Update succeeded
-            return { id, ...data };
-          }
-          // Update didn't succeed, this node probably doesn't exist, do a put instead,
-          // but need to add in other parent info.
-          return this.get(parent).then(parentNode => {
-            data = {
-              id,
-              parent,
-              lft,
-              root_id: parentNode.root_id,
-              changed: true,
-            };
-            return this.table.put(data).then(() => data);
-          });
-        })
-        .then(data => {
-          return db[CHANGES_TABLE].put({
-            key: id,
-            target,
-            position,
-            oldObj,
-            source: CLIENTID,
-            table: this.tableName,
-            type: CHANGE_TYPES.MOVED,
-          }).then(() => data);
-        });
+      // Ignore changes from this operation except for the
+      // explicit copy change we generate.
+      return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, CHANGES_TABLE, () => {
+        return this.tableCopy(data);
+      });
     });
+  },
+
+  tableCopy({ node, parent, payload, change }) {
+    payload = {
+      ...node,
+      ...payload,
+      published: false,
+      original_source_node_id: node.original_source_node_id || node.node_id,
+      source_channel_id: node.channel_id,
+      source_node_id: node.node_id,
+      channel_id: parent.channel_id,
+      root_id: parent.root_id,
+      // Set this node as copying until we get confirmation from the
+      // backend that it has finished copying
+      [COPYING_FLAG]: true,
+      // Set to null, but this should update to a task id to track the copy
+      // task once it has been initiated
+      [TASK_ID]: null,
+    };
+
+    // Manually put our changes into the tree changes for syncing table
+    return this.table
+      .put(payload)
+      .then(() => db[CHANGES_TABLE].put(change))
+      .then(() => payload);
   },
 
   getAncestors(id) {
@@ -1437,48 +1442,34 @@ export const Clipboard = new Resource({
       return this.table.bulkDelete(ids);
     });
   },
+
   copy(node_id, channel_id, clipboardRootId, extra_fields = null) {
-    return this.transaction({ mode: 'rw' }, TABLE_NAMES.CONTENTNODE, () => {
-      return this.tableCopy(node_id, channel_id, clipboardRootId, extra_fields);
-    });
-  },
+    return Promise.all([
+      ContentNode.get({ '[node_id+channel_id]': [node_id, channel_id] }),
+      this.where({ parent }).sortBy('lft'),
+    ]).then(([node, siblings]) => {
+      let lft = 1;
 
-  tableCopy(node_id, channel_id, clipboardRootId, extra_fields = null) {
-    const parent = clipboardRootId;
-    return this.table
-      .where({ parent })
-      .sortBy('lft')
-      .then(siblings => {
-        let lft = 1;
+      if (siblings.length) {
+        lft = siblings.slice(-1)[0].lft + 1;
+      }
 
-        if (siblings.length) {
-          lft = siblings.slice(-1)[0].lft + 1;
-        }
+      // Next, we'll add the new node immediately
+      const data = {
+        id: uuid4(),
+        lft,
+        source_channel_id: channel_id,
+        source_node_id: node_id,
+        root_id: clipboardRootId,
+        kind: node.kind,
+        parent: clipboardRootId,
+        extra_fields,
+      };
 
-        // Get source node so we can reference some specifics
-        const nodePromise = ContentNode.table.get({
-          '[node_id+channel_id]': [node_id, channel_id],
-        });
-
-        // Next, we'll add the new node immediately
-        return nodePromise.then(node => {
-          const data = {
-            id: uuid4(),
-            lft,
-            source_channel_id: channel_id,
-            source_node_id: node_id,
-            root_id: clipboardRootId,
-            kind: node.kind,
-            parent,
-            extra_fields,
-          };
-          return this.table.put(data).then(() => ({
-            // Return the id along with the data for further processing
-            source_id: node.id,
-            ...data,
-          }));
-        });
+      return this.transaction({ mode: 'rw' }, TABLE_NAMES.CONTENTNODE, () => {
+        return this.table.put(data).then(() => data);
       });
+    });
   },
 });
 

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -956,6 +956,7 @@ export const ContentNode = new Resource({
           lft,
           source_channel_id: node.channel_id,
           source_node_id: node.node_id,
+          channel_id: parentNode.channel_id,
           root_id: parentNode.root_id,
           parent: parentNode.id,
           // Set this node as copying until we get confirmation from the

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -141,7 +141,7 @@ def duplicate_nodes_task(
     ).exists()
 
     try:
-        source.copy_to(
+        new_node = source.copy_to(
             target,
             position,
             pk,
@@ -155,7 +155,9 @@ def duplicate_nodes_task(
         # Possible we might want to raise an error here, but not clear
         # whether this could then be a way to sniff for ids
         pass
-    return {"changes": [generate_update_event(pk, CONTENTNODE, {COPYING_FLAG: False})]}
+    return {"changes": [
+        generate_update_event(pk, CONTENTNODE, {COPYING_FLAG: False, "node_id": new_node.node_id})
+    ]}
 
 
 @task(bind=True, name="export_channel_task")

--- a/contentcuration/contentcuration/tests/test_asynctask.py
+++ b/contentcuration/contentcuration/tests/test_asynctask.py
@@ -175,10 +175,11 @@ class AsyncTaskTestCase(BaseAPITestCase):
             self.assertEqual(response.data["task_type"], "duplicate-nodes")
             self.assertEqual(response.data["metadata"]["progress"], 100)
             result = response.data["metadata"]["result"]
+            node_id = ContentNode.objects.get(pk=task_args["pk"]).node_id
             self.assertEqual(
                 result["changes"][0],
                 generate_update_event(
-                    task_args["pk"], CONTENTNODE, {COPYING_FLAG: False}
+                    task_args["pk"], CONTENTNODE, {COPYING_FLAG: False, "node_id": node_id}
                 ),
             )
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "material-design-icons": "^3.0.1",
     "material-icons": "^0.3.1",
     "mathquill": "^0.10.1-a",
+    "mutex-js": "^1.1.5",
     "node-vibrant": "^3.1.6",
     "papaparse": "^5.2.0",
     "pdfjs-dist": "^2.2.228",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13874,6 +13874,11 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mutex-js@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/mutex-js/-/mutex-js-1.1.5.tgz#501dfa1b6192ded109f0e100b77fa7f89523eeda"
+  integrity sha1-UB36G2GS3tEJ8OEAt3+n+JUj7to=
+
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"


### PR DESCRIPTION
## Description
The content node copy operation was assuming the relevant nodes were already loaded, which in the case of importing from search, wasn't true. 

This PR unwraps code out of a transaction such that we can use our resource methods that will attempt to retrieve the object from our API if it's not present locally or is stale. This required unwrapping it because the API response must be inserted into the IndexedDB. To prevent against edge cases that could cause inconsistencies in rapid calls to `ContentNode.copy` or `.move`, I added a small in-memory locking memory to ensure that if it does retrieve objects from the API, the operations should still happen in order.

#### Issue Addressed (if applicable)

Resolves: https://github.com/learningequality/studio/issues/2820

## Steps to Test
Preconditions: A channel created.
- [ ] Login to Studio
- [ ] Click a channel to load the channel editor page
- [ ] Click the Add button
- [ ] Click Import from other channels
- [ ] Do a search in the search field ("Science" in this specific case)
- [ ] Checkbox-select some topics/resources
- [ ] Click the Review button
- [ ] Click the Import button


## Checklist

- [ ] Is the code clean and well-commented?
- [x] Are there tests for this change?



