### PR TITLE
Add newly created channels to the current channel list page

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -58,6 +58,7 @@ export function createChannel(context) {
   };
   const channel = Channel.createObj(channelData);
   context.commit('ADD_CHANNEL', channel);
+  context.commit('ADD_CHANNEL_TO_PAGE', channel);
   return channel.id;
 }
 


### PR DESCRIPTION
## Description

This seems to fix https://github.com/learningequality/studio/issues/2815, the apparent deletion of one old channel upon the creation of a new one.

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/2815

## Steps to Test

- [ ] Log into one account
- [ ] Log out and log into another one that has some channels
- [ ] Take note of the channels listed on the channel list page
- [ ] Add a new channel
- [ ] Navigate back to the channel list page
- [ ] Ensure that all of the old channels are there, along with the channel you just created.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

@jayoshih's [recent PR to hotfixes added pagination on the channel list page](https://github.com/learningequality/studio/pull/2788).  This PR ensures that newly created channels get added to the page so that they will be displayed.

#### Does this introduce any tech-debt items?

I found a whole host of weird symptoms of this that I still don't fully understand.  Why, for example, was the newly created channel showing up in place of an old channel?  This is something that still baffles me.

There may be more issues here, and I'd suggest a more thorough revisit of the channel list pagination code when things have stabilized a bit.

## Checklist

- [ ] Are there tests for this change?