### PR TITLE
Transform `<br>` tags to newline characters in exercise markdown

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -178,6 +178,7 @@
           content = formulaHtmlToMd(content);
           content = imagesHtmlToMd(content);
           content = content.replaceAll('&nbsp;', ' ');
+          content = content.replaceAll('<br>', '\n');
           return content;
         }
       }


### PR DESCRIPTION
## Description

Transforms `<br>` tags into `\n` characters in the exercise editor.
 
#### Issue Addressed (if applicable)
Published exercises were showing `<br>` tags in Kolibri.

![image](https://user-images.githubusercontent.com/389782/105535536-98a8cc80-5cb4-11eb-8d4e-7ae3c20f7014.png)


## Steps to Test

- [ ] Make a channel with an exercise that has a question with some line breaks in it and answers with line breaks as well.
- [ ] Publish this channel
- [ ] Import it into Kolibri and make sure there aren't any `<br>` tags.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I did a string replacement to replace instances of `<br>` with `\n`

#### Does this introduce any tech-debt items?

I might be missing something about how this is supposed to work.