### PR TITLE
Fixes for exercise rendering in Kolibri

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -57,6 +57,7 @@
   import '../mathquill/mathquill.js';
   import 'codemirror/lib/codemirror.css';
   import '@toast-ui/editor/dist/toastui-editor.css';
+  import * as Showdown from 'showdown';
 
   import Editor from '@toast-ui/editor';
   import debounce from 'lodash/debounce';
@@ -172,12 +173,24 @@
       const tmpEditor = new Editor({
         el: this.$refs.editor,
       });
+      const showdown = new Showdown.Converter();
       const Convertor = tmpEditor.convertor.constructor;
       class CustomConvertor extends Convertor {
         toMarkdown(content) {
-          content = formulaHtmlToMd(content);
+          content = showdown.makeMarkdown(content);
           content = imagesHtmlToMd(content);
+          content = formulaHtmlToMd(content);
           content = content.replaceAll('&nbsp;', ' ');
+
+          // TUI.editor sprinkles in extra `<br>` tags that Kolibri renders literally
+          content = content.replaceAll('<br>', '');
+          return content;
+        }
+        toHTML(content) {
+          // Kolibri and showdown assume double newlines for a single line break,
+          // wheras TUI.editor prefers single newline characters.
+          content = content.replaceAll('\n\n', '\n');
+          content = super.toHTML(content);
           return content;
         }
       }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "pdfjs-dist": "^2.2.228",
     "qs": "^6.9.1",
     "regenerator-runtime": "^0.13.5",
+    "showdown": "^1.9.1",
     "spark-md5": "^3.0.0",
     "store2": "^2.11.0",
     "to-markdown": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17613,6 +17613,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+showdown@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.1.tgz#134e148e75cd4623e09c21b0511977d79b5ad0ef"
+  integrity sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==
+  dependencies:
+    yargs "^14.2"
+
 side-channel@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"
@@ -20778,6 +20785,14 @@ yargs-parser@^13.1.0, yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -20835,6 +20850,23 @@ yargs@^13.3.0, yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^14.2:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.1"
 
 yargs@^15.3.1:
   version "15.3.1"


### PR DESCRIPTION
## Description
Fixes basic formatting issues for viewing published exercises in Kolibri.

Markdown from the markdown editor wasn't rendering correctly in Kolibri.  HTML tags were being displayed literally.

#### before
![image](https://user-images.githubusercontent.com/389782/105756409-31885380-5f12-11eb-98b6-c2268f481866.png)


#### after
![image](https://user-images.githubusercontent.com/389782/105755709-4adcd000-5f11-11eb-953d-773e86ae9828.png)


## Steps to Test

- [ ] Make a channel with an exercise that has questions and answers with lots of formatting and line breaks
- [ ] Publish it and import to Kolibri (I was running Kolibri and Studio both locally on my system and added the local instance of Studio as an import source in Kolibri)

## Implementation Notes (optional)

#### At a high level, how did you implement this?

We weren't ever applying TUI.editor's HTML to markdown conversion.  So I tried applying it, but then it led to some other quirks, so I added a markdown conversion library called "showdown", which is a bit more customizable compared to TUI.editor's.  So, currently the state of things is, roughly:

- Showdown for HTML to Markdown conversion
- TUI.editor for Markdown to HTML conversion

#### Does this introduce any tech-debt items?
(Most of these were existing tech debt issues)
- In question answers, paragraphs are still rendering inline in Kolibri, but it doesn't seem to be Studio's fault.
- Formulas aren't styled as nicely in Kolibri as they are in Studio.  Why?
- Specific numbers of newlines are not preserved; i.e. `\n\n\n\n` will still convert to a single paragraph break.
- Apparently Perseus markdown is very special.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Comments
This isn't an ideal solution, but it improves things a lot.