### PR TITLE
Fix force sync on sign out

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
@@ -103,7 +103,9 @@ export default {
         window.sessionStorage.setItem('logoutConfirmed', true);
 
         return forceServerSync()
-          .then(client.get(window.Urls.logout()))
+          .then(() => {
+            return client.get(window.Urls.logout());
+          })
           .then(() => {
             resetDB();
             window.sessionStorage.setItem('logoutConfirmed', false);


### PR DESCRIPTION
## Description

This fixes logout problem when `/logout` was requested before `/sync` which in majority of cases resulted in `403` for the `/sync` call.

## Steps to Test

- [ ] *Increase `SYNC_IF_NO_CHANGES_FOR` for easier testing*
- [ ] *Go to a channel editor*
- [ ] *Add a new topic*
- [ ] *Sign out*
- [ ] *Confirm that you want to leave the page*
- [ ] *Check that `sync/` is called before `logout/` every time*

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are users' storage used being recalculated properly on any changes to their main tree files?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If any Python requirements have changed, are the updated requirements.txt files also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?
