### PR TITLE
add a promise to save and update everything in the difftracker before…

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -364,9 +364,6 @@
         type: Array,
         default: () => [],
       },
-      closingModal: {
-        type: Boolean,
-      },
     },
     data() {
       return {
@@ -534,9 +531,6 @@
           this.$nextTick(this.handleValidation);
         },
       },
-      closingModal: function(newValue) {
-        newValue === true ? this.immediateSaveAll() : null;
-      },
     },
     mounted() {
       this.$nextTick(this.handleValidation);
@@ -560,6 +554,9 @@
         }
         return Promise.resolve();
       },
+      /*
+       * @public
+       */
       immediateSaveAll() {
         return Promise.all(Object.keys(this.diffTracker).map(this.saveFromDiffTracker));
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -99,7 +99,6 @@
                 ref="editView"
                 :nodeIds="selected"
                 :tab="tab"
-                :closingModal="closingModal"
               />
             </VContent>
           </template>
@@ -243,7 +242,6 @@
         promptFailed: false,
         listElevated: false,
         storagePoll: null,
-        closingModal: false,
       };
     },
     computed: {
@@ -435,7 +433,6 @@
             this.promptInvalid = true;
           } else {
             this.closeModal();
-            this.closingModal = false;
           }
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -96,6 +96,7 @@
               />
               <EditView
                 v-else
+                ref="editView"
                 :nodeIds="selected"
                 :tab="tab"
                 :closingModal="closingModal"
@@ -423,9 +424,9 @@
         let assessmentItems = this.getAssessmentItems(this.nodeIds);
         assessmentItems.forEach(item => (item.question ? (item.isNew = false) : ''));
         this.updateAssessmentItems(assessmentItems);
-        this.closingModal = true;
-        // Wait for nextTick to let the Vuex mutation propagate
-        this.$nextTick().then(() => {
+        // reaches into Details Tab to run save of diffTracker
+        // before the validation pop up is executed
+        this.$refs.editView.immediateSaveAll().then(() => {
           // Catch uploads in progress and invalid nodes
           if (this.contentNodesAreUploading(this.nodeIds)) {
             this.promptUploading = true;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -98,6 +98,7 @@
                 v-else
                 :nodeIds="selected"
                 :tab="tab"
+                :closingModal="closingModal"
               />
             </VContent>
           </template>
@@ -241,6 +242,7 @@
         promptFailed: false,
         listElevated: false,
         storagePoll: null,
+        closingModal: false,
       };
     },
     computed: {
@@ -421,6 +423,7 @@
         let assessmentItems = this.getAssessmentItems(this.nodeIds);
         assessmentItems.forEach(item => (item.question ? (item.isNew = false) : ''));
         this.updateAssessmentItems(assessmentItems);
+        this.closingModal = true;
         // Wait for nextTick to let the Vuex mutation propagate
         this.$nextTick().then(() => {
           // Catch uploads in progress and invalid nodes
@@ -431,6 +434,7 @@
             this.promptInvalid = true;
           } else {
             this.closeModal();
+            this.closingModal = false;
           }
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -73,7 +73,11 @@
               <VAlert v-else-if="!areDetailsValid" :value="true" type="error" outline icon="error">
                 {{ $tr('errorBannerText') }}
               </VAlert>
-              <DetailsTabView :key="nodeIds.join('-')" :nodeIds="nodeIds" />
+              <DetailsTabView
+                :key="nodeIds.join('-')"
+                :nodeIds="nodeIds"
+                :closingModal="closingModal"
+              />
             </VTabItem>
             <VTabItem :key="tabs.QUESTIONS" ref="questionwindow" :value="tabs.QUESTIONS" lazy>
               <AssessmentTab :nodeId="nodeIds[0]" />
@@ -123,6 +127,9 @@
       tab: {
         type: String,
         default: TabNames.DETAILS,
+      },
+      closingModal: {
+        type: Boolean,
       },
     },
     data() {
@@ -178,7 +185,12 @@
         return this.$tr('editingMultipleCount', totals);
       },
       areDetailsValid() {
-        return !this.oneSelected || this.getContentNodeDetailsAreValid(this.nodeIds[0]);
+        // only run this if the modal isn't closing
+        // because async DOM updates during close can cause issues
+        if (!this.closingModal) {
+          return !this.oneSelected || this.getContentNodeDetailsAreValid(this.nodeIds[0]);
+        }
+        return null;
       },
       areAssessmentItemsValid() {
         return (

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -75,6 +75,7 @@
               </VAlert>
               <DetailsTabView
                 :key="nodeIds.join('-')"
+                ref="detailsTab"
                 :nodeIds="nodeIds"
                 :closingModal="closingModal"
               />
@@ -250,6 +251,15 @@
       },
       trackTab(name) {
         this.$analytics.trackClick('channel_editor_modal', name);
+      },
+      /*
+       * @public
+       * reaches into Details Tab to run save of diffTracker
+       * before the validation pop up is executed
+       */
+      immediateSaveAll: function() {
+        this.$refs.detailsTab.immediateSaveAll();
+        return Promise.resolve();
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -77,7 +77,6 @@
                 :key="nodeIds.join('-')"
                 ref="detailsTab"
                 :nodeIds="nodeIds"
-                :closingModal="closingModal"
               />
             </VTabItem>
             <VTabItem :key="tabs.QUESTIONS" ref="questionwindow" :value="tabs.QUESTIONS" lazy>
@@ -128,9 +127,6 @@
       tab: {
         type: String,
         default: TabNames.DETAILS,
-      },
-      closingModal: {
-        type: Boolean,
       },
     },
     data() {
@@ -186,12 +182,7 @@
         return this.$tr('editingMultipleCount', totals);
       },
       areDetailsValid() {
-        // only run this if the modal isn't closing
-        // because async DOM updates during close can cause issues
-        if (!this.closingModal) {
-          return !this.oneSelected || this.getContentNodeDetailsAreValid(this.nodeIds[0]);
-        }
-        return null;
+        return !this.oneSelected || this.getContentNodeDetailsAreValid(this.nodeIds[0]);
       },
       areAssessmentItemsValid() {
         return (
@@ -258,8 +249,7 @@
        * before the validation pop up is executed
        */
       immediateSaveAll: function() {
-        this.$refs.detailsTab.immediateSaveAll();
-        return Promise.resolve();
+        return this.$refs.detailsTab.immediateSaveAll();
       },
     },
     $trs: {


### PR DESCRIPTION
## Description

This PR refactors some code in the DetailsTabView to create an immediateSaveAll, that makes sure the content of the diffTracker is all updated before the Edit Modal closes

#### Issue Addressed (if applicable)

Addresses #2567 

## Steps to Test

- [ ] In the tree view, create a new exercise.
- [ ] Fill out the title, mastery criteria, and the license field
- [ ] When you fill out the last field, click the "Finish" button within <1s of updating the field. (This can be a little bit tricky. I find it easiest if I do this for the license field so I only have to update the 
