### PR TITLE
Don't calculate data when there are not resources in the channel

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1399,12 +1399,14 @@ class ContentNode(MPTTModel, models.Model):
         from contentcuration.viewsets.common import SQSum
 
         node = ContentNode.objects.filter(pk=self.id).order_by()
+
         descendants = (
             self.get_descendants()
             .prefetch_related("children", "files", "tags")
             .select_related("license", "language")
             .values("id")
         )
+
         if channel_id:
             channel = Channel.objects.filter(id=channel_id)[0]
         else:

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1412,7 +1412,7 @@ class ContentNode(MPTTModel, models.Model):
         else:
             channel = self.get_channel()
 
-        if not descendants:
+        if not descendants.exists():
             data = {
                 "last_update": pytz.utc.localize(datetime.now()).strftime(
                     settings.DATE_TIME_FORMAT


### PR DESCRIPTION
## Description

Adding annotations over a channel without resources in it was causing errors due to empty resultsets

#### Issue Addressed (if applicable)

Closes: #2868

#### Before/After Screenshots (if applicable)

From the admin page, click on a channel with no resources. Before this PR is applied a server error will happen. 


## Steps to Test

As an example, this channel has not resources https://studio.learningequality.org/en/administration/#/channels?page_size=25&page=1&descending=false&sortBy=name&deleted=false&keywords=33350aadd5324cfb9f28be6e16f4fdad

