### PR TITLE
Navigate to new staging tree if staging tree has changed

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -445,7 +445,17 @@
           Promise.all([
             this.loadAncestors({ id: this.nodeId }),
             this.loadChildren({ parent: this.nodeId, root_id: this.stagingId }),
-          ]).then(() => {
+          ]).then(results => {
+            // If the new staging id isn't an ancestor, make sure we navigate
+            // to the latest staging tree
+            if (results[0].every(n => n.id !== this.stagingId)) {
+              this.$router.replace({
+                ...this.$route,
+                params: {
+                  nodeId: this.stagingId,
+                },
+              });
+            }
             this.isLoading = false;
             this.loadCurrentChannelStagingDiff();
           });


### PR DESCRIPTION
Fixes https://github.com/learningequality/studio/issues/2361

If the staging tree isn't in the current node's ancestors, navigate to the correct tree