### PR TITLE
Fix for stale staging tree loading

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -434,6 +434,11 @@
           viewMode: viewModes.COMPACT,
         });
       },
+      stagingId() {
+        this.$router.push({
+          name: RouterNames.STAGING_TREE_VIEW_REDIRECT,
+        });
+      },
     },
     created() {
       return this.loadCurrentChannel({ staging: true })

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -680,10 +680,11 @@ class Resource extends mix(APIResource, IndexedDBResource) {
       /* eslint-enable */
     }
     return this.table.get(id).then(obj => {
+      const request = this.requestModel(id);
       if (obj) {
         return obj;
       }
-      return this.requestModel(id);
+      return request;
     });
   }
 }


### PR DESCRIPTION
* Replicates `where` stale while invalidate behaviour in `get` - as opposed to the previous stale without invalidate
* Redirects to the root staging view when we detect that the root staging id has changed

Fixes #2361 

@bjester interested in your thoughts on the change in the `get` default behaviour for cache invalidation.