### PR TITLE
Removes "undo" and "cancel" options in popups

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -356,7 +356,8 @@
         this.showSnackbar({
           duration: null,
           text: this.$tr('creatingClipboardCopies'),
-          actionText: this.$tr('cancel'),
+          //! COMMENTED OUT UNTIL FUNCTIONALITY UPDATED
+          // actionText: this.$tr('cancel'),
           actionCallback: () => changeTracker.revert(),
         });
 
@@ -366,7 +367,8 @@
         }).then(() => {
           return this.showSnackbar({
             text: this.$tr('copiedItemsToClipboard'),
-            actionText: this.$tr('undo'),
+            //! COMMENTED OUT UNTIL FUNCTIONALITY UPDATED
+            // actionText: this.$tr('undo'),
             actionCallback: () => changeTracker.revert(),
           });
         });
@@ -382,7 +384,8 @@
         this.showSnackbar({
           duration: null,
           text: this.$tr('removingItems'),
-          actionText: this.$tr('cancel'),
+          //! COMMENTED OUT UNTIL FUNCTIONALITY UPDATED
+          // actionText: this.$tr('cancel'),
           actionCallback: () => changeTracker.revert(),
         });
 
@@ -390,7 +393,8 @@
           this.resetSelectionState();
           return this.showSnackbar({
             text: this.$tr('removedFromClipboard'),
-            actionText: this.$tr('undo'),
+            //! COMMENTED OUT UNTIL FUNCTIONALITY UPDATED
+            // actionText: this.$tr('undo'),
             actionCallback: () => changeTracker.revert(),
           });
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -573,7 +573,8 @@
         this.showSnackbar({
           duration: null,
           text: this.$tr('creatingClipboardCopies'),
-          actionText: this.$tr('cancel'),
+          //! COMMENTED OUT UNTIL FUNCTIONALITY UPDATED
+          // actionText: this.$tr('cancel'),
           actionCallback: () => changeTracker.revert(),
         });
 
@@ -581,7 +582,8 @@
           this.clearSelections();
           return this.showSnackbar({
             text: this.$tr('copiedItemsToClipboard'),
-            actionText: this.$tr('undo'),
+            //! COMMENTED OUT UNTIL FUNCTIONALITY UPDATED
+            // actionText: this.$tr('undo'),
             actionCallback: () => changeTracker.revert(),
           });
         });


### PR DESCRIPTION
## Description

Removes the options to "undo"/"cancel" in global snackbar popups when performing the following options to/on the clipboard:

On clipboard:
- "Make a copy"
- "Delete"

To clipboard:
- "Copy to clipboard"

#### Issue Addressed (if applicable)

Addresses #2890

#### Screen Recordings
![2021-02-01 20 31 32](https://user-images.githubusercontent.com/13563002/106553882-2794c080-64cf-11eb-9c29-8ba4d8b0f9bc.gif)

## Steps to Test

### Deletion/Copy (from Clipboard)
1. Login to Studio
2. Click a channel
3. Select some resources and add them to the Clipboard
4. Click the floating Clipboard icon in the bottom right corner
5. Browse the resource tree and select a single resource
6. Click the Delete button in the Selection toolbar that appears
7. See the item deleted from Clipboard and the snackbar notification
8. Make sure it is deleted and check that the snackbar indicates it is deleted, but does not have an option to UNDO or CANCEL
9. Repeat but with a resource to copy

### Canceling the Copy to Clipboard
1. Login to Studio
2. Click a Channel with imported content
3. Select multiple resources and add them to the Clipboard
4. Click the floating Clipboard icon in the bottom right corner
5. Browse the resources tree and select multiple resources
6. Click the Copy button in the selection toolbar
8. See that the selected items are copied in the Clipboard and check that there is no option to CANCEL

## Implementation Notes (optional)

#### At a high level, how did you implement this?

Code for "undo"/"cancel" was commented out.

#### Does this introduce any tech-debt items?

Code will need to be commented back in once these operations are functional.

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?

## Comments

I kept the snackbar visible so that users with less-than-ideal Internet connectivity can see the status, but can also take out the snackbar completely if it's decided that would be better. 

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
