### PR TITLE
Nodes selection and move modal fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/CurrentTopicView.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/CurrentTopicView.spec.js
@@ -1,0 +1,168 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import VueRouter from 'vue-router';
+import cloneDeep from 'lodash/cloneDeep';
+
+import { STORE_CONFIG } from '../store';
+import router from '../router';
+
+import CurrentTopicView from '../views/CurrentTopicView';
+import storeFactory from 'shared/vuex/baseStore';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+
+const CHANNEL = {
+  id: 'id-channel',
+  name: 'Test channel',
+  edit: false,
+  ricecooker_version: null,
+};
+
+const TOPIC = {
+  id: 'id-topic',
+  parent: CHANNEL.id,
+  title: 'Test topic',
+  kind: ContentKindsNames.TOPIC,
+};
+
+const NODE_1 = {
+  id: 'id-node-1',
+  parent: TOPIC.id,
+  title: 'Test node 1',
+  kind: ContentKindsNames.DOCUMENT,
+};
+
+const NODE_2 = {
+  id: 'id-node-2',
+  parent: TOPIC.id,
+  title: 'Test node 2',
+  kind: ContentKindsNames.VIDEO,
+};
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(VueRouter);
+
+const makeWrapper = ({ store, topicId = TOPIC.id }) => {
+  return mount(CurrentTopicView, {
+    propsData: {
+      topicId,
+    },
+    localVue,
+    router,
+    store,
+  });
+};
+
+function getNodeListItems(wrapper) {
+  return wrapper.findAll('[data-test="node-list-item"]');
+}
+
+function hasEditSelectedBtn(wrapper) {
+  return wrapper.contains('[data-test="edit-selected-btn"]');
+}
+
+function hasCopySelectedToClipboardBtn(wrapper) {
+  return wrapper.contains('[data-test="copy-selected-to-clipboard-btn"]');
+}
+
+function hasMoveSelectedBtn(wrapper) {
+  return wrapper.contains('[data-test="move-selected-btn"]');
+}
+
+function hasDuplicateSelectedBtn(wrapper) {
+  return wrapper.contains('[data-test="duplicate-selected-btn"]');
+}
+
+function hasDeleteSelectedBtn(wrapper) {
+  return wrapper.contains('[data-test="delete-selected-btn"]');
+}
+
+function selectNode(wrapper, nodeIdx) {
+  const nodeCheckbox = getNodeListItems(wrapper)
+    .at(nodeIdx)
+    .find('input[type="checkbox"]');
+  nodeCheckbox.setChecked();
+}
+
+describe('CurrentTopicView', () => {
+  it('smoke test', () => {
+    const store = storeFactory(STORE_CONFIG);
+    const wrapper = makeWrapper({ store });
+
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  describe('for a topic with nodes', () => {
+    let store, wrapper;
+
+    beforeEach(() => {
+      global.CHANNEL_EDIT_GLOBAL.channel_id = CHANNEL.id;
+
+      const storeConfig = cloneDeep(STORE_CONFIG);
+      // `loadChildren` call needs to be resolved for NodePanel
+      //  to finish loading (see NodePanel's `created` hook)
+      jest.spyOn(storeConfig.modules.contentNode.actions, 'loadChildren').mockResolvedValue();
+      store = storeFactory(storeConfig);
+
+      store.commit('channel/ADD_CHANNEL', CHANNEL);
+      store.commit('contentNode/ADD_CONTENTNODE', TOPIC);
+      store.commit('contentNode/ADD_CONTENTNODE', NODE_1);
+      store.commit('contentNode/ADD_CONTENTNODE', NODE_2);
+
+      wrapper = makeWrapper({ store });
+    });
+
+    afterEach(() => {
+      // Do not delete the value and reset it to its default value
+      // set in jest_config/setup.js instead so that we don't
+      // accidentally remove it for other tests
+      delete global.CHANNEL_EDIT_GLOBAL.channel_id;
+
+      jest.resetAllMocks();
+    });
+
+    it('should display all nodes of a topic', () => {
+      const nodeListItems = getNodeListItems(wrapper);
+
+      expect(nodeListItems.length).toBe(2);
+      expect(nodeListItems.at(0).text()).toContain('Test node 1');
+      expect(nodeListItems.at(1).text()).toContain('Test node 2');
+    });
+
+    it("shouldn't display any nodes operations buttons when no nodes are selected", () => {
+      expect(hasEditSelectedBtn(wrapper)).toBe(false);
+      expect(hasCopySelectedToClipboardBtn(wrapper)).toBe(false);
+      expect(hasMoveSelectedBtn(wrapper)).toBe(false);
+      expect(hasDuplicateSelectedBtn(wrapper)).toBe(false);
+      expect(hasDeleteSelectedBtn(wrapper)).toBe(false);
+    });
+
+    describe("when a user can't edit a channel", () => {
+      it('should display only copy to clipboard button when some nodes are selected', () => {
+        selectNode(wrapper, 0);
+
+        expect(hasCopySelectedToClipboardBtn(wrapper)).toBe(true);
+        expect(hasEditSelectedBtn(wrapper)).toBe(false);
+        expect(hasMoveSelectedBtn(wrapper)).toBe(false);
+        expect(hasDuplicateSelectedBtn(wrapper)).toBe(false);
+        expect(hasDeleteSelectedBtn(wrapper)).toBe(false);
+      });
+    });
+
+    describe('when a user can edit a channel', () => {
+      beforeEach(() => {
+        store.commit('channel/ADD_CHANNEL', { ...CHANNEL, edit: true });
+      });
+
+      it('should display all nodes operations buttons when some nodes are selected', () => {
+        selectNode(wrapper, 0);
+
+        expect(hasCopySelectedToClipboardBtn(wrapper)).toBe(true);
+        expect(hasEditSelectedBtn(wrapper)).toBe(true);
+        expect(hasMoveSelectedBtn(wrapper)).toBe(true);
+        expect(hasDuplicateSelectedBtn(wrapper)).toBe(true);
+        expect(hasDeleteSelectedBtn(wrapper)).toBe(true);
+      });
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/CurrentTopicView.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/CurrentTopicView.spec.js
@@ -5,8 +5,8 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import { STORE_CONFIG } from '../store';
 import router from '../router';
-
 import CurrentTopicView from '../views/CurrentTopicView';
+import { resetJestGlobal } from 'shared/utils/testing';
 import storeFactory from 'shared/vuex/baseStore';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
@@ -113,11 +113,7 @@ describe('CurrentTopicView', () => {
     });
 
     afterEach(() => {
-      // Do not delete the value and reset it to its default value
-      // set in jest_config/setup.js instead so that we don't
-      // accidentally remove it for other tests
-      delete global.CHANNEL_EDIT_GLOBAL.channel_id;
-
+      resetJestGlobal();
       jest.resetAllMocks();
     });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/store.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/store.js
@@ -12,42 +12,44 @@ import storeFactory from 'shared/vuex/baseStore';
 import persistFactory from 'shared/vuex/persistFactory';
 import DraggablePlugin from 'shared/vuex/draggablePlugin';
 
-export function factory() {
-  return storeFactory({
-    state() {
-      return {
-        /**
-         * The current view mode of the channel edit page,
-         * which right now only controls the density of the
-         * node list.
-         *
-         * See viewMode.* constants for options.
-         */
-        viewMode: null,
+export const STORE_CONFIG = {
+  state() {
+    return {
+      /**
+       * The current view mode of the channel edit page,
+       * which right now only controls the density of the
+       * node list.
+       *
+       * See viewMode.* constants for options.
+       */
+      viewMode: null,
 
-        /**
-         * The view mode can be overridden by modals or panels,
-         * and this allows for that to happen. See the
-         * `isCompactViewMode` getter for how these are merged
-         * to override the current `viewMode`.
-         */
-        viewModeOverrides: [],
-      };
-    },
-    actions,
-    mutations,
-    getters,
-    plugins: [DraggablePlugin, persistFactory('channelEdit', ['SET_VIEW_MODE'])],
-    modules: {
-      task,
-      template,
-      assessmentItem,
-      clipboard,
-      contentNode,
-      currentChannel,
-      importFromChannels,
-    },
-  });
+      /**
+       * The view mode can be overridden by modals or panels,
+       * and this allows for that to happen. See the
+       * `isCompactViewMode` getter for how these are merged
+       * to override the current `viewMode`.
+       */
+      viewModeOverrides: [],
+    };
+  },
+  actions,
+  mutations,
+  getters,
+  plugins: [DraggablePlugin, persistFactory('channelEdit', ['SET_VIEW_MODE'])],
+  modules: {
+    task,
+    template,
+    assessmentItem,
+    clipboard,
+    contentNode,
+    currentChannel,
+    importFromChannels,
+  },
+};
+
+export function factory() {
+  return storeFactory(STORE_CONFIG);
 }
 
 const store = factory();

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -58,13 +58,6 @@
             :text="$tr('moveSelectedButton')"
             @click="openMoveModal"
           />
-          <MoveModal
-            v-if="moveModalOpen"
-            ref="moveModal"
-            v-model="moveModalOpen"
-            :moveNodeIds="selected"
-            @target="moveNodes"
-          />
           <IconButton
             v-if="canEdit"
             icon="copy"
@@ -79,7 +72,17 @@
           />
         </div>
       </VSlideXTransition>
+
+      <MoveModal
+        v-if="moveModalOpen"
+        ref="moveModal"
+        v-model="moveModalOpen"
+        :moveNodeIds="selected"
+        @target="moveNodes"
+      />
+
       <VSpacer />
+
       <VFadeTransition>
         <div v-show="selected.length" v-if="$vuetify.breakpoint.mdAndUp" class="px-1">
           {{ selectionText }}

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -45,29 +45,34 @@
             v-if="canEdit"
             icon="edit"
             :text="$tr('editSelectedButton')"
+            data-test="edit-selected-btn"
             @click="editNodes(selected)"
           />
           <IconButton
             icon="clipboard"
             :text="$tr('copySelectedButton')"
+            data-test="copy-selected-to-clipboard-btn"
             @click="copyToClipboard(selected)"
           />
           <IconButton
             v-if="canEdit"
             icon="move"
             :text="$tr('moveSelectedButton')"
+            data-test="move-selected-btn"
             @click="openMoveModal"
           />
           <IconButton
             v-if="canEdit"
             icon="copy"
             :text="$tr('duplicateSelectedButton')"
+            data-test="duplicate-selected-btn"
             @click="duplicateNodes(selected)"
           />
           <IconButton
             v-if="canEdit"
             icon="remove"
             :text="$tr('deleteSelectedButton')"
+            data-test="delete-selected-btn"
             @click="removeNodes(selected)"
           />
         </div>
@@ -174,6 +179,7 @@
         </DraggableRegion>
       </VFadeTransition>
       <ResourceDrawer
+        v-if="currentChannel"
         ref="resourcepanel"
         :nodeId="detailNodeId"
         :channelId="currentChannel.id"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -74,7 +74,6 @@
       </VSlideXTransition>
 
       <MoveModal
-        v-if="moveModalOpen"
         ref="moveModal"
         v-model="moveModalOpen"
         :moveNodeIds="selected"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -35,6 +35,7 @@
           :select="selected.indexOf(child.id) >= 0"
           :previewing="$route.params.detailNodeId === child.id"
           :hasSelection="selected.length > 0"
+          data-test="node-list-item"
           @select="$emit('select', child.id)"
           @deselect="$emit('deselect', child.id)"
           @infoClick="goToNodeDetail(child.id)"

--- a/contentcuration/contentcuration/frontend/shared/utils/testing.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/testing.js
@@ -1,0 +1,8 @@
+export function resetJestGlobal() {
+  // This global object is bootstraped into channel_edit.html and is
+  // assumed by the frontend code for it
+  global.window.CHANNEL_EDIT_GLOBAL = {
+    channel_id: '',
+    channel_error: '',
+  };
+}

--- a/jest_config/setup.js
+++ b/jest_config/setup.js
@@ -16,6 +16,7 @@ import { setupSchema } from 'shared/data';
 import icons from 'shared/vuetify/icons';
 import ActionLink from 'shared/views/ActionLink';
 import { i18nSetup } from 'shared/i18n';
+import { resetJestGlobal } from 'shared/utils/testing'
 
 global.beforeEach(() => {
   return new Promise(resolve => {
@@ -75,11 +76,6 @@ jest.setTimeout(10000); // 10 sec
 
 Object.defineProperty(window, 'scrollTo', { value: () => {}, writable: true });
 
-// This global object is bootstraped into channel_edit.html and is
-// assumed by the frontend code for it
-global.window.CHANNEL_EDIT_GLOBAL = {
-  channel_id: '',
-  channel_error: '',
-};
+resetJestGlobal();
 
 setupSchema();


### PR DESCRIPTION
## Description

MoveModal open/close logic was conflicting with a condition based on selected nodes length which was causing the modal to be closed prematurely without properly calling logic that is supposed to run on its close.

Contains some smaller updates related to testing - please see commit messages.

#### Issue Addressed

- Fixes #2866
- Fixes issue when selecting a node that was previously moved unexpectedly reopens the move modal
![move-modal-select-bug](https://user-images.githubusercontent.com/13509191/106714525-42188800-65fc-11eb-86e6-057cedf2fce9.gif)
- Fixes issue when a snackbar wasn't displayed after move operation finished (can be also seen in the recording above)

## Steps to Test

- [ ] *Go to the channel editor page for a channel that you can edit*
- [ ] *Select some nodes*
- [ ] *Check that operations buttons appear*
![Screenshot from 2021-02-03 09-00-38](https://user-images.githubusercontent.com/13509191/106716175-65dccd80-65fe-11eb-8831-4bf2d3d48727.png)
- [ ] *Click the move button*
- [ ] *Select a move destination in the move modal and confirm*
- [ ] *Check that nodes have been moved properly, there is no console error and "Moved to (destination)>" message appears in the snackbar in the bottom left corner*
- [ ] *Check that the move modal won't open if you select one of the nodes that you've moved in the previous steps*

## Checklist

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?