### PR TITLE
Fix call to get with unsupported parameters

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -703,7 +703,7 @@ describe('Clipboard methods', () => {
       where = mockMethod('where', () => siblings);
       getByNodeIdChannelId = jest
         .spyOn(ContentNode, 'getByNodeIdChannelId')
-        .mockImplementation(() => Promise.resolve([node].filter(Boolean)));
+        .mockImplementation(() => Promise.resolve(node));
       mocks.push(getByNodeIdChannelId);
     });
 

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -9,9 +9,14 @@ import {
   CHANGE_TYPES,
 } from 'shared/data/constants';
 import db, { CLIENTID } from 'shared/data/db';
-import { Clipboard, ContentNode, ContentNodePrerequisite, TreeResource, uuid4 } from 'shared/data/resources';
-import {ContentKindsNames} from "shared/leUtils/ContentKinds";
-
+import {
+  Clipboard,
+  ContentNode,
+  ContentNodePrerequisite,
+  TreeResource,
+  uuid4,
+} from 'shared/data/resources';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
 describe('TreeResource methods', () => {
   let resource = new TreeResource({
@@ -20,28 +25,21 @@ describe('TreeResource methods', () => {
   });
 
   describe('treeLock method', () => {
-    const wait = (time) => new Promise(resolve => setTimeout(resolve, time));
+    const wait = time => new Promise(resolve => setTimeout(resolve, time));
     it('should lock such that calls are kept in order', async () => {
       const results = [];
       const lockOne = resource.treeLock(123, () => {
-        return wait(30)
-          .then(() => results.push('Lock 1'));
+        return wait(30).then(() => results.push('Lock 1'));
       });
       const lockTwo = resource.treeLock(123, () => {
-        return wait(20)
-          .then(() => results.push('Lock 2'));
+        return wait(20).then(() => results.push('Lock 2'));
       });
       const lockThree = resource.treeLock(123, () => {
-        return wait(10)
-          .then(() => results.push('Lock 3'));
+        return wait(10).then(() => results.push('Lock 3'));
       });
 
-      await Promise.all([ lockOne, lockTwo, lockThree ]);
-      expect(results).toEqual([
-        'Lock 1',
-        'Lock 2',
-        'Lock 3',
-      ])
+      await Promise.all([lockOne, lockTwo, lockThree]);
+      expect(results).toEqual(['Lock 1', 'Lock 2', 'Lock 3']);
     });
   });
 
@@ -58,69 +56,117 @@ describe('TreeResource methods', () => {
       {
         id: uuid4(),
         lft: 3,
-      }
+      },
     ];
 
     it('should return 1 when no siblings', () => {
-      expect(resource.getNewSortOrder(null, "abc123", RELATIVE_TREE_POSITIONS.LAST_CHILD, []))
-        .toEqual(1);
+      expect(
+        resource.getNewSortOrder(null, 'abc123', RELATIVE_TREE_POSITIONS.LAST_CHILD, [])
+      ).toEqual(1);
     });
 
     it('should sort siblings', () => {
-      expect(resource.getNewSortOrder(siblings[0].id, "abc123", RELATIVE_TREE_POSITIONS.FIRST_CHILD, shuffle(siblings)))
-        .toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[0].id,
+          'abc123',
+          RELATIVE_TREE_POSITIONS.FIRST_CHILD,
+          shuffle(siblings)
+        )
+      ).toEqual(null);
     });
 
     it('should return null when already first child', () => {
-      expect(resource.getNewSortOrder(siblings[0].id, "abc123", RELATIVE_TREE_POSITIONS.FIRST_CHILD, siblings))
-        .toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[0].id,
+          'abc123',
+          RELATIVE_TREE_POSITIONS.FIRST_CHILD,
+          siblings
+        )
+      ).toEqual(null);
     });
 
     it('should return null when already last child', () => {
-      expect(resource.getNewSortOrder(siblings[2].id, "abc123", RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings))
-        .toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[2].id,
+          'abc123',
+          RELATIVE_TREE_POSITIONS.LAST_CHILD,
+          siblings
+        )
+      ).toEqual(null);
     });
 
     it('should return null when already left of target', () => {
-      expect(resource.getNewSortOrder(siblings[0].id, siblings[1].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
-        .toEqual(null);
-      expect(resource.getNewSortOrder(siblings[1].id, siblings[2].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
-        .toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[0].id,
+          siblings[1].id,
+          RELATIVE_TREE_POSITIONS.LEFT,
+          siblings
+        )
+      ).toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[1].id,
+          siblings[2].id,
+          RELATIVE_TREE_POSITIONS.LEFT,
+          siblings
+        )
+      ).toEqual(null);
     });
 
     it('should return null when already right of target', () => {
-      expect(resource.getNewSortOrder(siblings[2].id, siblings[1].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
-        .toEqual(null);
-      expect(resource.getNewSortOrder(siblings[1].id, siblings[0].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
-        .toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[2].id,
+          siblings[1].id,
+          RELATIVE_TREE_POSITIONS.RIGHT,
+          siblings
+        )
+      ).toEqual(null);
+      expect(
+        resource.getNewSortOrder(
+          siblings[1].id,
+          siblings[0].id,
+          RELATIVE_TREE_POSITIONS.RIGHT,
+          siblings
+        )
+      ).toEqual(null);
     });
 
     it('should return smallest sort order', () => {
-      expect(resource.getNewSortOrder(uuid4(), "abc123", RELATIVE_TREE_POSITIONS.FIRST_CHILD, siblings))
-        .toEqual(1 / 2);
+      expect(
+        resource.getNewSortOrder(uuid4(), 'abc123', RELATIVE_TREE_POSITIONS.FIRST_CHILD, siblings)
+      ).toEqual(1 / 2);
     });
 
     it('should return largest sort order', () => {
-      expect(resource.getNewSortOrder(uuid4(), "abc123", RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings))
-        .toEqual(4);
+      expect(
+        resource.getNewSortOrder(uuid4(), 'abc123', RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings)
+      ).toEqual(4);
     });
 
     it('should return sort order in between target and left sibling', () => {
-      expect(resource.getNewSortOrder(uuid4(), siblings[1].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
-        .toEqual(3 / 2);
-      expect(resource.getNewSortOrder(uuid4(), siblings[2].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
-        .toEqual(5 / 2);
+      expect(
+        resource.getNewSortOrder(uuid4(), siblings[1].id, RELATIVE_TREE_POSITIONS.LEFT, siblings)
+      ).toEqual(3 / 2);
+      expect(
+        resource.getNewSortOrder(uuid4(), siblings[2].id, RELATIVE_TREE_POSITIONS.LEFT, siblings)
+      ).toEqual(5 / 2);
     });
 
     it('should return sort order in between target and right sibling', () => {
-      expect(resource.getNewSortOrder(uuid4(), siblings[1].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
-        .toEqual(5 / 2);
-      expect(resource.getNewSortOrder(uuid4(), siblings[0].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
-        .toEqual(3 / 2);
+      expect(
+        resource.getNewSortOrder(uuid4(), siblings[1].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings)
+      ).toEqual(5 / 2);
+      expect(
+        resource.getNewSortOrder(uuid4(), siblings[0].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings)
+      ).toEqual(3 / 2);
     });
   });
 });
-
 
 describe('ContentNode methods', () => {
   const mocks = [];
@@ -293,12 +339,7 @@ describe('ContentNode methods', () => {
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
         expect(get).toHaveBeenCalledWith('abc123');
         expect(where).toHaveBeenCalledWith({ parent: parent.id });
-        expect(getNewSortOrder).toHaveBeenCalledWith(
-          'abc123',
-          'target',
-          'position',
-          siblings
-        );
+        expect(getNewSortOrder).toHaveBeenCalledWith('abc123', 'target', 'position', siblings);
         expect(cb).toBeCalled();
         const result = cb.mock.calls[0][0];
         expect(result).toMatchObject({
@@ -593,15 +634,16 @@ describe('ContentNode methods', () => {
         node_id: uuid4(),
       };
 
-      collection = [ Object.assign({}, node) ];
+      collection = [Object.assign({}, node)];
       requestCollection = mockMethod('requestCollection', () => Promise.resolve(collection));
       mockProperty('table', table);
     });
 
     it('should use the [node_id+channel_id] IndexedDB index', async () => {
       const { node_id, channel_id } = node;
-      await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id))
-        .resolves.toMatchObject(node);
+      await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id)).resolves.toMatchObject(
+        node
+      );
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(requestCollection).not.toBeCalled();
     });
@@ -609,20 +651,24 @@ describe('ContentNode methods', () => {
     it('should use call requestCollection when missing locally', async () => {
       const { node_id, channel_id } = node;
       node = null;
-      await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id))
-        .resolves.toMatchObject(collection[0]);
+      await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id)).resolves.toMatchObject(
+        collection[0]
+      );
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
-      expect(requestCollection).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
+      expect(requestCollection).toHaveBeenCalledWith({
+        '[node_id+channel_id]': [node_id, channel_id],
+      });
     });
 
     it('should be capable of returning no result', async () => {
       const { node_id, channel_id } = node;
       node = null;
       collection = [];
-      await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id))
-        .resolves.toBeFalsy();
+      await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id)).resolves.toBeFalsy();
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
-      expect(requestCollection).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
+      expect(requestCollection).toHaveBeenCalledWith({
+        '[node_id+channel_id]': [node_id, channel_id],
+      });
     });
   });
 });
@@ -644,13 +690,7 @@ describe('Clipboard methods', () => {
   });
 
   describe('copy method', () => {
-    let node_id,
-        channel_id,
-        clipboardRootId,
-        node,
-        siblings,
-        where,
-        getByNodeIdChannelId;
+    let node_id, channel_id, clipboardRootId, node, siblings, where, getByNodeIdChannelId;
     beforeEach(() => {
       node_id = uuid4();
       channel_id = uuid4();
@@ -661,7 +701,8 @@ describe('Clipboard methods', () => {
       };
       siblings = [];
       where = mockMethod('where', () => siblings);
-      getByNodeIdChannelId = jest.spyOn(ContentNode, 'getByNodeIdChannelId')
+      getByNodeIdChannelId = jest
+        .spyOn(ContentNode, 'getByNodeIdChannelId')
         .mockImplementation(() => Promise.resolve([node].filter(Boolean)));
       mocks.push(getByNodeIdChannelId);
     });
@@ -669,7 +710,7 @@ describe('Clipboard methods', () => {
     it('should create a bare copy of the node', async () => {
       const extra_fields = {
         field: 'extra',
-      }
+      };
       const expectedResult = {
         id: expect.not.stringMatching(new RegExp(`${node_id}|${parent.node_id}`)),
         lft: 1,
@@ -689,7 +730,7 @@ describe('Clipboard methods', () => {
     });
 
     it('should append with lft based off siblings', async () => {
-      siblings = [{lft: 2}, {lft: 1}];
+      siblings = [{ lft: 2 }, { lft: 1 }];
       const expectedResult = {
         id: expect.not.stringMatching(new RegExp(`${node_id}|${parent.node_id}`)),
         lft: 3,
@@ -710,8 +751,9 @@ describe('Clipboard methods', () => {
 
     it('should handle when source node is missing', async () => {
       node = null;
-      await expect(Clipboard.copy(node_id, channel_id, clipboardRootId))
-        .rejects.toThrow('Cannot load source node');
+      await expect(Clipboard.copy(node_id, channel_id, clipboardRootId)).rejects.toThrow(
+        'Cannot load source node'
+      );
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -656,7 +656,7 @@ describe('ContentNode methods', () => {
       );
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(requestCollection).toHaveBeenCalledWith({
-        '[node_id+channel_id]': [node_id, channel_id],
+        _node_id_channel_id___in: `${node_id},${channel_id}`,
       });
     });
 
@@ -667,7 +667,7 @@ describe('ContentNode methods', () => {
       await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id)).resolves.toBeFalsy();
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(requestCollection).toHaveBeenCalledWith({
-        '[node_id+channel_id]': [node_id, channel_id],
+        _node_id_channel_id___in: `${node_id},${channel_id}`,
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -9,7 +9,118 @@ import {
   CHANGE_TYPES,
 } from 'shared/data/constants';
 import db, { CLIENTID } from 'shared/data/db';
-import { ContentNode, ContentNodePrerequisite, uuid4 } from 'shared/data/resources';
+import { Clipboard, ContentNode, ContentNodePrerequisite, TreeResource, uuid4 } from 'shared/data/resources';
+import {ContentKindsNames} from "shared/leUtils/ContentKinds";
+
+
+describe('TreeResource methods', () => {
+  let resource = new TreeResource({
+    urlName: 'test',
+    tableName: 'test',
+  });
+
+  describe('treeLock method', () => {
+    const wait = (time) => new Promise(resolve => setTimeout(resolve, time));
+    it('should lock such that calls are kept in order', async () => {
+      const results = [];
+      const lockOne = resource.treeLock(123, () => {
+        return wait(30)
+          .then(() => results.push('Lock 1'));
+      });
+      const lockTwo = resource.treeLock(123, () => {
+        return wait(20)
+          .then(() => results.push('Lock 2'));
+      });
+      const lockThree = resource.treeLock(123, () => {
+        return wait(10)
+          .then(() => results.push('Lock 3'));
+      });
+
+      await Promise.all([ lockOne, lockTwo, lockThree ]);
+      expect(results).toEqual([
+        'Lock 1',
+        'Lock 2',
+        'Lock 3',
+      ])
+    });
+  });
+
+  describe('getNewSortOrder method', () => {
+    const siblings = [
+      {
+        id: uuid4(),
+        lft: 1,
+      },
+      {
+        id: uuid4(),
+        lft: 2,
+      },
+      {
+        id: uuid4(),
+        lft: 3,
+      }
+    ];
+
+    it('should return 1 when no siblings', () => {
+      expect(resource.getNewSortOrder(null, "abc123", RELATIVE_TREE_POSITIONS.LAST_CHILD, []))
+        .toEqual(1);
+    });
+
+    it('should sort siblings', () => {
+      expect(resource.getNewSortOrder(siblings[0].id, "abc123", RELATIVE_TREE_POSITIONS.FIRST_CHILD, shuffle(siblings)))
+        .toEqual(null);
+    });
+
+    it('should return null when already first child', () => {
+      expect(resource.getNewSortOrder(siblings[0].id, "abc123", RELATIVE_TREE_POSITIONS.FIRST_CHILD, siblings))
+        .toEqual(null);
+    });
+
+    it('should return null when already last child', () => {
+      expect(resource.getNewSortOrder(siblings[2].id, "abc123", RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings))
+        .toEqual(null);
+    });
+
+    it('should return null when already left of target', () => {
+      expect(resource.getNewSortOrder(siblings[0].id, siblings[1].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
+        .toEqual(null);
+      expect(resource.getNewSortOrder(siblings[1].id, siblings[2].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
+        .toEqual(null);
+    });
+
+    it('should return null when already right of target', () => {
+      expect(resource.getNewSortOrder(siblings[2].id, siblings[1].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
+        .toEqual(null);
+      expect(resource.getNewSortOrder(siblings[1].id, siblings[0].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
+        .toEqual(null);
+    });
+
+    it('should return smallest sort order', () => {
+      expect(resource.getNewSortOrder(uuid4(), "abc123", RELATIVE_TREE_POSITIONS.FIRST_CHILD, siblings))
+        .toEqual(1 / 2);
+    });
+
+    it('should return largest sort order', () => {
+      expect(resource.getNewSortOrder(uuid4(), "abc123", RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings))
+        .toEqual(4);
+    });
+
+    it('should return sort order in between target and left sibling', () => {
+      expect(resource.getNewSortOrder(uuid4(), siblings[1].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
+        .toEqual(3 / 2);
+      expect(resource.getNewSortOrder(uuid4(), siblings[2].id, RELATIVE_TREE_POSITIONS.LEFT, siblings))
+        .toEqual(5 / 2);
+    });
+
+    it('should return sort order in between target and right sibling', () => {
+      expect(resource.getNewSortOrder(uuid4(), siblings[1].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
+        .toEqual(5 / 2);
+      expect(resource.getNewSortOrder(uuid4(), siblings[0].id, RELATIVE_TREE_POSITIONS.RIGHT, siblings))
+        .toEqual(3 / 2);
+    });
+  });
+});
+
 
 describe('ContentNode methods', () => {
   const mocks = [];
@@ -171,10 +282,9 @@ describe('ContentNode methods', () => {
       it('should determine lft from siblings', async () => {
         let cb = jest.fn(() => Promise.resolve('results'));
         lft = 7;
-        let sortedSiblings = Array(6)
+        siblings = Array(6)
           .fill(1)
           .map((_, i) => ({ id: uuid4(), lft: i, title: `Sibling ${i}` }));
-        siblings = shuffle(sortedSiblings);
 
         await expect(
           ContentNode.resolveTreeInsert('abc123', 'target', 'position', false, cb)
@@ -187,7 +297,7 @@ describe('ContentNode methods', () => {
           'abc123',
           'target',
           'position',
-          sortedSiblings
+          siblings
         );
         expect(cb).toBeCalled();
         const result = cb.mock.calls[0][0];
@@ -463,6 +573,95 @@ describe('ContentNode methods', () => {
       // TODO: Fails
       // await expect(db[CHANGES_TABLE].get({ '[table+key]': [ContentNode.tableName, node.id] }))
       //   .resolves.toMatchObject(change);
+    });
+  });
+});
+
+describe('Clipboard methods', () => {
+  const mocks = [];
+
+  function mockMethod(name, implementation) {
+    const mock = jest.spyOn(Clipboard, name).mockImplementation(implementation);
+    mocks.push(mock);
+    return mock;
+  }
+
+  afterEach(() => {
+    while (mocks.length) {
+      mocks.pop().mockRestore();
+    }
+    return ContentNode.table.clear().then(() => Clipboard.table.clear());
+  });
+
+  describe('copy method', () => {
+    let node_id,
+        channel_id,
+        clipboardRootId,
+        node,
+        siblings,
+        where,
+        getByNodeIdChannelId;
+    beforeEach(() => {
+      node_id = uuid4();
+      channel_id = uuid4();
+      clipboardRootId = uuid4();
+      node = {
+        id: node_id,
+        kind: ContentKindsNames.DOCUMENT,
+      };
+      siblings = [];
+      where = mockMethod('where', () => siblings);
+      getByNodeIdChannelId = jest.spyOn(ContentNode, 'getByNodeIdChannelId')
+        .mockImplementation(() => Promise.resolve([node].filter(Boolean)));
+      mocks.push(getByNodeIdChannelId);
+    });
+
+    it('should create a bare copy of the node', async () => {
+      const extra_fields = {
+        field: 'extra',
+      }
+      const expectedResult = {
+        id: expect.not.stringMatching(new RegExp(`${node_id}|${parent.node_id}`)),
+        lft: 1,
+        source_channel_id: channel_id,
+        source_node_id: node_id,
+        root_id: clipboardRootId,
+        kind: node.kind,
+        parent: clipboardRootId,
+        extra_fields,
+      };
+
+      const result = await Clipboard.copy(node_id, channel_id, clipboardRootId, extra_fields);
+      await expect(result).toMatchObject(expectedResult);
+      await expect(Clipboard.table.get(result.id)).resolves.toMatchObject(expectedResult);
+      expect(getByNodeIdChannelId).toHaveBeenCalledWith(node_id, channel_id);
+      expect(where).toHaveBeenCalledWith({ parent: clipboardRootId });
+    });
+
+    it('should append with lft based off siblings', async () => {
+      siblings = [{lft: 2}, {lft: 1}];
+      const expectedResult = {
+        id: expect.not.stringMatching(new RegExp(`${node_id}|${parent.node_id}`)),
+        lft: 3,
+        source_channel_id: channel_id,
+        source_node_id: node_id,
+        root_id: clipboardRootId,
+        kind: node.kind,
+        parent: clipboardRootId,
+        extra_fields: null,
+      };
+
+      const result = await Clipboard.copy(node_id, channel_id, clipboardRootId);
+      await expect(result).toMatchObject(expectedResult);
+      await expect(Clipboard.table.get(result.id)).resolves.toMatchObject(expectedResult);
+      expect(getByNodeIdChannelId).toHaveBeenCalledWith(node_id, channel_id);
+      expect(where).toHaveBeenCalledWith({ parent: clipboardRootId });
+    });
+
+    it('should handle when source node is missing', async () => {
+      node = null;
+      await expect(Clipboard.copy(node_id, channel_id, clipboardRootId))
+        .rejects.toThrow('Cannot load source node');
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -656,7 +656,7 @@ describe('ContentNode methods', () => {
       );
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(requestCollection).toHaveBeenCalledWith({
-        _node_id_channel_id___in: `${node_id},${channel_id}`,
+        _node_id_channel_id_: [node_id, channel_id],
       });
     });
 
@@ -667,7 +667,7 @@ describe('ContentNode methods', () => {
       await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id)).resolves.toBeFalsy();
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(requestCollection).toHaveBeenCalledWith({
-        _node_id_channel_id___in: `${node_id},${channel_id}`,
+        _node_id_channel_id_: [node_id, channel_id],
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1212,10 +1212,12 @@ export const ContentNode = new TreeResource({
    * @return {Promise<{}|null>}
    */
   getByNodeIdChannelId(nodeId, channelId) {
-    const params = { '[node_id+channel_id]': [nodeId, channelId] };
-    return this.table.get(params).then(node => {
+    const values = [nodeId, channelId];
+    return this.table.get({ '[node_id+channel_id]': values }).then(node => {
       if (!node) {
-        return this.requestCollection(params).then(nodes => nodes[0]);
+        return this.requestCollection({ _node_id_channel_id___in: values.join(',') }).then(
+          nodes => nodes[0]
+        );
       }
       return node;
     });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1203,6 +1203,14 @@ export const ContentNode = new TreeResource({
     });
   },
 
+  /**
+   * Uses local IndexedDB index on node_id+channel_id, otherwise specifically requests the
+   * collection using the same params since GET detail endpoint doesn't support that the params
+   *
+   * @param {String} nodeId
+   * @param {String} channelId
+   * @return {Promise<{}|null>}
+   */
   getByNodeIdChannelId(nodeId, channelId) {
     const params = { '[node_id+channel_id]': [nodeId, channelId] };
     return this.table.get(params).then(node => {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1215,7 +1215,7 @@ export const ContentNode = new TreeResource({
     const values = [nodeId, channelId];
     return this.table.get({ '[node_id+channel_id]': values }).then(node => {
       if (!node) {
-        return this.requestCollection({ _node_id_channel_id___in: values.join(',') }).then(
+        return this.requestCollection({ _node_id_channel_id_: values }).then(
           nodes => nodes[0]
         );
       }

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1479,8 +1479,8 @@ export const Clipboard = new TreeResource({
     return Promise.all([
       ContentNode.getByNodeIdChannelId(node_id, channel_id),
       this.where({ parent: clipboardRootId }),
-    ]).then(([copyNodeResults, siblings]) => {
-      if (!copyNodeResults.length) {
+    ]).then(([node, siblings]) => {
+      if (!node) {
         return Promise.reject(new RangeError(`Cannot load source node`));
       }
 
@@ -1490,7 +1490,6 @@ export const Clipboard = new TreeResource({
         RELATIVE_TREE_POSITIONS.LAST_CHILD,
         siblings
       );
-      const [node] = copyNodeResults;
 
       // Next, we'll add the new node immediately
       const data = {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -5,6 +5,7 @@ import flatMap from 'lodash/flatMap';
 import get from 'lodash/get';
 import isArray from 'lodash/isArray';
 import isFunction from 'lodash/isFunction';
+import isString from 'lodash/isString';
 import matches from 'lodash/matches';
 import overEvery from 'lodash/overEvery';
 import pick from 'lodash/pick';
@@ -674,6 +675,10 @@ class Resource extends mix(APIResource, IndexedDBResource) {
   }
 
   get(id) {
+    if (!isString(id)) {
+      return Promise.reject('Only string ID format is supported');
+    }
+
     if (process.env.NODE_ENV !== 'production' && !process.env.TRAVIS) {
       /* eslint-disable no-console */
       console.groupCollapsed(`Getting instance for ${this.tableName} table with id: ${id}`);
@@ -694,7 +699,7 @@ class Resource extends mix(APIResource, IndexedDBResource) {
 /**
  * Tree resources mixin
  */
-class TreeResource extends Resource {
+export class TreeResource extends Resource {
   constructor(...args) {
     super(...args);
     this._locks = {};
@@ -713,6 +718,73 @@ class TreeResource extends Resource {
     }
 
     return this._locks[id].lock(callback);
+  }
+
+  /**
+   * @param {string} id
+   * @param {string} target
+   * @param {string} position
+   * @param {Object[]} siblings
+   * @return {null|number}
+   */
+  getNewSortOrder(id, target, position, siblings) {
+    if (!siblings.length) {
+      return 1;
+    }
+
+    // Check if this is a no-op
+    const targetNodeIndex = findIndex(siblings, { id: target });
+    siblings = sortBy(siblings, 'lft');
+
+    if (
+      // We are trying to move it to the first child, and it is already the first child
+      // when sorted by lft
+      (position === RELATIVE_TREE_POSITIONS.FIRST_CHILD && siblings[0].id === id) ||
+      // We are trying to move it to the last child, and it is already the last child
+      // when sorted by lft
+      (position === RELATIVE_TREE_POSITIONS.LAST_CHILD && siblings.slice(-1)[0].id === id) ||
+      // We are trying to move it to the immediate left of the target node,
+      // but it is already to the immediate left of the target node.
+      (position === RELATIVE_TREE_POSITIONS.LEFT &&
+        targetNodeIndex > 0 &&
+        siblings[targetNodeIndex - 1].id === id) ||
+      // We are trying to move it to the immediate right of the target node,
+      // but it is already to the immediate right of the target node.
+      (position === RELATIVE_TREE_POSITIONS.RIGHT &&
+        targetNodeIndex < siblings.length - 1 &&
+        siblings[targetNodeIndex + 1].id === id)
+    ) {
+      return null;
+    }
+
+    if (position === RELATIVE_TREE_POSITIONS.FIRST_CHILD) {
+      // For first child, just halve the first child sort order.
+      return siblings[0].lft / 2;
+    } else if (position === RELATIVE_TREE_POSITIONS.LAST_CHILD) {
+      // For the last child, just add one to the final child sort order.
+      return siblings.slice(-1)[0].lft + 1;
+    } else if (position === RELATIVE_TREE_POSITIONS.LEFT) {
+      // For left insertion, either find the middle value between the node that would be to
+      // the left of the newly inserted node and the node that we are inserting to the
+      // left of.
+      // If the node we are inserting to the left of is already the leftmost node of this
+      // parent, then we fallback to the same calculation as a first child insert.
+      const leftSort = siblings[targetNodeIndex - 1] ? siblings[targetNodeIndex - 1].lft : 0;
+      return (leftSort + siblings[targetNodeIndex].lft) / 2;
+    } else if (position === RELATIVE_TREE_POSITIONS.RIGHT) {
+      // For right insertion, similarly to left insertion, we find the middle value between
+      // the node that will be to the right of the inserted node and the node we are
+      // inserting to the right of.
+      // If there is no node to the right, and the target node is already the rightmost
+      // node, we produce a sort order value that is the same as we would calculate for a
+      // last child insertion.
+      const rightSort = siblings[targetNodeIndex + 1]
+        ? siblings[targetNodeIndex + 1].lft
+        : siblings[targetNodeIndex].lft + 2;
+      return (siblings[targetNodeIndex].lft + rightSort) / 2;
+    }
+
+    return null;
   }
 }
 
@@ -985,7 +1057,6 @@ export const ContentNode = new TreeResource({
             let lft = 1;
             if (siblings.length) {
               // If we're creating, we don't need to worry about passing the ID
-              siblings = sortBy(siblings, 'lft');
               lft = this.getNewSortOrder(isCreate ? null : id, target, position, siblings);
             } else {
               // if there are no siblings, overwrite
@@ -1027,68 +1098,6 @@ export const ContentNode = new TreeResource({
         );
       });
     });
-  },
-
-  /**
-   * @param {string} id
-   * @param {string} target
-   * @param {string} position
-   * @param {Object[]} siblings
-   * @return {null|number}
-   */
-  getNewSortOrder(id, target, position, siblings) {
-    // Check if this is a no-op
-    const targetNodeIndex = findIndex(siblings, { id: target });
-
-    if (
-      // We are trying to move it to the first child, and it is already the first child
-      // when sorted by lft
-      (position === RELATIVE_TREE_POSITIONS.FIRST_CHILD && siblings[0].id === id) ||
-      // We are trying to move it to the last child, and it is already the last child
-      // when sorted by lft
-      (position === RELATIVE_TREE_POSITIONS.LAST_CHILD && siblings.slice(-1)[0].id === id) ||
-      // We are trying to move it to the immediate left of the target node,
-      // but it is already to the immediate left of the target node.
-      (position === RELATIVE_TREE_POSITIONS.LEFT &&
-        targetNodeIndex > 0 &&
-        siblings[targetNodeIndex - 1].id === id) ||
-      // We are trying to move it to the immediate right of the target node,
-      // but it is already to the immediate right of the target node.
-      (position === RELATIVE_TREE_POSITIONS.RIGHT &&
-        targetNodeIndex < siblings.length - 2 &&
-        siblings[targetNodeIndex + 1].id === id)
-    ) {
-      return null;
-    }
-
-    if (position === RELATIVE_TREE_POSITIONS.FIRST_CHILD) {
-      // For first child, just halve the first child sort order.
-      return siblings[0].lft / 2;
-    } else if (position === RELATIVE_TREE_POSITIONS.LAST_CHILD) {
-      // For the last child, just add one to the final child sort order.
-      return siblings.slice(-1)[0].lft + 1;
-    } else if (position === RELATIVE_TREE_POSITIONS.LEFT) {
-      // For left insertion, either find the middle value between the node that would be to
-      // the left of the newly inserted node and the node that we are inserting to the
-      // left of.
-      // If the node we are inserting to the left of is already the leftmost node of this
-      // parent, then we fallback to the same calculation as a first child insert.
-      const leftSort = siblings[targetNodeIndex - 1] ? siblings[targetNodeIndex - 1].lft : 0;
-      return (leftSort + siblings[targetNodeIndex].lft) / 2;
-    } else if (position === RELATIVE_TREE_POSITIONS.RIGHT) {
-      // For right insertion, similarly to left insertion, we find the middle value between
-      // the node that will be to the right of the inserted node and the node we are
-      // inserting to the right of.
-      // If there is no node to the right, and the target node is already the rightmost
-      // node, we produce a sort order value that is the same as we would calculate for a
-      // last child insertion.
-      const rightSort = siblings[targetNodeIndex + 1]
-        ? siblings[targetNodeIndex + 1].lft
-        : siblings[targetNodeIndex].lft + 2;
-      return (siblings[targetNodeIndex].lft + rightSort) / 2;
-    }
-
-    return null;
   },
 
   move(id, target, position = RELATIVE_TREE_POSITIONS.FIRST_CHILD) {
@@ -1193,6 +1202,16 @@ export const ContentNode = new TreeResource({
       return this.requestCollection({ ancestors_of: id });
     });
   },
+
+  getByNodeIdChannelId(nodeId, channelId) {
+    const params = { '[node_id+channel_id]': [nodeId, channelId] };
+    return this.table.get(params).then(node => {
+      if (!node) {
+        return this.requestCollection(params).then(nodes => nodes[0]);
+      }
+      return node;
+    });
+  }
 });
 
 export const ChannelSet = new Resource({
@@ -1430,7 +1449,7 @@ export const File = new Resource({
   },
 });
 
-export const Clipboard = new Resource({
+export const Clipboard = new TreeResource({
   tableName: TABLE_NAMES.CLIPBOARD,
   urlName: 'clipboard',
   indexFields: ['parent'],
@@ -1448,15 +1467,15 @@ export const Clipboard = new Resource({
 
   copy(node_id, channel_id, clipboardRootId, extra_fields = null) {
     return Promise.all([
-      ContentNode.get({ '[node_id+channel_id]': [node_id, channel_id] }),
+      ContentNode.getByNodeIdChannelId(node_id, channel_id),
       this.where({ parent: clipboardRootId }),
-    ]).then(([node, siblings]) => {
-      let lft = 1;
-      siblings = sortBy(siblings, 'lft');
-
-      if (siblings.length) {
-        lft = siblings.slice(-1)[0].lft + 1;
+    ]).then(([copyNodeResults, siblings]) => {
+      if (!copyNodeResults.length) {
+        return Promise.reject(new RangeError(`Cannot load source node`));
       }
+
+      const lft = this.getNewSortOrder(null, clipboardRootId, RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings);
+      const [node] = copyNodeResults;
 
       // Next, we'll add the new node immediately
       const data = {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1215,9 +1215,7 @@ export const ContentNode = new TreeResource({
     const values = [nodeId, channelId];
     return this.table.get({ '[node_id+channel_id]': values }).then(node => {
       if (!node) {
-        return this.requestCollection({ _node_id_channel_id_: values }).then(
-          nodes => nodes[0]
-        );
+        return this.requestCollection({ _node_id_channel_id_: values }).then(nodes => nodes[0]);
       }
       return node;
     });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1219,7 +1219,7 @@ export const ContentNode = new TreeResource({
       }
       return node;
     });
-  }
+  },
 });
 
 export const ChannelSet = new Resource({
@@ -1482,7 +1482,12 @@ export const Clipboard = new TreeResource({
         return Promise.reject(new RangeError(`Cannot load source node`));
       }
 
-      const lft = this.getNewSortOrder(null, clipboardRootId, RELATIVE_TREE_POSITIONS.LAST_CHILD, siblings);
+      const lft = this.getNewSortOrder(
+        null,
+        clipboardRootId,
+        RELATIVE_TREE_POSITIONS.LAST_CHILD,
+        siblings
+      );
       const [node] = copyNodeResults;
 
       // Next, we'll add the new node immediately

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -525,6 +525,9 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
         queryset = super(ContentNodeViewSet, self).get_edit_queryset()
         return self._annotate_channel_id(queryset)
 
+    def list(self, request, *args, **kwargs):
+        return super(ContentNodeViewSet, self).list(request, *args, **kwargs)
+
     @detail_route(methods=["get"])
     def requisites(self, request, pk=None):
         if not pk:

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -525,9 +525,6 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
         queryset = super(ContentNodeViewSet, self).get_edit_queryset()
         return self._annotate_channel_id(queryset)
 
-    def list(self, request, *args, **kwargs):
-        return super(ContentNodeViewSet, self).list(request, *args, **kwargs)
-
     @detail_route(methods=["get"])
     def requisites(self, request, pk=None):
         if not pk:


### PR DESCRIPTION
## Description
Fixes an invalid function call to `.get` with params that are only supported when requesting collections. Adds more unit tests covering relevant code.

#### Issue Addressed (if applicable)

Resolves: https://github.com/learningequality/studio/issues/2903

### QA Notes
- This fixed a bug in the sort order code that would cause issues moving items to the end of a list, and could only occur when dragging downward, to end of the list, and dropping

## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

