### PR TITLE
Update progress modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -164,7 +164,7 @@
     <slot></slot>
 
     <PublishModal v-if="showPublishModal" v-model="showPublishModal" />
-    <ProgressModal v-model="showProgressModal" :syncing="syncing" />
+    <ProgressModal v-model="showProgressModal" :syncing="syncing" :noSyncNeeded="noSyncNeeded" />
     <template v-if="isPublished">
       <ChannelTokenModal v-model="showTokenModal" :channel="currentChannel" />
     </template>
@@ -173,6 +173,7 @@
       v-model="showSyncModal"
       :channel="currentChannel"
       @syncing="syncInProgress"
+      @nosync="noResourcesToSync"
     />
     <MessageDialog v-model="showDeleteModal" :header="$tr('deleteTitle')">
       {{ $tr('deletePrompt') }}
@@ -289,6 +290,7 @@
         showClipboard: false,
         showDeleteModal: false,
         syncing: false,
+        noSyncNeeded: false,
       };
     },
     computed: {
@@ -405,6 +407,10 @@
       },
       syncInProgress() {
         this.syncing = true;
+        this.showProgressModal = true;
+      },
+      noResourcesToSync() {
+        this.noSyncNeeded = true;
         this.showProgressModal = true;
       },
       deleteChannel() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -164,11 +164,16 @@
     <slot></slot>
 
     <PublishModal v-if="showPublishModal" v-model="showPublishModal" />
-    <ProgressModal />
+    <ProgressModal v-model="showProgressModal" :syncing="syncing" />
     <template v-if="isPublished">
       <ChannelTokenModal v-model="showTokenModal" :channel="currentChannel" />
     </template>
-    <SyncResourcesModal v-if="currentChannel" v-model="showSyncModal" :channel="currentChannel" />
+    <SyncResourcesModal
+      v-if="currentChannel"
+      v-model="showSyncModal"
+      :channel="currentChannel"
+      @syncing="syncInProgress"
+    />
     <MessageDialog v-model="showDeleteModal" :header="$tr('deleteTitle')">
       {{ $tr('deletePrompt') }}
       <template #buttons="{ close }">
@@ -280,8 +285,10 @@
         showPublishModal: false,
         showTokenModal: false,
         showSyncModal: false,
+        showProgressModal: false,
         showClipboard: false,
         showDeleteModal: false,
+        syncing: false,
       };
     },
     computed: {
@@ -395,6 +402,10 @@
       syncChannel() {
         this.showSyncModal = true;
         this.trackClickEvent('Sync');
+      },
+      syncInProgress() {
+        this.syncing = true;
+        this.showProgressModal = true;
       },
       deleteChannel() {
         this.showDeleteModal = true;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -2,7 +2,8 @@
 
   <div>
     <VDialog
-      v-if="(currentChannel && currentChannel.publishing) || currentTask"
+      v-if="(currentChannel && currentChannel.publishing)
+        || (currentTask && isSyncing && !currentChannel.publishing)"
       :value="true"
       persistent
       :width="575"
@@ -108,6 +109,10 @@
         type: String,
         default: '',
       },
+      syncing: {
+        type: Boolean,
+        default: false,
+      },
     },
     data() {
       return {
@@ -115,12 +120,17 @@
       };
     },
     computed: {
-      ...mapGetters('task', ['publishTaskForChannel']),
+      ...mapGetters('task', ['currentTaskForChannel']),
       ...mapGetters('currentChannel', ['currentChannel']),
       currentTask() {
-        return this.publishTaskForChannel(this.currentChannel.id) || null;
+        console.log('current task', this.currentTaskForChannel(this.currentChannel.id));
+        return this.currentTaskForChannel(this.currentChannel.id) || null;
+      },
+      isSyncing() {
+        return this.syncing;
       },
       progressPercent() {
+        console.log('percent progress', get(this.currentTask, ['metadata', 'progress'], 0));
         return get(this.currentTask, ['metadata', 'progress'], 0);
       },
       currentTaskError() {
@@ -141,6 +151,7 @@
             this.currentTask.task_type === 'sync-channel' ||
             this.currentTask.task_type === 'sync-nodes'
           ) {
+            console.log(this.currentTask);
             return this.$tr('syncHeader');
           }
         }
@@ -148,6 +159,7 @@
       },
       descriptionText() {
         if (this.currentTask) {
+          console.log(this.currentTask.task_type);
           if (this.progressPercent >= 100) {
             return this.$tr('finishedMessage');
           } else if (this.currentTask.task_type === 'duplicate-nodes') {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -42,7 +42,7 @@
             <VCardActions>
               <VSpacer />
               <VBtn
-                v-if="progressPercent === 100 || currentTaskError || nothingToSync"
+                v-if="progressPercent === 100 || currentTaskError "
                 color="primary"
                 data-test="refresh"
                 @click="closeOverlay"
@@ -127,7 +127,6 @@
       ...mapGetters('task', ['currentTasksForChannel']),
       ...mapGetters('currentChannel', ['currentChannel']),
       currentTasks() {
-        console.log('currentTasks');
         return this.currentTasksForChannel(this.currentChannel.id) || null;
       },
       isSyncing() {
@@ -141,7 +140,7 @@
         return this.noSyncNeeded;
       },
       isPublishing() {
-        return !this.syncing && this.currentTasks.find(task => task.task_type === 'export-channel');
+        return this.currentChannel && this.currentChannel.publishing;
       },
       currentTask() {
         if (this.isSyncing) {
@@ -187,7 +186,7 @@
             return this.$tr('publishDescription');
           } else if (this.currentTask.task_type === 'move-nodes') {
             return this.$tr('moveDescription');
-          } else if (this.isSyncing || this.nothingToSync) {
+          } else if (this.isSyncing) {
             return this.$tr('syncDescription');
           }
         } else if (this.nothingToSync) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -152,6 +152,9 @@
         }
       },
       progressPercent() {
+        if (this.nothingToSync) {
+          return 100;
+        }
         return get(this.currentTask, ['metadata', 'progress'], 0);
       },
       currentTaskError() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -42,7 +42,7 @@
             <VCardActions>
               <VSpacer />
               <VBtn
-                v-if="progressPercent === 100 || currentTaskError "
+                v-if="progressPercent === 100 || currentTaskError"
                 color="primary"
                 data-test="refresh"
                 @click="closeOverlay"
@@ -130,7 +130,7 @@
         return this.currentTasksForChannel(this.currentChannel.id) || null;
       },
       isSyncing() {
-        return this.syncing && !this.currentChannel.publishing;
+        return this.syncing && this.currentChannel && !this.currentChannel.publishing;
       },
       // this handles validation errors from the Sync Resources Modal
       // where .sync itself errors because of the validation error

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -5,13 +5,23 @@ import { factory } from '../../../store';
 const store = factory();
 
 const task = { task: { id: 123, task_type: 'test-task' } };
+const tasks = [
+  { task: { id: 123, task_type: 'test-task' } },
+  { task: { id: 456, task_type: 'test-task-2' } },
+];
 
 function makeWrapper(computed = {}) {
   return mount(ProgressModal, {
     store,
     computed: {
+      currentTasks() {
+        return tasks;
+      },
       currentTask() {
         return task;
+      },
+      isPublishing() {
+        return true;
       },
       ...computed,
     },
@@ -19,10 +29,16 @@ function makeWrapper(computed = {}) {
 }
 
 describe('progressModal', () => {
-  it('should be hidden if there is no task', () => {
+  it('should be hidden if the user is not syncing or publishing', () => {
     let wrapper = makeWrapper({
-      currentTask() {
-        return null;
+      isSyncing() {
+        return false;
+      },
+      nothingToSync() {
+        return false;
+      },
+      isPublishing() {
+        return false;
       },
     });
     expect(wrapper.find('[data-test="progressmodal"]').exists()).toBe(false);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -175,8 +175,7 @@
             this.confirmSyncModal = false;
             this.$emit('syncing');
           })
-          .catch(error => {
-            console.error(error);
+          .catch(() => {
             // add a way for the progress modal to provide feedback
             // since the available error message doesn't make sense here,
             // for now we will just have the operation be reported complete

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -170,10 +170,20 @@
           tags: this.syncTags,
           files: this.syncFiles,
           assessment_items: this.syncExercises,
-        }).then(() => {
-          this.confirmSyncModal = false;
-          this.$emit('syncing');
-        });
+        })
+          .then(() => {
+            this.confirmSyncModal = false;
+            this.$emit('syncing');
+          })
+          .catch(error => {
+            console.error(error);
+            // add a way for the progress modal to provide feedback
+            // since the available error message doesn't make sense here,
+            // for now we will just have the operation be reported complete
+            // see ProgressModal nothingToSync for more info
+            this.confirmSyncModal = false;
+            this.$emit('nosync');
+          });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -172,6 +172,7 @@
           assessment_items: this.syncExercises,
         }).then(() => {
           this.confirmSyncModal = false;
+          this.$emit('syncing');
         });
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
@@ -63,7 +63,7 @@ export function publishChannel(context, version_notes) {
 
 export function stopPublishing(context) {
   return Channel.clearPublish(context.state.currentChannelId).then(() => {
-    const publishTask = context.rootGetters['task/publishTaskForChannel'](
+    const publishTask = context.rootGetters['task/currentTaskForChannel'](
       context.state.currentChannelId
     );
     return publishTask

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
@@ -63,9 +63,9 @@ export function publishChannel(context, version_notes) {
 
 export function stopPublishing(context) {
   return Channel.clearPublish(context.state.currentChannelId).then(() => {
-    const publishTask = context.rootGetters['task/currentTaskForChannel'](
+    const publishTask = context.rootGetters['task/currentTasksForChannel'](
       context.state.currentChannelId
-    );
+    ).find(task => task.task_type === 'export-channel');
     return publishTask
       ? context.dispatch('task/deleteTask', publishTask, { root: true })
       : Promise.resolve();

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -24,13 +24,9 @@ export default {
         return state.asyncTasksMap[taskId];
       };
     },
-    currentTaskForChannel(state, getters) {
+    currentTasksForChannel(state, getters) {
       return function(id) {
-        return getters.asyncTasks.find(
-          task =>
-            (task.task_type === 'export-channel' || task.task_type === 'sync-channel') &&
-            task.channel === id
-        );
+        return getters.asyncTasks.filter(task => task.channel === id);
       };
     },
   },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -24,10 +24,12 @@ export default {
         return state.asyncTasksMap[taskId];
       };
     },
-    publishTaskForChannel(state, getters) {
+    currentTaskForChannel(state, getters) {
       return function(id) {
         return getters.asyncTasks.find(
-          task => task.task_type === 'export-channel' && task.channel === id
+          task =>
+            (task.task_type === 'export-channel' || task.task_type === 'sync-channel') &&
+            task.channel === id
         );
       };
     },


### PR DESCRIPTION
## Description

This PR updates the Progress Modal to be used for Sync Resources tasks to provide user feedback - both when there are resources that can be synced, and also when there aren't.

#### Issue Addressed (if applicable)

Addresses #2555 and #2688 


## Steps to Test

- [x] Sync resources for a channel that has imported resources. It should show that it is in progress (if it is a long task) and/or that it is complete, with a prompt to refresh the page.
- [ ] Sync resources for a channel that does not have any imported resources. Rather than nothing happening, you should still get the same prompt that the task is complete and to refresh the page. (This was a more straightforward option than disabling the sync option in the menu for these channels, due to where the validation happens).

#### Does this introduce any tech-debt items?

I wouldn't say there is new technical debt, but there is still some technical debt in the sense that not all of the tasks are truly managed by the ProgressModal - it's just the foundation that is there. This doesn't really change that, and there will probably have to be more changes that are made in the future based on use cases for different kinds of tasks/feedback.
