### PR TITLE
Hide the "delete" option from Channel Edit page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -145,14 +145,15 @@
             >
               <VListTileTitle>{{ $tr('openTrash') }}</VListTileTitle>
             </VListTile>
-            <VListTile
+            <!-- HIDES THE DELETE OPTION UNTIL FUNCTIONALITY IS FIXED -->
+            <!-- <VListTile
               v-if="canEdit"
               @click="deleteChannel"
             >
               <VListTileTitle class="red--text">
                 {{ $tr('deleteChannel') }}
               </VListTileTitle>
-            </VListTile>
+            </VListTile> -->
           </VList>
         </Menu>
       </VToolbarItems>


### PR DESCRIPTION
## Description

Because the functionality of "Delete channel" from the Channel Edit page is currently not working, we are just hiding this option from the view for the time being.

#### Issue Addressed (if applicable)

Addresses #2894 (but does not fix the issue - this is only temporary)

#### Before/After Screenshots (if applicable)
|Before|After|
|--|--|
|![2021-02-01 14 19 11](https://user-images.githubusercontent.com/13563002/106525286-99054c80-6498-11eb-98c4-117f5d5a375b.gif)|![Screen Shot 2021-02-04 at 7 54 06 PM](https://user-images.githubusercontent.com/13563002/106989217-8607ac00-6726-11eb-8237-8340ec31e61c.png)|

## Steps to Test

- [ ] Login to Studio
- [ ] Click on an existing channel from the Channel List page
- [ ] Click on the menu at the upper right hand corner (three dots next to "PUBLISH") of the Channel Editing page
- [ ] Notice that "Delete channel" is no longer an option in the dropdown menu

#### Does this introduce any tech-debt items?

This is temporary, and the functionality needs to be fixed in the future.

## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [x] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?