### PR TITLE
Fix mark incomplete command for topics

### DIFF
--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -31,23 +31,33 @@ class Command(BaseCommand):
         # Mark invalid licenses
         licensestart = time.time()
         logging.info('Marking blank licenses...')
-        count = ContentNode.objects.exclude(complete=False, kind_id=content_kinds.TOPIC).filter(license__isnull=True).order_by().update(complete=False)
+        count = ContentNode.objects.exclude(kind_id=content_kinds.TOPIC) \
+            .exclude(complete=False) \
+            .filter(license__isnull=True) \
+            .order_by() \
+            .update(complete=False)
         logging.info('Marked {} invalid licenses (finished in {})'.format(count, time.time() - licensestart))
 
         licensestart = time.time()
         logging.info('Marking blank license descriptions...')
         custom_licenses = list(License.objects.filter(is_custom=True).values_list("pk", flat=True))
-        count = ContentNode.objects.exclude(complete=False, kind_id=content_kinds.TOPIC)\
-            .filter(license_id__in=custom_licenses).filter(Q(license_description__isnull=True) | Q(license_description=''))\
-            .order_by().update(complete=False)
+        count = ContentNode.objects.exclude(kind_id=content_kinds.TOPIC) \
+            .exclude(complete=False) \
+            .filter(license_id__in=custom_licenses) \
+            .filter(Q(license_description__isnull=True) | Q(license_description='')) \
+            .order_by() \
+            .update(complete=False)
         logging.info('Marked {} invalid license descriptions (finished in {})'.format(count, time.time() - licensestart))
 
         licensestart = time.time()
         logging.info('Marking blank copyright holders...')
         copyright_licenses = list(License.objects.filter(copyright_holder_required=True).values_list("pk", flat=True))
-        count = ContentNode.objects.exclude(complete=False, kind_id=content_kinds.TOPIC)\
-            .filter(license_id__in=copyright_licenses).filter(Q(copyright_holder__isnull=True) | Q(copyright_holder=''))\
-            .order_by().update(complete=False)
+        count = ContentNode.objects.exclude(kind_id=content_kinds.TOPIC) \
+            .exclude(complete=False) \
+            .filter(license_id__in=copyright_licenses) \
+            .filter(Q(copyright_holder__isnull=True) | Q(copyright_holder=''))\
+            .order_by() \
+            .update(complete=False)
         logging.info('Marked {} invalid copyright holders (finished in {})'.format(count, time.time() - licensestart))
 
         # Mark invalid file resources


### PR DESCRIPTION
## Description

Update license validation queries to skip topics. The previous version validated licenses of topics that were previous set as complete. That doesn't make sense because we don't require license on topics and was also one part of the problem occurring for some historical topics incorrectly marked as incomplete (see "Steps to Test" for details)

## Steps to Test

I've discovered this issue by restoring ["Be Strong: Internet safety resources" channel](https://studio.learningequality.org/en/channels/d0ef6f71e4fe4e54bb87d7dab5eeaae2/#/f520e497104d42ccbb0611038db8850b) that contains topics with a license set but copyright holder missing even when it's required for the license, and even when we actually don't require a license for topics nor have UI to edit it.

Then I run ` yarn run devsetup` and many topics were marked as incomplete even though they have titles which is the only validation criteria for topics (e.g. "Module 1 - "My Digital Life").

Running `yarn run devsetup` on this channel with this fix should mark all topics that have a title as complete and there should be no errors in the channel editor app visible for these topics. 

## Comments

Related conversation https://learningequality.slack.com/archives/C0LK8QS9J/p1612791884401500