### PR TITLE
Add fallback value of ‘0’ when ‘border-left/top’ style of a node is empty, during PDF generation

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/utils/helpers.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/helpers.js
@@ -183,10 +183,10 @@ export async function generatePdf(
       const style = window.getComputedStyle(node, null);
       const paddingLeft = parseInt(style.getPropertyValue('padding-left'));
       const marginLeft = parseInt(style.getPropertyValue('margin-left'));
-      const borderLeft = parseInt(style.getPropertyValue('border-left'));
+      const borderLeft = parseInt(style.getPropertyValue('border-left') || '0');
       const paddingTop = parseInt(style.getPropertyValue('padding-top'));
       const marginTop = parseInt(style.getPropertyValue('margin-top'));
-      const borderTop = parseInt(style.getPropertyValue('border-top'));
+      const borderTop = parseInt(style.getPropertyValue('border-top') || '0');
       const x = nodeRect.left - boundingRect.left + paddingLeft + marginLeft + borderLeft;
       const y = nodeRect.top - boundingRect.top + paddingTop + marginTop + borderTop;
       const width = nodeRect.width;

--- a/contentcuration/contentcuration/frontend/shared/utils/helpers.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/helpers.js
@@ -5,6 +5,14 @@ import merge from 'lodash/merge';
 
 import { LicensesList } from 'shared/leUtils/Licenses';
 
+function safeParseInt(str) {
+  const parsed = parseInt(str);
+  if (Number.isNaN(parsed)) {
+    return 0;
+  }
+  return parsed;
+}
+
 const EXTENDED_SLOT = '__extendedSlot';
 
 /**
@@ -78,7 +86,7 @@ function insertText(doc, fontList, node, x, y, maxWidth, scale, isRtl = false) {
   const font = fontList[style.getPropertyValue('font-family')]
     ? style.getPropertyValue('font-family')
     : Object.keys(fontList)[0];
-  const fontSize = parseInt(style.getPropertyValue('font-size')) * scale;
+  const fontSize = safeParseInt(style.getPropertyValue('font-size')) * scale;
   const fontStyle = style.getPropertyValue('font-style');
   let align = style.getPropertyValue('text-align');
   let fontWeight = style.getPropertyValue('font-weight');
@@ -181,12 +189,12 @@ export async function generatePdf(
       }
       const nodeRect = node.getBoundingClientRect();
       const style = window.getComputedStyle(node, null);
-      const paddingLeft = parseInt(style.getPropertyValue('padding-left'));
-      const marginLeft = parseInt(style.getPropertyValue('margin-left'));
-      const borderLeft = parseInt(style.getPropertyValue('border-left') || '0');
-      const paddingTop = parseInt(style.getPropertyValue('padding-top'));
-      const marginTop = parseInt(style.getPropertyValue('margin-top'));
-      const borderTop = parseInt(style.getPropertyValue('border-top') || '0');
+      const paddingLeft = safeParseInt(style.getPropertyValue('padding-left'));
+      const marginLeft = safeParseInt(style.getPropertyValue('margin-left'));
+      const borderLeft = safeParseInt(style.getPropertyValue('border-left'));
+      const paddingTop = safeParseInt(style.getPropertyValue('padding-top'));
+      const marginTop = safeParseInt(style.getPropertyValue('margin-top'));
+      const borderTop = safeParseInt(style.getPropertyValue('border-top'));
       const x = nodeRect.left - boundingRect.left + paddingLeft + marginLeft + borderLeft;
       const y = nodeRect.top - boundingRect.top + paddingTop + marginTop + borderTop;
       const width = nodeRect.width;


### PR DESCRIPTION
… are empty



**Please remove any unused sections**

## Description

Fixes the broken PDF generation functionality by adding a fallback value of '0' when `style.getPropertyValue('border-left|top')` return `""`. This prevents the `x` and `y` local variables here from evaluating to `NaN` and later causing problems with the PDF generator:

https://github.com/jonboiser/content-curation/blob/cdfd96e8b3adb237fb0283700df564236048d79f/contentcuration/contentcuration/frontend/shared/utils/helpers.js#L184-L192

#### Issue Addressed (if applicable)

Fixes #2914
Fixes #2912

#### Before/After Screenshots (if applicable)

*Insert images here*


## Steps to Test

On the Channel Details modal for any channel, try to download the Summary PDF file. It should work on all browsers.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

*Briefly describe how this works*

#### Does this introduce any tech-debt items?

*List anything that will need to be addressed later*


## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
- [ ] Has the `docs` label been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] Has the `CHANGELOG` label been added to this pull request? Items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] Are there tests for this change?
- [ ] Are all user-facing strings translated properly (if applicable)?
- [ ] Has the `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
- [ ] Are users' storage used being recalculated properly on any changes to their main tree files?
- [ ] Are there any new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text)?
- [ ] Are there any new interactions that need to be added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)?
- [ ] Are there opportunities for using Google Analytics here (if applicable)?
- [ ] If any Python requirements have changed, are the updated requirements.txt files also included in this PR?
- [ ] Are the migrations [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (if applicable)?

## Comments

*Any additional notes you'd like to add*

## Reviewers

If you are looking to assign a reviewer, here are some options:
- Jordan jayoshih (full stack)
- Aron aronasorman (back end, devops)
- Micah micahscopes (full stack)
- Kevin kollivier (back end)
- Ivan ivanistheone ([Ricecooker](https://github.com/learningequality/ricecooker))
- Richard rtibbles (full stack, [Kolibri](https://github.com/learningequality/kolibri))
- Radina @radinamatic (documentation)
