### PR TITLE
Skips async refresh of local data for copy/move queries, and fixes sortBy finding new sort order

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -155,6 +155,11 @@ describe('TreeResource methods', () => {
       expect(
         resource.getNewSortOrder(uuid4(), siblings[2].id, RELATIVE_TREE_POSITIONS.LEFT, siblings)
       ).toEqual(5 / 2);
+
+      const unsorted = [siblings[1], siblings[2], siblings[0]];
+      expect(
+        resource.getNewSortOrder(uuid4(), siblings[0].id, RELATIVE_TREE_POSITIONS.LEFT, unsorted)
+      ).toEqual(1 / 2);
     });
 
     it('should return sort order in between target and right sibling', () => {
@@ -213,30 +218,30 @@ describe('ContentNode methods', () => {
       await expect(
         ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.FIRST_CHILD)
       ).resolves.toBe(node);
-      expect(get).toHaveBeenCalledWith(node.id);
+      expect(get).toHaveBeenCalledWith(node.id, false);
     });
 
     it('should return target node when last child', async () => {
       await expect(
         ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.LAST_CHILD)
       ).resolves.toBe(node);
-      expect(get).toHaveBeenCalledWith(node.id);
+      expect(get).toHaveBeenCalledWith(node.id, false);
     });
 
     it("should return target node's parent when inserting after", async () => {
       await expect(ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.RIGHT)).resolves.toBe(
         parent
       );
-      expect(get).toHaveBeenNthCalledWith(1, node.id);
-      expect(get).toHaveBeenNthCalledWith(2, parent.id);
+      expect(get).toHaveBeenNthCalledWith(1, node.id, false);
+      expect(get).toHaveBeenNthCalledWith(2, parent.id, false);
     });
 
     it("should return target node's parent when inserting before", async () => {
       await expect(ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.LEFT)).resolves.toBe(
         parent
       );
-      expect(get).toHaveBeenNthCalledWith(1, node.id);
-      expect(get).toHaveBeenNthCalledWith(2, parent.id);
+      expect(get).toHaveBeenNthCalledWith(1, node.id, false);
+      expect(get).toHaveBeenNthCalledWith(2, parent.id, false);
     });
 
     it("should reject when the target can't be found", async () => {
@@ -244,7 +249,7 @@ describe('ContentNode methods', () => {
       await expect(
         ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.FIRST_CHILD)
       ).rejects.toThrow(`Target ${node.id} does not exist`);
-      expect(get).toHaveBeenNthCalledWith(1, node.id);
+      expect(get).toHaveBeenNthCalledWith(1, node.id, false);
     });
 
     it("should reject when the target's parent can't be found", async () => {
@@ -252,8 +257,8 @@ describe('ContentNode methods', () => {
       await expect(
         ContentNode.resolveParent(node.id, RELATIVE_TREE_POSITIONS.LEFT)
       ).rejects.toThrow(`Target ${parent.id} does not exist`);
-      expect(get).toHaveBeenNthCalledWith(1, node.id);
-      expect(get).toHaveBeenNthCalledWith(2, parent.id);
+      expect(get).toHaveBeenNthCalledWith(1, node.id, false);
+      expect(get).toHaveBeenNthCalledWith(2, parent.id, false);
     });
   });
 
@@ -298,8 +303,8 @@ describe('ContentNode methods', () => {
         ).resolves.toEqual('results');
         expect(resolveParent).toHaveBeenCalledWith('target', 'position');
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123');
-        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(get).toHaveBeenCalledWith('abc123', false);
+        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).not.toBeCalled();
         expect(cb).toBeCalled();
         const result = cb.mock.calls[0][0];
@@ -337,8 +342,8 @@ describe('ContentNode methods', () => {
         ).resolves.toEqual('results');
         expect(resolveParent).toHaveBeenCalledWith('target', 'position');
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123');
-        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(get).toHaveBeenCalledWith('abc123', false);
+        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).toHaveBeenCalledWith('abc123', 'target', 'position', siblings);
         expect(cb).toBeCalled();
         const result = cb.mock.calls[0][0];
@@ -375,8 +380,8 @@ describe('ContentNode methods', () => {
         ).rejects.toThrow('New lft value evaluated to null');
         expect(resolveParent).toHaveBeenCalledWith('target', 'position');
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123');
-        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(get).toHaveBeenCalledWith('abc123', false);
+        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).toHaveBeenCalledWith('abc123', 'target', 'position', siblings);
         expect(cb).not.toBeCalled();
       });
@@ -390,8 +395,8 @@ describe('ContentNode methods', () => {
         ).resolves.toEqual('results');
         expect(resolveParent).toHaveBeenCalledWith('target', 'position');
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123');
-        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(get).toHaveBeenCalledWith('abc123', false);
+        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).not.toBeCalled();
         expect(cb).toBeCalled();
         const result = cb.mock.calls[0][0];
@@ -429,8 +434,8 @@ describe('ContentNode methods', () => {
         ).resolves.toEqual('results');
         expect(resolveParent).toHaveBeenCalledWith('target', 'position');
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123');
-        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(get).toHaveBeenCalledWith('abc123', false);
+        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).toHaveBeenCalledWith(null, 'target', 'position', siblings);
         expect(cb).toBeCalled();
         const result = cb.mock.calls[0][0];
@@ -468,8 +473,8 @@ describe('ContentNode methods', () => {
         ).rejects.toThrow('New lft value evaluated to null');
         expect(resolveParent).toHaveBeenCalledWith('target', 'position');
         expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123');
-        expect(where).toHaveBeenCalledWith({ parent: parent.id });
+        expect(get).toHaveBeenCalledWith('abc123', false);
+        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).toHaveBeenCalledWith(null, 'target', 'position', siblings);
         expect(cb).not.toBeCalled();
       });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1103,8 +1103,6 @@ export const ContentNode = new TreeResource({
               type: isCreate ? CHANGE_TYPES.COPIED : CHANGE_TYPES.MOVED,
             };
 
-            console.log('tree', target, position, payload.lft, siblings);
-
             return callback({
               node,
               parent,

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -748,8 +748,8 @@ export class TreeResource extends Resource {
     }
 
     // Check if this is a no-op
-    const targetNodeIndex = findIndex(siblings, { id: target });
     siblings = sortBy(siblings, 'lft');
+    const targetNodeIndex = findIndex(siblings, { id: target });
 
     if (
       // We are trying to move it to the first child, and it is already the first child
@@ -1102,6 +1102,8 @@ export const ContentNode = new TreeResource({
               table: this.tableName,
               type: isCreate ? CHANGE_TYPES.COPIED : CHANGE_TYPES.MOVED,
             };
+
+            console.log('tree', target, position, payload.lft, siblings);
 
             return callback({
               node,

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -596,7 +596,12 @@ class Resource extends mix(APIResource, IndexedDBResource) {
     return promise;
   }
 
-  where(params = {}) {
+  /**
+   * @param {Object} params
+   * @param {Boolean} [doRefresh=true] -- Whether or not to refresh async from server
+   * @return {Promise<Object[]>}
+   */
+  where(params = {}, doRefresh = true) {
     if (process.env.NODE_ENV !== 'production' && !process.env.TRAVIS) {
       /* eslint-disable no-console */
       console.groupCollapsed(`Getting data for ${this.tableName} table with params: `, params);
@@ -611,16 +616,18 @@ class Resource extends mix(APIResource, IndexedDBResource) {
       if (!objs.length) {
         return this.requestCollection(params);
       }
-      // Only fetch new updates if we've finished syncing the changes table
-      db[CHANGES_TABLE].where('table')
-        .equals(this.tableName)
-        .limit(1)
-        .toArray()
-        .then(pendingChanges => {
-          if (pendingChanges.length === 0) {
-            this.requestCollection(params);
-          }
-        });
+      if (doRefresh) {
+        // Only fetch new updates if we've finished syncing the changes table
+        db[CHANGES_TABLE].where('table')
+          .equals(this.tableName)
+          .limit(1)
+          .toArray()
+          .then(pendingChanges => {
+            if (pendingChanges.length === 0) {
+              this.requestCollection(params);
+            }
+          });
+      }
       return objs;
     });
   }
@@ -674,7 +681,12 @@ class Resource extends mix(APIResource, IndexedDBResource) {
     });
   }
 
-  get(id) {
+  /**
+   * @param {String} id
+   * @param {Boolean} [doRefresh=true] -- Whether or not to refresh async from server
+   * @return {Promise<{}|null>}
+   */
+  get(id, doRefresh = true) {
     if (!isString(id)) {
       return Promise.reject('Only string ID format is supported');
     }
@@ -687,11 +699,14 @@ class Resource extends mix(APIResource, IndexedDBResource) {
       /* eslint-enable */
     }
     return this.table.get(id).then(obj => {
-      const request = this.requestModel(id);
-      if (obj) {
-        return obj;
+      if (!obj || doRefresh) {
+        const request = this.requestModel(id);
+        if (!obj) {
+          return request;
+        }
       }
-      return request;
+
+      return obj;
     });
   }
 }
@@ -1002,7 +1017,7 @@ export const ContentNode = new TreeResource({
       return Promise.reject(new TypeError(`"${position}" is an invalid position`));
     }
 
-    return this.get(target)
+    return this.get(target, false)
       .then(node => {
         if (
           position === RELATIVE_TREE_POSITIONS.FIRST_CHILD ||
@@ -1012,7 +1027,7 @@ export const ContentNode = new TreeResource({
         }
 
         target = node.parent;
-        return node ? this.get(target) : null;
+        return node ? this.get(target, false) : null;
       })
       .then(node => {
         if (!node) {
@@ -1052,7 +1067,7 @@ export const ContentNode = new TreeResource({
       // happen while we're potentially waiting for some data we need (siblings, source node)
       return this.treeLock(parent.root_id, () => {
         // Preload the ID we're referencing, and get siblings to determine sort order
-        return Promise.all([this.get(id), this.where({ parent: parent.id })]).then(
+        return Promise.all([this.get(id, false), this.where({ parent: parent.id }, false)]).then(
           ([node, siblings]) => {
             let lft = 1;
             if (siblings.length) {


### PR DESCRIPTION
## Description
- Collaborated with @micahscopes 
- Adds parameter to `get()` and `where()` to skip the async refresh of local data, since that could interfere with data that has changed during the time until the request completes
- Repositions `sortBy` of siblings so it's _before_ determining the target's index :facepalm: 

#### Issue Addressed (if applicable)
Resolves: https://github.com/learningequality/studio/issues/2905
Resolves: https://github.com/learningequality/studio/issues/2902

## Checklist
- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?

