### PR TITLE
Add guard when `channel.accessible_languages` is `null`

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelCatalogFrontPage.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelCatalogFrontPage.vue
@@ -96,7 +96,9 @@
         return this.channelList.some(channel => channel.includes.exercises);
       },
       subtitles() {
-        return this.channelList.some(channel => channel.accessible_languages.length);
+        return this.channelList.some(channel => {
+          return channel.accessible_languages && channel.accessible_languages.length > 0;
+        });
       },
     },
     $trs: {


### PR DESCRIPTION
**Please remove any unused sections**

## Description

Adds guard in the `ChannelCatalogFrontPage` component to handle cases when `channel.accessibles_languages` is `null`, to avoid a type error when trying to access `null.length`.

#### Issue Addressed (if applicable)

This might be the root cause of #2914, which only occurs when trying to download a PDF report of multiple channels.

