### PR TITLE
swap kmodal in for primary dialogue component

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelTokenModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelTokenModal.vue
@@ -1,7 +1,7 @@
 <template>
 
-  <PrimaryDialog
-    v-model="dialog"
+  <KModal
+    v-if="dialog"
     :title="$tr('copyTitle')"
     :text="$tr('copyTokenInstructions')"
     lazy
@@ -16,19 +16,17 @@
         {{ $tr('close') }}
       </VBtn>
     </template>
-  </PrimaryDialog>
+  </KModal>
 
 </template>
 
 <script>
 
-  import PrimaryDialog from '../PrimaryDialog';
   import CopyToken from '../CopyToken';
 
   export default {
     name: 'ChannelTokenModal',
     components: {
-      PrimaryDialog,
       CopyToken,
     },
     props: {


### PR DESCRIPTION
## Description

This PR replaces the `PrimaryDialogue` component in `ChannelTokenModal` with `KModal`. There were no files where `ChannelTokenModal` is referenced that needed to be updated as a result of these changes - just the main component itself.

#### Issue Addressed (if applicable)

Addresses [KDS issue 153](https://github.com/learningequality/kolibri-design-system/issues/153)

## Steps to Test
There are two places to access the token modal

- [ ] First place: Open Channel Token Modal from the Channel list page by selecting "Copy Channel Token" from the menu on the bottom right corner
<img width="1052" alt="Screen Shot 2021-02-11 at 9 59 07 AM" src="https://user-images.githubusercontent.com/17235236/107653764-fdba6700-6c4f-11eb-8b2c-66c7afea7cd7.png">

- [ ] Second place: Open Channel Token Modal from the Channel (TreeView) page by selecting "Get Token" from the menu on the top right corner
<img width="1439" alt="Screen Shot 2021-02-11 at 10 00 12 AM" src="https://user-images.githubusercontent.com/17235236/107653783-027f1b00-6c50-11eb-919c-d1e4fba78f1c.png">

Both options the modal should open and close without any issue, and you should be able to successfully copy the token. 

#### Does this introduce any tech-debt items?

None that I am aware of