### PR TITLE
Rename RouterNames -> RouteNames

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/constants.js
+++ b/contentcuration/contentcuration/frontend/administration/constants.js
@@ -1,4 +1,4 @@
-export const RouterNames = {
+export const RouteNames = {
   CHANNELS: 'CHANNELS',
   CHANNEL: 'CHANNEL',
   USERS: 'USERS',

--- a/contentcuration/contentcuration/frontend/administration/pages/AdministrationAppError.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/AdministrationAppError.vue
@@ -26,7 +26,7 @@
 
 <script>
 
-  import { RouterNames } from '../constants';
+  import { RouteNames } from '../constants';
   import PermissionsError from 'shared/views/errors/PermissionsError';
   import ChannelNotFoundError from 'shared/views/errors/ChannelNotFoundError';
   import PageNotFoundError from 'shared/views/errors/PageNotFoundError';
@@ -61,10 +61,10 @@
       backFromCurrentPageUrl() {
         const currentPage = this.$route.name;
         let toName;
-        if (currentPage === RouterNames.USER) {
-          toName = RouterNames.USERS;
+        if (currentPage === RouteNames.USER) {
+          toName = RouteNames.USERS;
         } else {
-          toName = RouterNames.CHANNELS;
+          toName = RouteNames.CHANNELS;
         }
         return {
           to: { name: toName },

--- a/contentcuration/contentcuration/frontend/administration/pages/AdministrationIndex.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/AdministrationIndex.vue
@@ -28,7 +28,7 @@
 
 <script>
 
-  import { RouterNames } from '../constants';
+  import { RouteNames } from '../constants';
   import AdministrationAppError from './AdministrationAppError';
   import AppBar from 'shared/views/AppBar';
   import GlobalSnackbar from 'shared/views/GlobalSnackbar';
@@ -52,12 +52,12 @@
       },
       channelsLink() {
         return {
-          name: RouterNames.CHANNELS,
+          name: RouteNames.CHANNELS,
         };
       },
       usersLink() {
         return {
-          name: RouterNames.USERS,
+          name: RouteNames.USERS,
         };
       },
     },

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelActionsDropdown.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelActionsDropdown.vue
@@ -119,7 +119,7 @@
 
   import { mapActions, mapGetters } from 'vuex';
   import ConfirmationDialog from '../../components/ConfirmationDialog';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import { channelExportMixin } from 'shared/views/channel/mixins';
 
   export default {
@@ -151,7 +151,7 @@
       },
       searchChannelEditorsLink() {
         return {
-          name: RouterNames.USERS,
+          name: RouteNames.USERS,
           query: {
             search: `${this.name} ${this.channel.id}`,
           },

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelDetails.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelDetails.vue
@@ -54,7 +54,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelActionsDropdown from './ChannelActionsDropdown';
   import ChannelSharing from 'shared/views/channel/ChannelSharing';
   import Details from 'shared/views/details/Details';
@@ -109,7 +109,7 @@
       },
       backLink() {
         return {
-          name: RouterNames.CHANNELS,
+          name: RouteNames.CHANNELS,
           query: this.$route.query,
         };
       },

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
@@ -174,7 +174,7 @@
 
   import { mapGetters, mapActions } from 'vuex';
   import ClipboardChip from '../../components/ClipboardChip';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelActionsDropdown from './ChannelActionsDropdown';
   import Checkbox from 'shared/views/form/Checkbox';
   import { fileSizeMixin } from 'shared/mixins';
@@ -220,7 +220,7 @@
       },
       channelModalLink() {
         return {
-          name: RouterNames.CHANNEL,
+          name: RouteNames.CHANNEL,
           params: { channelId: this.channelId },
           query: this.$route.query,
         };
@@ -230,7 +230,7 @@
       },
       searchChannelEditorsLink() {
         return {
-          name: RouterNames.USERS,
+          name: RouteNames.USERS,
           query: {
             keywords: `${this.channel.name} ${this.channelId}`,
           },

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
@@ -101,7 +101,7 @@
 
   import { mapGetters, mapActions } from 'vuex';
   import { tableMixin, generateFilterMixin } from '../../mixins';
-  import { RouterNames, rowsPerPageItems } from '../../constants';
+  import { RouteNames, rowsPerPageItems } from '../../constants';
   import ChannelItem from './ChannelItem';
   import { channelExportMixin } from 'shared/views/channel/mixins';
   import { routerMixin } from 'shared/mixins';
@@ -195,7 +195,7 @@
       $route: {
         deep: true,
         handler(newRoute, oldRoute) {
-          if (newRoute.name === oldRoute.name && newRoute.name === RouterNames.CHANNELS)
+          if (newRoute.name === oldRoute.name && newRoute.name === RouteNames.CHANNELS)
             this.selected = [];
         },
       },

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelDetails.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelDetails.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
 import { factory } from '../../../store';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import ChannelDetails from './../ChannelDetails';
 
 const store = factory();
@@ -9,7 +9,7 @@ const store = factory();
 const channelId = '11111111111111111111111111111111';
 
 function makeWrapper() {
-  router.replace({ name: RouterNames.CHANNEL, params: { channelId } });
+  router.replace({ name: RouteNames.CHANNEL, params: { channelId } });
   return mount(ChannelDetails, {
     router,
     store,
@@ -37,7 +37,7 @@ describe('channelDetails', () => {
   });
   it('clicking close should close the modal', () => {
     wrapper.vm.dialog = false;
-    expect(wrapper.vm.$route.name).toBe(RouterNames.CHANNELS);
+    expect(wrapper.vm.$route.name).toBe(RouteNames.CHANNELS);
   });
   describe('load', () => {
     it('should automatically close if loadChannel does not find a channel', () => {
@@ -46,7 +46,7 @@ describe('channelDetails', () => {
         loadChannelDetails: jest.fn().mockReturnValue(Promise.resolve()),
       });
       return wrapper.vm.load().then(() => {
-        expect(wrapper.vm.$route.name).toBe(RouterNames.CHANNELS);
+        expect(wrapper.vm.$route.name).toBe(RouteNames.CHANNELS);
       });
     });
     it('load should call loadChannel and loadChannelDetails', () => {

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelItem.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelItem.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
 import { factory } from '../../../store';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import ChannelItem from '../ChannelItem';
 
 const store = factory();
@@ -21,7 +21,7 @@ const channel = {
 };
 
 function makeWrapper() {
-  router.replace({ name: RouterNames.CHANNELS });
+  router.replace({ name: RouteNames.CHANNELS });
   return mount(ChannelItem, {
     router,
     store,

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelTable.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
 import { factory } from '../../../store';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import ChannelTable from '../ChannelTable';
 
 const store = factory();
@@ -9,7 +9,7 @@ const store = factory();
 const loadChannels = jest.fn().mockReturnValue(Promise.resolve());
 const channelList = ['test', 'channel', 'table'];
 function makeWrapper() {
-  router.replace({ name: RouterNames.CHANNELS });
+  router.replace({ name: RouteNames.CHANNELS });
   return mount(ChannelTable, {
     router,
     store,

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
@@ -129,7 +129,7 @@
 
   import capitalize from 'lodash/capitalize';
   import { mapActions, mapGetters } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import UserStorage from './UserStorage';
   import UserActionsDropdown from './UserActionsDropdown';
   import { routerMixin, fileSizeMixin } from 'shared/mixins';
@@ -191,7 +191,7 @@
       },
       backLink() {
         return {
-          name: RouterNames.USERS,
+          name: RouteNames.USERS,
           query: this.$route.query,
         };
       },

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
@@ -96,7 +96,7 @@
 
   import capitalize from 'lodash/capitalize';
   import { mapGetters } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import UserActionsDropdown from './UserActionsDropdown';
   import UserStorage from './UserStorage';
   import Checkbox from 'shared/views/form/Checkbox';
@@ -146,14 +146,14 @@
       },
       userModalLink() {
         return {
-          name: RouterNames.USER,
+          name: RouteNames.USER,
           params: { userId: this.userId },
           query: this.$route.query,
         };
       },
       searchUserChannelsLink() {
         return {
-          name: RouterNames.CHANNELS,
+          name: RouteNames.CHANNELS,
           query: {
             keywords: `${this.user.name} ${this.user.email}`,
           },

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -103,7 +103,7 @@
 <script>
 
   import { mapGetters, mapActions } from 'vuex';
-  import { RouterNames, rowsPerPageItems } from '../../constants';
+  import { RouteNames, rowsPerPageItems } from '../../constants';
   import { tableMixin, generateFilterMixin } from '../../mixins';
   import EmailUsersDialog from './EmailUsersDialog';
   import UserItem from './UserItem';
@@ -195,7 +195,7 @@
       $route: {
         deep: true,
         handler(newRoute, oldRoute) {
-          if (newRoute.name === oldRoute.name && newRoute.name === RouterNames.USERS)
+          if (newRoute.name === oldRoute.name && newRoute.name === RouteNames.USERS)
             this.selected = [];
         },
       },

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userDetails.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userDetails.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
 import { factory } from '../../../store';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import UserDetails from '../UserDetails';
 
 const store = factory();
@@ -22,7 +22,7 @@ const details = {
 };
 
 function makeWrapper(userProps = {}) {
-  router.replace({ name: RouterNames.USER, params: { userId } });
+  router.replace({ name: RouteNames.USER, params: { userId } });
   return mount(UserDetails, {
     router,
     store,
@@ -53,7 +53,7 @@ describe('userDetails', () => {
   });
   it('clicking close should close the modal', () => {
     wrapper.vm.dialog = false;
-    expect(wrapper.vm.$route.name).toBe(RouterNames.USERS);
+    expect(wrapper.vm.$route.name).toBe(RouteNames.USERS);
   });
   describe('load', () => {
     it('should automatically close if loadUser does not find a channel', () => {
@@ -62,7 +62,7 @@ describe('userDetails', () => {
         loadUserDetails: jest.fn().mockReturnValue(Promise.resolve()),
       });
       return wrapper.vm.load().then(() => {
-        expect(wrapper.vm.$route.name).toBe(RouterNames.USERS);
+        expect(wrapper.vm.$route.name).toBe(RouteNames.USERS);
       });
     });
     it('load should call loadUser and loadUserDetails', () => {
@@ -79,7 +79,7 @@ describe('userDetails', () => {
     wrapper.setData({ loading: false });
     wrapper.find('[data-test="dropdown"]').vm.$emit('deleted');
     wrapper.vm.$nextTick(() => {
-      expect(wrapper.vm.$route.name).toBe(RouterNames.USERS);
+      expect(wrapper.vm.$route.name).toBe(RouteNames.USERS);
     });
   });
   it('progress bar should reflect storage used', () => {

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userItem.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userItem.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
 import { factory } from '../../../store';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import UserItem from '../UserItem';
 
 const store = factory();
@@ -16,7 +16,7 @@ const user = {
 };
 
 function makeWrapper() {
-  router.replace({ name: RouterNames.USERS });
+  router.replace({ name: RouteNames.USERS });
   return mount(UserItem, {
     router,
     store,

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import router from '../../../router';
 import { factory } from '../../../store';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import UserTable from '../UserTable';
 
 const store = factory();
@@ -9,7 +9,7 @@ const store = factory();
 const loadUsers = jest.fn().mockReturnValue(Promise.resolve());
 const userList = ['test', 'user', 'table'];
 function makeWrapper() {
-  router.replace({ name: RouterNames.USERS });
+  router.replace({ name: RouteNames.USERS });
   return mount(UserTable, {
     router,
     store,

--- a/contentcuration/contentcuration/frontend/administration/router.js
+++ b/contentcuration/contentcuration/frontend/administration/router.js
@@ -1,5 +1,5 @@
 import VueRouter from 'vue-router';
-import { RouterNames } from './constants';
+import { RouteNames } from './constants';
 import ChannelTable from './pages/Channels/ChannelTable';
 import ChannelDetails from './pages/Channels/ChannelDetails';
 import UserTable from './pages/Users/UserTable';
@@ -8,23 +8,23 @@ import UserDetails from './pages/Users/UserDetails';
 const router = new VueRouter({
   routes: [
     {
-      name: RouterNames.CHANNELS,
+      name: RouteNames.CHANNELS,
       path: '/channels/',
       component: ChannelTable,
     },
     {
-      name: RouterNames.CHANNEL,
+      name: RouteNames.CHANNEL,
       path: '/channels/:channelId',
       props: true,
       component: ChannelDetails,
     },
     {
-      name: RouterNames.USERS,
+      name: RouteNames.USERS,
       path: '/users/',
       component: UserTable,
     },
     {
-      name: RouterNames.USER,
+      name: RouteNames.USER,
       path: '/users/:userId',
       props: true,
       component: UserDetails,
@@ -32,7 +32,7 @@ const router = new VueRouter({
     // Catch-all redirect to channels tab
     {
       path: '*',
-      redirect: { name: RouterNames.CHANNELS },
+      redirect: { name: RouteNames.CHANNELS },
     },
   ],
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -7,7 +7,7 @@ import {
   importedChannelLink,
 } from '../utils';
 import router from '../router';
-import { RouterNames } from '../constants';
+import { RouteNames } from '../constants';
 import { AssessmentItemTypes } from 'shared/constants';
 
 describe('channelEdit utils', () => {
@@ -31,7 +31,7 @@ describe('channelEdit utils', () => {
       expect(isImportedContent(notImportedContent)).toBe(false);
 
       const expectedRoute = router.resolve({
-        name: RouterNames.ORIGINAL_SOURCE_NODE_IN_TREE_VIEW,
+        name: RouteNames.ORIGINAL_SOURCE_NODE_IN_TREE_VIEW,
         params: {
           originalSourceNodeId: 'source-node-id',
         },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -21,7 +21,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import MoveModal from '../move/MoveModal';
   import { withChangeTracker } from 'shared/data/changes';
 
@@ -59,7 +59,7 @@
       viewLink() {
         const channelURI = window.Urls.channel(this.channelId);
         const sourceNode = this.$router.resolve({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: this.node.parent,
             detailNodeId: this.node.id,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -38,7 +38,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { RouterNames } from '../constants';
+  import { RouteNames } from '../constants';
   import MoveModal from './move/MoveModal';
   import { withChangeTracker } from 'shared/data/changes';
   import { RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
@@ -78,7 +78,7 @@
       },
       editLink() {
         return {
-          name: RouterNames.CONTENTNODE_DETAILS,
+          name: RouteNames.CONTENTNODE_DETAILS,
           params: {
             ...this.$route.params,
             detailNodeIds: this.nodeId,
@@ -87,7 +87,7 @@
       },
       viewLink() {
         return {
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             ...this.$route.params,
             detailNodeId: this.nodeId,
@@ -114,7 +114,7 @@
         };
         this.createContentNode(nodeData).then(newId => {
           this.$router.push({
-            name: RouterNames.ADD_TOPICS,
+            name: RouteNames.ADD_TOPICS,
             params: {
               ...this.$route.params,
               detailNodeIds: newId,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
@@ -144,7 +144,7 @@
 
   import { mapGetters, mapActions } from 'vuex';
 
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
 
   import RelatedResourcesList from '../RelatedResourcesList/RelatedResourcesList';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
@@ -186,7 +186,7 @@
       ...mapActions('contentNode', ['removePreviousStepFromNode', 'removeNextStepFromNode']),
       onStepClick(nodeId) {
         const route = this.$router.resolve({
-          name: RouterNames.CONTENTNODE_DETAILS,
+          name: RouteNames.CONTENTNODE_DETAILS,
           params: {
             detailNodeIds: nodeId,
           },
@@ -205,7 +205,7 @@
       },
       onAddPreviousStepClick() {
         this.$router.push({
-          name: RouterNames.ADD_PREVIOUS_STEPS,
+          name: RouteNames.ADD_PREVIOUS_STEPS,
           params: {
             ...this.$route.params,
             targetNodeId: this.nodeId,
@@ -217,7 +217,7 @@
       },
       onAddNextStepClick() {
         this.$router.push({
-          name: RouterNames.ADD_NEXT_STEPS,
+          name: RouteNames.ADD_NEXT_STEPS,
           params: {
             ...this.$route.params,
             targetNodeId: this.nodeId,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
@@ -72,7 +72,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import { fileSizeMixin, fileStatusMixin } from 'shared/mixins';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
   import Checkbox from 'shared/views/form/Checkbox';
@@ -137,9 +137,9 @@
       canRemove() {
         return (
           this.canEdit &&
-          (this.$route.name === RouterNames.ADD_TOPICS ||
-            this.$route.name === RouterNames.UPLOAD_FILES ||
-            this.$route.name === RouterNames.ADD_EXERCISE)
+          (this.$route.name === RouteNames.ADD_TOPICS ||
+            this.$route.name === RouteNames.UPLOAD_FILES ||
+            this.$route.name === RouteNames.ADD_EXERCISE)
         );
       },
       uploadingFiles() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -177,7 +177,7 @@
 <script>
 
   import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
-  import { RouterNames, TabNames } from '../../constants';
+  import { RouteNames, TabNames } from '../../constants';
   import FileUploadDefault from '../../views/files/FileUploadDefault';
   import EditList from './EditList';
   import EditView from './EditView';
@@ -255,18 +255,18 @@
         return this.nodeIds.length > 1;
       },
       addTopicsMode() {
-        return this.$route.name === RouterNames.ADD_TOPICS;
+        return this.$route.name === RouteNames.ADD_TOPICS;
       },
       uploadMode() {
-        return this.$route.name === RouterNames.UPLOAD_FILES;
+        return this.$route.name === RouteNames.UPLOAD_FILES;
       },
       /* eslint-disable kolibri/vue-no-unused-properties */
       createExerciseMode() {
-        return this.$route.name === RouterNames.ADD_EXERCISE;
+        return this.$route.name === RouteNames.ADD_EXERCISE;
       },
       /* eslint-enable */
       editMode() {
-        return this.$route.name === RouterNames.CONTENTNODE_DETAILS;
+        return this.$route.name === RouteNames.CONTENTNODE_DETAILS;
       },
       showStorage() {
         return this.uploadMode || this.editMode;
@@ -303,10 +303,10 @@
     },
     beforeRouteEnter(to, from, next) {
       if (
-        to.name === RouterNames.CONTENTNODE_DETAILS ||
-        to.name === RouterNames.ADD_TOPICS ||
-        to.name === RouterNames.ADD_EXERCISE ||
-        to.name === RouterNames.UPLOAD_FILES
+        to.name === RouteNames.CONTENTNODE_DETAILS ||
+        to.name === RouteNames.ADD_TOPICS ||
+        to.name === RouteNames.ADD_EXERCISE ||
+        to.name === RouteNames.UPLOAD_FILES
       ) {
         return next(vm => {
           // Catch view-only enters before loading data
@@ -371,7 +371,7 @@
       navigateBack() {
         this.hideHTMLScroll(false);
         this.$router.push({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: { nodeId: this.$route.params.nodeId },
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -137,7 +137,7 @@
 <script>
 
   import { mapGetters, mapActions } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ResourceDrawer from '../ResourceDrawer';
   import NewTopicModal from './NewTopicModal';
   import Breadcrumbs from 'shared/views/Breadcrumbs';
@@ -245,7 +245,7 @@
       },
       goToLocation() {
         this.$router.push({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: this.targetNodeId,
           },

--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -1,6 +1,6 @@
 import { AssessmentItemTypes } from 'shared/constants';
 
-export const RouterNames = {
+export const RouteNames = {
   SANDBOX: 'SANDBOX',
   TREE_ROOT_VIEW: 'TREE_ROOT_VIEW',
   TREE_VIEW: 'TREE_VIEW',

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddNextStepsPage.vue
@@ -12,7 +12,7 @@
 <script>
 
   import { mapActions } from 'vuex';
-  import { RouterNames, TabNames } from '../constants';
+  import { RouteNames, TabNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
   import { routerMixin, titleMixin } from 'shared/mixins';
 
@@ -43,7 +43,7 @@
         });
       },
       onCancelClick() {
-        let routeName = RouterNames.CONTENTNODE_DETAILS;
+        let routeName = RouteNames.CONTENTNODE_DETAILS;
         if (this.$route.query && this.$route.query.last) {
           routeName = this.$route.query.last;
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/AddPreviousStepsPage.vue
@@ -12,7 +12,7 @@
 <script>
 
   import { mapActions } from 'vuex';
-  import { RouterNames, TabNames } from '../constants';
+  import { RouteNames, TabNames } from '../constants';
   import AddRelatedResourcesModal from '../components/AddRelatedResourcesModal';
   import { routerMixin, titleMixin } from 'shared/mixins';
 
@@ -43,7 +43,7 @@
         });
       },
       onCancelClick() {
-        let routeName = RouterNames.CONTENTNODE_DETAILS;
+        let routeName = RouteNames.CONTENTNODE_DETAILS;
         if (this.$route.query && this.$route.query.last) {
           routeName = this.$route.query.last;
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -4,7 +4,7 @@ import VueRouter from 'vue-router';
 import cloneDeep from 'lodash/cloneDeep';
 import flushPromises from 'flush-promises';
 
-import { RouterNames } from '../../constants';
+import { RouteNames } from '../../constants';
 import StagingTreePage from './index';
 import { createStore } from 'shared/vuex/draggablePlugin/test/setup';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
@@ -69,11 +69,11 @@ const initWrapper = ({ getters = GETTERS, actions = ACTIONS, mutations = MUTATIO
     routes: [
       { path: '/' },
       {
-        name: RouterNames.STAGING_TREE_VIEW,
+        name: RouteNames.STAGING_TREE_VIEW,
         path: '/staging/:nodeId/:detailNodeId?',
       },
       {
-        name: RouterNames.TREE_VIEW,
+        name: RouteNames.TREE_VIEW,
         path: '/:nodeId/:detailNodeId?',
       },
     ],
@@ -264,7 +264,7 @@ describe('StagingTreePage', () => {
         nonTopicResource.trigger('click');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: NODE_ID,
           detailNodeId: 'id-document',
@@ -277,7 +277,7 @@ describe('StagingTreePage', () => {
         nonTopicResource.trigger('dblclick');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: NODE_ID,
           detailNodeId: 'id-document',
@@ -290,7 +290,7 @@ describe('StagingTreePage', () => {
         nonTopicResource.trigger('click');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: NODE_ID,
           detailNodeId: 'id-document',
@@ -315,7 +315,7 @@ describe('StagingTreePage', () => {
         getChevronRightBtn(topic).trigger('click');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: 'id-topic',
           detailNodeId: null,
@@ -328,7 +328,7 @@ describe('StagingTreePage', () => {
         topic.trigger('click');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: 'id-topic',
           detailNodeId: null,
@@ -341,7 +341,7 @@ describe('StagingTreePage', () => {
         topic.trigger('dblclick');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: 'id-topic',
           detailNodeId: null,
@@ -354,7 +354,7 @@ describe('StagingTreePage', () => {
         getInfoBtn(topic).trigger('click');
 
         const currentRoute = wrapper.vm.$router.currentRoute;
-        expect(currentRoute.name).toBe(RouterNames.STAGING_TREE_VIEW);
+        expect(currentRoute.name).toBe(RouteNames.STAGING_TREE_VIEW);
         expect(currentRoute.params).toEqual({
           nodeId: NODE_ID,
           detailNodeId: 'id-topic',
@@ -424,7 +424,7 @@ describe('StagingTreePage', () => {
         getDeployBtn(wrapper).trigger('click');
         await flushPromises();
 
-        expect(wrapper.vm.$router.currentRoute.name).toBe(RouterNames.TREE_VIEW);
+        expect(wrapper.vm.$router.currentRoute.name).toBe(RouteNames.TREE_VIEW);
         expect(wrapper.vm.$router.currentRoute.params).toEqual({
           nodeId: ROOT_ID,
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -278,7 +278,7 @@
 
   import { mapGetters, mapMutations, mapActions } from 'vuex';
 
-  import { RouterNames, viewModes } from '../../constants';
+  import { RouteNames, viewModes } from '../../constants';
 
   import ContentNodeListItem from '../../components/ContentNodeListItem';
   import StudioTree from '../../components/StudioTree/StudioTree';
@@ -348,7 +348,7 @@
       },
       rootTreeRoute() {
         return {
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: this.rootId,
           },
@@ -370,7 +370,7 @@
             id: ancestor.id,
             title: ancestor.parent ? ancestor.title : this.currentChannel.name,
             to: {
-              name: RouterNames.STAGING_TREE_VIEW,
+              name: RouteNames.STAGING_TREE_VIEW,
               params: {
                 nodeId: ancestor.id,
               },
@@ -496,7 +496,7 @@
         }
 
         this.$router.push({
-          name: RouterNames.STAGING_TREE_VIEW,
+          name: RouteNames.STAGING_TREE_VIEW,
           params: {
             nodeId: this.nodeId,
             detailNodeId: nodeId,
@@ -509,7 +509,7 @@
         }
 
         this.$router.push({
-          name: RouterNames.STAGING_TREE_VIEW,
+          name: RouteNames.STAGING_TREE_VIEW,
           params: {
             nodeId: topicId,
             detailNodeId: null,
@@ -525,7 +525,7 @@
       },
       closePanel() {
         this.$router.push({
-          name: RouterNames.STAGING_TREE_VIEW,
+          name: RouteNames.STAGING_TREE_VIEW,
           params: {
             nodeId: this.nodeId,
             detailNodeId: null,

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -1,5 +1,5 @@
 import VueRouter from 'vue-router';
-import { RouterNames } from './constants';
+import { RouteNames } from './constants';
 import TreeView from './views/TreeView';
 import StagingTreePage from './pages/StagingTreePage';
 import store from './store';
@@ -9,7 +9,7 @@ import TrashModal from './views/trash/TrashModal';
 import SearchOrBrowseWindow from './views/ImportFromChannels/SearchOrBrowseWindow';
 import ReviewSelectionsPage from './views/ImportFromChannels/ReviewSelectionsPage';
 import EditModal from './components/edit/EditModal';
-import { RouterNames as ChannelRouterNames } from 'frontend/channelList/constants';
+import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
 import Sandbox from 'shared/views/Sandbox';
 import ChannelModal from 'shared/views/channel/ChannelModal';
 import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
@@ -17,7 +17,7 @@ import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
 const router = new VueRouter({
   routes: [
     {
-      name: RouterNames.SANDBOX,
+      name: RouteNames.SANDBOX,
       path: '/sandbox/:nodeId',
       props: true,
       component: Sandbox,
@@ -31,13 +31,13 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.TREE_ROOT_VIEW,
+      name: RouteNames.TREE_ROOT_VIEW,
       path: '/',
       beforeEnter: (to, from, next) => {
         return store.dispatch('currentChannel/loadChannel').then(channel => {
           const nodeId = channel.root_id;
           return next({
-            name: RouterNames.TREE_VIEW,
+            name: RouteNames.TREE_VIEW,
             params: {
               nodeId,
             },
@@ -47,31 +47,31 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+      name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
       path: '/import/:destNodeId/browse/:channelId?/:nodeId?',
       component: SearchOrBrowseWindow,
       props: true,
     },
     {
-      name: RouterNames.IMPORT_FROM_CHANNELS_SEARCH,
+      name: RouteNames.IMPORT_FROM_CHANNELS_SEARCH,
       path: '/import/:destNodeId/search/:searchTerm',
       component: SearchOrBrowseWindow,
       props: true,
     },
     {
-      name: RouterNames.IMPORT_FROM_CHANNELS_REVIEW,
+      name: RouteNames.IMPORT_FROM_CHANNELS_REVIEW,
       path: '/import/:destNodeId/review',
       component: ReviewSelectionsPage,
       props: true,
     },
     // Redirect to staging URL with root node ID
     {
-      name: RouterNames.STAGING_TREE_VIEW_REDIRECT,
+      name: RouteNames.STAGING_TREE_VIEW_REDIRECT,
       path: '/staging',
       beforeEnter: (to, from, next) => {
         return store.dispatch('currentChannel/loadChannel').then(channel => {
           return next({
-            name: RouterNames.STAGING_TREE_VIEW,
+            name: RouteNames.STAGING_TREE_VIEW,
             params: {
               nodeId: channel.staging_root_id,
             },
@@ -81,13 +81,13 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.STAGING_TREE_VIEW,
+      name: RouteNames.STAGING_TREE_VIEW,
       path: '/staging/:nodeId/:detailNodeId?',
       props: true,
       component: StagingTreePage,
     },
     {
-      name: RouterNames.ADD_PREVIOUS_STEPS,
+      name: RouteNames.ADD_PREVIOUS_STEPS,
       path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/previous-steps/:targetNodeId',
       props: true,
       component: AddPreviousStepsPage,
@@ -106,7 +106,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.ADD_NEXT_STEPS,
+      name: RouteNames.ADD_NEXT_STEPS,
       path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/next-steps/:targetNodeId',
       props: true,
       component: AddNextStepsPage,
@@ -125,7 +125,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.TRASH,
+      name: RouteNames.TRASH,
       path: '/:nodeId/:detailNodeId?/trash',
       component: TrashModal,
       props: true,
@@ -139,7 +139,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: ChannelRouterNames.CHANNEL_DETAILS,
+      name: ChannelRouteNames.CHANNEL_DETAILS,
       path: '/:nodeId/:detailNodeId?/channel/:channelId/details',
       component: ChannelDetailsModal,
       props: true,
@@ -153,7 +153,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: ChannelRouterNames.CHANNEL_EDIT,
+      name: ChannelRouteNames.CHANNEL_EDIT,
       path: '/:nodeId/:detailNodeId?/channel/:channelId/:tab',
       component: ChannelModal,
       props: true,
@@ -167,7 +167,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.CONTENTNODE_DETAILS,
+      name: RouteNames.CONTENTNODE_DETAILS,
       path: '/:nodeId/:detailNodeId?/details/:detailNodeIds/:tab?/:targetNodeId?',
       props: true,
       component: EditModal,
@@ -181,7 +181,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.ADD_TOPICS,
+      name: RouteNames.ADD_TOPICS,
       path: '/:nodeId/:detailNodeId?/topics/:detailNodeIds/:tab?',
       props: true,
       component: EditModal,
@@ -195,7 +195,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.ADD_EXERCISE,
+      name: RouteNames.ADD_EXERCISE,
       path: '/:nodeId/:detailNodeId?/exercise/:detailNodeIds/:tab?',
       props: true,
       component: EditModal,
@@ -209,7 +209,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.UPLOAD_FILES,
+      name: RouteNames.UPLOAD_FILES,
       path: '/:nodeId/:detailNodeId?/upload/:detailNodeIds?/:tab?',
       props: true,
       component: EditModal,
@@ -223,14 +223,14 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.ORIGINAL_SOURCE_NODE_IN_TREE_VIEW,
+      name: RouteNames.ORIGINAL_SOURCE_NODE_IN_TREE_VIEW,
       path: '/originalSourceNode/:originalSourceNodeId',
       beforeEnter: (to, from, next) => {
         return store
           .dispatch('contentNode/loadContentNodeByNodeId', to.params.originalSourceNodeId)
           .then(node => {
             next({
-              name: RouterNames.TREE_VIEW,
+              name: RouteNames.TREE_VIEW,
               params: {
                 nodeId: node.parent,
                 detailNodeId: node.id,
@@ -240,7 +240,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouterNames.TREE_VIEW,
+      name: RouteNames.TREE_VIEW,
       path: '/:nodeId/:detailNodeId?',
       props: true,
       component: TreeView,

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -1,5 +1,5 @@
 import translator from './translator';
-import { RouterNames } from './constants';
+import { RouteNames } from './constants';
 import { AssessmentItemTypes } from 'shared/constants';
 
 /**
@@ -132,7 +132,7 @@ export function importedChannelLink(node, router) {
   if (node && isImportedContent(node)) {
     const channelURI = window.Urls.channel(node.original_channel_id);
     const sourceNodeRoute = router.resolve({
-      name: RouterNames.ORIGINAL_SOURCE_NODE_IN_TREE_VIEW,
+      name: RouteNames.ORIGINAL_SOURCE_NODE_IN_TREE_VIEW,
       params: { originalSourceNodeId: node.original_source_node_id },
     });
     return `${channelURI + sourceNodeRoute.href}`;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -222,7 +222,7 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
-  import { RouterNames, viewModes, DraggableRegions, DraggableUniverses } from '../constants';
+  import { RouteNames, viewModes, DraggableRegions, DraggableUniverses } from '../constants';
   import ResourceDrawer from '../components/ResourceDrawer';
   import ContentNodeOptions from '../components/ContentNodeOptions';
   import MoveModal from '../components/move/MoveModal';
@@ -335,14 +335,14 @@
         return this.getContentNodeChildren(this.topicId);
       },
       uploadFilesLink() {
-        return { name: RouterNames.UPLOAD_FILES };
+        return { name: RouteNames.UPLOAD_FILES };
       },
       viewModes() {
         return Object.values(viewModes);
       },
       importFromChannelsRoute() {
         return {
-          name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
           params: {
             destNodeId: this.$route.params.nodeId,
           },
@@ -440,7 +440,7 @@
           kind: ContentKindsNames.TOPIC,
           title: '',
         };
-        this.newContentNode(RouterNames.ADD_TOPICS, nodeData);
+        this.newContentNode(RouteNames.ADD_TOPICS, nodeData);
         this.trackClickEvent('Add topics');
       },
       newExerciseNode() {
@@ -448,13 +448,13 @@
           kind: ContentKindsNames.EXERCISE,
           title: '',
         };
-        this.newContentNode(RouterNames.ADD_EXERCISE, nodeData);
+        this.newContentNode(RouteNames.ADD_EXERCISE, nodeData);
         this.trackClickEvent('Add exercise');
       },
       editNodes(ids) {
         this.trackClickEvent('Edit');
         this.$router.push({
-          name: RouterNames.CONTENTNODE_DETAILS,
+          name: RouteNames.CONTENTNODE_DETAILS,
           params: {
             detailNodeIds: ids.join(','),
           },
@@ -462,13 +462,13 @@
       },
       treeLink(params) {
         return {
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params,
         };
       },
       closePanel() {
         this.$router.push({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: this.$route.params.nodeId,
             detailNodeId: null,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -98,7 +98,7 @@
 
   export default {
     name: 'BrowsingCard',
-    inject: ['RouterNames'],
+    inject: ['RouteNames'],
     components: {
       IconButton,
       Thumbnail,
@@ -131,7 +131,7 @@
       },
       topicRoute() {
         return {
-          name: this.RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          name: this.RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
           params: {
             nodeId: this.node.id,
             channelId: this.inSearch ? this.node.channel_id : this.$route.params.channelId,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
@@ -53,7 +53,7 @@
 
   export default {
     name: 'ChannelInfoCard',
-    inject: ['RouterNames'],
+    inject: ['RouteNames'],
     components: { Thumbnail, ToggleText },
     mixins: [constantsTranslationMixin],
     props: {
@@ -68,7 +68,7 @@
       },
       channelRoute() {
         return {
-          name: this.RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          name: this.RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
           params: {
             channelId: this.channel.id,
             nodeId: this.channel.root_id,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -55,7 +55,7 @@
   import intersectionBy from 'lodash/intersectionBy';
   import { mapActions, mapGetters } from 'vuex';
   import find from 'lodash/find';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import BrowsingCard from './BrowsingCard';
   import Breadcrumbs from 'shared/views/Breadcrumbs';
   import Checkbox from 'shared/views/form/Checkbox';
@@ -121,7 +121,7 @@
           return {
             text: ancestor.title,
             to: {
-              name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+              name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
               params: {
                 channelId: this.$route.params.channelId,
                 nodeId: ancestor.id,
@@ -133,7 +133,7 @@
           {
             text: this.$tr('allChannelsLabel'),
             to: {
-              name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+              name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
               params: {},
               query: this.$route.query,
             },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -76,16 +76,16 @@
 
   import { mapActions, mapMutations, mapState } from 'vuex';
   import sumBy from 'lodash/sumBy';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ResourceDrawer from '../../components/ResourceDrawer';
   import { routerMixin } from 'shared/mixins';
   import FullscreenModal from 'shared/views/FullscreenModal';
 
   const IMPORT_ROUTES = [
-    RouterNames.IMPORT_FROM_CHANNELS,
-    RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
-    RouterNames.IMPORT_FROM_CHANNELS_SEARCH,
-    RouterNames.IMPORT_FROM_CHANNELS_REVIEW,
+    RouteNames.IMPORT_FROM_CHANNELS,
+    RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
+    RouteNames.IMPORT_FROM_CHANNELS_SEARCH,
+    RouteNames.IMPORT_FROM_CHANNELS_REVIEW,
   ];
 
   function getResourceCount(node) {
@@ -110,7 +110,7 @@
       };
     },
     provide: {
-      RouterNames,
+      RouteNames,
     },
     computed: {
       ...mapState('importFromChannels', ['selected']),
@@ -136,7 +136,7 @@
       },
       backLink() {
         return {
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: this.$route.params.destNodeId,
           },
@@ -147,7 +147,7 @@
           return { path: this.$route.query.last, query: this.$route.query };
         }
         return {
-          name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
           query: this.$route.query,
         };
       },
@@ -155,7 +155,7 @@
         return sumBy(this.selected, getResourceCount);
       },
       isReview() {
-        return this.$route.name === RouterNames.IMPORT_FROM_CHANNELS_REVIEW;
+        return this.$route.name === RouteNames.IMPORT_FROM_CHANNELS_REVIEW;
       },
       headerText() {
         return this.isReview ? this.$tr('reviewTitle') : this.$tr('importTitle');
@@ -201,7 +201,7 @@
       },
       handleClickReview() {
         this.$router.push({
-          name: RouterNames.IMPORT_FROM_CHANNELS_REVIEW,
+          name: RouteNames.IMPORT_FROM_CHANNELS_REVIEW,
           query: {
             ...this.$route.query,
             last: this.$route.path,
@@ -218,7 +218,7 @@
           this.showSnackbar = false;
           this.$store.commit('importFromChannels/CLEAR_NODES');
           this.$router.push({
-            name: RouterNames.TREE_VIEW,
+            name: RouteNames.TREE_VIEW,
             params: {
               nodeId: this.$route.params.destNodeId,
             },
@@ -233,10 +233,9 @@
       updateTitleForPage() {
         // NOTE: Tab title for ReviewSelectionPage is handled in that component
         if (
-          [
-            RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
-            RouterNames.IMPORT_FROM_CHANNELS_SEARCH,
-          ].includes(this.$route.name)
+          [RouteNames.IMPORT_FROM_CHANNELS_BROWSE, RouteNames.IMPORT_FROM_CHANNELS_SEARCH].includes(
+            this.$route.name
+          )
         ) {
           this.updateTabTitle(this.$store.getters.appendChannelName(this.$tr('importTitle')));
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
@@ -91,7 +91,7 @@
 
   export default {
     name: 'SavedSearchesModal',
-    inject: ['RouterNames'],
+    inject: ['RouteNames'],
     components: {
       EditSearchModal,
       MessageDialog,
@@ -158,7 +158,7 @@
         delete query.keywords;
 
         return {
-          name: this.RouterNames.IMPORT_FROM_CHANNELS_SEARCH,
+          name: this.RouteNames.IMPORT_FROM_CHANNELS_SEARCH,
           params: {
             ...this.$route.params,
             searchTerm,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -76,7 +76,7 @@
 <script>
 
   import { mapActions, mapMutations, mapState } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelList from './ChannelList';
   import ContentTreeList from './ContentTreeList';
   import SearchResultsList from './SearchResultsList';
@@ -101,7 +101,7 @@
     computed: {
       ...mapState('importFromChannels', ['selected']),
       isBrowsing() {
-        return this.$route.name === RouterNames.IMPORT_FROM_CHANNELS_BROWSE;
+        return this.$route.name === RouteNames.IMPORT_FROM_CHANNELS_BROWSE;
       },
       backToBrowseRoute() {
         const query = {
@@ -111,7 +111,7 @@
           return { path: this.$route.query.last, query };
         }
         return {
-          name: RouterNames.IMPORT_FROM_CHANNELS_BROWSE,
+          name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
           query,
         };
       },
@@ -124,7 +124,7 @@
     },
     beforeRouteLeave(to, from, next) {
       // Clear selections if going back to TreeView
-      if (to.name === RouterNames.TREE_VIEW) {
+      if (to.name === RouteNames.TREE_VIEW) {
         this.$store.commit('importFromChannels/CLEAR_NODES');
       }
       next();
@@ -145,7 +145,7 @@
       handleSearchTerm() {
         if (this.searchIsValid) {
           this.$router.push({
-            name: RouterNames.IMPORT_FROM_CHANNELS_SEARCH,
+            name: RouteNames.IMPORT_FROM_CHANNELS_SEARCH,
             params: {
               searchTerm: this.searchTerm.trim(),
             },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -51,7 +51,7 @@
 
   import { mapActions, mapGetters } from 'vuex';
 
-  import { RouterNames } from '../constants';
+  import { RouteNames } from '../constants';
   import ContentNodeEditListItem from '../components/ContentNodeEditListItem';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import LoadingText from 'shared/views/LoadingText';
@@ -111,7 +111,7 @@
         }
 
         this.$router.push({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: this.parentId,
             detailNodeId: nodeId,
@@ -124,7 +124,7 @@
         }
 
         this.$router.push({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId: topicId,
             detailNodeId: null,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -238,7 +238,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { DraggableRegions, DraggableUniverses, RouterNames } from '../../constants';
+  import { DraggableRegions, DraggableUniverses, RouteNames } from '../../constants';
   import PublishModal from '../../components/publish/PublishModal';
   import ProgressModal from '../progress/ProgressModal';
   import SyncResourcesModal from '../sync/SyncResourcesModal';
@@ -250,7 +250,7 @@
   import OfflineText from 'shared/views/OfflineText';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
   import MessageDialog from 'shared/views/MessageDialog';
-  import { RouterNames as ChannelRouterNames } from 'frontend/channelList/constants';
+  import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
   import { titleMixin } from 'shared/mixins';
   import DraggableRegion from 'shared/views/draggable/DraggableRegion';
   import { DropEffect } from 'shared/mixins/draggable/constants';
@@ -330,7 +330,7 @@
       },
       viewChannelDetailsLink() {
         return {
-          name: ChannelRouterNames.CHANNEL_DETAILS,
+          name: ChannelRouteNames.CHANNEL_DETAILS,
           query: {
             last: this.$route.name,
           },
@@ -342,7 +342,7 @@
       },
       editChannelLink() {
         return {
-          name: ChannelRouterNames.CHANNEL_EDIT,
+          name: ChannelRouteNames.CHANNEL_EDIT,
           query: {
             last: this.$route.name,
           },
@@ -355,13 +355,13 @@
       },
       trashLink() {
         return {
-          name: RouterNames.TRASH,
+          name: RouteNames.TRASH,
           params: this.$route.params,
         };
       },
       shareChannelLink() {
         return {
-          name: ChannelRouterNames.CHANNEL_EDIT,
+          name: ChannelRouteNames.CHANNEL_EDIT,
           params: {
             channelId: this.currentChannel.id,
             tab: 'share',
@@ -372,7 +372,7 @@
         };
       },
       showClipboardSpeedDial() {
-        return this.$route.name !== RouterNames.STAGING_TREE_VIEW;
+        return this.$route.name !== RouteNames.STAGING_TREE_VIEW;
       },
       draggableUniverse() {
         return DraggableUniverses.CONTENT_NODES;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.spec.js
@@ -3,7 +3,7 @@ import Vuex, { Store } from 'vuex';
 import VueRouter from 'vue-router';
 import cloneDeep from 'lodash/cloneDeep';
 
-import { RouterNames } from '../../constants';
+import { RouteNames } from '../../constants';
 import TreeView from './index';
 
 const localVue = createLocalVue();
@@ -50,7 +50,7 @@ const initWrapper = ({ getters = GETTERS, actions = ACTIONS, mutations = MUTATIO
   const router = new VueRouter({
     routes: [
       {
-        name: RouterNames.STAGING_TREE_VIEW,
+        name: RouteNames.STAGING_TREE_VIEW,
         path: '/staging/:nodeId/:detailNodeId?',
       },
     ],

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -138,7 +138,7 @@
 <script>
 
   import { mapActions, mapGetters, mapMutations } from 'vuex';
-  import { RouterNames, DraggableRegions, DraggableUniverses } from '../../constants';
+  import { RouteNames, DraggableRegions, DraggableUniverses } from '../../constants';
   import StudioTree from '../../components/StudioTree/StudioTree';
   import CurrentTopicView from '../CurrentTopicView';
   import TreeViewBase from './TreeViewBase';
@@ -222,7 +222,7 @@
       },
       stagingTreeLink() {
         return {
-          name: RouterNames.STAGING_TREE_VIEW,
+          name: RouteNames.STAGING_TREE_VIEW,
           params: {
             nodeId: this.stagingId,
           },
@@ -251,7 +251,7 @@
       pageNotFoundBackHomeLink() {
         return {
           to: {
-            name: RouterNames.TREE_ROOT_VIEW,
+            name: RouteNames.TREE_ROOT_VIEW,
           },
         };
       },
@@ -319,7 +319,7 @@
           return;
         }
         this.$router.push({
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: {
             nodeId,
           },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -127,7 +127,7 @@
 
   import { mapActions, mapGetters } from 'vuex';
   import sortBy from 'lodash/sortBy';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ResourceDrawer from '../../components/ResourceDrawer';
   import MoveModal from '../../components/move/MoveModal';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
@@ -190,7 +190,7 @@
       },
       backLink() {
         return {
-          name: RouterNames.TREE_VIEW,
+          name: RouteNames.TREE_VIEW,
           params: this.$route.params,
         };
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import TrashModal from '../TrashModal';
 import { factory } from '../../../store';
 import router from '../../../router';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 
 const store = factory();
 
@@ -67,7 +67,7 @@ describe('trashModal', () => {
   let wrapper;
   beforeEach(() => {
     wrapper = makeWrapper();
-    router.replace({ name: RouterNames.TRASH, params: { nodeId: 'test' } });
+    router.replace({ name: RouteNames.TRASH, params: { nodeId: 'test' } });
     wrapper.setData({ loading: false });
   });
   describe('on load', () => {

--- a/contentcuration/contentcuration/frontend/channelList/constants.js
+++ b/contentcuration/contentcuration/frontend/channelList/constants.js
@@ -12,7 +12,7 @@ export const ChannelInvitationMapping = {
   [InvitationShareModes.VIEW_ONLY]: ChannelListTypes.VIEW_ONLY,
 };
 
-export const RouterNames = {
+export const RouteNames = {
   CHANNELS_EDITABLE: 'CHANNELS_EDITABLE',
   CHANNELS_STARRED: 'CHANNELS_STARRED',
   CHANNELS_VIEW_ONLY: 'CHANNELS_VIEW_ONLY',
@@ -27,10 +27,10 @@ export const RouterNames = {
 };
 
 export const ListTypeToRouteMapping = {
-  [ChannelListTypes.EDITABLE]: RouterNames.CHANNELS_EDITABLE,
-  [ChannelListTypes.STARRED]: RouterNames.CHANNELS_STARRED,
-  [ChannelListTypes.VIEW_ONLY]: RouterNames.CHANNELS_VIEW_ONLY,
-  [ChannelListTypes.PUBLIC]: RouterNames.CHANNELS_PUBLIC,
+  [ChannelListTypes.EDITABLE]: RouteNames.CHANNELS_EDITABLE,
+  [ChannelListTypes.STARRED]: RouteNames.CHANNELS_STARRED,
+  [ChannelListTypes.VIEW_ONLY]: RouteNames.CHANNELS_VIEW_ONLY,
+  [ChannelListTypes.PUBLIC]: RouteNames.CHANNELS_PUBLIC,
 };
 
 export const RouteToListTypeMapping = invert(ListTypeToRouteMapping);

--- a/contentcuration/contentcuration/frontend/channelList/router.js
+++ b/contentcuration/contentcuration/frontend/channelList/router.js
@@ -3,7 +3,7 @@ import ChannelList from './views/Channel/ChannelList';
 import ChannelSetList from './views/ChannelSet/ChannelSetList';
 import ChannelSetModal from './views/ChannelSet/ChannelSetModal';
 import CatalogList from './views/Channel/CatalogList';
-import { RouterNames } from './constants';
+import { RouteNames } from './constants';
 import CatalogFAQ from './views/Channel/CatalogFAQ';
 import { ChannelListTypes } from 'shared/constants';
 import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
@@ -12,66 +12,66 @@ import ChannelModal from 'shared/views/channel/ChannelModal';
 const router = new VueRouter({
   routes: [
     {
-      name: RouterNames.CHANNELS_EDITABLE,
+      name: RouteNames.CHANNELS_EDITABLE,
       path: '/my-channels',
       component: ChannelList,
       props: { listType: ChannelListTypes.EDITABLE },
     },
     {
-      name: RouterNames.CHANNELS_STARRED,
+      name: RouteNames.CHANNELS_STARRED,
       path: '/starred',
       component: ChannelList,
       props: { listType: ChannelListTypes.STARRED },
     },
     {
-      name: RouterNames.CHANNELS_VIEW_ONLY,
+      name: RouteNames.CHANNELS_VIEW_ONLY,
       path: '/view-only',
       component: ChannelList,
       props: { listType: ChannelListTypes.VIEW_ONLY },
     },
     {
-      name: RouterNames.CHANNEL_DETAILS,
+      name: RouteNames.CHANNEL_DETAILS,
       path: '/:channelId/details',
       component: ChannelDetailsModal,
       props: true,
     },
     {
-      name: RouterNames.CHANNEL_EDIT,
+      name: RouteNames.CHANNEL_EDIT,
       path: '/:channelId/:tab',
       component: ChannelModal,
       props: true,
     },
     {
-      name: RouterNames.CHANNEL_SETS,
+      name: RouteNames.CHANNEL_SETS,
       path: '/collections',
       component: ChannelSetList,
     },
     {
-      name: RouterNames.CHANNEL_SET_DETAILS,
+      name: RouteNames.CHANNEL_SET_DETAILS,
       path: '/collections/:channelSetId',
       component: ChannelSetModal,
       props: true,
     },
     {
-      name: RouterNames.CATALOG_ITEMS,
+      name: RouteNames.CATALOG_ITEMS,
       path: '/public',
       component: CatalogList,
     },
     {
-      name: RouterNames.CATALOG_DETAILS,
+      name: RouteNames.CATALOG_DETAILS,
       path: '/public/:channelId',
       component: ChannelDetailsModal,
       props: true,
     },
     {
-      name: RouterNames.CATALOG_FAQ,
+      name: RouteNames.CATALOG_FAQ,
       path: '/faq',
       component: CatalogFAQ,
     },
     // Catch-all for unrecognized URLs
     {
       path: '*',
-      redirect: { name: RouterNames.CHANNELS_EDITABLE },
+      redirect: { name: RouteNames.CHANNELS_EDITABLE },
     },
   ],
 });

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilters.vue
@@ -113,7 +113,7 @@
 
   import { mapGetters } from 'vuex';
   import debounce from 'lodash/debounce';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import LanguageFilter from './components/LanguageFilter';
   import { catalogFilterMixin } from './mixins';
   import CatalogFilterBar from './CatalogFilterBar';
@@ -150,7 +150,7 @@
         return window.libraryMode;
       },
       faqLink() {
-        return { name: RouterNames.CATALOG_FAQ };
+        return { name: RouteNames.CATALOG_FAQ };
       },
       menuProps() {
         return { offsetY: true, maxHeight: 270 };

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -111,7 +111,7 @@
   import difference from 'lodash/difference';
   import isEqual from 'lodash/isEqual';
   import union from 'lodash/union';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelItem from './ChannelItem';
   import CatalogFilters from './CatalogFilters';
   import LoadingText from 'shared/views/LoadingText';
@@ -186,7 +186,7 @@
         return debounce(this.loadCatalog, 1000);
       },
       detailsRouteName() {
-        return RouterNames.CATALOG_DETAILS;
+        return RouteNames.CATALOG_DETAILS;
       },
       channels() {
         return this.getChannels(this.page.results);
@@ -197,7 +197,7 @@
     },
     watch: {
       $route(to) {
-        if (!isEqual(to.query, this.previousQuery) && to.name === RouterNames.CATALOG_ITEMS) {
+        if (!isEqual(to.query, this.previousQuery) && to.name === RouteNames.CATALOG_ITEMS) {
           this.loading = true;
           this.debouncedSearch();
 

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -227,7 +227,7 @@
 <script>
 
   import { mapActions, mapGetters, mapMutations } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelStar from './ChannelStar';
   import PrimaryDialog from 'shared/views/PrimaryDialog';
   import ChannelTokenModal from 'shared/views/channel/ChannelTokenModal';
@@ -251,7 +251,7 @@
       },
       detailsRouteName: {
         type: String,
-        default: RouterNames.CHANNEL_DETAILS,
+        default: RouteNames.CHANNEL_DETAILS,
       },
       allowEdit: {
         type: Boolean,
@@ -285,7 +285,7 @@
       },
       channelEditLink() {
         return {
-          name: RouterNames.CHANNEL_EDIT,
+          name: RouteNames.CHANNEL_EDIT,
           query: {
             // this component is used on the catalog search
             // page => do not lose search query

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -54,7 +54,7 @@
 
   import uniq from 'lodash/uniq';
   import { mapGetters, mapActions, mapState } from 'vuex';
-  import { RouterNames, CHANNEL_PAGE_SIZE } from '../../constants';
+  import { RouteNames, CHANNEL_PAGE_SIZE } from '../../constants';
   import ChannelItem from './ChannelItem';
   import LoadingText from 'shared/views/LoadingText';
   import Pagination from 'shared/views/Pagination';
@@ -117,7 +117,7 @@
         this.$analytics.trackClick('channel_list', 'Create channel');
         this.createChannel().then(id => {
           this.$router.push({
-            name: RouterNames.CHANNEL_EDIT,
+            name: RouteNames.CHANNEL_EDIT,
             params: { channelId: id, tab: 'edit' },
             query: { last: this.$route.name },
           });

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogList.spec.js
@@ -1,12 +1,12 @@
 import { mount } from '@vue/test-utils';
 import { factory } from '../../../store';
 import router from '../../../router';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import CatalogList from '../CatalogList';
 
 const store = factory();
 
-router.push({ name: RouterNames.CATALOG_ITEMS });
+router.push({ name: RouteNames.CATALOG_ITEMS });
 
 const results = ['channel-1', 'channel-2'];
 

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/channelItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/channelItem.spec.js
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import { factory } from '../../../store';
 import router from '../../../router';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import ChannelItem from '../ChannelItem.vue';
 
 const store = factory();
@@ -62,15 +62,15 @@ describe('channelItem', () => {
   });
   it('clicking the channel should open the channel', () => {
     wrapper.find('[data-test="channel-card"]').trigger('click');
-    expect(wrapper.vm.$route.name).toEqual(RouterNames.CHANNELS_EDITABLE);
+    expect(wrapper.vm.$route.name).toEqual(RouteNames.CHANNELS_EDITABLE);
   });
   it('clicking edit channel should open a channel editor modal', () => {
     wrapper.find('[data-test="edit-channel"]').trigger('click');
-    expect(wrapper.vm.$route.name).toEqual(RouterNames.CHANNEL_EDIT);
+    expect(wrapper.vm.$route.name).toEqual(RouteNames.CHANNEL_EDIT);
   });
   it('clicking the info icon should open a channel details modal ', () => {
     wrapper.find('[data-test="details-button"]').trigger('click');
-    expect(wrapper.vm.$route.name).toEqual(RouterNames.CHANNEL_DETAILS);
+    expect(wrapper.vm.$route.name).toEqual(RouteNames.CHANNEL_DETAILS);
   });
   it('clicking the token option should open the token modal', () => {
     wrapper.find('[data-test="token-listitem"]').trigger('click');
@@ -90,7 +90,7 @@ describe('channelItem', () => {
     });
     it('clicking channel card should open details modal', () => {
       wrapper.find('[data-test="channel-card"]').trigger('click');
-      expect(wrapper.vm.$route.name).toEqual(RouterNames.CHANNEL_DETAILS);
+      expect(wrapper.vm.$route.name).toEqual(RouteNames.CHANNEL_DETAILS);
     });
     it('clicking the token button should open the token modal', () => {
       wrapper.setData({ tokenDialog: false });

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListAppError.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListAppError.vue
@@ -26,7 +26,7 @@
 
 <script>
 
-  import { RouterNames } from '../constants';
+  import { RouteNames } from '../constants';
   import ChannelNotFoundError from 'shared/views/errors/ChannelNotFoundError';
   import PageNotFoundError from 'shared/views/errors/PageNotFoundError';
   import PermissionsError from 'shared/views/errors/PermissionsError';
@@ -56,7 +56,7 @@
       homeUrl() {
         return {
           to: {
-            name: RouterNames.CHANNELS_EDITABLE,
+            name: RouteNames.CHANNELS_EDITABLE,
           },
         };
       },

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -86,7 +86,7 @@
 
   import { mapActions, mapGetters, mapState } from 'vuex';
   import {
-    RouterNames,
+    RouteNames,
     ChannelInvitationMapping,
     ListTypeToRouteMapping,
     RouteToListTypeMapping,
@@ -102,9 +102,9 @@
   import PolicyModals from 'shared/views/policies/PolicyModals';
 
   const CATALOG_PAGES = [
-    RouterNames.CATALOG_ITEMS,
-    RouterNames.CATALOG_DETAILS,
-    RouterNames.CATALOG_FAQ,
+    RouteNames.CATALOG_ITEMS,
+    RouteNames.CATALOG_DETAILS,
+    RouteNames.CATALOG_FAQ,
   ];
 
   const CHANNEL_SETS = 'channel_sets';
@@ -141,10 +141,10 @@
         return window.libraryMode;
       },
       isFAQPage() {
-        return this.$route.name === RouterNames.CATALOG_FAQ;
+        return this.$route.name === RouteNames.CATALOG_FAQ;
       },
       isCatalogPage() {
-        return this.$route.name === RouterNames.CATALOG_ITEMS;
+        return this.$route.name === RouteNames.CATALOG_ITEMS;
       },
       currentListType() {
         return RouteToListTypeMapping[this.$route.name];
@@ -176,10 +176,10 @@
         return inviteMap;
       },
       channelSetLink() {
-        return { name: RouterNames.CHANNEL_SETS };
+        return { name: RouteNames.CHANNEL_SETS };
       },
       catalogLink() {
-        return { name: RouterNames.CATALOG_ITEMS };
+        return { name: RouteNames.CATALOG_ITEMS };
       },
       isChannelList() {
         return this.lists.includes(this.currentListType);
@@ -196,7 +196,7 @@
     },
     watch: {
       $route(route) {
-        if (this.loggedIn && route.name === RouterNames.CHANNELS_EDITABLE) {
+        if (this.loggedIn && route.name === RouteNames.CHANNELS_EDITABLE) {
           this.loadInvitationList();
         }
         if (this.fullPageError) {
@@ -213,7 +213,7 @@
         this.loadInvitationList();
       } else if (!CATALOG_PAGES.includes(this.$route.name)) {
         this.$router.push({
-          name: RouterNames.CATALOG_ITEMS,
+          name: RouteNames.CATALOG_ITEMS,
         });
       }
     },
@@ -232,15 +232,15 @@
         // Updates the tab title every time the top-level route changes
         let title;
         const routeName = this.$route.name;
-        if (routeName === RouterNames.CHANNEL_SETS) {
+        if (routeName === RouteNames.CHANNEL_SETS) {
           title = this.$tr('channelSets');
-        } else if (routeName === RouterNames.CATALOG_ITEMS) {
+        } else if (routeName === RouteNames.CATALOG_ITEMS) {
           title = this.translateConstant('public');
-        } else if (routeName === RouterNames.CHANNELS_VIEW_ONLY) {
+        } else if (routeName === RouteNames.CHANNELS_VIEW_ONLY) {
           title = this.translateConstant('view');
-        } else if (routeName === RouterNames.CHANNELS_STARRED) {
+        } else if (routeName === RouteNames.CHANNELS_STARRED) {
           title = this.translateConstant('bookmark');
-        } else if (routeName === RouterNames.CHANNELS_EDITABLE) {
+        } else if (routeName === RouteNames.CHANNELS_EDITABLE) {
           title = this.translateConstant('edit');
         }
         // Title changes for other routes are handled by other components, since

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetItem.vue
@@ -62,7 +62,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import MessageDialog from 'shared/views/MessageDialog';
   import CopyToken from 'shared/views/CopyToken';
 
@@ -90,7 +90,7 @@
       },
       channelSetDetailsLink() {
         return {
-          name: RouterNames.CHANNEL_SET_DETAILS,
+          name: RouteNames.CHANNEL_SET_DETAILS,
           params: { channelSetId: this.channelSet.id },
         };
       },

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -69,7 +69,7 @@
 
   import sortBy from 'lodash/sortBy';
   import { mapGetters, mapActions } from 'vuex';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelSetItem from './ChannelSetItem.vue';
   import MessageDialog from 'shared/views/MessageDialog';
   import LoadingText from 'shared/views/LoadingText';
@@ -111,7 +111,7 @@
       newChannelSet() {
         this.createChannelSet().then(id => {
           this.$router.push({
-            name: RouterNames.CHANNEL_SET_DETAILS,
+            name: RouteNames.CHANNEL_SET_DETAILS,
             params: { channelSetId: id },
           });
         });

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -154,7 +154,7 @@
   import Vue from 'vue';
   import { mapGetters, mapActions } from 'vuex';
   import difference from 'lodash/difference';
-  import { RouterNames } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelSelectionList from './ChannelSelectionList';
   import ChannelItem from './ChannelItem';
   import { NEW_OBJECT, ChannelListTypes, ErrorTypes } from 'shared/constants';
@@ -346,7 +346,7 @@
         this.changed = false;
         this.showUnsavedDialog = false;
         this.diffTracker = {};
-        this.$router.push({ name: RouterNames.CHANNEL_SETS });
+        this.$router.push({ name: RouteNames.CHANNEL_SETS });
       },
       verifyChannelSet(channelSetId) {
         return new Promise((resolve, reject) => {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetItem.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { factory } from '../../../store';
 import router from '../../../router';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import ChannelSetItem from '../ChannelSetItem.vue';
 
 const store = factory();
@@ -36,7 +36,7 @@ describe('channelSetItem', () => {
   });
   it('clicking the edit option should open the channel set edit modal', () => {
     wrapper.find('[data-test="edit"]').trigger('click');
-    expect(wrapper.vm.$route.name).toEqual(RouterNames.CHANNEL_SET_DETAILS);
+    expect(wrapper.vm.$route.name).toEqual(RouteNames.CHANNEL_SET_DETAILS);
   });
   it('clicking delete button in dialog should delete the channel set', () => {
     wrapper.vm.deleteDialog = true;

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetList.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { factory } from '../../../store';
 import router from '../../../router';
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import ChannelSetList from '../ChannelSetList.vue';
 
 const store = factory();
@@ -10,7 +10,7 @@ const id = '00000000000000000000000000000000';
 
 function makeWrapper(createChannelSetStub) {
   router.push({
-    name: RouterNames.CHANNEL_SETS,
+    name: RouteNames.CHANNEL_SETS,
   });
   const wrapper = mount(ChannelSetList, { store, router });
   wrapper.setMethods({

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -4,7 +4,7 @@ import VueRouter from 'vue-router';
 import { cloneDeep } from 'lodash';
 import flushPromises from 'flush-promises';
 
-import { RouterNames } from '../../../constants';
+import { RouteNames } from '../../../constants';
 import router from '../../../router';
 import channelSet from '../../../vuex/channelSet';
 import ChannelSetModal from '../ChannelSetModal';
@@ -46,9 +46,9 @@ const NEW_CHANNEL_SET = {
 };
 
 const makeWrapper = ({ store, channelSetId }) => {
-  if (router.currentRoute.name !== RouterNames.CHANNEL_SET_DETAILS) {
+  if (router.currentRoute.name !== RouteNames.CHANNEL_SET_DETAILS) {
     router.push({
-      name: RouterNames.CHANNEL_SET_DETAILS,
+      name: RouteNames.CHANNEL_SET_DETAILS,
       params: {
         channelSetId,
       },
@@ -232,7 +232,7 @@ describe('ChannelSetModal', () => {
       it('should redirect to channel sets page', () => {
         getCloseButton(wrapper).trigger('click');
 
-        expect(wrapper.vm.$route.name).toBe(RouterNames.CHANNEL_SETS);
+        expect(wrapper.vm.$route.name).toBe(RouteNames.CHANNEL_SETS);
       });
 
       it('should delete a channel set if it is new', () => {

--- a/contentcuration/contentcuration/frontend/settings/constants.js
+++ b/contentcuration/contentcuration/frontend/settings/constants.js
@@ -1,4 +1,4 @@
-export const RouterNames = {
+export const RouteNames = {
   ACCOUNT: 'ACCOUNT',
   STORAGE: 'STORAGE',
   USING_STUDIO: 'USING_STUDIO',

--- a/contentcuration/contentcuration/frontend/settings/pages/SettingsIndex.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/SettingsIndex.vue
@@ -6,13 +6,13 @@
       :style="{ color: $themeTokens.textInverted }"
     >
       <template #tabs>
-        <VTab :to="{ name: RouterNames.ACCOUNT }">
+        <VTab :to="{ name: RouteNames.ACCOUNT }">
           {{ $tr('accountLabel') }}
         </VTab>
-        <VTab :to="{ name: RouterNames.STORAGE }">
+        <VTab :to="{ name: RouteNames.STORAGE }">
           {{ $tr('storageLabel') }}
         </VTab>
-        <VTab :to="{ name: RouterNames.USING_STUDIO }">
+        <VTab :to="{ name: RouteNames.USING_STUDIO }">
           {{ $tr('usingStudioLabel') }}
         </VTab>
       </template>
@@ -39,7 +39,7 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
-  import { RouterNames } from '../constants';
+  import { RouteNames } from '../constants';
   import GlobalSnackbar from 'shared/views/GlobalSnackbar';
   import AppBar from 'shared/views/AppBar';
   import { routerMixin } from 'shared/mixins';
@@ -54,8 +54,8 @@
       ...mapState({
         offline: state => !state.connection.online,
       }),
-      RouterNames() {
-        return RouterNames;
+      RouteNames() {
+        return RouteNames;
       },
     },
     watch: {
@@ -73,11 +73,11 @@
         // Updates the tab title every time the top-level route changes
         let title;
         const routeName = this.$route.name;
-        if (routeName === RouterNames.ACCOUNT) {
+        if (routeName === RouteNames.ACCOUNT) {
           title = this.$tr('accountLabel');
-        } else if (routeName === RouterNames.STORAGE) {
+        } else if (routeName === RouteNames.STORAGE) {
           title = this.$tr('storageLabel');
-        } else if (routeName === RouterNames.USING_STUDIO) {
+        } else if (routeName === RouteNames.USING_STUDIO) {
           title = this.$tr('usingStudioLabel');
         }
         // TODO combine this `{firstItem} - {secondItem}` into a single message to support

--- a/contentcuration/contentcuration/frontend/settings/router.js
+++ b/contentcuration/contentcuration/frontend/settings/router.js
@@ -1,5 +1,5 @@
 import VueRouter from 'vue-router';
-import { RouterNames } from './constants';
+import { RouteNames } from './constants';
 import Account from './pages/Account/index';
 import Storage from './pages/Storage/index';
 import UsingStudio from './pages/UsingStudio';
@@ -7,19 +7,19 @@ import UsingStudio from './pages/UsingStudio';
 const router = new VueRouter({
   routes: [
     {
-      name: RouterNames.ACCOUNT,
+      name: RouteNames.ACCOUNT,
       path: '/account',
       props: true,
       component: Account,
     },
     {
-      name: RouterNames.STORAGE,
+      name: RouteNames.STORAGE,
       path: '/storage',
       props: true,
       component: Storage,
     },
     {
-      name: RouterNames.USING_STUDIO,
+      name: RouteNames.USING_STUDIO,
       path: '/using-studio',
       props: true,
       component: UsingStudio,
@@ -27,7 +27,7 @@ const router = new VueRouter({
     // Unrecognized paths go to default Account path
     {
       path: '*',
-      redirect: { name: RouterNames.ACCOUNT },
+      redirect: { name: RouteNames.ACCOUNT },
     },
   ],
 });


### PR DESCRIPTION
Renames all `RouterNames` tokens to `RouteNames`.

Fixes #2028 