### PR TITLE
Offline sign-in and registration error messages

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -6,7 +6,7 @@
     backButton
   >
     <div class="offline-text">
-      <OfflineText :offlineText="$tr('registrationFailedOffline')" indicator/>
+      <OfflineText :offlineText="$tr('registrationFailedOffline')" indicator />
     </div>
     <VImg
       height="200"
@@ -22,9 +22,6 @@
       <VForm ref="form" v-model="valid" lazy-validation @submit.prevent="submit">
         <Banner :value="!valid" error class="mb-4">
           {{ registrationFailed ? $tr('registrationFailed') : $tr('errorsMessage') }}
-        </Banner>
-        <Banner :value="offline" error class="mb-4">
-          {{ $tr('registrationFailedOffline') }}
         </Banner>
         <!-- Basic information -->
         <h1 class="font-weight-bold my-2 subheading">
@@ -162,7 +159,10 @@
         <p class="mb-4">
           {{ $tr('contactMessage') }}
         </p>
-        <VBtn color="primary" large type="submit">
+        <Banner :value="offline" error class="mb-4">
+          {{ $tr('registrationFailedOffline') }}
+        </Banner>
+        <VBtn color="primary" large :disabled="offline" type="submit">
           {{ $tr('finishButton') }}
         </VBtn>
       </VForm>
@@ -420,7 +420,7 @@
               this.$router.push({ name: 'ActivationSent' });
             })
             .catch(error => {
-              if (error.message === "Network Error") {
+              if (error.message === 'Network Error') {
                 this.$refs.top.scrollIntoView({ behavior: 'smooth' });
               } else if (error.response.status === 403) {
                 this.emailErrors = [this.$tr('emailExistsMessage')];

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -5,9 +5,6 @@
     :appBarText="$tr('backToLoginButton')"
     backButton
   >
-    <div class="offline-text">
-      <OfflineText :offlineText="$tr('registrationFailedOffline')" indicator />
-    </div>
     <VImg
       height="200"
       maxHeight="100"
@@ -22,6 +19,9 @@
       <VForm ref="form" v-model="valid" lazy-validation @submit.prevent="submit">
         <Banner :value="!valid" error class="mb-4">
           {{ registrationFailed ? $tr('registrationFailed') : $tr('errorsMessage') }}
+        </Banner>
+        <Banner :value="offline" error class="mb-4">
+          {{ $tr('registrationFailedOffline') }}
         </Banner>
         <!-- Basic information -->
         <h1 class="font-weight-bold my-2 subheading">
@@ -159,9 +159,6 @@
         <p class="mb-4">
           {{ $tr('contactMessage') }}
         </p>
-        <Banner :value="offline" error class="mb-4">
-          {{ $tr('registrationFailedOffline') }}
-        </Banner>
         <VBtn color="primary" large :disabled="offline" type="submit">
           {{ $tr('finishButton') }}
         </VBtn>
@@ -187,7 +184,6 @@
   import ImmersiveModalLayout from 'shared/layouts/ImmersiveModalLayout';
   import Banner from 'shared/views/Banner';
   import Checkbox from 'shared/views/form/Checkbox';
-  import OfflineText from 'shared/views/OfflineText';
   import { policies } from 'shared/constants';
 
   export default {
@@ -202,7 +198,6 @@
       PolicyModals,
       Banner,
       Checkbox,
-      OfflineText,
     },
     data() {
       return {
@@ -444,7 +439,7 @@
       errorsMessage: 'Please fix the errors below',
       registrationFailed: 'There was an error registering your account. Please try again',
       registrationFailedOffline:
-        'You seem to be offline. Please connect to the internet before finishing registration.',
+        'You seem to be offline. Please connect to the internet to create an account.',
 
       // Basic information strings
       basicInformationHeader: 'Basic information',
@@ -506,11 +501,6 @@
 
 
 <style lang="less" scoped>
-
-  .offline-text {
-    position: absolute;
-    top: 1em;
-  }
 
   .v-text-field {
     margin-top: 8px !important;

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -6,6 +6,9 @@
       justify-center
       class="main pt-5"
     >
+      <h3 class="corner">
+        <OfflineText indicator />
+      </h3>
       <div>
         <!-- Sign in -->
         <VCard class="pa-4" style="width: 300px;margin: 0 auto;">
@@ -20,6 +23,7 @@
             {{ $tr('kolibriStudio') }}
           </h2>
           <Banner :value="loginFailed" :text="$tr('loginFailed')" error />
+          <Banner :value="offline" :text="$tr('loginFailedOffline')" error />
           <Banner
             :value="Boolean(nextParam)"
             :text="$tr('loginToProceed')"
@@ -32,7 +36,7 @@
             <p>
               <ActionLink :to="{ name: 'ForgotPassword' }" :text="$tr('forgotPasswordLink')" />
             </p>
-            <VBtn block color="primary" large type="submit" :disabled="busy">
+            <VBtn block color="primary" large type="submit" :disabled="offline || busy">
               {{ $tr('signInButton') }}
             </VBtn>
             <VBtn block flat color="primary" class="mt-2" :to="{ name: 'Create' }">
@@ -79,13 +83,14 @@
 
 <script>
 
-  import { mapActions } from 'vuex';
+  import { mapActions, mapState } from 'vuex';
   import EmailField from 'shared/views/form/EmailField';
   import PasswordField from 'shared/views/form/PasswordField';
   import Banner from 'shared/views/Banner';
   import PolicyModals from 'shared/views/policies/PolicyModals';
   import { policies } from 'shared/constants';
   import LanguageSwitcherList from 'shared/languageSwitcher/LanguageSwitcherList';
+  import OfflineText from 'shared/views/OfflineText';
 
   export default {
     name: 'Main',
@@ -95,6 +100,7 @@
       LanguageSwitcherList,
       PasswordField,
       PolicyModals,
+      OfflineText,
     },
     data() {
       return {
@@ -102,9 +108,13 @@
         password: '',
         loginFailed: false,
         busy: false,
+        loginFailedOffline: false,
       };
     },
     computed: {
+      ...mapState({
+        offline: state => !state.connection.online,
+      }),
       nextParam() {
         const params = new URLSearchParams(window.location.search.substring(1));
         return params.get('next');
@@ -128,14 +138,19 @@
           };
           return this.login(credentials)
             .then(() => {
+              this.loginFailedOffline = false;
+              this.loginFailed = false;
               window.location.assign(this.nextParam || '/channels');
             })
             .catch(err => {
               this.busy = false;
-              if (err.response.status === 405) {
+              if (err.message === 'Network Error') {
+                this.loginFailedOffline = true;
+              } else if (err.response.status === 405) {
                 this.$router.push({ name: 'AccountNotActivated' });
+              } else {
+                this.loginFailed = true;
               }
-              this.loginFailed = true;
             });
         }
         return Promise.resolve();
@@ -153,6 +168,8 @@
       TOSLink: 'Terms of service',
       copyright: '© {year} Learning Equality',
       loginToProceed: 'You must sign in to view that page',
+      loginFailedOffline:
+        'You seem to be offline. Please connect to the internet before signing in.',
     },
   };
 
@@ -172,6 +189,12 @@
     color: var(--v-grey-base);
     vertical-align: middle;
     content: '•';
+  }
+
+  .corner {
+    position: absolute;
+    top: 1em;
+    left: 1em;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/create.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/create.spec.js
@@ -3,6 +3,16 @@ import router from '../../router';
 import { uses, sources } from '../../constants';
 import Create from '../Create';
 
+const connectionStateMocks = {
+  $store: {
+    state: {
+      connection: {
+        offline: true,
+      },
+    },
+  },
+};
+
 const defaultData = {
   first_name: 'Test',
   last_name: 'User',
@@ -34,6 +44,7 @@ function makeWrapper(formData) {
       },
     },
     stubs: ['PolicyModals'],
+    mocks: connectionStateMocks,
   });
   wrapper.setData({
     form: {
@@ -87,7 +98,7 @@ describe('create', () => {
   });
   it('should automatically fill the email if provided in the query param', () => {
     router.push({ name: 'Create', query: { email: 'newtest@test.com' } });
-    let wrapper = mount(Create, { router, stubs: ['PolicyModals'] });
+    let wrapper = mount(Create, { router, stubs: ['PolicyModals'], mocks: connectionStateMocks });
     expect(wrapper.vm.form.email).toBe('newtest@test.com');
   });
   describe('validation', () => {

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/main.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/main.spec.js
@@ -8,6 +8,15 @@ function makeWrapper() {
   let wrapper = mount(Main, {
     router,
     stubs: ['GlobalSnackbar', 'PolicyModals'],
+    mocks: {
+      $store: {
+        state: {
+          connection: {
+            online: true,
+          },
+        },
+      },
+    },
   });
   wrapper.setMethods({
     login: data => {

--- a/contentcuration/contentcuration/frontend/shared/views/OfflineText.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/OfflineText.vue
@@ -13,7 +13,7 @@
             </span>
           </div>
         </template>
-        <span>{{ $tr('offlineText') }}</span>
+        <span>{{ offlineText || $tr('offlineText') }}</span>
       </VTooltip>
       <ToolBar
         v-else-if="toolbar"
@@ -29,13 +29,13 @@
         <Icon class="mx-3">
           cloud_off
         </Icon>
-        <span>{{ $tr('offlineText') }}</span>
+        <span>{{ offlineText || $tr('offlineText') }}</span>
       </ToolBar>
       <div v-else>
         <Icon class="mx-3">
           cloud_off
         </Icon>
-        <span>{{ $tr('offlineText') }}</span>
+        <span>{{ offlineText || $tr('offlineText') }}</span>
       </div>
     </template>
   </VFadeTransition>
@@ -64,6 +64,10 @@
       offset: {
         type: Number,
         default: 0,
+      },
+      offlineText: {
+        type: String,
+        default: null,
       },
     },
     computed: {


### PR DESCRIPTION
## Description

- Adds some error banners when someone attempts to sign in or register while offline.
- Disables the submit buttons for signing in or finishing registration while offline.
- Adds an offline icon to the top of the screen while offline.

#### Issue Addressed

Addresses #https://github.com/learningequality/studio/issues/2938

#### Screenshots
 
![image](https://user-images.githubusercontent.com/389782/119171275-f8786f80-ba29-11eb-9ceb-30785ec99395.png)
![image](https://user-images.githubusercontent.com/389782/119171392-23fb5a00-ba2a-11eb-97f8-60c93cbe4bd8.png)
![image](https://user-images.githubusercontent.com/389782/119171420-2bbafe80-ba2a-11eb-8fd9-712c1de647e8.png)

## Steps to Test

- [x] go to the Studio login page
- [x] go offline: e.g. in chrome, under the "network" tab of chrome dev tools there's a dropdown that says "no throttling"... click it and select "offline"
![image](https://user-images.githubusercontent.com/389782/119165795-7d13bf80-ba23-11eb-979d-13af466b4b10.png)
- [x] verify that for both the login and signup pages, the submit buttons are disabled and there are banners prompting you to connect to the internet
- [x] verify that when you go back online (disable throttling in the dev tools) that the submit buttons are active again and the offline notification banners and icon disappear.
