### PR TITLE
Avoid left join when filtering for channel permissions

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -850,7 +850,12 @@ class Channel(models.Model):
 
         permission_filter = Q()
         if user_id:
-            permission_filter = Q(view=True) | Q(edit=True) | Q(deleted=False, pending_editors__email=user_email)
+            pending_channels = Invitation.objects.filter(email=user_email).values_list(
+                "channel_id", flat=True
+            )
+            permission_filter = (
+                Q(view=True) | Q(edit=True) | Q(deleted=False, id__in=pending_channels)
+            )
 
         return queryset.filter(permission_filter | Q(deleted=False, public=True))
 


### PR DESCRIPTION
## Description
`filter_view_queryset` was adding a left join on Invitations that was causing duplicated results when showing a list of channels.
This pr replaces the used query using only the list of pending invitations the user has. 
In any case I wonder if we should show to the user channels that have pending invitations

By the way: this issue hadn't been seen before because admins don't have this problem and most of LE staff are admins when testing Studio 

#### Issue Addressed (if applicable)

Closes #2899 

#### Before/After Screenshots (if applicable)

Documented in the refered issue


## Steps to Test

Login as a non-admin user
Look at the list of channels and check there are not repated channels in the list

