### PR TITLE
Fix "randomize question order" field not being synced when toggling its checkbox in EditModal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -255,7 +255,7 @@ function generateContentNodeData({
     if (extra_fields.n) {
       contentNodeData.extra_fields.n = extra_fields.n;
     }
-    if (extra_fields.randomize) {
+    if (extra_fields.randomize !== undefined) {
       contentNodeData.extra_fields.randomize = extra_fields.randomize;
     }
   }

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -534,8 +534,9 @@ class SyncTestCase(StudioAPITestCase):
     def test_update_contentnode_extra_fields(self):
         user = testdata.user()
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
-        m = 5
 
+        # Update extra_fields.m
+        m = 5
         self.client.force_authenticate(user=user)
         response = self.client.post(
             self.sync_url,
@@ -547,8 +548,8 @@ class SyncTestCase(StudioAPITestCase):
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"], m
         )
 
+        # Update extra_fields.m
         n = 10
-
         response = self.client.post(
             self.sync_url,
             [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.n": n})],
@@ -560,6 +561,24 @@ class SyncTestCase(StudioAPITestCase):
         )
         self.assertEqual(
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["n"], n
+        )
+
+        # Update extra_fields.randomize
+        randomize = True
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.randomize": randomize})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"], m
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["n"], n
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["randomize"], randomize
         )
 
     def test_update_contentnode_tags(self):

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -197,7 +197,6 @@ class ExtraFieldsSerializer(JSONFieldDictSerializer):
         choices=exercises.MASTERY_MODELS, allow_null=True, required=False
     )
     randomize = BooleanField()
-
     m = IntegerField(allow_null=True, required=False)
     n = IntegerField(allow_null=True, required=False)
 

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -21,6 +21,7 @@ from rest_framework.decorators import detail_route
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ChoiceField
+from rest_framework.serializers import BooleanField
 from rest_framework.serializers import DictField
 from rest_framework.serializers import IntegerField
 from rest_framework.serializers import ValidationError
@@ -195,6 +196,8 @@ class ExtraFieldsSerializer(JSONFieldDictSerializer):
     mastery_model = ChoiceField(
         choices=exercises.MASTERY_MODELS, allow_null=True, required=False
     )
+    randomize = BooleanField()
+
     m = IntegerField(allow_null=True, required=False)
     n = IntegerField(allow_null=True, required=False)
 


### PR DESCRIPTION
## Description

1. Adds `randomize` to `ExtraFieldsSerializer`
2. Fixes diffing code to properly handle the case when going from `randomized = true` -> `randomized = false`

#### Issue Addressed (if applicable)

Fixes #2864 


## Steps to Test

- Edit an exercise. All the fields should synchronize as they are modified

