### PR TITLE
Add flower to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ yarn run lint-all:fix
 
 Make sure you've set up pre-commit hooks as described above. This will ensure that linting is automatically run on staged changes before every commit.
 
+### Flower
+
+[Flower](https://flower.readthedocs.io/en/latest/) is a Celery monitoring dashboard. It is available on http://localhost:5555 after you run services:
+
+```bash
+yarn run services
+```
+
 ### Storybook
 
 Storybook is a development environment for UI components. If this is your first encounter with this tool, you can check [this presentation](https://docs.google.com/presentation/d/10JL4C9buygWsTbT62Ym149Yh9zSR9nY_ZqFumBKUY0o/edit?usp=sharing) or [its website](https://storybook.js.org/). You are encouraged to use it any time you need to develop a new UI component. It is especially suitable for smaller to middle size components that represent basic UI building blocks.

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -39,3 +39,4 @@ pypandoc
 git+https://github.com/someshchaturvedi/customizable-django-profiler.git#customizable-django-profiler
 tabulate==0.8.2
 fonttools
+flower==0.9.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements-dev.in
 #
+amqp==2.5.2
+    # via
+    #   -c requirements.txt
+    #   kombu
 appdirs==1.4.3
     # via virtualenv
 aspy.yaml==1.3.0
@@ -18,6 +22,14 @@ autopep8==1.4
     # via -r requirements-dev.in
 backcall==0.1.0
     # via ipython
+billiard==3.5.0.5
+    # via
+    #   -c requirements.txt
+    #   celery
+celery==4.1.1
+    # via
+    #   -c requirements.txt
+    #   flower
 certifi==2019.11.28
     # via
     #   -c requirements.txt
@@ -93,6 +105,8 @@ flask==1.1.2
     # via
     #   flask-basicauth
     #   locust
+flower==0.9.4
+    # via -r requirements-dev.in
 fonttools==4.17.1
     # via -r requirements-dev.in
 gevent==20.6.2
@@ -103,6 +117,8 @@ geventhttpclient==1.4.4
     # via locust
 greenlet==0.4.16
     # via gevent
+humanize==0.5.1
+    # via flower
 identify==1.4.11
     # via pre-commit
 idna==2.8
@@ -150,6 +166,10 @@ jinja2==2.11.2
     #   flask
 json-rpc==1.13.0
     # via -r requirements-dev.in
+kombu==4.3.0
+    # via
+    #   -c requirements.txt
+    #   celery
 lazy-object-proxy==1.4.3
     # via astroid
 locust==1.1.1
@@ -260,7 +280,9 @@ python-language-server==0.31.8
 pytz==2019.3
     # via
     #   -c requirements.txt
+    #   celery
     #   django
+    #   flower
 pyyaml==5.3
     # via
     #   aspy.yaml
@@ -303,6 +325,8 @@ tblib==1.7.0
     # via django-concurrent-test-helper
 toml==0.10.0
     # via pre-commit
+tornado==6.1
+    # via flower
 traitlets==4.3.3
     # via ipython
 typed-ast==1.4.1
@@ -320,6 +344,10 @@ urllib3==1.25.8
     # via
     #   -c requirements.txt
     #   requests
+vine==1.3.0
+    # via
+    #   -c requirements.txt
+    #   amqp
 virtualenv==20.0.3
     # via pre-commit
 watchdog==0.10.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,126 +4,346 @@
 #
 #    pip-compile requirements-dev.in
 #
-appdirs==1.4.3            # via virtualenv
-aspy.yaml==1.3.0          # via pre-commit
-astroid==2.3.3            # via pylint
-attrs==19.3.0             # via pytest
-autoflake==1.3.1          # via -r requirements-dev.in
-autopep8==1.4             # via -r requirements-dev.in
-backcall==0.1.0           # via ipython
-certifi==2019.11.28       # via -c requirements.txt, geventhttpclient, requests
-cfgv==3.0.0               # via pre-commit
-chardet==3.0.4            # via -c requirements.txt, requests
-click==7.0                # via flask, pip-tools
-codecov==2.0.15           # via -r requirements-dev.in
-colorama==0.4.3           # via pytest-watch
-configargparse==1.2.3     # via locust
-coreapi==2.3.3            # via drf-yasg
-coreschema==0.0.4         # via coreapi, drf-yasg
-coverage==5.0.3           # via -r requirements-dev.in, codecov, pytest-cov
-git+https://github.com/someshchaturvedi/customizable-django-profiler.git#customizable-django-profiler  # via -r requirements-dev.in
-decorator==4.4.1          # via ipython, traitlets
-distlib==0.3.0            # via virtualenv
-django-concurrent-test-helper==0.7.0  # via -r requirements-dev.in
-django-debug-panel==0.8.3  # via -r requirements-dev.in
-django-debug-toolbar==1.9.1  # via -r requirements-dev.in, django-debug-panel
-django==1.11.29           # via -c requirements.txt, django-debug-toolbar, drf-yasg
-djangorestframework==3.9.1  # via -c requirements.txt, drf-yasg
-docopt==0.6.2             # via pytest-watch
-drf-yasg==1.17.1          # via -r requirements-dev.in
-faker==0.7.3              # via -r requirements-dev.in, mixer
-filelock==3.0.12          # via virtualenv
-flake8==3.4.1             # via -r requirements-dev.in
-flask-basicauth==0.2.0    # via locust
-flask==1.1.2              # via flask-basicauth, locust
-fonttools==4.17.1         # via -r requirements-dev.in
-gevent==20.6.2            # via geventhttpclient, locust
-geventhttpclient==1.4.4   # via locust
-greenlet==0.4.16          # via gevent
-identify==1.4.11          # via pre-commit
-idna==2.8                 # via -c requirements.txt, requests
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, pre-commit, pytest, virtualenv
-importlib-resources==1.5.0  # via pre-commit, virtualenv
-importmagic==0.1.7        # via -r requirements-dev.in
-inflection==0.5.0         # via drf-yasg
-ipdb==0.12.3              # via -r requirements-dev.in
-ipython-genutils==0.2.0   # via traitlets
-ipython==7.12.0           # via ipdb
-isort==4.3.21             # via -r requirements-dev.in, pylint, pyls-isort
-itsdangerous==1.1.0       # via flask
-itypes==1.2.0             # via coreapi
-jedi==0.15.2              # via -r requirements-dev.in, ipython, python-language-server
-jinja2==2.11.2            # via coreschema, flask
-json-rpc==1.13.0          # via -r requirements-dev.in
-lazy-object-proxy==1.4.3  # via astroid
-locust==1.1.1             # via -r requirements-dev.in
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8, pylint
-mixer==5.6.6              # via -r requirements-dev.in
-mock==4.0.1               # via -r requirements-dev.in, django-concurrent-test-helper
-more-itertools==8.2.0     # via pytest
-msgpack==1.0.0            # via locust
-nodeenv==1.3.5            # via -r requirements-dev.in, pre-commit
-packaging==20.1           # via drf-yasg, pytest
-parso==0.6.1              # via jedi
-pathtools==0.1.2          # via watchdog
-pexpect==4.8.0            # via ipython
-pickleshare==0.7.5        # via ipython
-pip-tools==5.3.1          # via -r requirements-dev.in
-pluggy==0.13.1            # via pytest, python-language-server
-pre-commit==1.15.1        # via -r requirements-dev.in
-prompt-toolkit==3.0.3     # via ipython
-psutil==5.7.2             # via locust
-ptyprocess==0.6.0         # via pexpect
-py==1.8.1                 # via pytest
-pycodestyle==2.3.1        # via autopep8, flake8
-pyflakes==1.5.0           # via autoflake, flake8
-pygments==2.5.2           # via ipython
-pyinstrument-cext==0.2.2  # via pyinstrument
-pyinstrument==3.1.4       # via -r requirements-dev.in
-pylint==2.4.4             # via -r requirements-dev.in
-pyls-isort==0.1.1         # via -r requirements-dev.in
-pympler==0.8              # via -r requirements-dev.in
-pypandoc==1.5             # via -r requirements-dev.in
-pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1         # via -r requirements-dev.in
-pytest-django==3.8.0      # via -r requirements-dev.in
-pytest-logging==2015.11.4  # via -r requirements-dev.in
-pytest-pythonpath==0.7.3  # via -r requirements-dev.in
-pytest-timeout==1.4.2     # via -r requirements-dev.in
-pytest-watch==4.2.0       # via -r requirements-dev.in
-pytest==5.3.5             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-logging, pytest-pythonpath, pytest-timeout, pytest-watch
-python-dateutil==2.8.1    # via -c requirements.txt, faker
-python-jsonrpc-server==0.3.4  # via python-language-server
-python-language-server==0.31.8  # via -r requirements-dev.in, pyls-isort
-pytz==2019.3              # via -c requirements.txt, django
-pyyaml==5.3               # via aspy.yaml, pre-commit
-pyzmq==19.0.2             # via locust
-requests==2.22.0          # via -c requirements.txt, codecov, coreapi, locust
-rope==0.16.0              # via -r requirements-dev.in
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.10      # via drf-yasg
-service-factory==0.1.6    # via -r requirements-dev.in
-six==1.14.0               # via -c requirements.txt, astroid, django-concurrent-test-helper, drf-yasg, faker, geventhttpclient, packaging, pip-tools, pre-commit, python-dateutil, traitlets, virtualenv
-sqlparse==0.3.0           # via django-debug-toolbar
-tabulate==0.8.2           # via -r requirements-dev.in
-tblib==1.7.0              # via django-concurrent-test-helper
-toml==0.10.0              # via pre-commit
-traitlets==4.3.3          # via ipython
-typed-ast==1.4.1          # via astroid
-ujson==1.35               # via python-jsonrpc-server, python-language-server
-uritemplate==3.0.1        # via -c requirements.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -c requirements.txt, requests
-virtualenv==20.0.3        # via pre-commit
-watchdog==0.10.2          # via pytest-watch
-wcwidth==0.1.8            # via prompt-toolkit, pytest
-werkzeug==1.0.1           # via flask
-wheel==0.35.1             # via pypandoc
-wrapt==1.11.2             # via astroid
-yapf==0.29.0              # via -r requirements-dev.in
-zipp==2.2.0               # via importlib-metadata, importlib-resources
-zope.event==4.4           # via gevent
-zope.interface==5.1.0     # via gevent
+appdirs==1.4.3
+    # via virtualenv
+aspy.yaml==1.3.0
+    # via pre-commit
+astroid==2.3.3
+    # via pylint
+attrs==19.3.0
+    # via pytest
+autoflake==1.3.1
+    # via -r requirements-dev.in
+autopep8==1.4
+    # via -r requirements-dev.in
+backcall==0.1.0
+    # via ipython
+certifi==2019.11.28
+    # via
+    #   -c requirements.txt
+    #   geventhttpclient
+    #   requests
+cfgv==3.0.0
+    # via pre-commit
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+click==7.0
+    # via
+    #   flask
+    #   pip-tools
+codecov==2.0.15
+    # via -r requirements-dev.in
+colorama==0.4.3
+    # via pytest-watch
+configargparse==1.2.3
+    # via locust
+coreapi==2.3.3
+    # via drf-yasg
+coreschema==0.0.4
+    # via
+    #   coreapi
+    #   drf-yasg
+coverage==5.0.3
+    # via
+    #   -r requirements-dev.in
+    #   codecov
+    #   pytest-cov
+git+https://github.com/someshchaturvedi/customizable-django-profiler.git#customizable-django-profiler
+    # via -r requirements-dev.in
+decorator==4.4.1
+    # via
+    #   ipython
+    #   traitlets
+distlib==0.3.0
+    # via virtualenv
+django-concurrent-test-helper==0.7.0
+    # via -r requirements-dev.in
+django-debug-panel==0.8.3
+    # via -r requirements-dev.in
+django-debug-toolbar==1.9.1
+    # via
+    #   -r requirements-dev.in
+    #   django-debug-panel
+django==1.11.29
+    # via
+    #   -c requirements.txt
+    #   django-debug-toolbar
+    #   drf-yasg
+djangorestframework==3.9.1
+    # via
+    #   -c requirements.txt
+    #   drf-yasg
+docopt==0.6.2
+    # via pytest-watch
+drf-yasg==1.17.1
+    # via -r requirements-dev.in
+faker==0.7.3
+    # via
+    #   -r requirements-dev.in
+    #   mixer
+filelock==3.0.12
+    # via virtualenv
+flake8==3.4.1
+    # via -r requirements-dev.in
+flask-basicauth==0.2.0
+    # via locust
+flask==1.1.2
+    # via
+    #   flask-basicauth
+    #   locust
+fonttools==4.17.1
+    # via -r requirements-dev.in
+gevent==20.6.2
+    # via
+    #   geventhttpclient
+    #   locust
+geventhttpclient==1.4.4
+    # via locust
+greenlet==0.4.16
+    # via gevent
+identify==1.4.11
+    # via pre-commit
+idna==2.8
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==1.5.0
+    # via
+    #   importlib-resources
+    #   pluggy
+    #   pre-commit
+    #   pytest
+    #   virtualenv
+importlib-resources==1.5.0
+    # via
+    #   pre-commit
+    #   virtualenv
+importmagic==0.1.7
+    # via -r requirements-dev.in
+inflection==0.5.0
+    # via drf-yasg
+ipdb==0.12.3
+    # via -r requirements-dev.in
+ipython-genutils==0.2.0
+    # via traitlets
+ipython==7.12.0
+    # via ipdb
+isort==4.3.21
+    # via
+    #   -r requirements-dev.in
+    #   pylint
+    #   pyls-isort
+itsdangerous==1.1.0
+    # via flask
+itypes==1.2.0
+    # via coreapi
+jedi==0.15.2
+    # via
+    #   -r requirements-dev.in
+    #   ipython
+    #   python-language-server
+jinja2==2.11.2
+    # via
+    #   coreschema
+    #   flask
+json-rpc==1.13.0
+    # via -r requirements-dev.in
+lazy-object-proxy==1.4.3
+    # via astroid
+locust==1.1.1
+    # via -r requirements-dev.in
+markupsafe==1.1.1
+    # via jinja2
+mccabe==0.6.1
+    # via
+    #   flake8
+    #   pylint
+mixer==5.6.6
+    # via -r requirements-dev.in
+mock==4.0.1
+    # via
+    #   -r requirements-dev.in
+    #   django-concurrent-test-helper
+more-itertools==8.2.0
+    # via pytest
+msgpack==1.0.0
+    # via locust
+nodeenv==1.3.5
+    # via
+    #   -r requirements-dev.in
+    #   pre-commit
+packaging==20.1
+    # via
+    #   drf-yasg
+    #   pytest
+parso==0.6.1
+    # via jedi
+pathtools==0.1.2
+    # via watchdog
+pexpect==4.8.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
+pip-tools==5.3.1
+    # via -r requirements-dev.in
+pluggy==0.13.1
+    # via
+    #   pytest
+    #   python-language-server
+pre-commit==1.15.1
+    # via -r requirements-dev.in
+prompt-toolkit==3.0.3
+    # via ipython
+psutil==5.7.2
+    # via locust
+ptyprocess==0.6.0
+    # via pexpect
+py==1.8.1
+    # via pytest
+pycodestyle==2.3.1
+    # via
+    #   autopep8
+    #   flake8
+pyflakes==1.5.0
+    # via
+    #   autoflake
+    #   flake8
+pygments==2.5.2
+    # via ipython
+pyinstrument-cext==0.2.2
+    # via pyinstrument
+pyinstrument==3.1.4
+    # via -r requirements-dev.in
+pylint==2.4.4
+    # via -r requirements-dev.in
+pyls-isort==0.1.1
+    # via -r requirements-dev.in
+pympler==0.8
+    # via -r requirements-dev.in
+pypandoc==1.5
+    # via -r requirements-dev.in
+pyparsing==2.4.6
+    # via packaging
+pytest-cov==2.8.1
+    # via -r requirements-dev.in
+pytest-django==3.8.0
+    # via -r requirements-dev.in
+pytest-logging==2015.11.4
+    # via -r requirements-dev.in
+pytest-pythonpath==0.7.3
+    # via -r requirements-dev.in
+pytest-timeout==1.4.2
+    # via -r requirements-dev.in
+pytest-watch==4.2.0
+    # via -r requirements-dev.in
+pytest==5.3.5
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+    #   pytest-django
+    #   pytest-logging
+    #   pytest-pythonpath
+    #   pytest-timeout
+    #   pytest-watch
+python-dateutil==2.8.1
+    # via
+    #   -c requirements.txt
+    #   faker
+python-jsonrpc-server==0.3.4
+    # via python-language-server
+python-language-server==0.31.8
+    # via
+    #   -r requirements-dev.in
+    #   pyls-isort
+pytz==2019.3
+    # via
+    #   -c requirements.txt
+    #   django
+pyyaml==5.3
+    # via
+    #   aspy.yaml
+    #   pre-commit
+pyzmq==19.0.2
+    # via locust
+requests==2.22.0
+    # via
+    #   -c requirements.txt
+    #   codecov
+    #   coreapi
+    #   locust
+rope==0.16.0
+    # via -r requirements-dev.in
+ruamel.yaml.clib==0.2.0
+    # via ruamel.yaml
+ruamel.yaml==0.16.10
+    # via drf-yasg
+service-factory==0.1.6
+    # via -r requirements-dev.in
+six==1.14.0
+    # via
+    #   -c requirements.txt
+    #   astroid
+    #   django-concurrent-test-helper
+    #   drf-yasg
+    #   faker
+    #   geventhttpclient
+    #   packaging
+    #   pip-tools
+    #   pre-commit
+    #   python-dateutil
+    #   traitlets
+    #   virtualenv
+sqlparse==0.3.0
+    # via django-debug-toolbar
+tabulate==0.8.2
+    # via -r requirements-dev.in
+tblib==1.7.0
+    # via django-concurrent-test-helper
+toml==0.10.0
+    # via pre-commit
+traitlets==4.3.3
+    # via ipython
+typed-ast==1.4.1
+    # via astroid
+ujson==1.35
+    # via
+    #   python-jsonrpc-server
+    #   python-language-server
+uritemplate==3.0.1
+    # via
+    #   -c requirements.txt
+    #   coreapi
+    #   drf-yasg
+urllib3==1.25.8
+    # via
+    #   -c requirements.txt
+    #   requests
+virtualenv==20.0.3
+    # via pre-commit
+watchdog==0.10.2
+    # via pytest-watch
+wcwidth==0.1.8
+    # via
+    #   prompt-toolkit
+    #   pytest
+werkzeug==1.0.1
+    # via flask
+wheel==0.35.1
+    # via pypandoc
+wrapt==1.11.2
+    # via astroid
+yapf==0.29.0
+    # via -r requirements-dev.in
+zipp==2.2.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+zope.event==4.4
+    # via gevent
+zope.interface==5.1.0
+    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
## Description

Add [Flower](https://flower.readthedocs.io/en/latest/) to dev dependencies and mention that we have it available in README.

@aronasorman When I run `pip-compile`, it also changed other dependencies' format (maybe it's because I am using the newest version?) Is it okay? To make the review easier, I run `pip-compile` on the original _requirements-dev.in_ without adding any new updates and committed the diff. Then I added the `flower` package to requirements, recompiled them, and committed this change in another commit.
 
#### Issue Addressed

I hope this will make locating this tool easier for developers who are not so familiar with backend tooling like me. Also, I noticed that we actually [run flower](https://github.com/learningequality/studio/blob/develop/package.json#L45) already as part of [services command](https://github.com/learningequality/studio/blob/develop/package.json#L24) so I assumed that it would work, and it took me a while to figure out that it wasn't working just due to a missing dependency.

## Steps to Test

- [ ] *Run `pip install -r requirements-dev.txt`*
- [ ] *Run `yarn run services`*
- [ ] *See Flower dashboard on http://localhost:5555*

