### PR TITLE
Move and update size calculations for nodes.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/__tests__/module.spec.js
@@ -14,9 +14,9 @@ describe('currentChannel store', () => {
     });
   });
   describe('actions', () => {
-    it('loadChannelSize action should get from get_total_size endpoint', () => {
+    it('loadChannelSize action should get from contentnode_size endpoint', () => {
       return store.dispatch('currentChannel/loadChannelSize', 'root-id').then(() => {
-        expect(client.get.mock.calls[0][0]).toBe('get_total_size');
+        expect(client.get.mock.calls[0][0]).toBe('contentnode_size');
         client.get.mockRestore();
       });
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
@@ -13,8 +13,8 @@ export function loadChannel(context, { staging = false } = {}) {
 }
 
 export function loadChannelSize(context, rootId) {
-  return client.get(window.Urls.get_total_size(rootId)).then(response => {
-    return response.data && response.data.size;
+  return client.get(window.Urls.contentnode_size(rootId)).then(response => {
+    return response.data;
   });
 }
 

--- a/contentcuration/contentcuration/tests/test_node_views.py
+++ b/contentcuration/contentcuration/tests/test_node_views.py
@@ -39,23 +39,6 @@ class NodeViewsUtilityTestCase(BaseAPITestCase):
             task_mock.apply_async.assert_called_once_with((self.channel.main_tree.id,))
 
 
-class GetTotalSizeEndpointTestCase(BaseAPITestCase):
-    def test_200_post(self):
-        response = self.get(
-            reverse("get_total_size", kwargs={"ids": self.channel.main_tree.id})
-        )
-        self.assertEqual(response.status_code, 200)
-
-    def test_404_no_permission(self):
-        new_channel = Channel.objects.create()
-        new_channel.main_tree = tree()
-        new_channel.save()
-        response = self.get(
-            reverse("get_total_size", kwargs={"ids": new_channel.main_tree.id}),
-        )
-        self.assertEqual(response.status_code, 404)
-
-
 class GetTopicDetailsEndpointTestCase(BaseAPITestCase):
     def test_200_post(self):
         response = self.get(

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -1479,6 +1479,29 @@ class CRUDTestCase(StudioAPITestCase):
         except models.ContentNode.DoesNotExist:
             self.fail("Orphanage root was deleted")
 
+    def test_resource_size(self):
+        user = testdata.user()
+        channel = testdata.channel()
+        tree = TreeBuilder(user=user)
+        channel.main_tree = tree.root
+        channel.editors.add(user)
+        channel.save()
+
+        self.client.force_authenticate(user=user)
+        response = self.client.get(
+            reverse("contentnode-size", kwargs={"pk": channel.main_tree.id})
+        )
+
+        files_map = {}
+
+        for c in channel.main_tree.get_descendants(include_self=True):
+            for f in c.files.all():
+                files_map[f.checksum] = f.file_size
+
+        total_size = sum(files_map.values())
+
+        self.assertEqual(response.data, total_size)
+
 
 class AnnotationsTest(StudioAPITestCase):
     def setUp(self):

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -97,7 +97,6 @@ urlpatterns += [
 
 # Add node api enpoints
 urlpatterns += [
-    url(r'^api/get_total_size/(?P<ids>[^/]*)$', node_views.get_total_size, name='get_total_size'),
     url(r'^api/get_channel_details/(?P<channel_id>[^/]*)$', node_views.get_channel_details, name='get_channel_details'),
     url(r'^api/get_node_details/(?P<node_id>[^/]*)$', node_views.get_node_details, name='get_node_details'),
     url(r'^api/get_node_diff/(?P<updated_id>[^/]*)/(?P<original_id>[^/]*)$', node_views.get_node_diff, name='get_node_diff'),

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -562,7 +562,14 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
         if not pk:
             raise Http404
         node = self.get_object()
-        files = File.objects.filter(contentnode__in=node.get_descendants(include_self=True)).values("checksum").distinct()
+        files = (
+            File.objects.filter(
+                contentnode__in=node.get_descendants(include_self=True),
+                contentnode__complete=True,
+            )
+            .values("checksum")
+            .distinct()
+        )
         sizes = files.aggregate(resource_size=Sum("file_size"))
 
         return Response(sizes["resource_size"] or 0)

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -8,6 +8,7 @@ from django.db.models import F
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
+from django.db.models import Sum
 from django.db.models.functions import Coalesce
 from django.http import Http404
 from django.utils.timezone import now
@@ -555,6 +556,16 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
                 )
             ),
         )
+
+    @detail_route(methods=["get"])
+    def size(self, request, pk=None):
+        if not pk:
+            raise Http404
+        node = self.get_object()
+        files = File.objects.filter(contentnode__in=node.get_descendants(include_self=True)).values("checksum").distinct()
+        sizes = files.aggregate(resource_size=Sum("file_size"))
+
+        return Response(sizes["resource_size"] or 0)
 
     def annotate_queryset(self, queryset):
         queryset = queryset.annotate(total_count=(F("rght") - F("lft") - 1) / 2)


### PR DESCRIPTION
## Description

* Changes total size calculation to be a detail view for one node, as it is now only ever used for that purpose
* Move into contentnode to leverage node fetching and permissions on the ContentNodeViewset
* Recast as File object filtering to give more consistent performance on larger trees

#### Issue Addressed (if applicable)

Works towards #1523 but does not resolve it

## Steps to Test

```
When: You click publish
Then: The modal should appear with a size estimate in a short amount of time
```
