### PR TITLE
Fix channel thumbnail links in Details.vue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ storybook-static/
 
 # i18n
 /contentcuration/locale/CSV_FILES/*
+
+# pyenv
+.python-version

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
@@ -101,7 +101,7 @@
       <div v-for="channel in details.edit_channels" :key="channel.id" class="mb-2">
         <ActionLink
           :text="channel.name"
-          :href="`${window.Urls.channel(channel.id)}`"
+          :href="channelUrl(channel)"
           target="_blank"
         />
       </div>
@@ -115,7 +115,7 @@
       <div v-for="channel in details.viewonly_channels" :key="channel.id" class="mb-2">
         <ActionLink
           :text="channel.name"
-          :href="`${window.Urls.channel(channel.id)}`"
+          :href="channelUrl(channel)"
           target="_blank"
         />
       </div>
@@ -282,6 +282,9 @@
     },
     methods: {
       ...mapActions('userAdmin', ['loadUser', 'loadUserDetails']),
+      channelUrl(channel) {
+        return window.Urls.channel(channel.id);
+      },
       updateTitleForPage() {
         this.updateTabTitle(`${this.userFullName} - Users - Administration`);
       },

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserDetails.vue
@@ -101,7 +101,7 @@
       <div v-for="channel in details.edit_channels" :key="channel.id" class="mb-2">
         <ActionLink
           :text="channel.name"
-          :href="`/channels/${channel.id}`"
+          :href="`${window.Urls.channel(channel.id)}`"
           target="_blank"
         />
       </div>
@@ -115,7 +115,7 @@
       <div v-for="channel in details.viewonly_channels" :key="channel.id" class="mb-2">
         <ActionLink
           :text="channel.name"
-          :href="`/channels/${channel.id}`"
+          :href="`${window.Urls.channel(channel.id)}`"
           target="_blank"
         />
       </div>

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -231,7 +231,7 @@
             </VFlex>
             <a
               v-else
-              :href="`/channels/${channel.id}`"
+              :href="`${window.Urls.channel(channel.id)}`"
               target="_blank"
               class="notranslate primary--text"
             >

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -231,7 +231,7 @@
             </VFlex>
             <a
               v-else
-              :href="`/channels/${channel.id}/view`"
+              :href="`/channels/${channel.id}`"
               target="_blank"
               class="notranslate primary--text"
             >

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -231,7 +231,7 @@
             </VFlex>
             <a
               v-else
-              :href="`${window.Urls.channel(channel.id)}`"
+              :href="channelUrl(channel)"
               target="_blank"
               class="notranslate primary--text"
             >
@@ -380,6 +380,11 @@
       },
       tagPrintable() {
         return this.sortedTags.map(tag => tag.tag_name).join(', ');
+      },
+    },
+    methods: {
+      channelUrl(channel) {
+        return window.Urls.channel(channel.id);
       },
     },
     $trs: {


### PR DESCRIPTION
Fixes #2960, which was caused by an outdated URL in `Details.vue`