### PR TITLE
update stopPublish action to work also cancel sync tasks

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -68,7 +68,7 @@
               <VBtn flat data-test="cancelstop" @click="step--">
                 {{ $tr('cancel') }}
               </VBtn>
-              <VBtn color="primary" data-test="confirmstop" @click="cancelTask">
+              <VBtn color="primary" data-test="confirmstop" @click="cancelTask(currentTask)">
                 {{ stopButtonText || $tr('confirmStopButton') }}
               </VBtn>
             </VCardActions>
@@ -199,14 +199,16 @@
       },
     },
     methods: {
-      ...mapActions('currentChannel', ['stopPublishing']),
+      ...mapActions('currentChannel', ['stopTask']),
       closeOverlay() {
-        this.stopPublishing().then(() => {
+        this.stopTask().then(() => {
           window.location.reload();
         });
       },
-      cancelTask() {
-        this.stopPublishing();
+      cancelTask(task) {
+        this.stopTask(task).then(() => {
+          window.location.reload();
+        });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -45,7 +45,7 @@
                 v-if="progressPercent === 100 || currentTaskError"
                 color="primary"
                 data-test="refresh"
-                @click="closeOverlay"
+                @click="cancelTaskAndClose(currentTask)"
               >
                 {{ doneButtonText || $tr('refreshButton') }}
               </VBtn>
@@ -68,7 +68,11 @@
               <VBtn flat data-test="cancelstop" @click="step--">
                 {{ $tr('cancel') }}
               </VBtn>
-              <VBtn color="primary" data-test="confirmstop" @click="cancelTask(currentTask)">
+              <VBtn
+                color="primary"
+                data-test="confirmstop"
+                @click="cancelTaskAndClose(currentTask)"
+              >
                 {{ stopButtonText || $tr('confirmStopButton') }}
               </VBtn>
             </VCardActions>
@@ -200,12 +204,7 @@
     },
     methods: {
       ...mapActions('currentChannel', ['stopTask']),
-      closeOverlay() {
-        this.stopTask().then(() => {
-          window.location.reload();
-        });
-      },
-      cancelTask(task) {
+      cancelTaskAndClose(task) {
         this.stopTask(task).then(() => {
           window.location.reload();
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
@@ -61,13 +61,14 @@ export function publishChannel(context, version_notes) {
   return Channel.publish(context.state.currentChannelId, version_notes);
 }
 
-export function stopPublishing(context) {
-  return Channel.clearPublish(context.state.currentChannelId).then(() => {
-    const publishTask = context.rootGetters['task/currentTasksForChannel'](
-      context.state.currentChannelId
-    ).find(task => task.task_type === 'export-channel');
-    return publishTask
-      ? context.dispatch('task/deleteTask', publishTask, { root: true })
-      : Promise.resolve();
-  });
+export function stopTask(context, task) {
+  if (task && task.task_type === 'export-channel') {
+    return Channel.clearPublish(context.state.currentChannelId).then(() => {
+      return context.dispatch('task/deleteTask', task, { root: true });
+    });
+  } else if (task) {
+    return context.dispatch('task/deleteTask', task, { root: true });
+  } else {
+    Promise.resolve();
+  }
 }


### PR DESCRIPTION
## Description

This updates the stopPublish action and the Progress Modal to cancel sync tasks in addition to stopping publishing

#### Issue Addressed (if applicable)

Addresses #2952

#### Before/After Screenshots (if applicable)
BEFORE:
![sync-resources-before](https://user-images.githubusercontent.com/17235236/108265440-c60f5b80-7136-11eb-944a-28c5e27ca6f3.gif)
AFTER:
![sync-resources](https://user-images.githubusercontent.com/17235236/108265762-33bb8780-7137-11eb-89b8-4a86ea9e7219.gif)

## Steps to Test

- [ ] Import some resources into your channel
- [ ] Select the "sync resources" option and proceed through the modals. 
- [ ] When you get to the point of being "in progress", stop the task. The task should stop successfully and the page should reload
