### PR TITLE
Fix resource panel header width

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -35,7 +35,7 @@
         </VFlex>
         <VSpacer />
         <!-- Slot for elements like edit button -->
-        <VFlex grow>
+        <VFlex shrink>
           <slot name="actions"></slot>
         </VFlex>
       </VLayout>


### PR DESCRIPTION
## Description

Allows the header to expand to the width of the panel.

#### Issue Addressed (if applicable)

Addresses #2892 

#### Before/After Screenshots (if applicable)

|Before (Computer)|After (Computer)|
|--|--|
|![Screenshot from 2021-02-01 13-05-00](https://user-images.githubusercontent.com/1680573/106518056-2a22f600-648e-11eb-953a-f58e07fb48b4.png)|![2021-02-17 20 06 26](https://user-images.githubusercontent.com/13563002/108304090-1c42c580-715c-11eb-9b26-274b9abc0e38.gif)|

|Before (Responsive)|After (Responsive)|
|--|--|
|![Screen Shot 2021-02-17 at 9 09 49 PM](https://user-images.githubusercontent.com/13563002/108308388-83647800-7164-11eb-855b-ef587d53f64c.png)|![Screen Shot 2021-02-17 at 9 05 23 PM](https://user-images.githubusercontent.com/13563002/108308300-62038c00-7164-11eb-9804-920c50d534bd.png)|


## Steps to Test

1. Log in
2. Click on a channel
3. Look for a topic. Click on the three dots (kebab) to open the "Options" menu
4. Click on View details.
5. Check that the edit/options buttons are aligned to the right of the panel

## Implementation Notes (optional)

#### At a high level, how did you implement this?

I changed the `grow` in the `<VFlex>` to `shrink`. I don't quite understand why that works, though...

#### Does this introduce any tech-debt items?

`grow` does not work for IE 6-9.

## Checklist

*Delete any items that don't apply*

- [ ] Is the code clean and well-commented?
