### PR TITLE
Migrate ProgressModal to KDS

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -165,7 +165,7 @@
     <slot></slot>
 
     <PublishModal v-if="showPublishModal" v-model="showPublishModal" />
-    <ProgressModal v-model="showProgressModal" :syncing="syncing" :noSyncNeeded="noSyncNeeded" />
+    <ProgressModal :syncing="syncing" :noSyncNeeded="noSyncNeeded" />
     <template v-if="isPublished">
       <ChannelTokenModal v-model="showTokenModal" :channel="currentChannel" />
     </template>
@@ -287,7 +287,6 @@
         showPublishModal: false,
         showTokenModal: false,
         showSyncModal: false,
-        showProgressModal: false,
         showClipboard: false,
         showDeleteModal: false,
         syncing: false,
@@ -408,11 +407,9 @@
       },
       syncInProgress() {
         this.syncing = true;
-        this.showProgressModal = true;
       },
       noResourcesToSync() {
         this.noSyncNeeded = true;
-        this.showProgressModal = true;
       },
       deleteChannel() {
         this.showDeleteModal = true;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -47,20 +47,20 @@
                 data-test="refresh"
                 @click="closeOverlay"
               >
-                {{ doneButtonText || $tr('refreshButton') }}
+                {{ $tr('refreshButton') }}
               </VBtn>
               <VBtn v-else color="primary" data-test="stop" @click="step++">
-                {{ stopButtonText || $tr('stopButton') }}
+                {{ $tr('stopButton') }}
               </VBtn>
             </VCardActions>
           </VWindowItem>
 
           <VWindowItem :value="2">
             <VCardTitle class="font-weight-bold pb-0 title">
-              {{ cancelHeaderText || $tr('cancelHeader') }}
+              {{ $tr('cancelHeader') }}
             </VCardTitle>
             <VCardText class="py-4">
-              {{ cancelText || $tr('cancelText') }}
+              {{ $tr('cancelText') }}
             </VCardText>
 
             <VCardActions>
@@ -69,7 +69,7 @@
                 {{ $tr('cancel') }}
               </VBtn>
               <VBtn color="primary" data-test="confirmstop" @click="cancelTask">
-                {{ stopButtonText || $tr('confirmStopButton') }}
+                {{ $tr('confirmStopButton') }}
               </VBtn>
             </VCardActions>
           </VWindowItem>
@@ -93,22 +93,6 @@
       ProgressBar,
     },
     props: {
-      doneButtonText: {
-        type: String,
-        default: '',
-      },
-      stopButtonText: {
-        type: String,
-        default: '',
-      },
-      cancelHeaderText: {
-        type: String,
-        default: '',
-      },
-      cancelText: {
-        type: String,
-        default: '',
-      },
       syncing: {
         type: Boolean,
         default: false,
@@ -165,12 +149,8 @@
       },
       headerText() {
         if (this.currentTask) {
-          if (this.currentTask.task_type === 'duplicate-nodes') {
-            return this.$tr('copyHeader');
-          } else if (this.isPublishing) {
+          if (this.isPublishing) {
             return this.$tr('publishHeader');
-          } else if (this.currentTask.task_type === 'move-nodes') {
-            return this.$tr('moveHeader');
           } else if (this.isSyncing || this.nothingToSync) {
             return this.$tr('syncHeader');
           }
@@ -183,12 +163,8 @@
         if (this.currentTask) {
           if (this.progressPercent >= 100) {
             return this.$tr('finishedMessage');
-          } else if (this.currentTask.task_type === 'duplicate-nodes') {
-            return this.$tr('copyDescription');
           } else if (this.isPublishing) {
             return this.$tr('publishDescription');
-          } else if (this.currentTask.task_type === 'move-nodes') {
-            return this.$tr('moveDescription');
           } else if (this.isSyncing) {
             return this.$tr('syncDescription');
           }
@@ -210,8 +186,6 @@
       },
     },
     $trs: {
-      copyHeader: 'Importing resources',
-      copyDescription: 'Import is in progress, please wait...',
       /* eslint-disable kolibri/vue-no-unused-translations */
       defaultHeader: 'Updating channel',
       defaultDescription: 'Update is in progress, please wait...',
@@ -219,8 +193,6 @@
       defaultErrorText:
         'An unexpected error has occurred. Please try again, and if you continue to see this message, please contact support via the Help menu.',
       finishedMessage: 'Operation complete! Click "Refresh" to update the page.',
-      moveHeader: 'Moving Content',
-      moveDescription: 'Move operation is in progress, please wait...',
       publishHeader: 'Publishing channel',
       publishDescription:
         'Once publishing is complete, you will receive an email notification and will be able to make further edits to your channel.',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -48,24 +48,12 @@
       v-else
       data-test="cancel-modal"
       :title="$tr('cancelHeader')"
+      :submitText="$tr('confirmStopButton')"
+      :cancelText="$tr('cancel')"
+      @submit="cancelTask"
+      @cancel="displayCancelModal = false"
     >
       {{ $tr('cancelText') }}
-
-      <KButtonGroup slot="actions">
-        <KButton
-          data-test="cancel-stop-button"
-          @click="displayCancelModal = false"
-        >
-          {{ $tr('cancel') }}
-        </KButton>
-        <KButton
-          primary
-          data-test="confirm-stop-button"
-          @click="cancelTask"
-        >
-          {{ $tr('confirmStopButton') }}
-        </KButton>
-      </KButtonGroup>
     </KModal>
   </div>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -1,114 +1,366 @@
 import { mount } from '@vue/test-utils';
+import cloneDeep from 'lodash/cloneDeep';
+
 import ProgressModal from '../ProgressModal';
-import { factory } from '../../../store';
+import { STORE_CONFIG } from '../../../store';
+import storeFactory from 'shared/vuex/baseStore';
+import { resetJestGlobal } from 'shared/utils/testing';
 
-const store = factory();
+const PUBLISH_TASK = {
+  id: 'id-publish-task',
+  task_type: 'export-channel',
+  metadata: { progress: 0 },
+};
+const SYNC_TASK = { id: 'id-sync-task', task_type: 'sync-channel', metadata: { progress: 0 } };
 
-const task = { task: { id: 123, task_type: 'test-task' } };
-const tasks = [
-  { task: { id: 123, task_type: 'test-task' } },
-  { task: { id: 456, task_type: 'test-task-2' } },
-];
-
-function makeWrapper(computed = {}) {
+function makeWrapper({ propsData, store }) {
   return mount(ProgressModal, {
+    propsData,
     store,
-    computed: {
-      currentTasks() {
-        return tasks;
-      },
-      currentTask() {
-        return task;
-      },
-      isPublishing() {
-        return true;
-      },
-      ...computed,
-    },
   });
 }
 
-describe('progressModal', () => {
-  it('should be hidden if the user is not syncing or publishing', () => {
-    let wrapper = makeWrapper({
-      isSyncing() {
-        return false;
-      },
-      nothingToSync() {
-        return false;
-      },
-      isPublishing() {
-        return false;
-      },
-    });
-    expect(wrapper.find('[data-test="progressmodal"]').exists()).toBe(false);
-  });
-  it('should show an error if the task failed', () => {
-    let wrapper = makeWrapper({
-      currentTaskError() {
-        return { data: 'nope' };
-      },
-    });
-    expect(wrapper.find('[data-test="error"]').exists()).toBe(true);
-  });
-  it('refresh button should be shown if task is done', () => {
-    let wrapper = makeWrapper({
-      progressPercent() {
-        return 100;
-      },
-    });
-    expect(wrapper.find('[data-test="refresh"]').exists()).toBe(true);
-  });
-  it('refresh button should be shown if task failed', () => {
-    let wrapper = makeWrapper({
-      currentTaskError() {
-        return { data: 'uh-oh!' };
-      },
-    });
-    expect(wrapper.find('[data-test="refresh"]').exists()).toBe(true);
-  });
-  it('refresh button should reload the page', () => {
-    const closeOverlay = jest.fn();
-    let wrapper = makeWrapper({
-      progressPercent() {
-        return 100;
-      },
-    });
-    wrapper.setMethods({ closeOverlay });
-    wrapper.find('[data-test="refresh"]').trigger('click');
-    expect(closeOverlay).toHaveBeenCalled();
+function getProgressModal(wrapper) {
+  return wrapper.find('[data-test="progress-modal"]');
+}
+
+function getCancelModal(wrapper) {
+  return wrapper.find('[data-test="cancel-modal"]');
+}
+
+function getProgressBar(wrapper) {
+  return wrapper.find('[data-test="progress-bar"]');
+}
+
+function getStopButton(wrapper) {
+  return wrapper.find('[data-test="stop-button"]');
+}
+
+function getConfirmStopButton(wrapper) {
+  return wrapper.find('[data-test="confirm-stop-button"]');
+}
+
+function getCancelStopButton(wrapper) {
+  return wrapper.find('[data-test="cancel-stop-button"]');
+}
+
+function getRefreshButton(wrapper) {
+  return wrapper.find('[data-test="refresh-button"]');
+}
+
+describe('ProgressModal', () => {
+  let pageReload;
+
+  beforeEach(() => {
+    pageReload = jest.fn();
+    global.location.reload = pageReload;
   });
 
-  describe('on cancel task', () => {
-    let wrapper;
+  afterEach(() => {
+    jest.resetAllMocks();
+    resetJestGlobal();
+  });
+
+  it('smoke test', () => {
+    const store = storeFactory(STORE_CONFIG);
+    const wrapper = makeWrapper({ store });
+
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('should be hidden if the user is not syncing or publishing', () => {
+    const propsData = {
+      syncing: false,
+    };
+    const storeConfig = cloneDeep(STORE_CONFIG);
+    jest
+      .spyOn(storeConfig.modules.currentChannel.getters, 'currentChannel')
+      .mockReturnValue({ publishing: false });
+    const store = storeFactory(storeConfig);
+    const wrapper = makeWrapper({ propsData, store });
+
+    expect(getProgressModal(wrapper).exists()).toBe(false);
+    expect(getCancelModal(wrapper).exists()).toBe(false);
+  });
+
+  describe('when publishing', () => {
+    let storeConfig, stopPublishing;
+
     beforeEach(() => {
-      wrapper = makeWrapper({
-        progressPercent() {
-          return 50;
-        },
+      storeConfig = cloneDeep(STORE_CONFIG);
+      jest
+        .spyOn(storeConfig.modules.currentChannel.getters, 'currentChannel')
+        .mockReturnValue({ publishing: true });
+      stopPublishing = jest
+        .spyOn(storeConfig.modules.currentChannel.actions, 'stopPublishing')
+        .mockResolvedValue();
+    });
+
+    it('progress modal should be displayed', () => {
+      const store = storeFactory(storeConfig);
+      const wrapper = makeWrapper({ store });
+
+      expect(getProgressModal(wrapper).exists()).toBe(true);
+      expect(getCancelModal(wrapper).exists()).toBe(false);
+    });
+
+    describe('is in progress', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        const store = storeFactory(storeConfig);
+        wrapper = makeWrapper({ store });
+      });
+
+      it('should display publishing message', () => {
+        expect(getProgressModal(wrapper).text()).toContain(
+          'Once publishing is complete, you will receive an email notification and will be able to make further edits to your channel.'
+        );
+      });
+
+      it('should display progress bar', () => {
+        expect(getProgressBar(wrapper).exists()).toBe(true);
+      });
+
+      it("shouldn't display refresh button", () => {
+        expect(getRefreshButton(wrapper).exists()).toBe(false);
+      });
+
+      it('should display stop button', () => {
+        expect(getStopButton(wrapper).exists()).toBe(true);
+      });
+
+      it('clicking stop button should switch to cancel modal', () => {
+        getStopButton(wrapper).trigger('click');
+
+        expect(getCancelModal(wrapper).exists()).toBe(true);
+        expect(getProgressModal(wrapper).exists()).toBe(false);
+      });
+
+      it('clicking cancel button on cancel modal should go back to progress modal', () => {
+        getStopButton(wrapper).trigger('click');
+        expect(getCancelModal(wrapper).exists()).toBe(true);
+
+        getCancelStopButton(wrapper).trigger('click');
+        expect(getCancelModal(wrapper).exists()).toBe(false);
+        expect(getProgressModal(wrapper).exists()).toBe(true);
+      });
+
+      // TODO @MisRob: and reload the page (this logic has been added in another branch)
+      it('clicking confirm stop button on cancel modal should stop publishing', () => {
+        getStopButton(wrapper).trigger('click');
+        getConfirmStopButton(wrapper).trigger('click');
+
+        expect(stopPublishing).toHaveBeenCalledTimes(1);
       });
     });
-    it('stop task button should be shown if task is in progress', () => {
-      expect(wrapper.find('[data-test="stop"]').exists()).toBe(true);
+
+    describe('errored out', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        const publishTask = cloneDeep(PUBLISH_TASK);
+        publishTask.status = 'FAILURE';
+        const store = storeFactory(storeConfig);
+        store.commit('task/ADD_ASYNC_TASK', publishTask);
+        wrapper = makeWrapper({ store });
+      });
+
+      it('should display an error message', () => {
+        expect(wrapper.text()).toContain('An unexpected error has occurred');
+      });
+
+      it('should display progress bar', () => {
+        expect(getProgressBar(wrapper).exists()).toBe(true);
+      });
+
+      it("shouldn't display stop button", () => {
+        expect(getStopButton(wrapper).exists()).toBe(false);
+      });
+
+      it('should display refresh button', () => {
+        expect(getRefreshButton(wrapper).exists()).toBe(true);
+      });
+
+      it('clicking on refresh button should stop publishing and reload the page', async () => {
+        getRefreshButton(wrapper).trigger('click');
+
+        await wrapper.vm.$nextTick();
+
+        expect(stopPublishing).toHaveBeenCalledTimes(1);
+        expect(pageReload).toHaveBeenCalledTimes(1);
+      });
     });
-    it('clicking stop button should switch window to confirmation window', () => {
-      wrapper.find('[data-test="stop"]').trigger('click');
-      expect(wrapper.vm.step).toBe(2);
+
+    describe('is complete', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        const publishTask = cloneDeep(PUBLISH_TASK);
+        publishTask.metadata.progress = 100;
+        const store = storeFactory(storeConfig);
+        store.commit('task/ADD_ASYNC_TASK', publishTask);
+        wrapper = makeWrapper({ store });
+      });
+
+      it('should display complete message', () => {
+        expect(getProgressModal(wrapper).text()).toContain(
+          'Once publishing is complete, you will receive an email notification and will be able to make further edits to your channel.'
+        );
+      });
+
+      it("shouldn't display progress bar", () => {
+        expect(getProgressBar(wrapper).exists()).toBe(false);
+      });
+
+      it("shouldn't display stop button", () => {
+        expect(getStopButton(wrapper).exists()).toBe(false);
+      });
+
+      it('should display refresh button', () => {
+        expect(getRefreshButton(wrapper).exists()).toBe(true);
+      });
+
+      it('clicking on refresh button should stop publishing and reload the page', async () => {
+        getRefreshButton(wrapper).trigger('click');
+
+        await wrapper.vm.$nextTick();
+
+        expect(stopPublishing).toHaveBeenCalledTimes(1);
+        expect(pageReload).toHaveBeenCalledTimes(1);
+      });
     });
-    it('clicking stop button on confirmation window should cancel the task', () => {
-      const cancelTask = jest.fn();
-      wrapper.setMethods({ cancelTask });
-      wrapper.setData({ step: 2 });
-      wrapper.find('[data-test="confirmstop"]').trigger('click');
-      expect(cancelTask).toHaveBeenCalled();
+  });
+
+  describe('when syncing', () => {
+    let propsData, storeConfig;
+
+    beforeEach(() => {
+      propsData = {
+        syncing: true,
+      };
+      storeConfig = cloneDeep(STORE_CONFIG);
+      jest
+        .spyOn(storeConfig.modules.currentChannel.getters, 'currentChannel')
+        .mockReturnValue({ publishing: false });
     });
-    it('clicking cancel button on confirmation window should go back to progress window', () => {
-      const cancelTask = jest.fn();
-      wrapper.setMethods({ cancelTask });
-      wrapper.setData({ step: 2 });
-      wrapper.find('[data-test="cancelstop"]').trigger('click');
-      expect(wrapper.vm.step).toBe(1);
-      expect(cancelTask).not.toHaveBeenCalled();
+
+    it('progress modal should be displayed', () => {
+      const store = storeFactory(storeConfig);
+      const wrapper = makeWrapper({ propsData, store });
+
+      expect(getProgressModal(wrapper).exists()).toBe(true);
+      expect(getCancelModal(wrapper).exists()).toBe(false);
+    });
+
+    describe('is in progress', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        const store = storeFactory(storeConfig);
+        wrapper = makeWrapper({ propsData, store });
+      });
+
+      it('should display syncing message', () => {
+        expect(getProgressModal(wrapper).text()).toContain(
+          'Channel syncing is in progress, please wait...'
+        );
+      });
+
+      it('should display progress bar', () => {
+        expect(getProgressBar(wrapper).exists()).toBe(true);
+      });
+
+      it("shouldn't display refresh button", () => {
+        expect(getRefreshButton(wrapper).exists()).toBe(false);
+      });
+
+      it('should display stop button', () => {
+        expect(getStopButton(wrapper).exists()).toBe(true);
+      });
+
+      it('clicking stop button should switch to cancel modal', () => {
+        getStopButton(wrapper).trigger('click');
+
+        expect(getCancelModal(wrapper).exists()).toBe(true);
+        expect(getProgressModal(wrapper).exists()).toBe(false);
+      });
+
+      it('clicking cancel button on cancel modal should go back to progress modal', () => {
+        getStopButton(wrapper).trigger('click');
+        expect(getCancelModal(wrapper).exists()).toBe(true);
+
+        getCancelStopButton(wrapper).trigger('click');
+        expect(getCancelModal(wrapper).exists()).toBe(false);
+        expect(getProgressModal(wrapper).exists()).toBe(true);
+      });
+
+      // TODO @MisRob (this logic has been added in another branch)
+      it('clicking confirm stop button on cancel modal should stop syncing and reload the page', () => {});
+    });
+
+    describe('errored out', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        const syncTask = cloneDeep(SYNC_TASK);
+        syncTask.status = 'FAILURE';
+        const store = storeFactory(storeConfig);
+        store.commit('task/ADD_ASYNC_TASK', syncTask);
+        wrapper = makeWrapper({ propsData, store });
+      });
+
+      it('should display an error message', () => {
+        expect(wrapper.text()).toContain('An unexpected error has occurred');
+      });
+
+      it('should display progress bar', () => {
+        expect(getProgressBar(wrapper).exists()).toBe(true);
+      });
+
+      it("shouldn't display stop button", () => {
+        expect(getStopButton(wrapper).exists()).toBe(false);
+      });
+
+      it('should display refresh button', () => {
+        expect(getRefreshButton(wrapper).exists()).toBe(true);
+      });
+
+      // TODO @MisRob (this logic has been added in another branch)
+      it('clicking on refresh button should stop syncing and reload the page', () => {});
+    });
+
+    describe('is complete', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        const syncTask = cloneDeep(SYNC_TASK);
+        syncTask.metadata.progress = 100;
+        const store = storeFactory(storeConfig);
+        store.commit('task/ADD_ASYNC_TASK', syncTask);
+        wrapper = makeWrapper({ propsData, store });
+      });
+
+      it('should display complete message', () => {
+        expect(getProgressModal(wrapper).text()).toContain(
+          'Operation complete! Click "Refresh" to update the page.'
+        );
+      });
+
+      it("shouldn't display progress bar", () => {
+        expect(getProgressBar(wrapper).exists()).toBe(false);
+      });
+
+      it("shouldn't display stop button", () => {
+        expect(getStopButton(wrapper).exists()).toBe(false);
+      });
+
+      it('should display refresh button', () => {
+        expect(getRefreshButton(wrapper).exists()).toBe(true);
+      });
+
+      // TODO @MisRob (this logic has been added in another branch)
+      it('clicking on refresh button should stop syncing and reload the page', () => {});
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -36,12 +36,8 @@ function getStopButton(wrapper) {
   return wrapper.find('[data-test="stop-button"]');
 }
 
-function getConfirmStopButton(wrapper) {
-  return wrapper.find('[data-test="confirm-stop-button"]');
-}
-
 function getCancelStopButton(wrapper) {
-  return wrapper.find('[data-test="cancel-stop-button"]');
+  return wrapper.find('[data-test="cancel-modal"]').find('[name="cancel"]');
 }
 
 function getRefreshButton(wrapper) {
@@ -137,7 +133,7 @@ describe('ProgressModal', () => {
         expect(getProgressModal(wrapper).exists()).toBe(false);
       });
 
-      it('clicking cancel button on cancel modal should go back to progress modal', () => {
+      it('cancelling the cancel modal should go back to progress modal', () => {
         getStopButton(wrapper).trigger('click');
         expect(getCancelModal(wrapper).exists()).toBe(true);
 
@@ -147,9 +143,13 @@ describe('ProgressModal', () => {
       });
 
       // TODO @MisRob: and reload the page (this logic has been added in another branch)
-      it('clicking confirm stop button on cancel modal should stop publishing', () => {
+      it('confirmation of the cancel modal should stop publishing', () => {
+        // open the cancel modal
         getStopButton(wrapper).trigger('click');
-        getConfirmStopButton(wrapper).trigger('click');
+        // confirm stop publishing
+        getCancelModal(wrapper)
+          .find('form')
+          .trigger('submit');
 
         expect(stopPublishing).toHaveBeenCalledTimes(1);
       });
@@ -286,7 +286,7 @@ describe('ProgressModal', () => {
         expect(getProgressModal(wrapper).exists()).toBe(false);
       });
 
-      it('clicking cancel button on cancel modal should go back to progress modal', () => {
+      it('cancelling the cancel modal should go back to progress modal', () => {
         getStopButton(wrapper).trigger('click');
         expect(getCancelModal(wrapper).exists()).toBe(true);
 
@@ -296,7 +296,7 @@ describe('ProgressModal', () => {
       });
 
       // TODO @MisRob (this logic has been added in another branch)
-      it('clicking confirm stop button on cancel modal should stop syncing and reload the page', () => {});
+      it('confirmation of the cancel modal should stop syncing and reload the page', () => {});
     });
 
     describe('errored out', () => {


### PR DESCRIPTION
## Description

- Use `KModal` instead of `VDialog` in `ProgressModal`
- Related refactoring and simplification of the component
- Enhanced test suite

At first, I tried to only swap `VDialog` and `KModal` in this component. However, in this case, it seemed to be easier to switch to the KDS approach completely, for the whole component, especially due to differences related to the actions buttons slot.

The first commit contains a small cleanup that has made all my further work easier. See the commit message for explanations.

#### Issue Addressed

One part of https://github.com/learningequality/kolibri-design-system/issues/156

#### Before/After Screenshots

##### Publish

| Before | After |
|---|---|
| ![before-publish-inprogress](https://user-images.githubusercontent.com/13509191/108539172-ee868980-72df-11eb-9be5-cbed0cf6bc85.png) | ![after-publish-inprogress](https://user-images.githubusercontent.com/13509191/108539200-f80ff180-72df-11eb-803f-4abab1e447ba.png) |
| ![before-publish-error](https://user-images.githubusercontent.com/13509191/108539265-0d851b80-72e0-11eb-9537-6aacde955268.png) | ![afterpublish-error](https://user-images.githubusercontent.com/13509191/108539271-10800c00-72e0-11eb-8911-bcefb5e7dca9.png) |
| ![before-publish-complete](https://user-images.githubusercontent.com/13509191/108539291-183fb080-72e0-11eb-9934-f8db943a12cf.png) | ![after-publish-complete](https://user-images.githubusercontent.com/13509191/108539294-1aa20a80-72e0-11eb-88b2-ee93426cf814.png) |
| ![before-publish-cancel](https://user-images.githubusercontent.com/13509191/108539300-1bd33780-72e0-11eb-9362-73039476a3b2.png) | ![after-publish-cancel](https://user-images.githubusercontent.com/13509191/108539303-1d046480-72e0-11eb-87b0-d9bba8ce7b09.png) |

##### Sync

| Before | After |
|---|---|
| ![before-sync-inprogress](https://user-images.githubusercontent.com/13509191/108539588-7b314780-72e0-11eb-89fb-89d59c551feb.png) |![after-sync-inprogress](https://user-images.githubusercontent.com/13509191/108539605-7ff5fb80-72e0-11eb-9bd1-ad6b191502c2.png) |
| ![before-sync-error](https://user-images.githubusercontent.com/13509191/108539639-8edcae00-72e0-11eb-8aa4-4cc1d9d0a1c4.png) | ![after-sync-error](https://user-images.githubusercontent.com/13509191/108539652-9308cb80-72e0-11eb-8900-084178d9d81e.png) |
| ![before-sync-complete](https://user-images.githubusercontent.com/13509191/108539667-98feac80-72e0-11eb-9378-c1c3aec3b17a.png) | ![after-sync-complete](https://user-images.githubusercontent.com/13509191/108539682-9bf99d00-72e0-11eb-8fb7-4b1075be79e4.png) |
| ![before-sync-cancel](https://user-images.githubusercontent.com/13509191/108539720-a1ef7e00-72e0-11eb-85a1-09e79c7c43ae.png) | ![after-sync-cancel](https://user-images.githubusercontent.com/13509191/108539726-a4ea6e80-72e0-11eb-8548-031e59c60cc7.png) |

## Steps to Test

- [ ] *[Publish a channel](https://github.com/learningequality/studio/blob/hotfixes/integration_testing/features/publish-channel.feature)*
- [ ] *[Sync a channel](https://github.com/learningequality/studio/blob/hotfixes/integration_testing/features/sync-channel.feature)*

#### Does this introduce any tech-debt items?

By this work, we've lost some transition animations between the progress window and the cancel window. I've decided not to implement it because, at this point, our transitions, in general, seem to be rather random than consistent (compare transitions in the first two steps of sync workflow to publish workflow, for example).

## Checklist

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?

## Comments

Some relevant issues (follow-ups or current problems with tasks):

- #2952 (resolved, but merged only to hotfixes at this point)
- #2969
- #2953
- #2971

