### PR TITLE
Add additional language field check 

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -280,7 +280,10 @@
       ...mapActions('channel', ['updateChannel', 'loadChannel', 'commitChannel']),
       ...mapMutations('channel', ['REMOVE_CHANNEL']),
       saveChannel() {
-        if (this.$refs.detailsform.validate()) {
+        // the additional this.language check below is to account
+        // for a validation error caused in some browsers
+        // when a user set a default language in the old version of Studio
+        if (this.$refs.detailsform.validate() && this.language) {
           this.changed = false;
           if (this.isNew) {
             return this.commitChannel({ id: this.channelId, ...this.diffTracker }).then(() => {

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -280,10 +280,7 @@
       ...mapActions('channel', ['updateChannel', 'loadChannel', 'commitChannel']),
       ...mapMutations('channel', ['REMOVE_CHANNEL']),
       saveChannel() {
-        // the additional this.language check below is to account
-        // for a validation error caused in some browsers
-        // when a user set a default language in the old version of Studio
-        if (this.$refs.detailsform.validate() && this.language) {
+        if (this.$refs.detailsform.validate()) {
           this.changed = false;
           if (this.isNew) {
             return this.commitChannel({ id: this.channelId, ...this.diffTracker }).then(() => {

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -46,7 +46,7 @@ export function createChannel(context) {
   const channelData = {
     name: '',
     description: '',
-    language: session.preferences ? session.preferences.language : session.currentLanguage,
+    language: '',
     content_defaults: session.preferences,
     thumbnail_url: '',
     bookmark: false,


### PR DESCRIPTION
## Description

This adds an additional form validation to see if the language field on the form has a value, to account for validation error that is occurring in some browsers due to having set a default language in the old Studio. 

#### Issue Addressed (if applicable)

Addresses #2895 

## Steps to Test

- [ ] Test 1 (no errors/regressions): Create a new channel as a user without a default language set. Don't add a language. On close, you should see a front-end validation error and be prompted to fill in the language before the form closes.
- [ ] Test 2 (to account for this edge case): Create a new channel as a user with a default language that had been previously set. Don't add a language. On close, you should see a front-end validation error and be prompted to fill in the language before the form closes.

(I will be asking @radinamatic for a QA review - in addition to asking a dev for review - since she has and account set up that will allow for testing on her machine and I want to be sure I'm correctly understanding and addressing the problem.)