### PR TITLE
Replace VDialog with KModal in "Related resources tab"

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesTab/RelatedResourcesTab.vue
@@ -26,45 +26,24 @@
       />
     </p>
 
-    <VDialog
-      v-model="showResourcePreview"
-      width="490"
+    <KModal
+      v-if="showResourcePreview"
+      :title="$tr('resourcePreviewDialogTitle')"
+      :cancelText="$tr('dialogCloseBtnLabel')"
+      @cancel="showResourcePreview = false"
     >
-      <VCard>
-        <VCardTitle>
-          <h3 class="font-weight-bold title">
-            {{ $tr('resourcePreviewDialogTitle') }}
-          </h3>
-        </VCardTitle>
-
-        <VCardText>
-          <img src="./related-resources-preview.png" class="resource-preview">
-
-          <VLayout mt-3>
-            <VFlex>
-              <Icon color="primary" class="mx-1">
-                $vuetify.icons.light_bulb
-              </Icon>
-            </VFlex>
-            <VFlex class="mx-2">
-              <p>{{ $tr('resourcePreviewDialogHelpText') }}</p>
-            </VFlex>
-          </VLayout>
-
-          <VLayout justify-end>
-            <VFlex shrink>
-              <VBtn
-                color="greyBackground"
-                class="font-weight-bold"
-                @click="showResourcePreview = false"
-              >
-                {{ $tr('dialogCloseBtnLabel') }}
-              </VBtn>
-            </VFlex>
-          </VLayout>
-        </VCardText>
-      </VCard>
-    </VDialog>
+      <img src="./related-resources-preview.png" class="resource-preview">
+      <VLayout mt-3>
+        <VFlex>
+          <Icon color="primary" class="mx-1">
+            $vuetify.icons.light_bulb
+          </Icon>
+        </VFlex>
+        <VFlex class="mx-2">
+          <p>{{ $tr('resourcePreviewDialogHelpText') }}</p>
+        </VFlex>
+      </VLayout>
+    </KModal>
 
     <VLayout justify-start wrap>
       <VFlex


### PR DESCRIPTION
## Description

Replace VDialog with KModal in "Related resources tab"

#### Issue Addressed

Part of https://github.com/learningequality/kolibri-design-system/issues/156

#### Before/After Screenshots

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/13509191/108755692-dd3fb600-7547-11eb-9fdf-bc5b094beada.png) | ![after](https://user-images.githubusercontent.com/13509191/108755716-e4ff5a80-7547-11eb-936d-f7107ce8955a.png) |

## Steps to Test

- [ ] *Navigate to a channel editor*
- [ ] *Open edit modal for a resource*
- [ ] *Navigate to "Related" tab*
- [ ] *Click "Show me" link under the title*
