### PR TITLE
Fix mismatch between Progress Modal content and current task

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -168,38 +168,22 @@
         );
       },
       headerText() {
-        if (this.currentTask) {
-          if (this.currentTask.task_type === 'duplicate-nodes') {
-            return this.$tr('copyHeader');
-          } else if (this.isPublishing) {
-            return this.$tr('publishHeader');
-          } else if (this.currentTask.task_type === 'move-nodes') {
-            return this.$tr('moveHeader');
-          } else if (this.isSyncing || this.nothingToSync) {
-            return this.$tr('syncHeader');
-          }
-        } else if (this.nothingToSync) {
+        if ((this.currentTask && this.isPublishing) || this.currentChannel.publishing) {
+          return this.$tr('publishHeader');
+        } else if (this.syncing || (this.currentTask && this.isSyncing)) {
           return this.$tr('syncHeader');
         }
-        return this.$tr('publishHeader');
+        return '';
       },
       descriptionText() {
-        if (this.currentTask) {
-          if (this.progressPercent >= 100) {
-            return this.$tr('finishedMessage');
-          } else if (this.currentTask.task_type === 'duplicate-nodes') {
-            return this.$tr('copyDescription');
-          } else if (this.isPublishing) {
-            return this.$tr('publishDescription');
-          } else if (this.currentTask.task_type === 'move-nodes') {
-            return this.$tr('moveDescription');
-          } else if (this.isSyncing) {
-            return this.$tr('syncDescription');
-          }
-        } else if (this.nothingToSync) {
+        if (this.progressPercent >= 100 || this.nothingToSync) {
           return this.$tr('finishedMessage');
+        } else if ((this.currentTask && this.isPublishing) || this.currentChannel.publishing) {
+          return this.$tr('publishDescription');
+        } else if (this.syncing || (this.currentTask && this.isSyncing)) {
+          return this.$tr('syncDescription');
         }
-        return this.$tr('publishDescription');
+        return '';
       },
     },
     methods: {
@@ -211,8 +195,8 @@
       },
     },
     $trs: {
-      copyHeader: 'Importing resources',
-      copyDescription: 'Import is in progress, please wait...',
+      // copyHeader: 'Importing resources',
+      // copyDescription: 'Import is in progress, please wait...',
       /* eslint-disable kolibri/vue-no-unused-translations */
       defaultHeader: 'Updating channel',
       defaultDescription: 'Update is in progress, please wait...',
@@ -220,8 +204,8 @@
       defaultErrorText:
         'An unexpected error has occurred. Please try again, and if you continue to see this message, please contact support via the Help menu.',
       finishedMessage: 'Operation complete! Click "Refresh" to update the page.',
-      moveHeader: 'Moving Content',
-      moveDescription: 'Move operation is in progress, please wait...',
+      // moveHeader: 'Moving Content',
+      // moveDescription: 'Move operation is in progress, please wait...',
       publishHeader: 'Publishing channel',
       publishDescription:
         'Once publishing is complete, you will receive an email notification and will be able to make further edits to your channel.',


### PR DESCRIPTION
## Description

This PR fixes a mismatch that was occurring where the Publish Task text was the default, and it was appearing before the Sync Task text appeared during sync tasks. It also removes some extra code and comments out (but doesn't delete) strings that aren't being used.

#### Issue Addressed (if applicable)

Addresses #2977 

#### Before/After Screenshots (if applicable)
Before (Sync Task @ 0%)
![sync-before](https://user-images.githubusercontent.com/17235236/108760661-ef0b6400-751b-11eb-8ce1-59750cf186e8.gif)

After (Sync Task @ 0%)
![sync-after](https://user-images.githubusercontent.com/17235236/108760720-fdf21680-751b-11eb-9ed1-ed61524a3b54.gif)


## Steps to Test

- [ ] In the tree view, navigate to Sync Resources 
- [ ] Proceed through the modals - when the Progress Modal appears, there should not be a "flash" of the publish text while the task is not started/at 0%
