### PR TITLE
Count every resource even if the content_id is repeated

### DIFF
--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -417,7 +417,6 @@ class ChannelViewSet(ValuesViewset):
             channel_main_tree_nodes.exclude(kind_id=content_kinds.TOPIC)
             .values_list("content_id", flat=True)
             .order_by()
-            .distinct()
         )
 
         queryset = queryset.annotate(


### PR DESCRIPTION
## Description

Counts every resource in a channel even , ignoring if the content_id is repeated, so different resources with the same content and different languages are considered.

#### Issue Addressed (if applicable)

Closes #2757 

## Steps to Test

1. In the main channels page select any channel, and take note of the number of resources
2. Open the channel and count the number of resources for every topic, adding them all must match with the number in 1

## Implementation Notes (optional)

Easiest fix in a long time (after you know what the problem is)
