### PR TITLE
Delete channels from the channel edit view

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -145,15 +145,14 @@
             >
               <VListTileTitle>{{ $tr('openTrash') }}</VListTileTitle>
             </VListTile>
-            <!-- HIDES THE DELETE OPTION UNTIL FUNCTIONALITY IS FIXED -->
-            <!-- <VListTile
+            <VListTile
               v-if="canEdit"
-              @click="deleteChannel"
+              @click="deleteChannelModal"
             >
               <VListTileTitle class="red--text">
                 {{ $tr('deleteChannel') }}
               </VListTileTitle>
-            </VListTile> -->
+            </VListTile>
           </VList>
         </Menu>
       </VToolbarItems>
@@ -414,7 +413,7 @@
         this.noSyncNeeded = true;
         this.showProgressModal = true;
       },
-      deleteChannel() {
+      deleteChannelModal() {
         this.showDeleteModal = true;
         this.trackClickEvent('Delete channel');
       },

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -899,11 +899,14 @@ export const Channel = new Resource({
   },
 
   softDelete(id) {
+    let modelUrl = this.modelUrl(id);
     // Call endpoint directly in case we need to navigate to new page
     return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
-      return this.table.update(id, { deleted: true }).then(() => {
-        return client.patch(this.modelUrl(id), { deleted: true });
-      });
+      return this.table.update(id, { deleted: true });
+    }).then(() => {
+      // make sure transaction is closed before calling a non-Dexie async function
+      // see here: https://bit.ly/3dJtsIe
+      return client.patch(modelUrl, { deleted: true });
     });
   },
 });


### PR DESCRIPTION
## Description

Fixes deletion of channels from the channel edit page.
#### Issue Addressed (if applicable)

Fixes #2894

## Steps to Test

- [x] Edit channel that you want to delete
- [x] Delete the channel using the "..." menu in the upper right corner of the channel edit page
- [x] Ensure that the channel was deleted, you were redirected to the channel list page and that the snackbar message appears.

## Implementation Notes (optional)

#### At a high level, how did you implement this?

There were two small bugs:
- Two functions shared the same name
- A promise was being returned from inside of a Dexie transaction