### PR TITLE
Don't filter for ancestors if target is root node

### DIFF
--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -20,8 +20,8 @@ from le_utils.constants import roles
 from rest_framework.decorators import detail_route
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.serializers import ChoiceField
 from rest_framework.serializers import BooleanField
+from rest_framework.serializers import ChoiceField
 from rest_framework.serializers import DictField
 from rest_framework.serializers import IntegerField
 from rest_framework.serializers import ValidationError
@@ -88,13 +88,22 @@ class ContentNodeFilter(RequiredFilterSet):
         )
 
     def filter_ancestors_of(self, queryset, name, value):
-        # For simplicity include the target node in the query
-        target_node_query = ContentNode.objects.filter(pk=value)
-        return queryset.filter(
-            tree_id=target_node_query.values_list("tree_id", flat=True)[:1],
-            lft__lte=target_node_query.values_list("lft", flat=True)[:1],
-            rght__gte=target_node_query.values_list("rght", flat=True)[:1],
-        )
+        """
+        See MPTTModel.get_ancestors()
+        """
+        try:
+            # Includes the target node in the query
+            target_node = ContentNode.objects.get(pk=value)
+            if target_node.is_root_node():
+                return queryset.filter(pk=value)
+
+            return queryset.filter(
+                tree_id=target_node.tree_id,
+                lft__lte=target_node.lft,
+                rght__gte=target_node.rght,
+            )
+        except ContentNode.DoesNotExist:
+            return queryset.none()
 
     def filter__node_id_channel_id(self, queryset, name, value):
         query = Q()


### PR DESCRIPTION
## Description
[This issue](https://github.com/learningequality/studio/issues/2927) was caused by a pending call to get the ancestors of the root node of the channel, which blocked the loading of the page and thereby prevented copying. Unfortunately, this ancestors call can take several seconds on hotfixes and production (90 seconds on hotfixes for me once), even though the root node has no ancestors. This PR makes a change to take a shortcut in that scenario to only return the target node.

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/2927
Addresses https://github.com/learningequality/studio/issues/2889

## Steps to Reproduce/Test
- [ ] *Create a new channel on hotfixes*
- [ ] *Open the channel*
- [ ] *While the ancestors call is pending, you should see an empty gray channel*
- [ ] *Copying is not possible until the ancestors call completes and you see "Click ADD..."*
- [ ] *Once the API call completes, which should be much faster with this change, you should see the screenshot below and should be able to drag and drop from clipboard to the channel*
![Screenshot from 2021-02-24 15-30-59](https://user-images.githubusercontent.com/819838/109083674-367c2680-76bb-11eb-8c3e-02634337ef99.png)


## Checklist

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

