### PR TITLE
Add additional fields for pending channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ venv
 Pipfile
 
 Thumbs.db
+.DS_Store
 
 # Ignore javascript bundle output dirs
 /contentcuration/contentcuration/static/js/bundles

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -850,7 +850,7 @@ class Channel(models.Model):
 
         permission_filter = Q()
         if user_id:
-            pending_channels = Invitation.objects.filter(email=user_email).values_list(
+            pending_channels = Invitation.objects.filter(email=user_email, revoked=False, declined=False, accepted=False).values_list(
                 "channel_id", flat=True
             )
             permission_filter = (


### PR DESCRIPTION
## Description

When dealing with invitations, the model for `Channels` had not been updated to include `revoked`, `declined`, and `accepted`, as per the new `Invitation` models. This PR updates that in the `pending_channels`


## Checklist

*Delete any items that don't apply*

- [x] Is the code clean and well-commented?
- [x] Are views organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)?
