### PR TITLE
Disable the login button while the login request is running

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -32,7 +32,7 @@
             <p>
               <ActionLink :to="{ name: 'ForgotPassword' }" :text="$tr('forgotPasswordLink')" />
             </p>
-            <VBtn block color="primary" large type="submit">
+            <VBtn block color="primary" large type="submit" :disabled="busy">
               {{ $tr('signInButton') }}
             </VBtn>
             <VBtn block flat color="primary" class="mt-2" :to="{ name: 'Create' }">
@@ -101,6 +101,7 @@
         username: '',
         password: '',
         loginFailed: false,
+        busy: false,
       };
     },
     computed: {
@@ -120,6 +121,7 @@
       },
       submit() {
         if (this.$refs.form.validate()) {
+          this.busy = true;
           let credentials = {
             username: this.username,
             password: this.password,
@@ -129,6 +131,7 @@
               window.location.assign(this.nextParam || '/channels');
             })
             .catch(err => {
+              this.busy = false;
               if (err.response.status === 405) {
                 this.$router.push({ name: 'AccountNotActivated' });
               }


### PR DESCRIPTION
## Description

Disable the login button while the login request is running to prevent subsequent clicks and more active login requests than one at a time.

#### Issue Addressed

Closes #2937

#### Before/After Screenshots

**After**

![Peek 2021-02-25 10-44](https://user-images.githubusercontent.com/13509191/109135047-f36f9100-7756-11eb-8cfd-3ac0939a1d67.gif)

## Steps to Test

- [ ] Follow steps to reproduce of [the issue addressed](https://github.com/learningequality/studio/issues/2937). There should be no multiple overlapping requests.
- [ ] Check that you can successfully login with correct credentials
