### PR TITLE
Breakout docker builds into separate service builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ dummyusers:
 	cd contentcuration/ && python manage.py loaddata contentcuration/fixtures/admin_user.json
 	cd contentcuration/ && python manage.py loaddata contentcuration/fixtures/admin_user_token.json
 
+runserver:
+	cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8080
+
 prodceleryworkers:
 	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3 --without-mingle --without-gossip
 
@@ -182,3 +185,8 @@ dcservicesup:
 dcservicesdown:
 	# stop services that were started using dcservicesup
 	docker-compose -f docker-compose.yml -f docker-compose.alt.yml down
+
+docker-build: | docker-build-dev
+
+docker-build-%:
+	@$(MAKE) -C docker build DEPLOY_ENV=$(subst docker-build-,,$@)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ x-studio-environment:
     SHELL: /bin/bash
     AWS_S3_ENDPOINT_URL: http://minio:9000
     DATA_DB_HOST: postgres
-    DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
+    DJANGO_SETTINGS_MODULE: contentcuration.settings
     RUN_MODE: docker-compose
     CELERY_TIMEZONE: America/Los_Angeles
     CELERY_REDIS_DB: 0
@@ -17,43 +17,32 @@ x-studio-environment:
 
 services:
   app:
-    image: learningequality/studio-app:dev
+    image: learningequality/studio-app:prod
     depends_on:
       - minio
       - postgres
       - redis
-    volumes:
-      - ./contentcuration:/src/contentcuration
     environment: *studio-environment
-    command: make runserver
+    command: make gunicornserver
 
   worker:
-    image: learningequality/studio-app:dev
+    image: learningequality/studio-app:prod
     depends_on:
       - minio
       - postgres
       - redis
-    volumes:
-      - ./contentcuration:/src/contentcuration
     environment: *studio-environment
     command: make prodceleryworkers
 
-  webpack:
-    image: learningequality/studio-webpack:dev
-    volumes:
-      - ./contentcuration:/src/contentcuration
-    ports:
-      - "4000:4000"
-
   nginx:
-    image: learningequality/studio-nginx:dev
+    image: learningequality/studio-nginx:prod
     environment:
       STUDIO_UPSTREAM_HOST: app
       STUDIO_UPSTREAM_PORT: 8080
       AWS_S3_ENDPOINT_URL: http://minio:9000
+      AWS_S3_BUCKET_NAME: http://minio:9000
     depends_on:
       - app
-      - webpack
     ports:
       - "8080:8080"
 
@@ -81,7 +70,7 @@ services:
     image: redis:4.0.9
 
   prober:
-    image: learningequality/studio-prober:dev
+    image: learningequality/studio-prober:prod
     environment: *studio-environment
     working_dir: /src/deploy
     entrypoint: ""

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,12 @@
+SERVICES = app nginx prober webpack
+DEPLOY_ENV = dev
+
+# `make build` will trigger `make build-*` for each service
+build: | $(addprefix build-, $(SERVICES))
+
+# nginx:prod requires webpack:prod to be built already
+build-nginx: | build-webpack
+
+# delegate to individual service Makefiles for building
+build-%:
+	@$(MAKE) -C $(subst build-,,$@) build-$(DEPLOY_ENV)

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,32 @@
+# learningequality/studio-app:base
+FROM python:3.6-buster
+
+# Set the timezone
+ENV DEBIAN_FRONTEND noninteractive
+# Default Python file.open file encoding to UTF-8 instead of ASCII,
+# workaround for le-utils setup.py issue
+ENV LANG C.UTF-8
+ENV PATH /usr/local/bin:$PATH
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+
+# System packages ##############################################################
+RUN apt-get update --fix-missing && \
+    apt-get -y install \
+        curl git man make \
+        gcc libpq-dev make git gettext libjpeg-dev && \
+    apt-get -y autoremove && \
+    apt-get clean
+
+# Sources ######################################################################
+WORKDIR /src
+RUN mkdir -p /src/contentcuration
+COPY Makefile requirements.txt /src/
+################################################################################
+
+# Python packages ##############################################################
+RUN pip install \
+    --isolated \
+    --no-cache-dir \
+    --ignore-installed \
+    -r requirements.txt
+################################################################################

--- a/docker/app/Makefile
+++ b/docker/app/Makefile
@@ -1,0 +1,27 @@
+IMAGE_TAG_BASE = learningequality/studio-app
+
+.PHONY: build-base build-dev build-prod clean
+
+build/entrypoint.py: dev/entrypoint.py
+build/flake.lock: ../../flake.lock
+build/flake.nix: ../../flake.nix
+build/pytest.ini: ../../pytest.ini
+build/requirements.txt: ../../requirements.txt
+build/requirements-dev.txt: ../../requirements-dev.txt
+build/Makefile: ../../Makefile
+build/setup.cfg: ../../setup.cfg
+build/%:
+	@mkdir -p build
+	@cp $< $@
+
+build-base: | clean build/Makefile build/requirements.txt
+	@docker build -t $(IMAGE_TAG_BASE):base -f Dockerfile ./build
+
+build-dev: | build-base build/entrypoint.py build/flake.lock build/flake.nix build/pytest.ini build/requirements-dev.txt build/setup.cfg
+	@docker build -t $(IMAGE_TAG_BASE):dev -f dev/Dockerfile ./build
+
+build-prod: | build-base
+	@docker build -t $(IMAGE_TAG_BASE):prod -f prod/Dockerfile ../../contentcuration
+
+clean:
+	@rm -rf ./build

--- a/docker/app/dev/Dockerfile
+++ b/docker/app/dev/Dockerfile
@@ -1,0 +1,18 @@
+# learningequality/studio-app:dev
+FROM learningequality/studio-app:base
+
+VOLUME /src/contentcuration
+ENTRYPOINT ["/usr/local/bin/python", "entrypoint.py"]
+
+# [DEV] Python packages ########################################################
+COPY requirements-dev.txt /src/
+RUN pip install \
+    --isolated \
+    --no-cache-dir \
+    --ignore-installed \
+    -r requirements-dev.txt
+################################################################################
+
+# Files ########################################################################
+COPY entrypoint.py flake.lock flake.nix pytest.ini setup.cfg /src/
+################################################################################

--- a/docker/app/dev/entrypoint.py
+++ b/docker/app/dev/entrypoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
 The entrypoint for the studio-app docker image for development purposes.
 This script is not used in the production, develop, or staging setups (k8s).

--- a/docker/app/prod/Dockerfile
+++ b/docker/app/prod/Dockerfile
@@ -1,0 +1,7 @@
+# learningequality/studio-app:dev
+FROM learningequality/studio-app:base
+
+EXPOSE 8000
+ENTRYPOINT ["make", "altprodserver"]
+
+COPY . /src/contentcuration

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,9 @@
+# learningequality/studio-nginx:base
+FROM nginx:1.19
+
+ENV AWS_S3_BUCKET_NAME=""
+
+RUN mkdir -p /etc/nginx/templates /app/contentcuration/static
+
+COPY nginx.conf /etc/nginx/
+COPY ./templates/* /etc/nginx/templates/

--- a/docker/nginx/Makefile
+++ b/docker/nginx/Makefile
@@ -1,0 +1,24 @@
+IMAGE_TAG_BASE = learningequality/studio-nginx
+
+.PHONY: build-base build-dev build-prod clean
+
+# Keep Docker build context small, only files the we need
+build/nginx.conf: ./nginx.conf
+build/templates: ./templates
+build/%:
+	@mkdir -p build
+	@cp -r $< $@
+
+build-base: | clean build/nginx.conf build/templates
+	@docker build -t $(IMAGE_TAG_BASE):base -f Dockerfile ./build
+
+build-dev: | build-base
+	@cp ./dev/templates/* ./build/templates/
+	@docker build -t $(IMAGE_TAG_BASE):dev -f dev/Dockerfile ./build
+
+build-prod: | build-base
+	@cp ./prod/templates/* ./build/templates/
+	@docker build -t $(IMAGE_TAG_BASE):prod -f prod/Dockerfile ./build
+
+clean:
+	@rm -rf ./build

--- a/docker/nginx/dev/Dockerfile
+++ b/docker/nginx/dev/Dockerfile
@@ -1,0 +1,4 @@
+# learningequality/studio-nginx:dev
+FROM learningequality/studio-nginx:base
+
+COPY ./templates/* /etc/nginx/templates/

--- a/docker/nginx/dev/templates/default.conf.template
+++ b/docker/nginx/dev/templates/default.conf.template
@@ -1,0 +1,98 @@
+# Configuration for Nginx
+server {
+    # Listen on port 8080
+    # See https://nginx.org/en/docs/http/server_names.html for how this interacts with server_name
+    listen 8080 default_server;
+
+    # Explicitly set server_name to be empty.
+    server_name "";
+
+    # Never actually utilized
+    location @nowhere {
+        return 404;
+    }
+
+    location @django {
+        proxy_pass         http://studio;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+
+    location @staticLocal {
+        root /app/contentcuration/static/;
+    }
+
+    location @staticWebpack {
+        proxy_pass         http://webpack:4000;
+        proxy_set_header   Host $proxy_host;
+        proxy_set_header   Accept-Encoding Identity;
+        proxy_redirect     off;
+    }
+
+    # Settings to serve static files
+    location /static/  {
+        try_files @staticLocal @staticWebpack @django;
+        expires 4h;
+    }
+
+    # Serve a static file (ex. favico)
+    # outside /static directory
+    location = /favico.ico  {
+        root /app/favico.ico;
+    }
+
+    # Proxy connections to django
+    location / {
+        # `try_files` requires at least two options, so trick it with a always-404 location first
+        try_files @nowhere @django;
+    }
+
+    location @minioContent {
+        proxy_http_version 1.1;
+        proxy_pass         http://minio:9000;
+        proxy_set_header   Host $proxy_host;
+        proxy_set_header   Accept-Encoding Identity;
+        proxy_redirect     off;
+        gzip off;
+    }
+
+    location @prodContent {
+        proxy_pass         https://studio.learningequality.org;
+        proxy_set_header   Host $proxy_host;
+        proxy_set_header   Accept-Encoding Identity;
+        proxy_redirect     off;
+        gzip off;
+    }
+
+    location /content/ {
+        try_files @minioContent @prodContent;
+    }
+
+    # We cache the following expensive API endpoints.
+
+    # cache the public channel endpoint.
+    # the return value of this should be the same across all users,
+    # and the return value should rarely change as well. This makes it
+    # a candidate for long-running caches keyed simply by the URI.
+    location /get_user_public_channels/ {
+        proxy_cache public_channel_cache;
+        proxy_pass  http://studio/get_user_public_channels/;
+
+        # cache any 200 OK status code values for 10 minutes
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 200 10m;
+
+        # ignore any get params
+        proxy_cache_key $scheme$proxy_host$uri;
+        # next two directives make nginx serve the cached value even when we're refreshing it
+        proxy_cache_use_stale updating error;
+        proxy_cache_background_update on;
+
+        # proxy_cache_lock sends only 1 query to the server if there's a lot of them at once,
+        # preventing stampedes
+        proxy_cache_lock on;
+
+        # show the cache status in a header
+        add_header X-Cache-Status $upstream_cache_status;
+    }
+}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,43 @@
+# Adapted from Docker nginx:1.19:/etc/nginx/nginx.conf
+user  nginx;
+worker_processes  1;
+
+#error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+    client_max_body_size 1000M;
+
+    proxy_cache_path /tmp/proxycache levels=1:2 keys_zone=public_channel_cache:10m max_size=10g
+                     inactive=600m use_temp_path=off;
+
+    gzip              on;
+    gzip_http_version 1.0;
+    gzip_proxied      any;
+    gzip_min_length   500;
+    gzip_disable      "MSIE [1-6]\.";
+    gzip_types        text/plain text/xml text/css
+                      text/comma-separated-values
+                      text/javascript
+                      application/x-javascript
+                      application/atom+xml;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/nginx/prod/Dockerfile
+++ b/docker/nginx/prod/Dockerfile
@@ -1,0 +1,6 @@
+# learningequality/studio-nginx:prod
+FROM learningequality/studio-webpack:prod AS static
+FROM learningequality/studio-nginx:base
+
+COPY ./templates /etc/nginx/templates/
+COPY --from=static /app/contentcuration/static /app/contentcuration/static/

--- a/docker/nginx/prod/templates/catalog.conf.template
+++ b/docker/nginx/prod/templates/catalog.conf.template
@@ -1,0 +1,31 @@
+# Allow-list filter for content catalog paths
+server {
+    listen 8080;
+    server_name catalog.learningequality.org;
+    location = / {
+        proxy_pass         http://studio;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+    location /static/  {
+        autoindex on;
+        alias /app/contentworkshop_static/;
+        expires 4h;
+    }
+    location /content/ {
+        proxy_http_version 1.1;
+        proxy_pass         ${AWS_S3_ENDPOINT_URL}/${AWS_S3_BUCKET_NAME}/;
+        proxy_set_header   Host $proxy_host;
+        proxy_set_header   Accept-Encoding Identity;
+        proxy_redirect     off;
+        gzip off;
+    }
+    location ~ ^/(api/catalog|stealthz|healthz|api/get_channel_details|jsreverse|i18n) {
+        proxy_pass         http://studio;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+    location / {
+        deny all;
+    }
+}

--- a/docker/nginx/prod/templates/default.conf.template
+++ b/docker/nginx/prod/templates/default.conf.template
@@ -1,0 +1,64 @@
+# Configuration for Nginx
+server {
+    # Listen on port 8080
+    # See https://nginx.org/en/docs/http/server_names.html for how this interacts with server_name
+    listen 8080 default_server;
+
+    # Explicitly set server_name to be empty.
+    server_name "";
+
+    # Settings to serve static files
+    location /static/  {
+        autoindex on;
+        alias /app/contentcuration/static/;
+        expires 4h;
+    }
+    # Serve a static file (ex. favico)
+    # outside /static directory
+    location = /favico.ico  {
+        root /app/favico.ico;
+    }
+    # Proxy connections to django
+    location / {
+        proxy_pass         http://studio;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+
+    location /content/ {
+        proxy_http_version 1.1;
+        proxy_pass         ${AWS_S3_ENDPOINT_URL}/${AWS_S3_BUCKET_NAME}/;
+        proxy_set_header   Host $proxy_host;
+        proxy_set_header   Accept-Encoding Identity;
+        proxy_redirect     off;
+        gzip off;
+    }
+
+    # We cache the following expensive API endpoints.
+
+    # cache the public channel endpoint.
+    # the return value of this should be the same across all users,
+    # and the return value should rarely change as well. This makes it
+    # a candidate for long-running caches keyed simply by the URI.
+    location /get_user_public_channels/ {
+        proxy_cache public_channel_cache;
+        proxy_pass  http://studio/get_user_public_channels/;
+
+        # cache any 200 OK status code values for 10 minutes
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 200 10m;
+
+        # ignore any get params
+        proxy_cache_key $scheme$proxy_host$uri;
+        # next two directives make nginx serve the cached value even when we're refreshing it
+        proxy_cache_use_stale updating error;
+        proxy_cache_background_update on;
+
+        # proxy_cache_lock sends only 1 query to the server if there's a lot of them at once,
+        # preventing stampedes
+        proxy_cache_lock on;
+
+        # show the cache status in a header
+        add_header X-Cache-Status $upstream_cache_status;
+    }
+}

--- a/docker/nginx/templates/00-upstream.conf.template
+++ b/docker/nginx/templates/00-upstream.conf.template
@@ -1,0 +1,3 @@
+upstream studio {
+    server ${STUDIO_UPSTREAM_HOST}:${STUDIO_UPSTREAM_PORT};
+}

--- a/docker/prober/Dockerfile
+++ b/docker/prober/Dockerfile
@@ -1,0 +1,11 @@
+# learningequality/studio-prober:base
+FROM python:3.6-buster
+
+RUN apt-get update && apt-get install -y curl unzip
+
+RUN pip install requests>=2.20.0 && pip install psycopg2-binary==2.7.4 && pip install le-utils>=0.1.19
+
+COPY ./cloudprober.cfg /deploy/
+COPY ./send_metrics_newrelic.py /deploy/
+COPY ./prober-entrypoint.sh /deploy/
+COPY ./probers /deploy/probers/

--- a/docker/prober/Makefile
+++ b/docker/prober/Makefile
@@ -1,0 +1,23 @@
+IMAGE_TAG_BASE = learningequality/studio-prober
+
+.PHONY: build-base build-dev build-prod clean
+
+build/cloudprober.cfg: ../../deploy/cloudprober.cfg
+build/send_metrics_newrelic.py: ../../deploy/send_metrics_newrelic.py
+build/prober-entrypoint.sh: ../../deploy/prober-entrypoint.sh
+build/probers: ../../deploy/probers
+build/%:
+	@mkdir -p build
+	@cp -R $< $@
+
+build-base: | clean build/cloudprober.cfg build/send_metrics_newrelic.py build/prober-entrypoint.sh build/probers
+	@docker build -t $(IMAGE_TAG_BASE):base -f Dockerfile ./build
+
+build-dev: | build-base
+	@docker tag $(IMAGE_TAG_BASE):base $(IMAGE_TAG_BASE):dev
+
+build-prod: | build-base
+	@docker tag $(IMAGE_TAG_BASE):base $(IMAGE_TAG_BASE):prod
+
+clean:
+	@rm -rf ./build

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -1,0 +1,26 @@
+# learningequality/studio-webpack:base
+FROM node:10-buster
+
+RUN apt-get update --fix-missing && \
+    apt-get -y install gcc git gettext libjpeg-dev && \
+    apt-get -y autoremove && \
+    apt-get clean
+
+# Sources ######################################################################
+RUN mkdir -p /app/contentcuration/static /src/contentcuration/contentcuration/frontend
+WORKDIR /src
+################################################################################
+
+# Node packages ################################################################
+COPY package.json yarn.lock /src/
+RUN yarn install \
+    --no-default-rc \
+    --non-interactive \
+    --network-timeout 1000000 \
+    --pure-lockfile \
+    --link-duplicates
+################################################################################
+
+# Other files ##################################################################
+COPY babel.config.js postcss.config.js webpack.config.js /src/
+################################################################################

--- a/docker/webpack/Makefile
+++ b/docker/webpack/Makefile
@@ -1,0 +1,28 @@
+IMAGE_TAG_BASE = learningequality/studio-webpack
+
+.PHONY: build-base build-dev build-prod clean
+
+build/.eslintrc.js: ../../.eslintrc.js
+build/.htmlhintrc.js: ../../.htmlhintrc.js
+build/.huskyrc: ../../.huskyrc
+build/.prettierrc.js: ../../.prettierrc.js
+build/babel.config.js: ../../babel.config.js
+build/postcss.config.js: ../../postcss.config.js
+build/package.json: ../../package.json
+build/yarn.lock: ../../yarn.lock
+build/webpack.config.js: ../../webpack.config.js
+build/%:
+	@mkdir -p build
+	@cp $< $@
+
+build-base: | clean build/babel.config.js build/postcss.config.js build/package.json build/yarn.lock build/webpack.config.js
+	@docker build -t $(IMAGE_TAG_BASE):base -f Dockerfile ./build
+
+build-dev: | build-base build/.eslintrc.js build/.htmlhintrc.js build/.huskyrc build/.prettierrc.js
+	@docker build -t $(IMAGE_TAG_BASE):dev -f dev/Dockerfile ./build
+
+build-prod: | build-base
+	@docker build -t $(IMAGE_TAG_BASE):prod -f prod/Dockerfile ../../contentcuration
+
+clean:
+	@rm -rf ./build

--- a/docker/webpack/dev/Dockerfile
+++ b/docker/webpack/dev/Dockerfile
@@ -1,0 +1,11 @@
+# learningequality/studio-webpack:dev
+FROM learningequality/studio-webpack:base
+
+# Assume we're mounting a volume in dev
+VOLUME /src/contentcuration
+EXPOSE 4000
+CMD ["yarn", "run", "build:dev:hot"]
+
+# Sources ######################################################################
+COPY .eslintrc.js .htmlhintrc.js .huskyrc .prettierrc.js /src/
+################################################################################

--- a/docker/webpack/prod/Dockerfile
+++ b/docker/webpack/prod/Dockerfile
@@ -1,0 +1,7 @@
+# learningequality/studio-webpack:prod
+FROM learningequality/studio-webpack:base
+
+# Build frontend assets ########################################################
+COPY contentcuration/frontend /src/contentcuration/contentcuration/frontend/
+RUN yarn run build --env.docker
+################################################################################

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,12 +15,6 @@ const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin');
 
 const { InjectManifest } = require('workbox-webpack-plugin');
 
-const djangoProjectDir = path.resolve('contentcuration');
-const staticFilesDir = path.resolve(djangoProjectDir, 'contentcuration', 'static');
-const srcDir = path.resolve(djangoProjectDir, 'contentcuration', 'frontend');
-
-const bundleOutputDir = path.resolve(staticFilesDir, 'studio');
-
 function recursiveIssuer(m) {
   if (m.issuer) {
     return recursiveIssuer(m.issuer);
@@ -37,10 +31,21 @@ function recursiveIssuer(m) {
 module.exports = (env = {}) => {
   const dev = env.dev;
   const hot = env.hot;
+
+  const rootDir = path.resolve(env.docker ? '/src' : './');
+  const djangoProjectDir = path.resolve(rootDir, 'contentcuration');
+  const staticFilesDir = path.resolve(
+    env.docker ? '/app' : djangoProjectDir,
+    'contentcuration',
+    'static'
+  );
+  const srcDir = path.resolve(djangoProjectDir, 'contentcuration', 'frontend');
+  const bundleOutputDir = path.resolve(staticFilesDir, 'studio');
+
   const postCSSLoader = {
     loader: 'postcss-loader',
     options: {
-      config: { path: path.resolve(__dirname, './postcss.config.js') },
+      config: { path: path.resolve('postcss.config.js') },
       sourceMap: dev,
     },
   };
@@ -213,10 +218,14 @@ module.exports = (env = {}) => {
       // This must be added in dev mode if you want to do dev work
       // on the service worker.
     ].concat(
-      dev ? [] : [new InjectManifest({
-        swSrc: path.resolve(srcDir, 'serviceWorker/index.js'),
-        swDest: 'serviceWorker.js',
-      })]
+      dev
+        ? []
+        : [
+            new InjectManifest({
+              swSrc: path.resolve(srcDir, 'serviceWorker', 'index.js'),
+              swDest: 'serviceWorker.js',
+            }),
+          ]
     ),
     // new in webpack 4. Specifies the default bundle type
     mode: 'development',


### PR DESCRIPTION
_**DRAFT: first pass at multi-stage builds for studio**_

## Description
- Splits app Dockerfile into separate services, so frontend is built in separate container than backend
- Updated base images to prebuilt python and node.js images
- Adds new Dockerfiles for webpack and nginx services
- Adds Makefiles for managing building of docker images
- Makes dev env mimic production as much as possible; nginx service is now used locally when running in dev
- TODO: Integrate and resolve issues with generating prod images
- TODO: avoid building wheels in Docker build if possible
- TODO: add prerequisite step to production build to pull latest community images
- ~TODO: pin all python requirements to rightfully trigger docker rebuild when a package needs updating?~
- TODO: consolidate commands executed through `yarn` and `make` into each respectively for Node.js-based and Python-based scripts to avoid Node.js and Python cross dependencies

#### Issue Addressed (if applicable)

Addresses https://github.com/learningequality/studio/issues/2875

## Steps to Test

- [ ] *TBD 1*
- [ ] *TBD 2*


## Checklist
- [ ] Is the code clean and well-commented?
- [ ] If any Python requirements have changed, are the updated requirements.txt files also included in this PR?
