### PR TITLE
Add license and title validation to `views.internal::create_nodes`

### DIFF
--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -98,10 +98,10 @@ class Command(BaseCommand):
 
         exercise_check_query = With(AssessmentItem.objects.exclude(type=exercises.PERSEUS_QUESTION)
                                     .filter(
-                                        Q(question='') |
-                                        Q(answers='[]') |
+                                        Q(question='')
+                                        | Q(answers='[]')
                                         # hack to check if no correct answers
-                                        (~Q(type=exercises.INPUT_QUESTION) & ~Q(answers__iregex=r'"correct":\s*true'))).order_by(), name="t_assessmentitem")
+                                        | (~Q(type=exercises.INPUT_QUESTION) & ~Q(answers__iregex=r'"correct":\s*true'))).order_by(), name="t_assessmentitem")
 
         query = exercise_check_query.join(ContentNode, id=has_questions_query.col.contentnode_id) \
             .with_cte(exercise_check_query) \

--- a/contentcuration/contentcuration/management/commands/mark_incomplete.py
+++ b/contentcuration/contentcuration/management/commands/mark_incomplete.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         count = ContentNode.objects.exclude(kind_id=content_kinds.TOPIC) \
             .exclude(complete=False) \
             .filter(license_id__in=copyright_licenses) \
-            .filter(Q(copyright_holder__isnull=True) | Q(copyright_holder=''))\
+            .filter(Q(copyright_holder__isnull=True) | Q(copyright_holder='')) \
             .order_by() \
             .update(complete=False)
         logging.info('Marked {} invalid copyright holders (finished in {})'.format(count, time.time() - licensestart))
@@ -65,13 +65,13 @@ class Command(BaseCommand):
         logging.info('Marking file resources...')
         file_check_query = With(File.objects.filter(preset__supplementary=False).values("contentnode_id").order_by(), name="t_file")
 
-        query = file_check_query.join(ContentNode, id=file_check_query.col.contentnode_id, _join_type=LOUTER)\
+        query = file_check_query.join(ContentNode, id=file_check_query.col.contentnode_id, _join_type=LOUTER) \
             .with_cte(file_check_query) \
             .annotate(t_contentnode_id=file_check_query.col.contentnode_id) \
             .exclude(kind_id=content_kinds.TOPIC) \
             .exclude(kind_id=content_kinds.EXERCISE) \
             .exclude(complete=False) \
-            .filter(t_contentnode_id__isnull=True)\
+            .filter(t_contentnode_id__isnull=True) \
             .order_by()
         count = ContentNode.objects.filter(id__in=query.order_by().values_list('id', flat=True)).update(complete=False)
         logging.info('Marked {} invalid file resources (finished in {})'.format(count, time.time() - resourcestart))
@@ -82,12 +82,12 @@ class Command(BaseCommand):
 
         has_questions_query = With(AssessmentItem.objects.all().values("contentnode_id").order_by(), name="t_assessmentitem")
 
-        query = has_questions_query.join(ContentNode, id=has_questions_query.col.contentnode_id, _join_type=LOUTER)\
+        query = has_questions_query.join(ContentNode, id=has_questions_query.col.contentnode_id, _join_type=LOUTER) \
             .with_cte(has_questions_query) \
             .annotate(t_contentnode_id=has_questions_query.col.contentnode_id) \
             .filter(kind_id=content_kinds.EXERCISE) \
             .exclude(complete=False) \
-            .filter(t_contentnode_id__isnull=True)\
+            .filter(t_contentnode_id__isnull=True) \
             .order_by()
         exercisestart = time.time()
         count = ContentNode.objects.filter(id__in=query.order_by().values_list('id', flat=True)).update(complete=False)
@@ -103,7 +103,7 @@ class Command(BaseCommand):
                                         # hack to check if no correct answers
                                         (~Q(type=exercises.INPUT_QUESTION) & ~Q(answers__iregex=r'"correct":\s*true'))).order_by(), name="t_assessmentitem")
 
-        query = exercise_check_query.join(ContentNode, id=has_questions_query.col.contentnode_id)\
+        query = exercise_check_query.join(ContentNode, id=has_questions_query.col.contentnode_id) \
             .with_cte(exercise_check_query) \
             .annotate(t_contentnode_id=exercise_check_query.col.contentnode_id) \
             .filter(kind_id=content_kinds.EXERCISE) \
@@ -116,14 +116,14 @@ class Command(BaseCommand):
 
         exercisestart = time.time()
         logging.info('Marking mastery_model less exercises...')
-        count = ContentNode.objects.exclude(complete=False).filter(kind_id=content_kinds.EXERCISE).filter(~Q(extra_fields__has_key='mastery_model'))\
+        count = ContentNode.objects.exclude(complete=False).filter(kind_id=content_kinds.EXERCISE).filter(~Q(extra_fields__has_key='mastery_model')) \
             .order_by().update(complete=False)
         logging.info('Marked {} mastery_model less exercises(finished in {})'.format(count, time.time() - exercisestart))
 
         exercisestart = time.time()
         logging.info('Marking bad mastery model exercises...')
-        count = ContentNode.objects.exclude(complete=False).filter(kind_id=content_kinds.EXERCISE)\
-            .filter(Q(extra_fields__mastery_model=exercises.M_OF_N) & (~Q(extra_fields__has_key='m') | ~Q(extra_fields__has_key='n')))\
+        count = ContentNode.objects.exclude(complete=False).filter(kind_id=content_kinds.EXERCISE) \
+            .filter(Q(extra_fields__mastery_model=exercises.M_OF_N) & (~Q(extra_fields__has_key='m') | ~Q(extra_fields__has_key='n'))) \
             .order_by().update(complete=False)
         logging.info('Marked {} bad mastery model exercises (finished in {})'.format(count, time.time() - exercisestart))
 


### PR DESCRIPTION
## Summary

### Description of the change(s) you made

1. In `views.internal::create_nodes`, adds checks to validate the title and license. Sets the new node's `complete` field to false if the checks fail.
2. Some code cleanup

### Manual verification steps performed

(I'm not sure how to test this, since I think this API is only used via Sushi Chef)

## Reviewer guidance
### How can a reviewer test these changes?

* Read the code carefully, does any of the new code do anything unsafe (e.g. commit a potential Key Error)

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References

Partially addresses #2806, (does not invalidate nodes based on rest of criteria in `mark_complete.py`)


