### PR TITLE
KDS to Studio: KModal on staging tree page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -382,12 +382,10 @@ describe('StagingTreePage', () => {
       expect(removeMultipleSpaces(text)).toBe('Total size: 8 MB (+ 8 MB)');
     });
 
-    it('summary details dialog is not visible by default', () => {
-      expect(getSummaryDetailsDialog(wrapper).isVisible()).toBe(false);
-    });
-
     it('opens summary details dialog when view summary button is clicked', () => {
+      expect(getSummaryDetailsDialog(wrapper).exists()).toBe(false);
       getDisplaySummaryDetailsDialogBtn(wrapper).trigger('click');
+
       expect(getSummaryDetailsDialog(wrapper).isVisible()).toBe(true);
     });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -166,10 +166,6 @@ const getDeployDialogStagedResources = wrapper => {
   return wrapper.find('[data-test="deploy-dialog-staged-resources"]');
 };
 
-const getDeployBtn = wrapper => {
-  return wrapper.find('[data-test="deploy-btn"]');
-};
-
 describe('StagingTreePage', () => {
   it('renders back to viewing link leading to a root tree page in the toolbar', () => {
     const wrapper = initWrapper();
@@ -389,12 +385,10 @@ describe('StagingTreePage', () => {
       expect(getSummaryDetailsDialog(wrapper).isVisible()).toBe(true);
     });
 
-    it('deploy dialog is not visible by default', () => {
-      expect(getDeployDialog(wrapper).isVisible()).toBe(false);
-    });
-
     it('opens deploy dialog when deploy button is clicked', () => {
+      expect(getDeployDialog(wrapper).exists()).toBe(false);
       getDisplayDeployDialogBtn(wrapper).trigger('click');
+
       expect(getDeployDialog(wrapper).isVisible()).toBe(true);
     });
 
@@ -414,12 +408,13 @@ describe('StagingTreePage', () => {
       });
 
       it('dispatches deploy channel action on deploy channel button click', () => {
-        getDeployBtn(wrapper).trigger('click');
+        getDeployDialog(wrapper).vm.$emit('submit');
+
         expect(mockDeployCurrentChannel).toHaveBeenCalledTimes(1);
       });
 
       it('redirects to a root tree page after deploy channel button click', async () => {
-        getDeployBtn(wrapper).trigger('click');
+        getDeployDialog(wrapper).vm.$emit('submit');
         await flushPromises();
 
         expect(wrapper.vm.$router.currentRoute.name).toBe(RouteNames.TREE_VIEW);

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -178,65 +178,13 @@
               {{ $tr('openSummaryDetailsDialogBtn') }}
             </VBtn>
 
-            <VDialog
-              v-model="displayDeployDialog"
-              width="500"
+            <VBtn
+              color="primary"
+              data-test="display-deploy-dialog-btn"
+              @click="displayDeployDialog = true"
             >
-              <template v-slot:activator="{ on }">
-                <VBtn
-                  color="primary"
-                  data-test="display-deploy-dialog-btn"
-                  v-on="on"
-                >
-                  {{ $tr('deployChannel') }}
-                </VBtn>
-              </template>
-
-              <VCard data-test="deploy-dialog">
-                <VCardTitle primary-title class="font-weight-bold title">
-                  {{ $tr('deployChannel') }}
-                </VCardTitle>
-                <VCardText>
-                  <p>{{ $tr('deployDialogDescription') }}</p>
-
-                  <VLayout data-test="deploy-dialog-live-resources">
-                    <VFlex xs4 class="font-weight-bold">
-                      {{ $tr('liveResources') }}:
-                    </VFlex>
-                    <VFlex>
-                      {{ $tr('topicsCount', { count: topicsCountLive }) }},
-                      {{ $tr('resourcesCount', { count: resourcesCountLive }) }}
-                    </VFlex>
-                  </VLayout>
-
-                  <VLayout data-test="deploy-dialog-staged-resources">
-                    <VFlex xs4 class="font-weight-bold">
-                      {{ $tr('stagedResources') }}:
-                    </VFlex>
-                    <VFlex>
-                      {{ $tr('topicsCount', { count: topicsCountStaged }) }},
-                      {{ $tr('resourcesCount', { count: resourcesCountStaged }) }}
-                    </VFlex>
-                  </VLayout>
-                </VCardText>
-                <VCardActions>
-                  <VSpacer />
-                  <VBtn
-                    flat
-                    @click="displayDeployDialog = false"
-                  >
-                    {{ $tr('cancelDeployBtn') }}
-                  </VBtn>
-                  <VBtn
-                    color="primary"
-                    data-test="deploy-btn"
-                    @click="onDeployChannelClick"
-                  >
-                    {{ $tr('confirmDeployBtn') }}
-                  </VBtn>
-                </VCardActions>
-              </VCard>
-            </VDialog>
+              {{ $tr('deployChannel') }}
+            </VBtn>
           </VFLex>
         </VLayout>
       </BottomBar>
@@ -249,6 +197,38 @@
         @cancel="displaySummaryDetailsDialog = false"
       >
         <DiffTable :stagingDiff="stagingDiff" @reload="reloadCurrentChannelStagingDiff" />
+      </KModal>
+
+      <KModal
+        v-if="displayDeployDialog"
+        data-test="deploy-dialog"
+        :title="$tr('deployChannel')"
+        :submitText="$tr('confirmDeployBtn')"
+        :cancelText="$tr('cancelDeployBtn')"
+        @submit="onDeployChannelClick"
+        @cancel="displayDeployDialog = false"
+      >
+        <p>{{ $tr('deployDialogDescription') }}</p>
+
+        <VLayout data-test="deploy-dialog-live-resources">
+          <VFlex xs4 class="font-weight-bold">
+            {{ $tr('liveResources') }}:
+          </VFlex>
+          <VFlex>
+            {{ $tr('topicsCount', { count: topicsCountLive }) }},
+            {{ $tr('resourcesCount', { count: resourcesCountLive }) }}
+          </VFlex>
+        </VLayout>
+
+        <VLayout data-test="deploy-dialog-staged-resources">
+          <VFlex xs4 class="font-weight-bold">
+            {{ $tr('stagedResources') }}:
+          </VFlex>
+          <VFlex>
+            {{ $tr('topicsCount', { count: topicsCountStaged }) }},
+            {{ $tr('resourcesCount', { count: resourcesCountStaged }) }}
+          </VFlex>
+        </VLayout>
       </KModal>
     </template>
   </div>

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -170,38 +170,13 @@
           </VFlex>
 
           <VFlex class="bottom-bar-btns">
-            <VDialog
-              v-model="displaySummaryDetailsDialog"
-              width="500"
+            <VBtn
+              flat
+              data-test="display-summary-details-dialog-btn"
+              @click="displaySummaryDetailsDialog = true"
             >
-              <template v-slot:activator="{ on }">
-                <VBtn
-                  flat
-                  data-test="display-summary-details-dialog-btn"
-                  v-on="on"
-                >
-                  {{ $tr('openSummaryDetailsDialogBtn') }}
-                </VBtn>
-              </template>
-
-              <VCard data-test="summary-details-dialog">
-                <VCardTitle primary-title class="font-weight-bold title">
-                  {{ $tr('summaryDetailsDialogTitle') }}
-                </VCardTitle>
-                <VCardText>
-                  <DiffTable :stagingDiff="stagingDiff" @reload="reloadCurrentChannelStagingDiff" />
-                </VCardText>
-                <VCardActions>
-                  <VSpacer />
-                  <VBtn
-                    color="primary"
-                    @click="displaySummaryDetailsDialog = false"
-                  >
-                    {{ $tr('closeSummaryDetailsDialogBtn') }}
-                  </VBtn>
-                </VCardActions>
-              </VCard>
-            </VDialog>
+              {{ $tr('openSummaryDetailsDialogBtn') }}
+            </VBtn>
 
             <VDialog
               v-model="displayDeployDialog"
@@ -265,6 +240,16 @@
           </VFLex>
         </VLayout>
       </BottomBar>
+
+      <KModal
+        v-if="displaySummaryDetailsDialog"
+        data-test="summary-details-dialog"
+        :title="$tr('summaryDetailsDialogTitle')"
+        :cancelText="$tr('closeSummaryDetailsDialogBtn')"
+        @cancel="displaySummaryDetailsDialog = false"
+      >
+        <DiffTable :stagingDiff="stagingDiff" @reload="reloadCurrentChannelStagingDiff" />
+      </KModal>
     </template>
   </div>
 


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made

Use KModal instead of VDialog on the staging tree page and related updates.

### Manual verification steps performed
1. Go to a staging tree page
2. Open and close summary modal
3. Open deploy modal and cancel deploy
4. Open deploy modal and confirm channel deploy

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

| Before | After |
| --------- | ------ |
| ![summary-details-before](https://user-images.githubusercontent.com/13509191/109797463-cf5df500-7c19-11eb-8560-d29a2461728e.png) | ![summary-details-after](https://user-images.githubusercontent.com/13509191/109797476-d553d600-7c19-11eb-8bb6-a3b4d22aed75.png) |
| ![deploy-before](https://user-images.githubusercontent.com/13509191/109797540-e6044c00-7c19-11eb-9a2e-dfc3aa1f3bf6.png) | ![deploy-after](https://user-images.githubusercontent.com/13509191/109797555-ea306980-7c19-11eb-9a4a-057d07149c0c.png) |

### Does this introduce any tech-debt items?

Nothing that I am aware of.

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

Follow the manual verifications steps above.

If you don't have a channel with a staging tree available for testing locally, you can create one in the following way:

1. Download one of our sushi chefs. I used [Let's Read Asia](https://github.com/learningequality/sushi-chef-lets-read-asia). If you'd like to use it too and don't want to run it a long time, you can modify [this line](https://github.com/learningequality/sushi-chef-lets-read-asia/blob/master/sushichef.py#L97) to `for book in books[:5]:`
2. [Install ricecooker](https://ricecooker.readthedocs.io/en/latest/installation.html)
3. Change `STUDIO_URL` environment variable to your local Studio instance (e.g. `export STUDIO_URL=http://127.0.0.1:8080/
`)
4. [Run the sushi chef](https://ricecooker.readthedocs.io/en/latest/tutorial/gettingstarted.html#running-the-sushichef-script) with a [token obtained](https://ricecooker.readthedocs.io/en/latest/tutorial/gettingstarted.html#obtaining-a-studio-access-token) from your local Studio
5. Navigate to the channel's list in Studio and open the channel
6. Navigate to a staging tree page by clicking on "Updated resources are ready for review " banner
 
![Screenshot from 2021-03-03 12-31-45](https://user-images.githubusercontent.com/13509191/109799575-793e8100-7c1c-11eb-93d0-4b6b3109f4f0.png)
 
## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
 
Part of https://github.com/learningequality/kolibri-design-system/issues/156

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specific:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
