### PR TITLE
Filter out revoked/declined/accepted invitations when loading sharing page; delete invalid invitations when view-access is revoked

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharingTable.vue
@@ -84,7 +84,7 @@
         <VBtn
           color="primary"
           data-test="confirm-remove"
-          @click="handleRemoveViewer(selected.id)"
+          @click="handleRemoveViewer(selected)"
         >
           {{ $tr('removeViewerConfirm') }}
         </VBtn>
@@ -253,13 +253,24 @@
           });
         });
       },
-      handleRemoveViewer(userId) {
+      handleRemoveViewer(user) {
+        const userId = user.id;
         this.showRemoveViewer = false;
-        this.removeViewer({ userId, channelId: this.channelId }).then(() => {
-          this.$store.dispatch('showSnackbar', {
-            text: this.$tr('userRemovedMessage'),
+        this.removeViewer({ userId, channelId: this.channelId })
+          .then(() => {
+            // In Vuex, delete any invitations for the same email address so they
+            // do not re-appear as pending invitations
+            this.invitations.forEach(invite => {
+              if (invite.email === user.email) {
+                this.$store.commit('channel/DELETE_INVITATION', invite.id);
+              }
+            });
+          })
+          .then(() => {
+            this.$store.dispatch('showSnackbar', {
+              text: this.$tr('userRemovedMessage'),
+            });
           });
-        });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
@@ -202,7 +202,7 @@ describe('Channel sharing vuex', () => {
     can_view: true,
     can_edit: false,
   };
-  let testInvitations
+  let testInvitations;
   function makeInvitations(channelId) {
     const base = {
       share_mode: SharingPermissions.EDIT,
@@ -211,7 +211,7 @@ describe('Channel sharing vuex', () => {
       declined: false,
       revoked: false,
       channel: channelId,
-    }
+    };
     return [
       {
         ...base,
@@ -226,8 +226,8 @@ describe('Channel sharing vuex', () => {
         ...base,
         id: 'revoked-invitation',
         revoked: true,
-      }
-    ]
+      },
+    ];
   }
   const channelDatum = {
     id: 'test',
@@ -243,7 +243,7 @@ describe('Channel sharing vuex', () => {
         ...testUser,
       };
       const invitations = makeInvitations(channelId);
-      testInvitations = invitations
+      testInvitations = invitations;
 
       return User.put(user).then(() => {
         return ViewerM2M.put({ user: user.id, channel: channelDatum.id }).then(() => {
@@ -354,7 +354,9 @@ describe('Channel sharing vuex', () => {
 
       Invitation.put(declinedInvitation).then(() => {
         store.dispatch('channel/loadChannelUsers', channelId).then(() => {
-          expect(Object.keys(store.state.channel.invitationsMap)).not.toContain('choosy-invitation');
+          expect(Object.keys(store.state.channel.invitationsMap)).not.toContain(
+            'choosy-invitation'
+          );
           done();
         });
       });

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/getters.js
@@ -44,10 +44,11 @@ export function getInvitation(state) {
 export function getChannelInvitations(state) {
   return function(channelId, shareMode = SharingPermissions.VIEW_ONLY) {
     return Object.values(state.invitationsMap).filter(
-      invitation => invitation.channel === channelId
-        && invitation.share_mode === shareMode
-        && !invitation.declined
-        && !invitation.revoked
+      invitation =>
+        invitation.channel === channelId &&
+        invitation.share_mode === shareMode &&
+        !invitation.declined &&
+        !invitation.revoked
     );
   };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/getters.js
@@ -44,7 +44,10 @@ export function getInvitation(state) {
 export function getChannelInvitations(state) {
   return function(channelId, shareMode = SharingPermissions.VIEW_ONLY) {
     return Object.values(state.invitationsMap).filter(
-      invitation => invitation.channel === channelId && invitation.share_mode === shareMode
+      invitation => invitation.channel === channelId
+        && invitation.share_mode === shareMode
+        && !invitation.declined
+        && !invitation.revoked
     );
   };
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/getters.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/getters.js
@@ -47,6 +47,7 @@ export function getChannelInvitations(state) {
       invitation =>
         invitation.channel === channelId &&
         invitation.share_mode === shareMode &&
+        !invitation.accepted &&
         !invitation.declined &&
         !invitation.revoked
     );


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

1. In the `getChannelInvitations` SPA, we filter out declined, revoked, and accepted Invitations so that they do not appear in the `ChannelSharing` page, even if they are still available in memory in the `channel/invitationsMap` or indexedDB. Fixes #2989 
2. In `ChannelSharingTable`, if a user is removed as a viewer, we also remove all invitations still in memory (in Vuex) for that user. This prevents that user's stale and accepted invite from reappearing in the table. Fixes #2990

Because these fixes make the starting state for #1404 impossible, it also Fixes #1404

### Manual verification steps performed

For Fix 1

1. Using the `user@c.com` created by the `devsetup` script, I invite `a@a.com` to be viewer of "empty channel". 
2. After logging in as `a@a.com`, I decline the invitation.
2. After logging back in as `user@c.com`, I see that `a@a.com`'s invite is gone (previously, it would show up upon logging in and going to the sharing page, but would disappear after a refresh)

For Fix 2

(Use two different browsers, e.g. firefox and chrome for each account)

1. As `c`, invite `a` to view a channel (do not leave the Sharing page)
2. As `a`, accept the invitation
3. As `c`, refresh the page to see that `a` has accepted the invitation (at this point, the invitation might still be in vuex in a stale unaccepted state).
4. As `c`, remove `a`'s view access
5. `a` should disappear from the table

### Does this introduce any tech-debt items?

The Fix for 2 probably should be implemented higher up as business logic, instead of being handled by the `ChannelSharingTable`. That is, the rule "if a user's view access is revoked, then all of that user's un-accepted invites should be invoked as well" should be implemented on the backend or elsewhere.

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [x] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [x] Automated test coverage is satisfactory
- [x] PR is fully functional
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] Contributor is in AUTHORS.md
Fixes #2989
- [ ] Documentation is updated
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
