### PR TITLE
Remove pagination code

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -35,12 +35,6 @@
                 fullWidth
               />
             </template>
-            <VLayout justify-center>
-              <Pagination
-                :pageNumber="page.page_number"
-                :totalPages="page.total_pages"
-              />
-            </VLayout>
           </VFlex>
         </VLayout>
       </VFlex>
@@ -52,12 +46,11 @@
 
 <script>
 
-  import uniq from 'lodash/uniq';
-  import { mapGetters, mapActions, mapState } from 'vuex';
+  import { mapGetters, mapActions } from 'vuex';
+  import sortBy from 'lodash/sortBy';
   import { RouterNames, CHANNEL_PAGE_SIZE } from '../../constants';
   import ChannelItem from './ChannelItem';
   import LoadingText from 'shared/views/LoadingText';
-  import Pagination from 'shared/views/Pagination';
   import { ChannelListTypes } from 'shared/constants';
 
   function listTypeValidator(value) {
@@ -70,7 +63,6 @@
     components: {
       ChannelItem,
       LoadingText,
-      Pagination,
     },
     props: {
       listType: {
@@ -85,14 +77,20 @@
       };
     },
     computed: {
-      ...mapGetters('channel', ['getChannels', 'channels']),
-      ...mapState('channel', ['page']),
+      ...mapGetters('channel', ['channels']),
       listChannels() {
-        const channels = this.isStarred ? this.channels : this.getChannels(uniq(this.page.results));
+        const channels = this.channels;
         if (!channels) {
           return [];
         }
-        return channels.filter(channel => channel[this.listType] && !channel.deleted);
+        const sortFields = ['-modified'];
+        if (this.listType === ChannelListTypes.PUBLIC) {
+          sortFields.shift('-priority');
+        }
+        return sortBy(
+          this.channels.filter(channel => channel[this.listType] && !channel.deleted),
+          sortFields
+        );
       },
       isEditable() {
         return this.listType === ChannelListTypes.EDITABLE;
@@ -140,7 +138,7 @@
           parameters.page_size = CHANNEL_PAGE_SIZE;
         }
 
-        this.loadChannelList(parameters).then(() => {
+        this.loadChannelList({ listType }).then(() => {
           this.loading = false;
         });
       },

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/channelList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/channelList.spec.js
@@ -10,7 +10,7 @@ localVue.use(VueRouter);
 
 const GETTERS = {
   channel: {
-    getChannels: jest.fn().mockReturnValue(() => []),
+    channels: jest.fn(),
   },
 };
 
@@ -27,9 +27,6 @@ function makeWrapper({ propsData = {}, getters = GETTERS, actions = ACTIONS } = 
     modules: {
       channel: {
         namespaced: true,
-        state: {
-          page: {},
-        },
         getters: getters.channel,
         actions: actions.channel,
       },
@@ -41,7 +38,6 @@ function makeWrapper({ propsData = {}, getters = GETTERS, actions = ACTIONS } = 
     localVue,
     router,
     store,
-    stubs: ['Pagination'],
   });
 }
 

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
@@ -68,7 +68,6 @@ export function acceptInvitation(context, invitationId) {
             data[permission] = false;
           });
           data[invitation.share_mode] = true;
-          context.commit('channel/ADD_CHANNEL_TO_PAGE', data.id, { root: true });
           context.commit('channel/UPDATE_CHANNEL', data, { root: true });
           return channel;
         });

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -10,14 +10,9 @@ export function loadChannelList(context, payload = {}) {
     payload[payload.listType] = true;
     delete payload.listType;
   }
-  return Channel.where(payload).then(pageData => {
-    if (pageData.results) {
-      context.commit('SET_PAGE', pageData);
-      context.commit('ADD_CHANNELS', pageData.results);
-      return pageData.results;
-    }
-    context.commit('ADD_CHANNELS', pageData);
-    return pageData;
+  return Channel.where(payload).then(channels => {
+    context.commit('ADD_CHANNELS', channels);
+    return channels;
   });
 }
 
@@ -58,7 +53,6 @@ export function createChannel(context) {
   };
   const channel = Channel.createObj(channelData);
   context.commit('ADD_CHANNEL', channel);
-  context.commit('ADD_CHANNEL_TO_PAGE', channel);
   return channel.id;
 }
 

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/index.js
@@ -30,14 +30,6 @@ export default {
      */
     channelViewersMap: {},
     channelsMap: {},
-    page: {
-      next: null,
-      previous: null,
-      page_number: null,
-      count: null,
-      total_pages: null,
-      results: [],
-    },
   }),
   getters,
   mutations,

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import map from 'lodash/map';
 import pick from 'lodash/pick';
 import { ContentDefaults, NEW_OBJECT } from 'shared/constants';
 import { mergeMapItem } from 'shared/vuex/utils';
@@ -109,27 +108,4 @@ export function REMOVE_EDITOR_FROM_CHANNEL(state, { channel, user } = {}) {
   if (state.channelEditorsMap[channel]) {
     Vue.delete(state.channelEditorsMap[channel], user);
   }
-}
-
-export function SET_PAGE(
-  state,
-  {
-    next = null,
-    previous = null,
-    page_number = null,
-    count = null,
-    total_pages = null,
-    results = [],
-  } = {}
-) {
-  state.page.next = next;
-  state.page.previous = previous;
-  state.page.page_number = page_number;
-  state.page.count = count;
-  state.page.total_pages = total_pages;
-  state.page.results = map(results, r => r.id);
-}
-
-export function ADD_CHANNEL_TO_PAGE(state, channelId) {
-  state.page.results = [channelId].concat(state.page.results);
 }


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR reverts our use of pagination on the channelList in Studio. It essentially just removes much of the added code from [this previous PR](https://github.com/learningequality/studio/pull/2788/files#diff-286de1f5ca6af1ae4b033d0eb77cd8698436b647a9b6aad82d3a3ff70171a962R13)

Fixes #3005 

### Manual verification steps performed
1. Add a new channel 
2. Navigate back to channel page 
3. All channels should continue to appear (none should disappear from the bottom) 

### Does this introduce any tech-debt items?
This will require re-adding pagination at a later date, as needed
___
## Reviewer guidance

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [x] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
