### PR TITLE
Content defaults reactivity fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -244,8 +244,8 @@
       contentDefaults: {
         get() {
           return {
-            ...(this.diffTracker.content_defaults || {}),
             ...(this.channel.content_defaults || {}),
+            ...(this.diffTracker.contentDefaults || {}),
           };
         },
         set(contentDefaults) {

--- a/contentcuration/contentcuration/frontend/shared/views/form/__tests__/contentDefaults.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/form/__tests__/contentDefaults.spec.js
@@ -100,7 +100,7 @@ function updateFormValues(wrapper, contentDefaults) {
 
 describe('contentDefaults', () => {
   describe('initial state', () => {
-    it('should fill fields with defaults', () => {
+    it('should fill fields with provided content defaults', () => {
       const contentDefaults = {
         author: 'Buster McTester',
         provider: 'USA',
@@ -117,7 +117,7 @@ describe('contentDefaults', () => {
       assertFormValues(wrapper, contentDefaults);
     });
 
-    it('should fill fields with defaults', () => {
+    it('should fill fields with default values when no content defaults provided', () => {
       const wrapper = makeWrapper({});
       assertFormValues(wrapper, constants.ContentDefaultsDefaults);
     });
@@ -131,7 +131,7 @@ describe('contentDefaults', () => {
   });
 
   describe('updating state', () => {
-    it('should update fields with new content defaults', () => {
+    it('should update fields with new content defaults received from a parent', () => {
       const contentDefaults = {
         author: 'Buster McTester',
         provider: 'USA',
@@ -159,7 +159,7 @@ describe('contentDefaults', () => {
       });
     });
 
-    it('should fill fields with defaults', () => {
+    it('should update a parent with new content defaults', () => {
       const setValues = {
         author: 'Buster McTester',
         provider: 'USA',

--- a/contentcuration/contentcuration/frontend/shared/views/form/__tests__/contentDefaults.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/form/__tests__/contentDefaults.spec.js
@@ -131,6 +131,34 @@ describe('contentDefaults', () => {
   });
 
   describe('updating state', () => {
+    it('should update fields with new content defaults', () => {
+      const contentDefaults = {
+        author: 'Buster McTester',
+        provider: 'USA',
+        aggregator: 'Aggregator R Us',
+        copyright_holder: 'Learning Equality',
+        license: 'Special Permissions',
+        license_description: 'You need to ask Buster first.',
+        auto_derive_audio_thumbnail: false,
+        auto_derive_document_thumbnail: true,
+        auto_derive_html5_thumbnail: true,
+        auto_derive_video_thumbnail: false,
+      };
+      const wrapper = makeWrapper(contentDefaults);
+      assertFormValues(wrapper, contentDefaults);
+
+      wrapper.setProps({
+        contentDefaults: {
+          ...contentDefaults,
+          author: 'Gabhowla Gabrielleclaw',
+        },
+      });
+      assertFormValues(wrapper, {
+        ...contentDefaults,
+        author: 'Gabhowla Gabrielleclaw',
+      });
+    });
+
     it('should fill fields with defaults', () => {
       const setValues = {
         author: 'Buster McTester',


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Make content defaults component reactive when updated data are provided by its parent (expected behavior of v-model) and a couple of other smaller fixes related to content defaults updates. Please see commit messages for details.

Fixes [part (1) ](https://github.com/learningequality/studio/issues/2888#issuecomment-795316259) of #2888. Please check https://github.com/learningequality/studio/issues/2888#issuecomment-795316259 before reviewing to understand the bug reported as there are more issues depending on `/sync` timing.

### Manual verification steps performed

1. Login to Studio
2. Click a Channel
3. Click the pencil icon to load the channel's edit details page
4. Make some amendments of the channel's content defaults
5. Click Save Changes button
6. Make sure to close the channel's edit details page before `/sync` gets called
7. Wait for `/sync` call to happen (otherwise you will run [into (2)](https://github.com/learningequality/studio/issues/2888#issuecomment-795316259) which has not been fixed yet)
8. Click the pencil icon to load the channel's edit details page
9. See the changes made are visible

### Screenshots (if applicable)

**After**

![Peek 2021-03-10 13-31](https://user-images.githubusercontent.com/13509191/110629885-fdf14800-81a4-11eb-930d-1e70caa014c9.gif)


### Does this introduce any tech-debt items?

Nothing that I am aware of.
___

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

Please follow manual verification steps.

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->

Please check that all content defaults updates are saved properly.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
