### PR TITLE
add distinct to pagination querysets

### DIFF
--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -79,6 +79,6 @@ def get_order_queryset(request, queryset, field_map):
     if request.GET.get("descending", "true") == "false" and order != "undefined":
         order = "-" + order
 
-    queryset = queryset.distinct().order_by() if order == "undefined" else queryset.order_by(order)
+    queryset = queryset.distinct().order_by() if order == "undefined" else queryset.distinct().order_by(order)
 
     return (order, queryset)

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -79,6 +79,6 @@ def get_order_queryset(request, queryset, field_map):
     if request.GET.get("descending", "true") == "false" and order != "undefined":
         order = "-" + order
 
-    queryset = queryset.order_by() if order == "undefined" else queryset.order_by(order)
+    queryset = queryset.distinct().order_by() if order == "undefined" else queryset.order_by(order)
 
     return (order, queryset)


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

This PR adds `.distinct()` to the pagination queryset. It is for the purpose of fixing pagination in the admin table, but hopefully will improve pagination overall. 

Fixes #2998 


### Manual verification steps performed
1. Signed in as an admin 
2. On the /administration page, searched a query
3. The correct count and users returned with correct pagination


### Screenshots (if applicable)
Before: 
![image](https://user-images.githubusercontent.com/17235236/111010151-a0572a00-8363-11eb-8eb6-0b61ba0e5ded.png)

After:
![admin-table](https://user-images.githubusercontent.com/17235236/111010139-96cdc200-8363-11eb-8fdf-dfb30f07f129.gif)

___
## Reviewer guidance
### How can a reviewer test these changes?

Testing with the Admin Table users tab 

1. Ensure you db has a number of users with editing permissions on various channels 
2. Sign in as an admin 
3. On the /administration page, go the the users tab and search 
4. The correct count and users should return, and the pagination should be correct 

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
