### PR TITLE
Remove Django Admin in production mode

### DIFF
--- a/contentcuration/contentcuration/dev_urls.py
+++ b/contentcuration/contentcuration/dev_urls.py
@@ -31,6 +31,7 @@ schema_view = get_schema_view(
 
 urlpatterns = urlpatterns + [
     url(r"^__open-in-editor/", webpack_redirect_view),
+    url(r'^admin/', include(admin.site.urls)),
     url(
         r"^swagger(?P<format>\.json|\.yaml)$",
         schema_view.without_ui(cache_timeout=0),

--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -9,7 +9,6 @@ from contentcuration.utils.secretmanagement import get_secret
 # production_settings.py -- production studio settings override
 #
 # noinspection PyUnresolvedReferences
-ADMIN_ENABLED = False
 
 MEDIA_ROOT = base_settings.STORAGE_ROOT
 

--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -9,6 +9,7 @@ from contentcuration.utils.secretmanagement import get_secret
 # production_settings.py -- production studio settings override
 #
 # noinspection PyUnresolvedReferences
+ADMIN_ENABLED = False
 
 MEDIA_ROOT = base_settings.STORAGE_ROOT
 

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -23,6 +23,8 @@ import pycountry
 from contentcuration.utils.incidents import INCIDENTS
 from contentcuration.utils.secretmanagement import get_secret
 
+ADMIN_ENABLED = True
+
 logging.getLogger("newrelic").setLevel(logging.CRITICAL)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 logging.getLogger("boto3").setLevel(logging.WARNING)
@@ -68,7 +70,6 @@ ALLOWED_HOSTS = ["*"]  # In production, we serve through a file socket, so this 
 
 INSTALLED_APPS = (
     'contentcuration.apps.ContentConfig',
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -87,6 +88,9 @@ INSTALLED_APPS = (
     'django_filters',
     'mathfilters',
 )
+
+if ADMIN_ENABLED is True:
+    INSTALLED_APPS.append('django.contrib.admin')
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -90,7 +90,7 @@ INSTALLED_APPS = (
 )
 
 if ADMIN_ENABLED is True:
-    INSTALLED_APPS.append('django.contrib.admin')
+    INSTALLED_APPS + ('django.contrib.admin',)
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -23,8 +23,6 @@ import pycountry
 from contentcuration.utils.incidents import INCIDENTS
 from contentcuration.utils.secretmanagement import get_secret
 
-ADMIN_ENABLED = True
-
 logging.getLogger("newrelic").setLevel(logging.CRITICAL)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 logging.getLogger("boto3").setLevel(logging.WARNING)
@@ -72,6 +70,7 @@ INSTALLED_APPS = (
     'contentcuration.apps.ContentConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.admin',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.sites',
@@ -88,9 +87,6 @@ INSTALLED_APPS = (
     'django_filters',
     'mathfilters',
 )
-
-if ADMIN_ENABLED is True:
-    INSTALLED_APPS + ('django.contrib.admin',)
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -179,6 +179,10 @@ urlpatterns += i18n_patterns(
     url(r'^api/deferred_user_data/$', registration_views.deferred_user_data, name="deferred_user_data"),
     url(r'^settings/$', settings_views.settings, name='settings'),
     url(r'^administration/', admin_views.administration, name='administration'),
-    url(r'^admin/', include(admin.site.urls)),
     url(r'^manifest.webmanifest$', pwa.ManifestView.as_view(), name="manifest"),
 )
+
+if settings.ADMIN_ENABLED is True:
+    urlpatterns += i18n_patterns(
+        url(r'^admin/', include(admin.site.urls)),
+    )

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -181,8 +181,3 @@ urlpatterns += i18n_patterns(
     url(r'^administration/', admin_views.administration, name='administration'),
     url(r'^manifest.webmanifest$', pwa.ManifestView.as_view(), name="manifest"),
 )
-
-if settings.ADMIN_ENABLED is True:
-    urlpatterns += i18n_patterns(
-        url(r'^admin/', include(admin.site.urls)),
-    )


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
To not run django in production mode I have made some changes in settings file as I added condition to it and done some changes in URL file too.

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
Issue - #3016
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
We can simply check if we can access the admin panel in production mode.

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
