### PR TITLE
Enable admin editing of channels in the UI.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/getters.js
@@ -6,17 +6,17 @@ export function getCurrentChannelStagingDiff(state) {
   return state.currentChannelStagingDiff;
 }
 
-export function canEdit(state, getters) {
+export function canEdit(state, getters, rootState, rootGetters) {
   return (
     getters.currentChannel &&
-    getters.currentChannel.edit &&
+    (getters.currentChannel.edit || rootGetters.isAdmin) &&
     !getters.currentChannel.ricecooker_version
   );
 }
 
 // Allow some extra actions for ricecooker channels
-export function canManage(state, getters) {
-  return getters.currentChannel && getters.currentChannel.edit;
+export function canManage(state, getters, rootState, rootGetters) {
+  return getters.currentChannel && (getters.currentChannel.edit || rootGetters.isAdmin);
 }
 
 // For the most part, we use !canEdit, but this is a way of

--- a/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
@@ -78,6 +78,9 @@ export default {
     clipboardRootId(state) {
       return state.currentUser.clipboard_tree_id;
     },
+    isAdmin(state) {
+      return state.currentUser.is_admin;
+    },
   },
   actions: {
     async saveSession(context, currentUser) {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

* Adds isAdmin getter to session vuex module
* Uses isAdmin getter to allow editing and managing of any channel, regardless of whether a user is a direct admin


### Manual verification steps performed
1. Create a new super user with `./contentcuration/manage.py createsuperuser`
2. Activate the super user
3. Login
4. Navigate to any channel
5. Confirm that the UI now lets you edit

## References
Fixes #3015

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
