### PR TITLE
Use 'usage' to ensure polyfills.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,7 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        useBuiltIns: 'entry',
+        useBuiltIns: 'usage',
         corejs: '3',
       },
     ],

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -1,4 +1,3 @@
-import 'core-js';
 import 'regenerator-runtime/runtime';
 import Vue from 'vue';
 import VueRouter from 'vue-router';

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
@@ -22,7 +22,7 @@ export const imageMdToParams = imageMd => {
 };
 
 export const paramsToImageMd = ({ src, alt, width, height }) => {
-  src = src.split('/').lastItem;
+  src = src.split('/').slice(-1)[0];
   if (width && width !== 'auto' && height && height !== 'auto') {
     return `![${alt}](${IMAGE_PLACEHOLDER}/${src} =${width}x${height})`;
   } else {

--- a/jest_config/setup.js
+++ b/jest_config/setup.js
@@ -1,4 +1,3 @@
-import 'core-js';
 import 'regenerator-runtime/runtime';
 import * as Aphrodite from 'aphrodite';
 import * as AphroditeNoImportant from 'aphrodite/no-important';


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* We were using the `entry` option for `useBuiltIns` for `babel/preset-env`
* This was causing some things to not be fully polyfilled
* Switching to `usage` seems to do the trick instead, which allows us to defer to babel as to which things should be polyfilled.


### Manual verification steps performed
1. Build studio frontend code: `yarn run build`
2. Run only `yarn run runserver`
3. Visit your local devserver via BrowserStack with a version of Opera browser < 56
4. Confirm in the developer console that `Array.prototype.flat` is defined, and that no errors from calling the method `flat` occur in the JS console on the Channel List page.

## References
Fixes #2855

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
