### PR TITLE
Revert "Check event has a target before checking the target tagName."

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -263,7 +263,7 @@
       ...mapActions('task', ['deleteTask']),
       handleTileClick(e) {
         // Ensures that clicking an icon button is not treated the same as clicking the card
-        if (e.target && e.target.tagName !== 'svg' && !this.copying) {
+        if (e.target.tagName !== 'svg' && !this.copying) {
           this.isTopic ? this.$emit('topicChevronClick') : this.$emit('infoClick');
         }
       },


### PR DESCRIPTION
Reverts learningequality/studio#3053 -- this change will be included in the next sprint release