### PR TITLE
KDS to Studio: Replace ResponsiveDialog by KModal in SavedSearchesModal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
@@ -7,7 +7,7 @@
       :cancelText="$tr('closeButtonLabel')"
       @cancel="dialog = false"
     >
-      <LoadingText v-if="loading" />
+      <KCircularLoader v-if="loading" :size="40" />
       <p v-else-if="savedSearches.length === 0" class="grey--text pa-2">
         {{ $tr('noSavedSearches') }}
       </p>
@@ -89,7 +89,6 @@
   import EditSearchModal from './EditSearchModal';
   import MessageDialog from 'shared/views/MessageDialog';
   import IconButton from 'shared/views/IconButton';
-  import LoadingText from 'shared/views/LoadingText';
 
   export default {
     name: 'SavedSearchesModal',
@@ -98,7 +97,6 @@
       EditSearchModal,
       MessageDialog,
       IconButton,
-      LoadingText,
     },
     props: {
       value: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
@@ -1,57 +1,59 @@
 <template>
 
-  <ResponsiveDialog
-    v-model="dialog"
-    width="600px"
-    :header="$tr('savedSearchesTitle')"
-  >
-    <LoadingText v-if="loading" />
-    <p v-else-if="savedSearches.length === 0" class="grey--text pa-2">
-      {{ $tr('noSavedSearches') }}
-    </p>
-    <VList v-else>
-      <template v-for="(search, index) in savedSearches">
-        <VListTile :key="index" class="py-2">
-          <VListTileContent>
-            <VListTileTitle>
-              <ActionLink
-                class="font-weight-bold"
-                :to="searchResultsRoute(search)"
-                :text="search.name"
-                @click="dialog = false"
+  <div>
+    <ResponsiveDialog
+      v-model="dialog"
+      width="600px"
+      :header="$tr('savedSearchesTitle')"
+    >
+      <LoadingText v-if="loading" />
+      <p v-else-if="savedSearches.length === 0" class="grey--text pa-2">
+        {{ $tr('noSavedSearches') }}
+      </p>
+      <VList v-else>
+        <template v-for="(search, index) in savedSearches">
+          <VListTile :key="index" class="py-2">
+            <VListTileContent>
+              <VListTileTitle>
+                <ActionLink
+                  class="font-weight-bold"
+                  :to="searchResultsRoute(search)"
+                  :text="search.name"
+                  @click="dialog = false"
+                />
+              </VListTileTitle>
+              <VListTileSubTitle class="metadata">
+                <span>
+                  {{ $formatRelative(search.created, { now: new Date() }) }}
+                </span>
+                <span>
+                  {{ $tr('filterCount', { count: searchFilterCount(search) }) }}
+                </span>
+              </VListTileSubTitle>
+            </VListTileContent>
+
+            <VListTileAction>
+              <IconButton
+                icon="edit"
+                color="grey"
+                :text="$tr('editAction')"
+                @click="handleClickEdit(search.id)"
               />
-            </VListTileTitle>
-            <VListTileSubTitle class="metadata">
-              <span>
-                {{ $formatRelative(search.created, { now: new Date() }) }}
-              </span>
-              <span>
-                {{ $tr('filterCount', { count: searchFilterCount(search) }) }}
-              </span>
-            </VListTileSubTitle>
-          </VListTileContent>
+            </VListTileAction>
 
-          <VListTileAction>
-            <IconButton
-              icon="edit"
-              color="grey"
-              :text="$tr('editAction')"
-              @click="handleClickEdit(search.id)"
-            />
-          </VListTileAction>
-
-          <VListTileAction>
-            <IconButton
-              icon="clear"
-              color="grey"
-              :text="$tr('deleteAction')"
-              @click="handleClickDelete(search.id)"
-            />
-          </VListTileAction>
-        </VListTile>
-        <VDivider v-if="index < savedSearches.length - 1" :key="index + 'divider'" />
-      </template>
-    </VList>
+            <VListTileAction>
+              <IconButton
+                icon="clear"
+                color="grey"
+                :text="$tr('deleteAction')"
+                @click="handleClickDelete(search.id)"
+              />
+            </VListTileAction>
+          </VListTile>
+          <VDivider v-if="index < savedSearches.length - 1" :key="index + 'divider'" />
+        </template>
+      </VList>
+    </ResponsiveDialog>
 
     <MessageDialog
       v-model="showDelete"
@@ -75,7 +77,7 @@
       @submit="showEdit = false"
       @cancel="showEdit = false"
     />
-  </ResponsiveDialog>
+  </div>
 
 </template>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SavedSearchesModal.vue
@@ -1,10 +1,11 @@
 <template>
 
   <div>
-    <ResponsiveDialog
-      v-model="dialog"
-      width="600px"
-      :header="$tr('savedSearchesTitle')"
+    <KModal
+      v-if="dialog"
+      :title="$tr('savedSearchesTitle')"
+      :cancelText="$tr('closeButtonLabel')"
+      @cancel="dialog = false"
     >
       <LoadingText v-if="loading" />
       <p v-else-if="savedSearches.length === 0" class="grey--text pa-2">
@@ -53,7 +54,7 @@
           <VDivider v-if="index < savedSearches.length - 1" :key="index + 'divider'" />
         </template>
       </VList>
-    </ResponsiveDialog>
+    </KModal>
 
     <MessageDialog
       v-model="showDelete"
@@ -89,7 +90,6 @@
   import MessageDialog from 'shared/views/MessageDialog';
   import IconButton from 'shared/views/IconButton';
   import LoadingText from 'shared/views/LoadingText';
-  import ResponsiveDialog from 'shared/views/ResponsiveDialog';
 
   export default {
     name: 'SavedSearchesModal',
@@ -99,7 +99,6 @@
       MessageDialog,
       IconButton,
       LoadingText,
-      ResponsiveDialog,
     },
     props: {
       value: {
@@ -180,6 +179,7 @@
       },
     },
     $trs: {
+      closeButtonLabel: 'Close',
       editAction: 'Edit',
       deleteAction: 'Delete',
       savedSearchesTitle: 'Saved searches',


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made

Replace `ResponsiveDialog` by `KModal` in `SavedSearchesModal`

### Manual verification steps performed
1. Open the channel editor page for a channel that you can edit
2. Click "ADD" dropdown button in the upper right corner
3. Select "Import from channels"
4. Type a search string to search input and click "SEARCH" button
5. Click "View saved searches" (to see some searches in "Saved searches" modal, you can click "Save search" before opening the modal)

### Screenshots
<!-- If not applicable, please delete this section -->

| Before | After |
|----------|--------|
| ![loading-before](https://user-images.githubusercontent.com/13509191/113100644-f3522d80-91fb-11eb-9b6e-da052cdb895d.png) | ![loading-after](https://user-images.githubusercontent.com/13509191/113100664-f8af7800-91fb-11eb-8f66-9cc17c2690bc.png) |
| ![no_searches-before](https://user-images.githubusercontent.com/13509191/113100688-ff3def80-91fb-11eb-9309-72c47b6e6923.png) | ![no_searches-after](https://user-images.githubusercontent.com/13509191/113100698-0402a380-91fc-11eb-8a6e-12f4e68f1aa1.png) |
| ![searches-before](https://user-images.githubusercontent.com/13509191/113100713-0c5ade80-91fc-11eb-9a2d-9a70f504e9f2.png) | ![searches-after](https://user-images.githubusercontent.com/13509191/113100723-111f9280-91fc-11eb-95c5-2d3dbde22055.png) |

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

Nothing that I am aware of regarding Studio code.
I've discovered a bug in KDS that has been [reported here](https://github.com/learningequality/kolibri-design-system/issues/210).

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

Please follow "Manual verification steps"

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->

Please check that you can edit and remove saved searches

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

Part of https://github.com/learningequality/kolibri-design-system/issues/157

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
