### PR TITLE
Use get_or_create_async_task for queuing user storage calc task

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1701,7 +1701,7 @@ class ContentNode(MPTTModel, models.Model):
 
     def recalculate_editors_storage(self):
         from contentcuration.utils.user import calculate_user_storage
-        for editor in self.files.values_list('uploaded_by_id', flat=True):
+        for editor in self.files.values_list('uploaded_by_id', flat=True).distinct():
             calculate_user_storage(editor)
 
     def on_create(self):

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -8,7 +8,6 @@ from builtins import str
 from celery import states
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from django.core.cache import cache
 from django.core.mail import EmailMessage
 from django.db import IntegrityError
 from django.db.utils import OperationalError
@@ -27,7 +26,6 @@ from contentcuration.utils.nodes import calculate_resource_size
 from contentcuration.utils.nodes import generate_diff
 from contentcuration.utils.publish import publish_channel
 from contentcuration.utils.sync import sync_channel
-from contentcuration.utils.user import CACHE_USER_STORAGE_KEY
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import CONTENTNODE
 from contentcuration.viewsets.sync.constants import COPYING_FLAG
@@ -266,7 +264,6 @@ def calculate_user_storage_task(user_id):
     try:
         user = User.objects.get(pk=user_id)
         user.set_space_used()
-        cache.delete(CACHE_USER_STORAGE_KEY.format(user_id))
     except User.DoesNotExist:
         logging.error("Tried to calculate user storage for user with id {} but they do not exist".format(user_id))
 
@@ -296,6 +293,7 @@ type_mapping = {
     "export-channel": export_channel_task,
     "sync-channel": sync_channel_task,
     "get-node-diff": generatenodediff_task,
+    "calculate-user-storage": calculate_user_storage_task,
     "calculate-resource-size": calculate_resource_size_task,
 }
 


### PR DESCRIPTION
## Summary
We observed some slowdowns on `hotfixes` likely due to the user storage calculation query. We recently added `get_or_create_async_task` to only queue a task if there isn't one pending. The queuing of the user storage calculation task was using another approach, based off a cache value that may not work as expected (and observed odd behavior locally).

### Description of the change(s) you made
Updated the queuing of the user storage calculation task to use `get_or_create_asyn_task`, and updated one instance that could call the function multiple times with the same user.

### Manual verification steps performed
1. Upload a file
2. Verify a calculation task was queued and executed
3. Move the file to trash
4. Verify a calculation task was queued and executed

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
We should move `contentcuration.utils.user.calculate_user_storage` to the User model, since we require a User object for queuing tasks.

___
## Reviewer guidance
### How can a reviewer test these changes?
There isn't visibility into this particular task on the front-end, unfortunately.

----

### Contributor's Checklist

Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
