### PR TITLE
KDS to Studio: Replace ResponsiveDialog by KModal in InfoModal

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
@@ -1,35 +1,38 @@
 <template>
 
-  <ResponsiveDialog
-    v-model="dialog"
-    width="550"
-    :header="header"
-  >
-    <template #activator="{ on }">
-      <Icon color="primary" v-on="on">
-        help
-      </Icon>
-    </template>
-    <slot></slot>
-    <div v-for="(item, index) in items" :key="`info-${index}`" class="mb-4">
-      <h1 class="font-weight-bold mb-1 subheading">
-        <slot name="header" :item="item"></slot>
-      </h1>
-      <p class="body-1 grey--text">
-        <slot name="description" :item="item"></slot>
-      </p>
-    </div>
-  </ResponsiveDialog>
+  <div :style="{ display: 'inline' }">
+    <Icon
+      color="primary"
+      data-test="info-icon"
+      @click="displayDialog = !displayDialog"
+    >
+      help
+    </Icon>
+    <KModal
+      v-if="displayDialog"
+      data-test="info-dialog"
+      :title="header"
+      :cancelText="$tr('close')"
+      @cancel="displayDialog = false"
+    >
+      <slot></slot>
+      <div v-for="(item, index) in items" :key="`info-${index}`" class="mb-4 mt-3">
+        <h1 class="font-weight-bold mb-1 subheading">
+          <slot name="header" :item="item"></slot>
+        </h1>
+        <p class="body-1 grey--text">
+          <slot name="description" :item="item"></slot>
+        </p>
+      </div>
+    </KModal>
+  </div>
 
 </template>
 
 <script>
 
-  import ResponsiveDialog from './ResponsiveDialog';
-
   export default {
     name: 'InfoModal',
-    components: { ResponsiveDialog },
     props: {
       header: {
         type: String,
@@ -44,8 +47,11 @@
     },
     data() {
       return {
-        dialog: false,
+        displayDialog: false,
       };
+    },
+    $trs: {
+      close: 'Close',
     },
   };
 
@@ -55,6 +61,7 @@
 
   /deep/ p {
     font-size: 12pt;
+    line-height: normal;
     color: var(--v-grey-darken3);
   }
 

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/infoModal.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/infoModal.spec.js
@@ -1,40 +1,31 @@
-import Vue from 'vue';
-import Vuetify from 'vuetify';
 import { mount } from '@vue/test-utils';
 import InfoModal from '../InfoModal.vue';
 
-Vue.use(Vuetify);
-
-document.body.setAttribute('data-app', true); // Vuetify prints a warning without this
-
 function makeWrapper(props = {}) {
   return mount(InfoModal, {
-    attachToDocument: true,
     propsData: props,
-    slots: {
-      content: 'Test Content',
-    },
   });
 }
 
-describe('infoModal', () => {
+describe('InfoModal', () => {
   let wrapper;
-  beforeEach(() => {
-    wrapper = makeWrapper({ header: 'testHeader' });
-  });
-  it('clicking the info button should open the dialog', () => {
-    expect(wrapper.find('.v-dialog').isVisible()).toBe(false);
-    let button = wrapper.find('.v-icon');
-    button.trigger('click');
-    expect(wrapper.find('.v-dialog').isVisible()).toBe(true);
-  });
-  it('clicking the close button should close the dialog', () => {
-    let button = wrapper.find('.v-icon');
-    button.trigger('click');
-    expect(wrapper.find('.v-dialog').isVisible()).toBe(true);
 
-    let closeButton = wrapper.find('.v-card__actions .v-btn');
-    closeButton.trigger('click');
-    expect(wrapper.find('.v-dialog').isVisible()).toBe(false);
+  beforeEach(() => {
+    wrapper = makeWrapper();
+  });
+
+  it('clicking the info button should open the dialog', () => {
+    expect(wrapper.contains('[data-test="info-dialog"]')).toBe(false);
+
+    wrapper.find('[data-test="info-icon"]').trigger('click');
+    expect(wrapper.find('[data-test="info-dialog"]').isVisible()).toBe(true);
+  });
+
+  it('clicking the close button should close the dialog', () => {
+    wrapper.find('[data-test="info-icon"]').trigger('click');
+    expect(wrapper.find('[data-test="info-dialog"]').isVisible()).toBe(true);
+
+    wrapper.find('[data-test="info-dialog"]').vm.$emit('cancel');
+    expect(wrapper.contains('[data-test="info-dialog"]')).toBe(false);
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/masteryDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/masteryDropdown.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import MasteryDropdown from '../MasteryDropdown.vue';
-import InfoModal from '../InfoModal.vue';
 import TestForm from './TestForm.vue';
 import { constantStrings } from 'shared/mixins';
 import MasteryModels from 'shared/leUtils/MasteryModels';
@@ -87,14 +86,6 @@ describe('masteryDropdown', () => {
         expect(mInput.attributes('disabled')).toEqual('disabled');
         expect(nInput.attributes('disabled')).toEqual('disabled');
       });
-    });
-  });
-  describe('mastery model info modal', () => {
-    it('should open the info modal when button is clicked', () => {
-      expect(wrapper.find('.v-dialog').isVisible()).toBe(false);
-      let button = wrapper.find(InfoModal).find('.v-icon');
-      button.trigger('click');
-      expect(wrapper.find('.v-dialog').isVisible()).toBe(true);
     });
   });
   describe('emitted events', () => {

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/visibilityDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/visibilityDropdown.spec.js
@@ -1,6 +1,5 @@
 import _ from 'underscore';
 import { mount } from '@vue/test-utils';
-import InfoModal from '../InfoModal.vue';
 import VisibilityDropdown from '../VisibilityDropdown.vue';
 import TestForm from './TestForm.vue';
 import Roles from 'shared/leUtils/Roles';
@@ -80,14 +79,6 @@ describe('visibilityDropdown', () => {
           .find('input')
           .attributes('disabled')
       ).toEqual('disabled');
-    });
-  });
-  describe('visibility info modal', () => {
-    it('should open the info modal when button is clicked', () => {
-      expect(wrapper.find('.v-dialog').isVisible()).toBe(false);
-      let button = wrapper.find(InfoModal).find('.v-icon');
-      button.trigger('click');
-      expect(wrapper.find('.v-dialog').isVisible()).toBe(true);
     });
   });
   describe('emitted events', () => {


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

Replace `ResponsiveDialog` by `KModal` in `InfoModal`, which affects the following:
- storage request form in settings
- visibility, license, and mastery model dropdowns on resource edit page

### Manual verification steps performed

**Storage request form in settings**

1. Go to "Settings" -> "Storage" tab
2. Click "Open form" in "Request more space" section
3. See the help icon next to "Who can use your content?"
4. Click the icon
5. See the modal with information on licenses to appear
6. Close the modal by clicking "Close" button or by pressing "Escape" key

**Visibility dropdown on resource edit page**

1. Go to a channel editor for a channel that you can edit
2. Go to the edit page for a resource
3. Navigate to "Audience" section of "Details" tab
4. See the help icon next to "Visible to" dropdown
5. Click the icon
6. See the modal with information on resource visibility to appear
7. Close the modal by clicking "Close" button or by pressing "Escape" key

**License dropdown on resource edit page**

1. Go to a channel editor for a channel that you can edit
2. Go to the edit page for a resource
3. Navigate to "Source" section of "Details" tab
4. See the help icon next to "License" dropdown
5. Click the icon
6. See the modal with information on licenses to appear
7. Close the modal by clicking "Close" button or by pressing "Escape" key

**Mastery model dropdown on resource edit page**

1. Go to a channel editor for a channel that you can edit
2. Go to the edit page for an exercise resource
3. Navigate to "Assessment options" section of "Details" tab
4. See the help icon next to "Mastery criteria" dropdown
5. Click the icon
6. See the modal with information on exercises to appear
7. Close the modal by clicking "Close" button or by pressing "Escape" key

### Screenshots

**Storage request form in settings**

| Before | After |
|-----------|--------|
| ![storage-request-modal-before](https://user-images.githubusercontent.com/13509191/113990837-29be2700-9852-11eb-8511-e9652648e2d4.png) | ![storage-request-modal-after](https://user-images.githubusercontent.com/13509191/113990853-2fb40800-9852-11eb-8ec1-859ec0730226.png) |

**Visibility dropdown on resource edit page**

| Before | After |
|-----------|--------|
| ![edit-visibility-modal-before](https://user-images.githubusercontent.com/13509191/113990916-3e9aba80-9852-11eb-9b4f-ce1b0593241f.png) | ![edit-visibility-modal-after](https://user-images.githubusercontent.com/13509191/113990934-435f6e80-9852-11eb-826e-c8501a9174d5.png) |

**License dropdown on resource edit page**

| Before | After |
|-----------|--------|
| ![edit-license-modal-before](https://user-images.githubusercontent.com/13509191/113991035-5a9e5c00-9852-11eb-9fba-f350753fa418.png) | ![edit-license-modal-after](https://user-images.githubusercontent.com/13509191/113991052-5eca7980-9852-11eb-9c11-58b0dcb46596.png) |

**Mastery model dropdown on resource edit page**

| Before | After |
|-----------|--------|
| ![edit-mastery-modal-before](https://user-images.githubusercontent.com/13509191/113991082-668a1e00-9852-11eb-9131-b062d8fb1d90.png) | ![edit-mastery-modal-after](https://user-images.githubusercontent.com/13509191/113991102-6c7fff00-9852-11eb-9e4d-f34e5d72f0a9.png) |

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

Nothing that I am aware of.

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

Please follow "Manual verification steps"

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

Part of https://github.com/learningequality/kolibri-design-system/issues/157

## Comments
<!-- Additional comments may be added here -->

An alternative solution would be to get rid of `InfoModal` altogether and use `KModal` directly from the places where `InfoModal` is used. I've decided to keep `InfoModal` because I find it to be a useful abstraction as it also contains the logic related to the info icon and opening/closing the modal which would otherwise need to be implemented in every component that uses `InfoModal`.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
