### PR TITLE
Pagination integration proof of concept

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/mixins.js
+++ b/contentcuration/contentcuration/frontend/administration/mixins.js
@@ -3,7 +3,6 @@ import difference from 'lodash/difference';
 import findKey from 'lodash/findKey';
 import intersection from 'lodash/intersection';
 import transform from 'lodash/transform';
-import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
 
 function _getBooleanVal(value) {
@@ -137,10 +136,10 @@ export const tableMixin = {
           {
             ...this.$route.query,
             page_size: pagination.rowsPerPage,
-            ...omit(pagination, ['rowsPerPage', 'totalItems']),
+            ...pagination,
           },
-          value => {
-            return value !== null;
+          (value, key) => {
+            return value !== null && key !== 'rowsPerPage' && key !== 'totalItems';
           }
         );
 
@@ -156,6 +155,17 @@ export const tableMixin = {
           });
       },
     },
+    fetchParams() {
+      const params = {
+        ...this.$route.query,
+      };
+      if (params.sortBy) {
+        params.ordering = (params.descending ? '-' : '') + params.sortBy;
+        delete params.sortBy;
+        delete params.descending;
+      }
+      return params;
+    },
   },
   watch: {
     '$route.query'() {
@@ -168,7 +178,7 @@ export const tableMixin = {
   methods: {
     _loadItems() {
       this.loading = true;
-      this.fetch(this.$route.query).then(() => {
+      this.fetch(this.fetchParams).then(() => {
         this.loading = false;
       });
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
@@ -78,7 +78,7 @@
           ),
 
           // Channels
-          ...this.channels.map(channelId =>
+          ...this.channel_id__in.map(channelId =>
             createFilter(
               channelId,
               this.getChannelName(channelId),

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -13,7 +13,7 @@
       :menu-props="menuProps"
     />
     <MultiSelect
-      v-model="channels"
+      v-model="channel_id__in"
       :label="$tr('channelSourceLabel')"
       :items="channelOptions"
       item-text="name"
@@ -197,8 +197,8 @@
       loadChannels(listType) {
         this.loadingChannels = true;
         this.loadChannelList({ listType }).then(channels => {
-          if (this.channels.length) {
-            this.channels = [];
+          if (this.channel_id__in.length) {
+            this.channel_id__in = [];
           }
 
           this.channelOptions = channels.filter(c => c.id !== this.currentChannelId);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/mixins.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/mixins.js
@@ -4,7 +4,7 @@ import { generateSearchMixin } from 'shared/mixins';
 const searchFilters = {
   kinds: filterTypes.MULTISELECT,
   resources: filterTypes.BOOLEAN,
-  channels: filterTypes.MULTISELECT,
+  channel_id__in: filterTypes.MULTISELECT,
   languages: filterTypes.MULTISELECT,
   licenses: filterTypes.MULTISELECT,
   coach: filterTypes.BOOLEAN,

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -9,6 +9,7 @@ import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import matches from 'lodash/matches';
 import overEvery from 'lodash/overEvery';
+import pick from 'lodash/pick';
 import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
@@ -57,26 +58,20 @@ const validPositions = new Set(Object.values(RELATIVE_TREE_POSITIONS));
 
 const EMPTY_ARRAY = Symbol('EMPTY_ARRAY');
 
-const PAGE_NUMBER_KEYS = new Set(['page', 'page_size']);
-
-const LIMIT_OFFSET_KEYS = new Set(['page', 'page_size']);
-
 class Paginator {
   constructor(params) {
-    for (let key of PAGE_NUMBER_KEYS) {
-      if (params[key]) {
-        this[key] = params[key];
-      }
-    }
+    // Get parameters for page number based pagination
+    Object.assign(this, pick(params, 'page', 'page_size'));
+    // At a minimum, this pagination style requires a page_size
+    // parameter, so we check to see if that exists.
     if (this.page_size) {
       this.pageNumberType = true;
       this.page = this.page || 1;
     }
-    for (let key of LIMIT_OFFSET_KEYS) {
-      if (params[key]) {
-        this[key] = params[key];
-      }
-    }
+    // Get parameters for limit offset pagination
+    Object.assign(this, pick(params, 'limit', 'offset'));
+    // At a minimum, this pagination style requires a limit
+    // parameter, so we check to see if that exists.
     if (this.limit) {
       this.limitOffsetType = true;
       this.offset = this.offset || 0;

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -89,7 +89,7 @@ class ValuesViewsetPageNumberPagination(PageNumberPagination):
     def get_paginated_response(self, data):
         return Response(
             {
-                "page_number": self.page.number,
+                "page": self.page.number,
                 "count": self.page.paginator.count,
                 "total_pages": self.page.paginator.num_pages,
                 "results": data,
@@ -105,6 +105,14 @@ class ValuesViewsetPageNumberPagination(PageNumberPagination):
                     'example': 123,
                 },
                 'results': schema,
+                'page': {
+                    'type': 'integer',
+                    'example': 123,
+                },
+                'total_pages': {
+                    'type': 'integer',
+                    'example': 123,
+                },
             },
         }
 

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -25,7 +25,7 @@ class ValuesViewsetPaginator(Paginator):
         if not isinstance(object_list, QuerySet):
             raise TypeError("ValuesViewsetPaginator is only intended for use with Querysets")
         self.queryset = object_list
-        object_list = object_list.values_list("pk", flat=True)
+        object_list = object_list.values_list("pk", flat=True).distinct()
         return super(ValuesViewsetPaginator, self).__init__(object_list, *args, **kwargs)
 
     def _get_page(self, object_list, *args, **kwargs):

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -2,7 +2,6 @@ import re
 
 from django.db import transaction
 from django_bulk_update.helper import bulk_update
-from django_filters.rest_framework import DjangoFilterBackend
 from le_utils.constants import exercises
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import ValidationError
@@ -196,7 +195,6 @@ class AssessmentItemViewSet(BulkCreateMixin, BulkUpdateMixin, ValuesViewset):
     queryset = AssessmentItem.objects.all()
     serializer_class = AssessmentItemSerializer
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = AssessmentItemFilter
     values = (
         "question",

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -378,6 +378,8 @@ class ValuesViewsetOrderingFilter(OrderingFilter):
                     ordering.append(new_term)
                 else:
                     ordering.append(term)
+        if len(ordering) > 1:
+            raise ValidationError("Can only define a single ordering field")
         return ordering
 
 

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -354,7 +354,8 @@ class ValuesViewsetOrderingFilter(OrderingFilter):
         mapped_fields = {v: k for k, v in view.field_map.items() if isinstance(v, str)}
         model_fields = {f.name for f in queryset.model._meta.get_fields()}
         for field in view.values:
-            if field in model_fields or field in queryset.query.annotations:
+            fk_ref = field.split("__")[0]
+            if field in model_fields or field in queryset.query.annotations or fk_ref in model_fields:
                 if field in mapped_fields:
                     default_fields.add((mapped_fields[field], mapped_fields[field]))
                 else:

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -350,12 +350,36 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
 class ValuesViewsetOrderingFilter(OrderingFilter):
 
     def get_default_valid_fields(self, queryset, view, context={}):
+        """
+        The original implementation of this makes the assumption that the DRF serializer for the class
+        encodes all the serialization behaviour for the viewset:
+        https://github.com/encode/django-rest-framework/blob/version-3.12.2/rest_framework/filters.py#L208
+
+        With the ValuesViewset, this is no longer the case so here we do an equivalent mapping from the values
+        defined by the values viewset, with consideration for the mapped fields.
+
+        Importantly, we filter out values that have not yet been annotated on the queryset, so if an annotated
+        value is requried for ordering, it should be defined in the get_queryset method of the viewset, and not
+        the annotate_queryset method, which is executed after filtering.
+        """
         default_fields = set()
+        # All the fields that we have field maps defined for - this only allows for simple mapped fields
+        # where the field is essentially a rename, as we have no good way of doing ordering on a field that
+        # that is doing more complex function based mapping.
         mapped_fields = {v: k for k, v in view.field_map.items() if isinstance(v, str)}
+        # All the fields of the model
         model_fields = {f.name for f in queryset.model._meta.get_fields()}
+        # Loop through every value in the view's values tuple
         for field in view.values:
+            # If the value is for a foreign key lookup, we split it here to make sure that the first relation key
+            # exists on the model - it's unlikely this would ever not be the case, as otherwise the viewset would
+            # be returning 500s.
             fk_ref = field.split("__")[0]
+            # Check either if the field is a model field, a currently annotated annotation, or
+            # is a foreign key lookup on an FK on this model.
             if field in model_fields or field in queryset.query.annotations or fk_ref in model_fields:
+                # If the field is a mapped field, we store the field name as returned to the client
+                # not the actual internal field - this will later be mapped when we come to do the ordering.
                 if field in mapped_fields:
                     default_fields.add((mapped_fields[field], mapped_fields[field]))
                 else:
@@ -368,12 +392,15 @@ class ValuesViewsetOrderingFilter(OrderingFilter):
         Modified from https://github.com/encode/django-rest-framework/blob/version-3.12.2/rest_framework/filters.py#L259
         to do filtering based on valuesviewset setup
         """
+        # We filter the mapped fields to ones that do simple string mappings here, any functional maps are excluded.
         mapped_fields = {k: v for k, v in view.field_map.items() if isinstance(v, str)}
         valid_fields = [item[0] for item in self.get_valid_fields(queryset, view, {'request': request})]
         ordering = []
         for term in fields:
             if term.lstrip("-") in valid_fields:
                 if term.lstrip("-") in mapped_fields:
+                    # In the case that the ordering field is a mapped field on the values viewset
+                    # we substitute the serialized name of the field for the database name.
                     prefix = "-" if term[0] == "-" else ""
                     new_term = prefix + mapped_fields[term.lstrip("-")]
                     ordering.append(new_term)

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -5,7 +5,9 @@ from django.db.models import Q
 from django.http import Http404
 from django_bulk_update.helper import bulk_update
 from django_filters.constants import EMPTY_VALUES
+from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
+from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.serializers import ListSerializer
@@ -345,12 +347,47 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
         return created_objects
 
 
+class ValuesViewsetOrderingFilter(OrderingFilter):
+
+    def get_default_valid_fields(self, queryset, view, context={}):
+        default_fields = set()
+        mapped_fields = {v: k for k, v in view.field_map.items() if isinstance(v, str)}
+        model_fields = {f.name for f in queryset.model._meta.get_fields()}
+        for field in view.values:
+            if field in model_fields or field in queryset.query.annotations:
+                if field in mapped_fields:
+                    default_fields.add((mapped_fields[field], mapped_fields[field]))
+                else:
+                    default_fields.add((field, field))
+
+        return default_fields
+
+    def remove_invalid_fields(self, queryset, fields, view, request):
+        """
+        Modified from https://github.com/encode/django-rest-framework/blob/version-3.12.2/rest_framework/filters.py#L259
+        to do filtering based on valuesviewset setup
+        """
+        mapped_fields = {k: v for k, v in view.field_map.items() if isinstance(v, str)}
+        valid_fields = [item[0] for item in self.get_valid_fields(queryset, view, {'request': request})]
+        ordering = []
+        for term in fields:
+            if term.lstrip("-") in valid_fields:
+                if term.lstrip("-") in mapped_fields:
+                    prefix = "-" if term[0] == "-" else ""
+                    new_term = prefix + mapped_fields[term.lstrip("-")]
+                    ordering.append(new_term)
+                else:
+                    ordering.append(term)
+        return ordering
+
+
 class ReadOnlyValuesViewset(SimpleReprMixin, ReadOnlyModelViewSet):
     """
     A viewset that uses a values call to get all model/queryset data in
     a single database query, rather than delegating serialization to a
     DRF ModelSerializer.
     """
+    filter_backends = (DjangoFilterBackend, ValuesViewsetOrderingFilter)
 
     # A tuple of values to get from the queryset
     values = None
@@ -485,9 +522,6 @@ class ReadOnlyValuesViewset(SimpleReprMixin, ReadOnlyModelViewSet):
     def annotate_queryset(self, queryset):
         return queryset
 
-    def prefetch_queryset(self, queryset):
-        return queryset
-
     def _map_fields(self, item):
         for key, value in self._field_map.items():
             if callable(value):
@@ -509,18 +543,22 @@ class ReadOnlyValuesViewset(SimpleReprMixin, ReadOnlyModelViewSet):
         return self.consolidate(list(map(self._map_fields, queryset or [])), queryset)
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.prefetch_queryset(self.get_queryset()))
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page_queryset = self.paginate_queryset(queryset)
+
+        if page_queryset is not None:
+            queryset = page_queryset
+
         queryset = self._cast_queryset_to_values(queryset)
 
-        page = self.paginate_queryset(queryset)
-
-        if page is not None:
-            return self.get_paginated_response(self.serialize(page))
+        if page_queryset is not None:
+            return self.get_paginated_response(self.serialize(queryset))
 
         return Response(self.serialize(queryset))
 
     def serialize_object(self, **filter_kwargs):
-        queryset = self.prefetch_queryset(self.get_queryset())
+        queryset = self.get_queryset()
         try:
             filter_kwargs = filter_kwargs or self._get_lookup_filter()
             return self.serialize(

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -2,7 +2,6 @@ from django.db.models import Exists
 from django.db.models import OuterRef
 from django.db.models import Q
 from django_filters.rest_framework import BooleanFilter
-from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 
@@ -69,7 +68,6 @@ class ChannelSetFilter(FilterSet):
 class ChannelSetViewSet(ValuesViewset):
     queryset = ChannelSet.objects.all()
     serializer_class = ChannelSetSerializer
-    filter_backends = (DjangoFilterBackend,)
     filter_class = ChannelSetFilter
     permission_classes = [IsAuthenticated]
     values = ("id", "name", "description", "channels", "secret_token__token", "edit")

--- a/contentcuration/contentcuration/viewsets/clipboard.py
+++ b/contentcuration/contentcuration/viewsets/clipboard.py
@@ -3,7 +3,6 @@ from django.db.models import IntegerField
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.db.models.functions import Cast
-from django_filters.rest_framework import DjangoFilterBackend
 from le_utils.constants import content_kinds
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import BooleanField
@@ -105,7 +104,6 @@ class ClipboardSerializer(BulkModelSerializer):
 
 class ClipboardViewSet(ValuesViewset):
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = ClipboardFilter
     serializer_class = ClipboardSerializer
     values = (

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -16,7 +16,6 @@ from django.http import Http404
 from django.utils.timezone import now
 from django_cte import CTEQuerySet
 from django_filters.rest_framework import CharFilter
-from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import UUIDFilter
 from le_utils.constants import content_kinds
 from le_utils.constants import exercises
@@ -517,7 +516,6 @@ class ContentNodeViewSet(BulkUpdateMixin, ChangeEventMixin, ValuesViewset):
     queryset = ContentNode.objects.all()
     serializer_class = ContentNodeSerializer
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = ContentNodeFilter
     values = (
         "id",

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -2,7 +2,6 @@ import codecs
 
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest
-from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -85,7 +84,6 @@ class FileViewSet(BulkDeleteMixin, BulkUpdateMixin, ReadOnlyValuesViewset):
     queryset = File.objects.all()
     serializer_class = FileSerializer
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = FileFilter
     values = (
         "id",

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -1,5 +1,4 @@
 from django_filters.rest_framework import CharFilter
-from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
@@ -95,7 +94,6 @@ def get_sender_name(item):
 class InvitationViewSet(ValuesViewset):
     queryset = Invitation.objects.all()
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = InvitationFilter
     serializer_class = InvitationSerializer
     values = (

--- a/contentcuration/contentcuration/viewsets/task.py
+++ b/contentcuration/contentcuration/viewsets/task.py
@@ -1,7 +1,6 @@
 import uuid
 
 from celery import states
-from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import UUIDFilter
 from rest_framework.permissions import IsAuthenticated
 
@@ -31,7 +30,6 @@ class TaskViewSet(ReadOnlyValuesViewset, DestroyModelMixin):
     order_by = 'created'
     queryset = Task.objects.order_by(order_by)
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = TaskFilter
     lookup_field = "task_id"
 

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -351,8 +351,6 @@ class AdminUserViewSet(ValuesViewset):
         "date_joined",
         "is_admin",
         "is_active",
-        "editable_channels__ids",
-        "view_only_channels__ids",
         "name",
         "edit_count",
         "view_count",
@@ -372,10 +370,6 @@ class AdminUserViewSet(ValuesViewset):
         )
 
         queryset = queryset.annotate(
-            editable_channels__ids=NotNullArrayAgg("editable_channels__id"),
-            view_only_channels__ids=NotNullArrayAgg(
-                "view_only_channels__id"
-            ),
             name=Concat(
                 F("first_name"), Value(" "), F("last_name"), output_field=CharField()
             ),
@@ -383,7 +377,7 @@ class AdminUserViewSet(ValuesViewset):
             view_count=SQCount(viewonly_channel_query, field="id"),
         )
         return queryset
-    
+
     @action(detail=True, methods=("get",))
     def metadata(self, request, pk=None):
         user = self._get_object_from_queryset(self.queryset)

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -13,11 +13,9 @@ from django.db.models.functions import Cast
 from django.db.models.functions import Concat
 from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import CharFilter
-from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -26,13 +24,12 @@ from contentcuration.constants import feature_flags
 from contentcuration.models import boolean_val
 from contentcuration.models import Channel
 from contentcuration.models import User
-from contentcuration.utils.pagination import get_order_queryset
+from contentcuration.utils.pagination import ValuesViewsetPageNumberPagination
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ReadOnlyValuesViewset
 from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.base import ValuesViewset
-from contentcuration.viewsets.common import CatalogPaginator
 from contentcuration.viewsets.common import NotNullArrayAgg
 from contentcuration.viewsets.common import SQCount
 from contentcuration.viewsets.common import UUIDFilter
@@ -42,23 +39,10 @@ from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import VIEWER_M2M
 
 
-class UserListPagination(PageNumberPagination):
+class UserListPagination(ValuesViewsetPageNumberPagination):
     page_size = None
     page_size_query_param = "page_size"
     max_page_size = 100
-    django_paginator_class = CatalogPaginator
-
-    def get_paginated_response(self, data):
-        return Response(
-            {
-                "next": self.get_next_link(),
-                "previous": self.get_previous_link(),
-                "page_number": self.page.number,
-                "count": self.page.paginator.count,
-                "total_pages": self.page.paginator.num_pages,
-                "results": data,
-            }
-        )
 
 
 class UserFilter(FilterSet):
@@ -123,7 +107,6 @@ class UserViewSet(ReadOnlyValuesViewset):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = UserFilter
     values = (
         "id",
@@ -178,7 +161,6 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     filterset_class = ChannelUserFilter
     values = (
         "id",
@@ -357,8 +339,8 @@ class AdminUserViewSet(ValuesViewset):
     permission_classes = [IsAdminUser]
     serializer_class = AdminUserSerializer
     filterset_class = AdminUserFilter
-    filter_backends = (DjangoFilterBackend,)
-    base_values = (
+
+    values = (
         "id",
         "email",
         "first_name",
@@ -369,42 +351,15 @@ class AdminUserViewSet(ValuesViewset):
         "date_joined",
         "is_admin",
         "is_active",
+        "editable_channels__ids",
+        "view_only_channels__ids",
+        "name",
+        "edit_count",
+        "view_count",
     )
-    values = base_values
     queryset = User.objects.all()
 
-    def paginate_queryset(self, queryset):
-        order, queryset = get_order_queryset(self.request, queryset, self.field_map)
-        page_results = self.paginator.paginate_queryset(
-            queryset, self.request, view=self
-        )
-        ids = [result["id"] for result in page_results]
-
-        self.values = self.base_values
-        queryset = User.objects.filter(id__in=ids).values(*(self.values))
-        if order != "undefined":
-            queryset = queryset.order_by(order)
-        return queryset.annotate(**self.annotations)
-
-    def get_queryset(self):
-        self.annotations = self.compose_annotations()
-        order = self.request.GET.get("sortBy", "")
-        if order in self.annotations:
-            self.values = self.values + (order,)
-        return User.objects.values("id").order_by("email")
-
     def annotate_queryset(self, queryset):
-        # will do it after paginate excepting for order by
-        order = self.request.GET.get("sortBy", "")
-        if order in self.annotations:
-            queryset = queryset.annotate(**{order: self.annotations[order]})
-        return queryset
-
-    def compose_annotations(self):
-        annotations = {}
-        annotations["name"] = Concat(
-            F("first_name"), Value(" "), F("last_name"), output_field=CharField()
-        )
         edit_channel_query = (
             Channel.objects.filter(editors__id=OuterRef("id"), deleted=False)
             .values_list("id", flat=True)
@@ -415,10 +370,20 @@ class AdminUserViewSet(ValuesViewset):
             .values_list("id", flat=True)
             .distinct()
         )
-        annotations["edit_count"] = SQCount(edit_channel_query, field="id")
-        annotations["view_count"] = SQCount(viewonly_channel_query, field="id")
-        return annotations
 
+        queryset = queryset.annotate(
+            editable_channels__ids=NotNullArrayAgg("editable_channels__id"),
+            view_only_channels__ids=NotNullArrayAgg(
+                "view_only_channels__id"
+            ),
+            name=Concat(
+                F("first_name"), Value(" "), F("last_name"), output_field=CharField()
+            ),
+            edit_count=SQCount(edit_channel_query, field="id"),
+            view_count=SQCount(viewonly_channel_query, field="id"),
+        )
+        return queryset
+    
     @action(detail=True, methods=("get",))
     def metadata(self, request, pk=None):
         user = self._get_object_from_queryset(self.queryset)

--- a/contentcuration/search/viewsets/contentnode.py
+++ b/contentcuration/search/viewsets/contentnode.py
@@ -1,7 +1,6 @@
 import re
 
 from django.db.models import Case
-from django.db.models import CharField
 from django.db.models import F
 from django.db.models import IntegerField
 from django.db.models import OuterRef
@@ -23,6 +22,8 @@ from contentcuration.viewsets.base import RequiredFilterSet
 from contentcuration.viewsets.common import NotNullMapArrayAgg
 from contentcuration.viewsets.common import SQArrayAgg
 from contentcuration.viewsets.common import SQCount
+from contentcuration.viewsets.common import UUIDFilter
+from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.contentnode import ContentNodeViewSet
 
 
@@ -51,6 +52,22 @@ class ContentNodeFilter(RequiredFilterSet):
     resources = BooleanFilter(method="filter_resources")
     assessments = BooleanFilter(method="filter_assessments")
     created_after = CharFilter(method="filter_created_after")
+    channel_id__in = UUIDInFilter(name="channel_id")
+    channel_list = CharFilter(method="filter_channel_list")
+    exclude_channel = UUIDFilter(name="channel_id", exclude=True)
+
+    def filter_channel_list(self, queryset, name, value):
+        user = not self.request.user.is_anonymous() and self.request.user
+        channel_ids = []
+        if value == "public":
+            channel_ids = Channel.objects.filter(public=True, deleted=False).values_list("id", flat=True)
+        elif value == "edit" and user:
+            channel_ids = user.editable_channels.values_list("id", flat=True)
+        elif value == "bookmark" and user:
+            channel_ids = user.bookmarked_channels.values_list("id", flat=True)
+        elif value == "view" and user:
+            channel_ids = user.view_only_channels.values_list("id", flat=True)
+        return queryset.filter(channel_id__in=list(channel_ids))
 
     def filter_keywords(self, queryset, name, value):
         filter_query = Q(title__icontains=value) | Q(description__icontains=value)
@@ -126,8 +143,6 @@ class SearchContentNodeViewSet(ContentNodeViewSet):
         "id",
         "content_id",
         "node_id",
-    )
-    base_values = (
         "title",
         "description",
         "author",
@@ -147,55 +162,13 @@ class SearchContentNodeViewSet(ContentNodeViewSet):
         "original_channel_name",
     )
 
-    def paginate_queryset(self, queryset):
-        page_results = self.paginator.paginate_queryset(
-            queryset, self.request, view=self
-        )
-        ids = [result["id"] for result in page_results]
-        queryset = self._annotate_channel_id(ContentNode.objects.filter(id__in=ids))
-        queryset = self.complete_annotations(queryset)
-        self.values = self.values + self.base_values
-        return list(queryset.values(*self.values))
-
-    def get_accessible_nodes_queryset(self):
-        # jayoshih: May the force be with you, optimizations team...
-        user_id = not self.request.user.is_anonymous and self.request.user.id
-
-        # Filter by channel type
-        channel_type = self.request.query_params.get("channel_list", "public")
-        if channel_type == "public":
-            channel_args = {"public": True}
-        elif channel_type == "edit":
-            channel_args = {"editors": user_id}
-        elif channel_type == "bookmark":
-            channel_args = {"bookmarked_by": user_id}
-        elif channel_type == "view":
-            channel_args = {"viewers": user_id}
-        else:
-            channel_args = {}
-
-        # Filter by specific channels
-        if self.request.query_params.get("channels"):
-            channel_args.update({"pk__in": self.request.query_params["channels"]})
-
-        return ContentNode.objects.filter(
-            tree_id__in=Channel.objects.filter(deleted=False, **channel_args)
-            .exclude(pk=self.request.query_params.get("exclude_channel", ""))
-            .values_list("main_tree__tree_id", flat=True)
-            .order_by()
-            .distinct()
-        ).annotate(channel_id=Value("", output_field=CharField()),)
-
-    def get_queryset(self):
-        return self.get_accessible_nodes_queryset()
-
     def annotate_queryset(self, queryset):
         """
         1. Do a distinct by 'content_id,' using the original node if possible
         2. Annotate lists of content node and channel pks
         """
         # Get accessible content nodes that match the content id
-        content_id_query = self.get_accessible_nodes_queryset().filter(
+        content_id_query = ContentNode.filter_view_queryset(ContentNode.objects.all(), self.request.user).filter(
             content_id=OuterRef("content_id")
         )
 
@@ -214,9 +187,7 @@ class SearchContentNodeViewSet(ContentNodeViewSet):
         queryset = queryset.filter(
             pk__in=Subquery(deduped_content_query.values_list("id", flat=True)[:1])
         ).order_by()
-        return queryset
 
-    def complete_annotations(self, queryset):
         thumbnails = File.objects.filter(
             contentnode=OuterRef("id"), preset__thumbnail=True
         )
@@ -230,9 +201,6 @@ class SearchContentNodeViewSet(ContentNodeViewSet):
             .exclude(kind_id=content_kinds.TOPIC)
             .values("id", "role_visibility", "changed")
             .order_by()
-        )
-        content_id_query = self.get_accessible_nodes_queryset().filter(
-            content_id=OuterRef("content_id")
         )
         original_channel_name = Coalesce(
             Subquery(

--- a/contentcuration/search/viewsets/savedsearch.py
+++ b/contentcuration/search/viewsets/savedsearch.py
@@ -1,4 +1,3 @@
-from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.serializers import PrimaryKeyRelatedField
 from search.models import SavedSearch
@@ -37,7 +36,6 @@ class SavedSearchViewSet(ValuesViewset):
     queryset = SavedSearch.objects.all()
     serializer_class = SavedSearchSerializer
     permission_classes = [IsAuthenticated]
-    filter_backends = (DjangoFilterBackend,)
     values = (
         "id",
         "name",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -92,7 +92,7 @@ django==3.2.3
     #   django-debug-toolbar
     #   djangorestframework
     #   drf-yasg
-djangorestframework==3.12.1
+djangorestframework==3.12.4
     # via
     #   -c requirements.txt
     #   drf-yasg

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ attrs==19.3.0
 django-cte==1.1.5
 django-mptt==0.11.0
 django-filter==2.4.0
-djangorestframework==3.12.1
+djangorestframework==3.12.4
 psycopg2-binary==2.8.6
 django-js-reverse==0.9.1
 django-registration==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ django==3.2.3
     #   django-s3-storage
     #   djangorestframework
     #   jsonfield
-djangorestframework==3.12.1
+djangorestframework==3.12.4
     # via -r requirements.in
 future==0.18.2
     # via -r requirements.in


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

After numerous issues arising because of pagination, this creates a prototype to ensure full integration of both the ValuesViewset and the frontend resource layer with both ordering and pagination.

This means that we can use standard Django Rest Framework `ordering` syntax for specifying the ordering of results from the API (https://www.django-rest-framework.org/api-guide/filtering/#orderingfilter) and this will be properly interpreted by both the backend and the IndexedDB `where` wrapper command.

In addition, this adds support in the backend for PageNumberPagination to be added to any ValuesViewset class when needed, and to leverage the efficiency gains that were added specifically to the AdminChannel and AdminUser viewsets.

In the frontend it adds support for PageNumberPagination and LimitOffsetPagination for IndexedDB queries through `where`.


### Manual verification steps performed
Checked all places that ordering and pagination are currently used:
* Admin channel and user viewsets
* Content node search viewsets
* Catalog listing for a logged in user (changed to using `where` and verified that pagination worked as expected)

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
