### PR TITLE
Quick change to disable synchronous calculation of resource size

### DIFF
--- a/contentcuration/contentcuration/tests/utils/test_nodes.py
+++ b/contentcuration/contentcuration/tests/utils/test_nodes.py
@@ -92,12 +92,14 @@ class CalculateResourceSizeTestCase(SimpleTestCase):
         self.node.get_descendant_count.return_value = STALE_MAX_CALCULATION_SIZE + 1
         self.assertCalculation(cache, helper, force=True)
 
+    @mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
     def test_missing__small(self, cache, helper):
         self.node.get_descendant_count.return_value = 1
         cache().get_size.return_value = None
         cache().get_modified.return_value = None
         self.assertCalculation(cache, helper)
 
+    @mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
     def test_unforced__took_too_long(self, cache, helper):
         self.node.get_descendant_count.return_value = 1
         cache().get_size.return_value = None
@@ -115,6 +117,7 @@ class CalculateResourceSizeTestCase(SimpleTestCase):
             self.assertIsInstance(report_exception.mock_calls[0][1][0], SlowCalculationError)
 
 
+@mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
 class CalculateResourceSizeIntegrationTestCase(BaseTestCase):
     """
     Integration test case

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import uuid
 
+import mock
 import pytest
 from django.conf import settings
 from django.core.management import call_command
@@ -1531,6 +1532,7 @@ class CRUDTestCase(StudioAPITestCase):
         except models.ContentNode.DoesNotExist:
             self.fail("Orphanage root was deleted")
 
+    @mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
     def test_resource_size(self):
         user = testdata.user()
         channel = testdata.channel()

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -353,7 +353,8 @@ class ResourceSizeHelper:
         # return result['modified_since']
 
 
-STALE_MAX_CALCULATION_SIZE = 5000
+# TODO: clean up sync vs async calculation switching
+STALE_MAX_CALCULATION_SIZE = 0
 SLOW_UNFORCED_CALC_THRESHOLD = 5
 
 


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
Synchronous calculations of resource size are taking too long.

### Description of the change(s) you made
Changes the constant used to determine whether it should try calculation synchronously or not such that it shouldn't try to do so


### Manual verification steps performed
1. Open a small channel
3. Click <kbd>Publish</kbd>
4. You should observe a loading spinner until the resource size task completes
5. Verify you see the channel size once it does complete


## References

Addresses: https://github.com/learningequality/studio/issues/3084
Follow up: https://github.com/learningequality/studio/issues/3089
Gherkin: [integration_testing/features/publish-channel.feature](https://github.com/learningequality/studio/blob/hotfixes/integration_testing/features/publish-channel.feature)

----

### Contributor's Checklist


- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
