### PR TITLE
Clean up and consolidate permissions.

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1151,8 +1151,8 @@ class ContentNode(MPTTModel, models.Model):
         ).values_list("tree_id", flat=True)[:1]
 
     @classmethod
-    def filter_edit_queryset(cls, queryset, user=None, user_id=None):
-        user_id = user_id or not user.is_anonymous() and user.id
+    def filter_edit_queryset(cls, queryset, user):
+        user_id = not user.is_anonymous() and user.id
 
         queryset = queryset.exclude(pk=settings.ORPHANAGE_ROOT_ID)
 
@@ -1164,6 +1164,7 @@ class ContentNode(MPTTModel, models.Model):
         queryset = queryset.with_cte(edit_cte).annotate(
             edit=edit_cte.exists(cls._permission_filter),
         )
+
         if user.is_admin:
             return queryset
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -184,113 +184,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         super(User, self).delete()
 
     def can_edit(self, channel_id):
-        channel = Channel.objects.filter(pk=channel_id).first()
-        if not self.is_admin and channel and not channel.editors.filter(pk=self.pk).exists():
-            raise PermissionDenied("Cannot edit content")
-        return True
-
-    def can_view_channel(self, channel):
-        if channel and channel.public:
-            return True
-        if not self.is_admin and channel and not channel.editors.filter(pk=self.pk).exists() and not channel.viewers.filter(pk=self.pk).exists():
-            raise PermissionDenied("Cannot view content")
-        return True
-
-    def can_view(self, channel_id):
-        channel = Channel.objects.filter(pk=channel_id).first()
-        return self.can_view_channel(channel)
-
-    def can_view_channels(self, channels):
-        channels_user_has_perms_for = channels.filter(Q(editors__id__contains=self.id) | Q(viewers__id__contains=self.id) | Q(public=True))
-        # The channel user has perms for is a subset of all the channels that were passed in.
-        # We check the count for simplicity, as if the user does not have permissions for
-        # even one of the channels the content is drawn from, then the number of channels
-        # will be smaller.
-        total_channels = channels.distinct().count()
-        # If no channels, then these nodes are orphans - do not let them be viewed except by an admin.
-        if not total_channels or total_channels > channels_user_has_perms_for.distinct().count():
-            raise PermissionDenied("Cannot view content")
-        return True
-
-    def can_view_channel_ids(self, channel_ids):
-        if self.is_admin:
-            return True
-        channels = Channel.objects.filter(pk__in=channel_ids)
-        return self.can_view_channels(channels)
-
-    def can_view_node(self, node):
-        if self.is_admin:
-            return True
-        root = node.get_root()
-        if root == self.clipboard_tree or root.pk == settings.ORPHANAGE_ROOT_ID:
-            return True
-        channel_id = Channel.objects.filter(Q(main_tree=root)
-                                            | Q(chef_tree=root)
-                                            | Q(trash_tree=root)
-                                            | Q(staging_tree=root)
-                                            | Q(previous_tree=root)).values_list("id", flat=True).first()
-        if not channel_id:
-            # Don't let a non-admin view orphaned nodes
-            raise PermissionDenied("Cannot view content")
-        return self.can_view(channel_id)
-
-    def can_view_nodes(self, nodes):
-        if self.is_admin:
-            return True
-        root_nodes_all = ContentNode.objects.filter(parent=None, tree_id__in=nodes.values_list("tree_id", flat=True).distinct()).distinct()
-        # If all the nodes belong to the clipboard, skip the channel check.
-
-        root_nodes = root_nodes_all.exclude(tree_id=self.clipboard_tree.tree_id).exclude(pk=settings.ORPHANAGE_ROOT_ID)
-        if root_nodes.count() == 0 and root_nodes_all.count() > 0:
-            return True
-
-        channels = Channel.objects.filter(Q(main_tree__in=root_nodes)
-                                          | Q(chef_tree__in=root_nodes)
-                                          | Q(trash_tree__in=root_nodes)
-                                          | Q(staging_tree__in=root_nodes)
-                                          | Q(previous_tree__in=root_nodes))
-        return self.can_view_channels(channels)
-
-    def can_edit_node(self, node):
-        if self.is_admin:
-            return True
-        root = node.get_root()
-        if root == self.clipboard_tree or root.pk == settings.ORPHANAGE_ROOT_ID:
-            return True
-
-        channel_id = Channel.objects.filter(Q(main_tree=root)
-                                            | Q(chef_tree=root)
-                                            | Q(trash_tree=root)
-                                            | Q(staging_tree=root)
-                                            | Q(previous_tree=root)).values_list("id", flat=True).first()
-        if not channel_id:
-            # Don't let a non-admin edit orphaned nodes
-            raise PermissionDenied("Cannot edit content")
-        return self.can_edit(channel_id)
-
-    def can_edit_nodes(self, nodes):
-        if self.is_admin:
-            return True
-        root_nodes_all = ContentNode.objects.filter(parent=None, tree_id__in=nodes.values_list("tree_id", flat=True).distinct()).distinct()
-        # If all the nodes belong to the clipboard, skip the channel check.
-        root_nodes = root_nodes_all.exclude(tree_id=self.clipboard_tree.tree_id).exclude(pk=settings.ORPHANAGE_ROOT_ID)
-        if root_nodes.count() == 0 and root_nodes_all.count() > 0:
-            return True
-        channels = Channel.objects.filter(Q(main_tree__in=root_nodes)
-                                          | Q(chef_tree__in=root_nodes)
-                                          | Q(trash_tree__in=root_nodes)
-                                          | Q(staging_tree__in=root_nodes)
-                                          | Q(previous_tree__in=root_nodes))
-        channels_user_can_edit = channels.filter(editors__id__contains=self.id)
-        # The channel user has perms for is a subset of all the channels that were passed in.
-        # We check the count for simplicity, as if the user does not have permissions for
-        # even one of the channels the content is drawn from, then the number of channels
-        # will be smaller.
-        total_channels = channels.distinct().count()
-        # If no channels, then these nodes are orphans - do not let them be edited except by an admin.
-        if not total_channels or total_channels > channels_user_can_edit.distinct().count():
-            raise PermissionDenied("Cannot edit content")
-        return True
+        return Channel.filter_edit_queryset(Channel.objects.all(), self).filter(pk=channel_id).exists()
 
     def check_space(self, size, checksum):
         active_files = self.get_user_active_files()
@@ -820,6 +714,10 @@ class Channel(models.Model):
     ])
 
     @classmethod
+    def get_editable(cls, user, channel_id):
+        return cls.filter_edit_queryset(cls.objects.all(), user).get(id=channel_id)
+
+    @classmethod
     def filter_edit_queryset(cls, queryset, user):
         user_id = not user.is_anonymous() and user.id
 
@@ -828,7 +726,11 @@ class Channel(models.Model):
             return queryset.none()
 
         edit = Exists(User.editable_channels.through.objects.filter(user_id=user_id, channel_id=OuterRef("id")))
-        return queryset.annotate(edit=edit).filter(edit=True)
+        queryset = queryset.annotate(edit=edit)
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(edit=True)
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):
@@ -847,6 +749,9 @@ class Channel(models.Model):
             edit=edit,
             view=view,
         )
+
+        if user.is_admin:
+            return queryset
 
         permission_filter = Q()
         if user_id:
@@ -1058,7 +963,11 @@ class ChannelSet(models.Model):
             return queryset.none()
         user_id = not user.is_anonymous() and user.id
         edit = Exists(User.channel_sets.through.objects.filter(user_id=user_id, channelset_id=OuterRef("id")))
-        return queryset.annotate(edit=edit).filter(edit=True)
+        queryset = queryset.annotate(edit=edit)
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(edit=True)
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):
@@ -1252,9 +1161,13 @@ class ContentNode(MPTTModel, models.Model):
 
         edit_cte = PermissionCTE.editable_channels(user_id)
 
-        return queryset.with_cte(edit_cte).annotate(
+        queryset = queryset.with_cte(edit_cte).annotate(
             edit=edit_cte.exists(cls._permission_filter),
-        ).filter(Q(edit=True) | Q(tree_id=cls._orphan_tree_id_subquery()))
+        )
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(Q(edit=True) | Q(tree_id=cls._orphan_tree_id_subquery()))
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):
@@ -1278,6 +1191,9 @@ class ContentNode(MPTTModel, models.Model):
             edit=edit_cte.exists(cls._permission_filter),
             view=view_cte.exists(cls._permission_filter),
         )
+
+        if user.is_admin:
+            return queryset
 
         return queryset.filter(
             Q(view=True)
@@ -1927,9 +1843,14 @@ class AssessmentItem(models.Model):
 
         edit_cte = PermissionCTE.editable_channels(user_id)
 
-        return queryset.with_cte(edit_cte).annotate(
+        queryset = queryset.with_cte(edit_cte).annotate(
             edit=edit_cte.exists(cls._permission_filter),
-        ).filter(edit=True)
+        )
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(edit=True)
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):
@@ -1953,6 +1874,9 @@ class AssessmentItem(models.Model):
             edit=edit_cte.exists(cls._permission_filter),
             view=view_cte.exists(cls._permission_filter),
         )
+
+        if user.is_admin:
+            return queryset
 
         return queryset.filter(Q(view=True) | Q(edit=True) | Q(public=True))
 
@@ -2008,7 +1932,12 @@ class File(models.Model):
             return queryset.none()
 
         cte = PermissionCTE.editable_channels(user_id)
-        return queryset.with_cte(cte).annotate(edit=cte.exists(cls._permission_filter)).filter(
+        queryset = queryset.with_cte(cte).annotate(edit=cte.exists(cls._permission_filter))
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(
             Q(edit=True) | Q(uploaded_by=user, contentnode__isnull=True, assessment_item__isnull=True)
         )
 
@@ -2035,6 +1964,9 @@ class File(models.Model):
             edit=edit_cte.exists(cls._permission_filter),
             view=view_cte.exists(cls._permission_filter),
         )
+
+        if user.is_admin:
+            return queryset
 
         return queryset.filter(
             Q(view=True)
@@ -2208,6 +2140,9 @@ class Invitation(models.Model):
         if user.is_anonymous():
             return queryset.none()
 
+        if user.is_admin:
+            return queryset
+
         return queryset.filter(
             Q(email__iexact=user.email)
             | Q(sender=user)
@@ -2219,6 +2154,8 @@ class Invitation(models.Model):
         if user.is_anonymous():
             return queryset.none()
 
+        if user.is_admin:
+            return queryset
         return queryset.filter(
             Q(email__iexact=user.email)
             | Q(sender=user)

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -137,7 +137,7 @@ def duplicate_nodes_task(
     target = ContentNode.objects.get(id=target_id)
 
     can_edit_source_channel = ContentNode.filter_edit_queryset(
-        ContentNode.objects.filter(id=source_id), user_id=user_id
+        ContentNode.objects.filter(id=source_id), user=User.objects.get(id=user_id)
     ).exists()
 
     new_node = None

--- a/contentcuration/contentcuration/tests/test_models.py
+++ b/contentcuration/contentcuration/tests/test_models.py
@@ -113,6 +113,7 @@ class PermissionQuerysetTestCase(StudioTestCase):
     def anonymous_user(self):
         user = mock.Mock()
         user.is_anonymous.return_value = True
+        user.is_admin = False
         return user
 
     @property
@@ -318,25 +319,6 @@ class ContentNodeTestCase(PermissionQuerysetTestCase):
         self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
         self.assertQuerysetContains(queryset, pk=contentnode.id)
 
-    def test_filter_edit_queryset__public_channel__user_id(self):
-        channel = self.public_channel
-        contentnode = create_contentnode(channel.main_tree_id)
-
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=987)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetDoesNotContain(queryset, pk=contentnode.id)
-
-        user = testdata.user()
-        channel.viewers.add(user)
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=user.id)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetDoesNotContain(queryset, pk=contentnode.id)
-
-        channel.editors.add(user)
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=user.id)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetContains(queryset, pk=contentnode.id)
-
     def test_filter_edit_queryset__public_channel__anonymous(self):
         channel = self.public_channel
         contentnode = create_contentnode(channel.main_tree_id)
@@ -364,25 +346,6 @@ class ContentNodeTestCase(PermissionQuerysetTestCase):
         self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
         self.assertQuerysetContains(queryset, pk=contentnode.id)
 
-    def test_filter_edit_queryset__private_channel__user_id(self):
-        channel = testdata.channel()
-        contentnode = create_contentnode(channel.main_tree_id)
-
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=987)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetDoesNotContain(queryset, pk=contentnode.id)
-
-        user = testdata.user()
-        channel.viewers.add(user)
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=user.id)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetDoesNotContain(queryset, pk=contentnode.id)
-
-        channel.editors.add(user)
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=user.id)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetContains(queryset, pk=contentnode.id)
-
     def test_filter_edit_queryset__private_channel__anonymous(self):
         channel = testdata.channel()
         contentnode = create_contentnode(channel.main_tree_id)
@@ -396,13 +359,6 @@ class ContentNodeTestCase(PermissionQuerysetTestCase):
 
         user = testdata.user()
         queryset = ContentNode.filter_edit_queryset(self.base_queryset, user=user)
-        self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
-        self.assertQuerysetContains(queryset, pk=contentnode.id)
-
-    def test_filter_edit_queryset__orphan_tree__user_id(self):
-        contentnode = create_contentnode(settings.ORPHANAGE_ROOT_ID)
-
-        queryset = ContentNode.filter_edit_queryset(self.base_queryset, user_id=987)
         self.assertQuerysetDoesNotContain(queryset, pk=settings.ORPHANAGE_ROOT_ID)
         self.assertQuerysetContains(queryset, pk=contentnode.id)
 

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -242,22 +242,16 @@ def channel(request, channel_id):
 
     # Check if channel exists
     try:
-        channel = Channel.objects.get(id=channel_id)
-        channel_id = channel.id
+        channel = Channel.filter_view_queryset(Channel.objects.all(), request.user).get(id=channel_id)
     except Channel.DoesNotExist:
         channel_error = "CHANNEL_EDIT_ERROR_CHANNEL_NOT_FOUND"
-        channel_id = ""
+        channel = None
 
-    # Check if user has permission to view channel
-    if channel_id != "":
-        try:
-            request.user.can_view_channel(channel)
-            # If user can view channel, but it's deleted, then we show
-            # an option to restore the channel in the Administration page
-            if channel.deleted:
-                channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED'
-        except PermissionDenied:
-            channel_error = "CHANNEL_EDIT_ERROR_CHANNEL_NOT_FOUND"
+    if channel is not None:
+        # If user can view channel, but it's deleted, then we show
+        # an option to restore the channel in the Administration page
+        if channel.deleted:
+            channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED'
 
     return render(
         request,

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -418,7 +418,7 @@ def get_channel_status_bulk(request):
     data = json.loads(request.body)
     try:
         channel_ids = data['channel_ids']
-        permissioned_ids = set(Channel.filter_edit_queryset(Channel.objects.all(), request.user).filter(id__in=channel_ids))
+        permissioned_ids = set(Channel.filter_edit_queryset(Channel.objects.all(), request.user).filter(id__in=channel_ids).values_list("id", flat=True))
         if permissioned_ids != set(channel_ids):
             raise PermissionDenied()
         statuses = {cid: get_status(cid) for cid in data['channel_ids']}

--- a/contentcuration/contentcuration/views/users.py
+++ b/contentcuration/contentcuration/views/users.py
@@ -9,6 +9,7 @@ from django.contrib.auth.views import PasswordResetConfirmView
 from django.contrib.auth.views import PasswordResetView
 from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponse
@@ -56,7 +57,8 @@ def send_invitation_email(request):
 
         recipient = User.get_for_email(user_email)
 
-        request.user.can_edit(channel_id)
+        if not request.user.can_edit(channel_id):
+            raise PermissionDenied()
 
         fields = {
             "invited": recipient,

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -432,8 +432,6 @@ class ReadOnlyValuesViewset(SimpleReprMixin, ReadOnlyModelViewSet):
 
     def get_queryset(self):
         queryset = super(ReadOnlyValuesViewset, self).get_queryset()
-        if self.request.user.is_admin:
-            return queryset
         if hasattr(queryset.model, "filter_view_queryset"):
             return queryset.model.filter_view_queryset(queryset, self.request.user)
         return queryset
@@ -444,8 +442,6 @@ class ReadOnlyValuesViewset(SimpleReprMixin, ReadOnlyModelViewSet):
         that a user is able to edit, rather than view.
         """
         queryset = super(ReadOnlyValuesViewset, self).get_queryset()
-        if self.request.user.is_admin:
-            return queryset
         if hasattr(queryset.model, "filter_edit_queryset"):
             return queryset.model.filter_edit_queryset(queryset, self.request.user)
         return self.get_queryset()

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -160,7 +160,8 @@ class ChannelUserFilter(RequiredFilterSet):
 
     def filter_channel(self, queryset, name, value):
         # Check permissions
-        self.request.user.can_edit(value)
+        if not self.request.user.can_edit(value):
+            return queryset.none()
         user_queryset = User.objects.filter(id=OuterRef("id"))
         queryset = queryset.annotate(
             can_edit=Exists(user_queryset.filter(editable_channels=value)),


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Consolidates all our permission checking against `filter_view_queryset` and `filter_edit_queryset` class methods.
Removes permissions from users for the now unused orphan tree.


### Manual verification steps performed
Did not change the semantics for internal views - but wondering if we want to move completely to 404s instead of 403s.

## Reviewer guidance
### How can a reviewer test these changes?
These endpoints should be covered by unit tests.


### Are there any risky areas that deserve extra testing?
This might need some integration testing with ricecooker.


## References
Fixes #3071 by making `filter_edit_queryset` filter nothing for admins.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
