### PR TITLE
Reinstate synchronous channel size calculation with lower threshold, and resolve misc task related issues

### DIFF
--- a/contentcuration/contentcuration/tasks_test.py
+++ b/contentcuration/contentcuration/tasks_test.py
@@ -32,6 +32,17 @@ def error_test_task(**kwargs):
     raise Exception("I'm sorry Dave, I'm afraid I can't do that.")
 
 
+@app.task(bind=True, name="caught_error_test_task")
+def caught_error_test_task(self, **kwargs):
+    """
+    This is a mock task designed to test that we properly report errors to the client.
+    """
+    try:
+        raise Exception("I'm sorry Dave, I'm afraid I can't do that.")
+    except Exception as e:
+        self.report_exception(e)
+
+
 @app.task(bind=True, name="progress_test_task", track_progress=True)
 def progress_test_task(self, **kwargs):
     """

--- a/contentcuration/contentcuration/tests/utils/test_nodes.py
+++ b/contentcuration/contentcuration/tests/utils/test_nodes.py
@@ -92,14 +92,12 @@ class CalculateResourceSizeTestCase(SimpleTestCase):
         self.node.get_descendant_count.return_value = STALE_MAX_CALCULATION_SIZE + 1
         self.assertCalculation(cache, helper, force=True)
 
-    @mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
     def test_missing__small(self, cache, helper):
         self.node.get_descendant_count.return_value = 1
         cache().get_size.return_value = None
         cache().get_modified.return_value = None
         self.assertCalculation(cache, helper)
 
-    @mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
     def test_unforced__took_too_long(self, cache, helper):
         self.node.get_descendant_count.return_value = 1
         cache().get_size.return_value = None
@@ -117,7 +115,6 @@ class CalculateResourceSizeTestCase(SimpleTestCase):
             self.assertIsInstance(report_exception.mock_calls[0][1][0], SlowCalculationError)
 
 
-@mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
 class CalculateResourceSizeIntegrationTestCase(BaseTestCase):
     """
     Integration test case

--- a/contentcuration/contentcuration/utils/celery/tasks.py
+++ b/contentcuration/contentcuration/utils/celery/tasks.py
@@ -1,4 +1,5 @@
 import math
+import traceback as _traceback
 from functools import partial
 
 from celery import states
@@ -97,8 +98,10 @@ class CeleryTask(Task):
         :type e: Exception
         """
         # @see AsyncResult.traceback
-        self.update_state(state=states.FAILURE, traceback=e.__traceback__)
+        traceback = '\n'.join(_traceback.format_tb(e.__traceback__))
+        self.update_state(state=states.FAILURE, traceback=traceback)
         report_exception(e)
+        raise e
 
     def update_state(self, task_id=None, state=None, meta=None, traceback=None):
         """

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -353,8 +353,7 @@ class ResourceSizeHelper:
         # return result['modified_since']
 
 
-# TODO: clean up sync vs async calculation switching
-STALE_MAX_CALCULATION_SIZE = 0
+STALE_MAX_CALCULATION_SIZE = 500
 SLOW_UNFORCED_CALC_THRESHOLD = 5
 
 


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
[Reports from QA](https://github.com/learningequality/studio/pull/3090) after we made the channel size calculation always asynchronous suggests that we should keep synchronous calculation. Since the previous threshold was 5000 nodes and logging showed that 50-60 seconds was the upper limit for slow calculations, I've set it to 10% of that or 500 nodes to hopefully get close to a max of 5 seconds for synchronous calculation.

### Manual verification steps performed
Unit testing

___
## Reviewer guidance
### How can a reviewer test these changes?
Verify publishing works


## References
Resolves: https://github.com/learningequality/studio/issues/3089
Resolves: https://github.com/learningequality/studio/issues/3106
Resolves: https://github.com/learningequality/studio/issues/3105

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
