### PR TITLE
Add editing permissions condition to view/display Publish Modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -87,7 +87,7 @@
     },
     computed: {
       ...mapGetters('task', ['currentTasksForChannel']),
-      ...mapGetters('currentChannel', ['currentChannel']),
+      ...mapGetters('currentChannel', ['currentChannel', 'canManage']),
       currentTasks() {
         return this.currentTasksForChannel(this.currentChannel.id) || null;
       },
@@ -102,7 +102,11 @@
         return this.noSyncNeeded;
       },
       isPublishing() {
-        return this.currentChannel && this.currentChannel.publishing;
+        // add condition so that publishing modal is only visible for users
+        // who have channel publishing permissions
+        if (this.canManage) {
+          return this.currentChannel && this.currentChannel.publishing;
+        }
       },
       currentTask() {
         if (this.isSyncing) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -107,6 +107,7 @@
         if (this.canManage) {
           return this.currentChannel && this.currentChannel.publishing;
         }
+        return false;
       },
       currentTask() {
         if (this.isSyncing) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -79,7 +79,7 @@ describe('ProgressModal', () => {
     expect(getCancelModal(wrapper).exists()).toBe(false);
   });
 
-  describe('when publishing', () => {
+  describe('when publishing as a user with publish permissions', () => {
     let storeConfig, stopTask;
 
     beforeEach(() => {
@@ -87,6 +87,9 @@ describe('ProgressModal', () => {
       jest
         .spyOn(storeConfig.modules.currentChannel.getters, 'currentChannel')
         .mockReturnValue({ publishing: true });
+      jest
+        .spyOn(storeConfig.modules.currentChannel.getters, 'canManage')
+        .mockReturnValue({ canManage: true });
       stopTask = jest
         .spyOn(storeConfig.modules.currentChannel.actions, 'stopTask')
         .mockResolvedValue();
@@ -228,6 +231,25 @@ describe('ProgressModal', () => {
         await wrapper.vm.$nextTick();
         expect(pageReload).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe('when a user without publish permissions is viewing a channel currently being published by another user', () => {
+    it('progress modal should not be displayed', () => {
+
+      const storeConfig = cloneDeep(STORE_CONFIG);
+      const store = storeFactory(storeConfig);
+      const wrapper = makeWrapper({ store });
+
+      jest
+        .spyOn(storeConfig.modules.currentChannel.getters, 'currentChannel')
+        .mockReturnValue({ publishing: true });
+      jest
+        .spyOn(storeConfig.modules.currentChannel.getters, 'canManage')
+        .mockReturnValue({ canManage: false });
+
+      expect(getProgressModal(wrapper).exists()).toBe(false);
+      expect(getCancelModal(wrapper).exists()).toBe(false);
     });
   });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -234,9 +234,8 @@ describe('ProgressModal', () => {
     });
   });
 
-  describe('when a user without publish permissions is viewing a channel currently being published by another user', () => {
+  describe('when a user without publish permissions views a channel being published by another user', () => {
     it('progress modal should not be displayed', () => {
-
       const storeConfig = cloneDeep(STORE_CONFIG);
       const store = storeFactory(storeConfig);
       const wrapper = makeWrapper({ store });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

This PR adds a condition based on canManage to determine if Publish Modal is visible. 
Fixes #3079 


### Manual verification steps performed
1. Share a channel as "view only" with an admin user
2. Log in as the channel owner/creator in one window, and in an incognito window, also log in as the admin user who has "view only" permissions
3. Update and publish the shared channel as the user with editor permissions. 
4. Without these changes, the modal should appear in the "view-only" admin window, even though the user cannot access/click in to the modal themselves. With the changes, the modal should not appear.

### Screenshots (if applicable)
Before 
<img width="1373" alt="Screen Shot 2021-04-19 at 2 16 14 PM" src="https://user-images.githubusercontent.com/17235236/115284944-4ba18e80-a11b-11eb-9d7a-f67c78cd1725.png">

After
<img width="1426" alt="Screen Shot 2021-04-19 at 2 26 13 PM" src="https://user-images.githubusercontent.com/17235236/115284929-48a69e00-a11b-11eb-9624-e0998192751e.png">


### Does this introduce any tech-debt items?
Not that I am aware of 

___
## Reviewer guidance
### How can a reviewer test these changes?
Please follow the manual QA process above.

### Are there any risky areas that deserve extra testing?
The Progress/Publish modal in general is a bit of a fragile piece of code, so going over more than once manually may be helpful (I have tested this a few times)

## Comments
I was curious if this was also a problem with the "syncing" option of the progress modal but wasn't able to reproduce it. If it comes up, I can implement the same change for that portion of the modal as well.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
