### PR TITLE
Make sure to always annotate can_edit and can_view.

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_user.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_user.py
@@ -91,3 +91,27 @@ class CRUDTestCase(StudioAPITestCase):
             reverse("user-detail", kwargs={"pk": self.user.id})
         )
         self.assertEqual(response.status_code, 405, response.content)
+
+
+class ChannelUserCRUDTestCase(StudioAPITestCase):
+    def setUp(self):
+        super(ChannelUserCRUDTestCase, self).setUp()
+        self.channel = testdata.channel()
+        self.user = testdata.user()
+        self.channel.editors.add(self.user)
+
+    def test_fetch_users(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse("user-list"), data={"channel": self.channel.id}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_fetch_users_no_permissions(self):
+        new_channel = testdata.channel()
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse("user-list"), data={"channel": new_channel.id}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.json(), [])

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -22,6 +22,7 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from contentcuration.models import boolean_val
 from contentcuration.models import Channel
 from contentcuration.models import User
 from contentcuration.utils.pagination import get_order_queryset
@@ -161,7 +162,7 @@ class ChannelUserFilter(RequiredFilterSet):
     def filter_channel(self, queryset, name, value):
         # Check permissions
         if not self.request.user.can_edit(value):
-            return queryset.none()
+            return queryset.none().annotate(can_edit=boolean_val(False), can_view=boolean_val(False))
         user_queryset = User.objects.filter(id=OuterRef("id"))
         queryset = queryset.annotate(
             can_edit=Exists(user_queryset.filter(editable_channels=value)),


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Fixes regression whereby can_edit and can_view were not getting annotated on the User queryset for the ChannelUser endpoint.
Adds regression test to try to catch this in the future.


Fixes #3125
