### PR TITLE
Enhance email regex to catch common errors

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharing.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharing.vue
@@ -111,7 +111,7 @@
       validate() {
         if (!this.email.trim()) {
           this.error = this.$tr('emailRequiredMessage');
-        } else if (!/.+@.+\..+/.test(this.email)) {
+        } else if (!/^[^(),:;<>@[\\\]]{1,64}@\[?[A-Za-z0-9\-().]+\]?$/.test(this.email)) {
           this.error = this.$tr('validEmailMessage');
         } else if (this.checkUsers(this.channelId, this.email)) {
           this.error = this.$tr('alreadyHasAccessError');

--- a/contentcuration/contentcuration/frontend/shared/views/channel/__tests__/channelSharing.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/__tests__/channelSharing.spec.js
@@ -72,8 +72,23 @@ describe('channelSharing', () => {
     wrapper.vm.submitEmail();
     expect(sendInvitation).not.toHaveBeenCalled();
   });
-  it('should not call sendInvitation if email is invalid', () => {
-    wrapper.setData({ email: 'not a real email', loading: false });
+  // Examples drawn from:
+  // https://en.wikipedia.org/wiki/Email_address#Examples
+  it.each([
+    'not a real email',
+    '<this@hotmail.com>',
+    'Abc.example.com',
+    'A@b@c@example.com',
+    'a"b(c)d,e:f;g<h>i[j\\k]l@example.com',
+    // Don't validate these two examples just yet
+    // 'just"not"right@example.com',
+    // 'this is"not\allowed@example.com',
+    'this\\ still\\"not\\\\allowed@example.com',
+    '1234567890123456789012345678901234567890123456789012345678901234+x@example.com',
+    'i_like_underscore@but_its_not_allowed_in_this_part.example.com',
+    'QA[icon]CHOCOLATE[icon]@test.com',
+  ])('should not call sendInvitation if email is invalid: %s', email => {
+    wrapper.setData({ email, loading: false });
     wrapper.vm.submitEmail();
     expect(sendInvitation).not.toHaveBeenCalled();
   });
@@ -99,11 +114,30 @@ describe('channelSharing', () => {
     expect(wrapper.vm.error).toBeTruthy();
     expect(sendInvitation).not.toHaveBeenCalled();
   });
-  it('should call sendInvitation if email is valid', () => {
-    wrapper.setData({ email: 'test@test.com' });
+  // Examples drawn from:
+  // https://en.wikipedia.org/wiki/Email_address#Examples
+  it.each([
+    'simple@example.com',
+    'very.common@example.com',
+    'disposable.style.email.with+symbol@example.com',
+    'other.email-with-hyphen@example.com',
+    'fully-qualified-domain@example.com',
+    'user.name+tag+sorting@example.com',
+    'x@example.com',
+    'example-indeed@strange-example.com',
+    'test/test@test.com',
+    'admin@mailserver1',
+    'example@s.example',
+    '" "@example.org',
+    '"john..doe"@example.org',
+    'mailhost!username@example.org',
+    'user%example.com@example.org',
+    'user-@example.org',
+  ])('should call sendInvitation if email is valid: %s', email => {
+    wrapper.setData({ email });
     wrapper.vm.submitEmail();
     expect(sendInvitation).toHaveBeenCalledWith({
-      email: 'test@test.com',
+      email,
       shareMode: SharingPermissions.EDIT,
       channelId,
     });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Adds some extra restrictions to the email validation to protect against `<` and `>` being wrapped around email addresses.

Adds many tests to ensure we are not being too restrictive of valid email addresses, adds some tests of other emails we can safely exclude.

Examples drawn from here: https://en.wikipedia.org/wiki/Email_address#Examples

### Manual verification steps performed
Unit tests

___
## Reviewer guidance
### How can a reviewer test these changes?
Check that valid email addresses can still have channels shared with them.
Check that `<this@this.com>` cannot be shared with.


## References
Fixes #3021

### Contributor's Checklist

Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
