### PR TITLE
User-scoped channel quiz feature

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -104,6 +104,14 @@
             :label="$tr('randomizeQuestionLabel')"
             :indeterminate="!isUnique(randomizeOrder)"
           />
+
+          <!-- Feature flag: Channel quizzes -->
+          <Checkbox
+            v-if="allowChannelQuizzes"
+            v-model="channelQuiz"
+            :label="$tr('channelQuizzesLabel')"
+            :indeterminate="!oneSelected"
+          />
         </VFlex>
       </VLayout>
 
@@ -308,7 +316,7 @@
   import VisibilityDropdown from 'shared/views/VisibilityDropdown';
   import Checkbox from 'shared/views/form/Checkbox';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
-  import { NEW_OBJECT } from 'shared/constants';
+  import { NEW_OBJECT, FeatureFlagKeys, ContentModalities } from 'shared/constants';
 
   // Define an object to act as the place holder for non unique values.
   const nonUniqueValue = {};
@@ -479,6 +487,16 @@
         },
       },
       thumbnailEncoding: generateGetterSetter('thumbnail_encoding'),
+      channelQuiz: {
+        get() {
+          const options = this.getExtraFieldsValueFromNodes('options') || {};
+          return options.modality === ContentModalities.QUIZ;
+        },
+        set(val) {
+          const options = { modality: val ? ContentModalities.QUIZ : null };
+          this.updateExtraFields({ options });
+        },
+      },
 
       /* COMPUTED PROPS */
       disableAuthEdits() {
@@ -520,6 +538,9 @@
       },
       newContent() {
         return !this.nodes.some(n => n[NEW_OBJECT]);
+      },
+      allowChannelQuizzes() {
+        return this.$store.getters.hasFeatureEnabled(FeatureFlagKeys.channel_quizzes);
       },
     },
     watch: {
@@ -656,6 +677,7 @@
       tagsLabel: 'Tags',
       noTagsFoundText: 'No results found for "{text}". Press \'Enter\' key to create a new tag',
       randomizeQuestionLabel: 'Randomize question order for learners',
+      channelQuizzesLabel: 'Allowed as a channel quiz',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -677,7 +677,7 @@
       tagsLabel: 'Tags',
       noTagsFoundText: 'No results found for "{text}". Press \'Enter\' key to create a new tag',
       randomizeQuestionLabel: 'Randomize question order for learners',
-      channelQuizzesLabel: 'Allowed as a channel quiz',
+      channelQuizzesLabel: 'Allow as a channel quiz',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -258,6 +258,9 @@ function generateContentNodeData({
     if (extra_fields.randomize !== undefined) {
       contentNodeData.extra_fields.randomize = extra_fields.randomize;
     }
+    if (extra_fields.options) {
+      contentNodeData.extra_fields.options = extra_fields.options;
+    }
   }
   if (prerequisite !== NOVALUE) {
     contentNodeData.prerequisite = prerequisite;
@@ -282,11 +285,21 @@ export function updateContentNode(context, { id, ...payload } = {}) {
 
   // Don't overwrite existing extra_fields data
   if (contentNodeData.extra_fields) {
+    const extraFields = (node.extra_fields || {});
+
+    // Don't overwrite existing options data
+    if (contentNodeData.extra_fields.options) {
+      contentNodeData.extra_fields.options = {
+        ...(extraFields.options || {}),
+        ...contentNodeData.extra_fields.options,
+      }
+    }
+
     contentNodeData = {
       ...contentNodeData,
       extra_fields: {
-        ...(node.extra_fields || {}),
-        ...(contentNodeData.extra_fields || {}),
+        ...extraFields,
+        ...contentNodeData.extra_fields,
       },
     };
   }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -285,14 +285,14 @@ export function updateContentNode(context, { id, ...payload } = {}) {
 
   // Don't overwrite existing extra_fields data
   if (contentNodeData.extra_fields) {
-    const extraFields = (node.extra_fields || {});
+    const extraFields = node.extra_fields || {};
 
     // Don't overwrite existing options data
     if (contentNodeData.extra_fields.options) {
       contentNodeData.extra_fields.options = {
         ...(extraFields.options || {}),
         ...contentNodeData.extra_fields.options,
-      }
+      };
     }
 
     contentNodeData = {

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -166,5 +166,5 @@ export const FeatureFlagKeys = Object.keys(FeatureFlagsSchema.properties).reduce
 );
 
 export const ContentModalities = {
-  QUIZ: 'QUIZ'
+  QUIZ: 'QUIZ',
 };

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -157,10 +157,14 @@ export const ValidationErrors = {
 
 export const FeatureFlagsSchema = featureFlagsSchema;
 
-export const FeatureFlagKeys = Object.keys(FeatureFlagsSchema).reduce(
+export const FeatureFlagKeys = Object.keys(FeatureFlagsSchema.properties).reduce(
   (featureFlags, featureFlag) => {
     featureFlags[featureFlag] = featureFlag;
     return featureFlags;
   },
   {}
 );
+
+export const ContentModalities = {
+  QUIZ: 'QUIZ'
+};

--- a/contentcuration/contentcuration/static/feature_flags.json
+++ b/contentcuration/contentcuration/static/feature_flags.json
@@ -8,6 +8,11 @@
       "title": "Test development feature",
       "description": "This no-op feature flag is excluded from non-dev environments",
       "$env": "development"
+    },
+    "channel_quizzes": {
+      "type": "boolean",
+      "title": "Channel quizzes",
+      "description": "Allows an exercise to be marked as a channel quiz"
     }
   },
   "examples": [

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -243,6 +243,10 @@ class ContentNodeListSerializer(BulkListSerializer):
         return all_objects
 
 
+class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
+    modality = ChoiceField(choices=(("QUIZ", "Quiz"),), allow_null=True, required=False)
+
+
 class ExtraFieldsSerializer(JSONFieldDictSerializer):
     mastery_model = ChoiceField(
         choices=exercises.MASTERY_MODELS, allow_null=True, required=False
@@ -250,6 +254,7 @@ class ExtraFieldsSerializer(JSONFieldDictSerializer):
     randomize = BooleanField()
     m = IntegerField(allow_null=True, required=False)
     n = IntegerField(allow_null=True, required=False)
+    options = ExtraFieldsOptionsSerializer(required=False)
 
 
 class TagField(DotPathValueMixin, DictField):


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
Adds the ability to mark exercises as "channel quizzes," but only for admin users or users who have the feature enabled

### Description of the change(s) you made
- Adds a feature flag for "channel quiz" functionality
- Adds a checkbox to toggle "channel quiz" modality only when editing an exercise
- Updates logic for saving content node extra fields so the new modality gets saved

### Manual verification steps performed
1. Sign in as non-admin user
2. Open a channel that has exercises
3. Edit an exercise
4. Verify you do not see the new checkbox
5. In another browser or incognito session, sign in as an admin
6. As the admin, update the non-admin's account enabling the channel quiz feature
7. Refresh the non-admin's page
8. Edit an exercise
9. Observe the new checkbox
10. Enable the channel quiz functionality
11. Save your edits
12. Verify the change is saved in the database


### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
| Before / User-feature disabled | After / User-feature enabled |
| --- | --- |
| ![Screenshot from 2021-05-04 14-54-10](https://user-images.githubusercontent.com/819838/117075018-0075a700-ace9-11eb-912f-7da15b1b94e9.png) | ![Screenshot from 2021-05-04 14-59-07](https://user-images.githubusercontent.com/819838/117075230-54808b80-ace9-11eb-800e-5304f69423fd.png) |


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

Resolves https://github.com/learningequality/studio/issues/3119

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

Studio-specifc:

- [ ] All user-facing strings are translated properly


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
