### PR TITLE
Fixes two Django 1.11 to 3.2 upgrade issues in search.

### DIFF
--- a/contentcuration/search/tests.py
+++ b/contentcuration/search/tests.py
@@ -1,1 +1,31 @@
-# Create your tests here.
+from __future__ import absolute_import
+
+from django.urls import reverse
+
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+
+
+class SearchViewsetTestCase(StudioAPITestCase):
+
+    def test_filter_exclude_channels(self):
+        user = testdata.user()
+        self.client.force_authenticate(user=user)
+        channel = testdata.channel()
+        channel.editors.add(user)
+        response = self.client.get(
+            reverse("search-list"), data={"exclude_channel": channel.id}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.data["results"], [])
+
+    def test_filter_channels_by_edit(self):
+        user = testdata.user()
+        self.client.force_authenticate(user=user)
+        channel = testdata.channel()
+        channel.editors.add(user)
+        response = self.client.get(
+            reverse("search-list"), data={"channel_list": "edit"}, format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertNotEqual(response.data["results"], [])

--- a/contentcuration/search/viewsets/contentnode.py
+++ b/contentcuration/search/viewsets/contentnode.py
@@ -32,12 +32,6 @@ class ListPagination(CachedListPagination):
     page_size_query_param = "page_size"
     max_page_size = 100
 
-    def get_page_number(self, request):
-        try:
-            return int(request.query_params[self.page_query_param])
-        except (KeyError, ValueError):
-            return 1
-
 
 uuid_re = re.compile("([a-f0-9]{32})")
 
@@ -52,12 +46,12 @@ class ContentNodeFilter(RequiredFilterSet):
     resources = BooleanFilter(method="filter_resources")
     assessments = BooleanFilter(method="filter_assessments")
     created_after = CharFilter(method="filter_created_after")
-    channel_id__in = UUIDInFilter(name="channel_id")
+    channel_id__in = UUIDInFilter(field_name="channel_id")
     channel_list = CharFilter(method="filter_channel_list")
-    exclude_channel = UUIDFilter(name="channel_id", exclude=True)
+    exclude_channel = UUIDFilter(field_name="channel_id", exclude=True)
 
     def filter_channel_list(self, queryset, name, value):
-        user = not self.request.user.is_anonymous() and self.request.user
+        user = not self.request.user.is_anonymous and self.request.user
         channel_ids = []
         if value == "public":
             channel_ids = Channel.objects.filter(public=True, deleted=False).values_list("id", flat=True)


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds basic coverage for some commonly used filters on search endpoint.
* Fixes extant use of `user.is_anonymous` as a method not a property
* Updates `django_filter` initialization arguments from `name` to `field_name`


### Manual verification steps performed
1. Search for anything on the search page
2. See no 500s

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
Fixes #3168

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
