### PR TITLE
Fix password reset for Django 3.2 upgrade

### DIFF
--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -17,6 +17,7 @@ import django_js_reverse.views as django_js_reverse_views
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.urls import include
+from django.urls import path
 from django.urls import re_path
 from django.views.generic.base import RedirectView
 from rest_framework import routers
@@ -164,9 +165,8 @@ urlpatterns += i18n_patterns(
     re_path(r'^accounts/logout/$', registration_views.logout, name='logout'),
     re_path(r'^accounts/request_activation_link/$', registration_views.request_activation_link, name='request_activation_link'),
     re_path(r"^accounts/$", views.accounts, name="accounts"),
-    re_path(r'^accounts/password/reset/$', registration_views.UserPasswordResetView.as_view(), name='auth_password_reset'),
-    re_path(r'^accounts/password/reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        registration_views.UserPasswordResetConfirmView.as_view(), name='auth_password_reset_confirm'),
+    path(r'accounts/password/reset/', registration_views.UserPasswordResetView.as_view(), name='auth_password_reset'),
+    path(r'accounts/password/reset/confirm/<uidb64>/<token>/', registration_views.UserPasswordResetConfirmView.as_view(), name='auth_password_reset_confirm'),
     re_path(r'^accounts/register/$', registration_views.UserRegistrationView.as_view(), name='register'),
     re_path(r'^activate/(?P<activation_key>[-:\w]+)/$', registration_views.UserActivationView.as_view(), name='registration_activate'),
     re_path(r'^api/send_invitation_email/$', registration_views.send_invitation_email, name='send_invitation_email'),


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Copies latest URLs path from Django 3.2


### Manual verification steps performed
1. Attempt to request reset password link
2. Navigate to reset password link
3. Reset password

## References
Fixes #3173

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
