### PR TITLE
Add Zim to FormatPresets

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/leUtils/FormatPresets.js
+++ b/contentcuration/contentcuration/frontend/shared/leUtils/FormatPresets.js
@@ -384,6 +384,22 @@ const FormatPresetsMap = new Map([
       associated_mimetypes: ['image/jpeg', 'image/png'],
     },
   ],
+  [
+    'zim',
+    {
+      id: 'zim',
+      readable_name: 'ZIM Document',
+      multi_language: false,
+      supplementary: false,
+      thumbnail: false,
+      subtitle: false,
+      display: true,
+      order: 1,
+      kind_id: 'document',
+      allowed_formats: ['zim'],
+      associated_mimetypes: ['.zim'],
+    },
+  ],
 ]);
 
 export default FormatPresetsMap;
@@ -415,4 +431,5 @@ export const FormatPresetsNames = {
   VIDEO_DEPENDENCY: 'video_dependency',
   VIDEO_SUBTITLE: 'video_subtitle',
   VIDEO_THUMBNAIL: 'video_thumbnail',
+  ZIM: 'zim',
 };

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -131,6 +131,7 @@ export const constantStrings = createTranslator('ConstantStrings', {
   exercise: 'Exercise',
   h5p: 'H5P App',
   html5: 'HTML5 App',
+  zim: 'ZIM document',
   slideshow: 'Slideshow',
   coach: 'Coaches',
   learner: 'Anyone',


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

This change adds support for the Zim format to Kolibri Studio's frontend. The rest of this is being added in learningequality/le-utils#89.

## Reviewer guidance

I'm very new to Kolibri Studio - and this part of Kolibri in general - so please let me know if I have missed anything important.

## Comments

This is part of some ongoing work to support https://github.com/endlessm/kolibri-zim-plugin/.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
