### PR TITLE
Fix tag assignment in ricecooker endpoints.

### DIFF
--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -219,7 +219,7 @@ def api_commit_channel(request):
         event = generate_update_event(
             channel_id,
             CHANNEL,
-            {"root_id": obj.main_tree.id, "staging_root_id": obj.staging_tree.id,},
+            {"root_id": obj.main_tree.id, "staging_root_id": obj.staging_tree.id},
         )
 
         # Mark old staging tree for garbage collection
@@ -441,7 +441,7 @@ def get_channel_status_bulk(request):
             raise PermissionDenied()
         statuses = {cid: get_status(cid) for cid in data['channel_ids']}
 
-        return Response({"success": True, "statuses": statuses,})
+        return Response({"success": True, "statuses": statuses})
     except (Channel.DoesNotExist, PermissionDenied):
         return HttpResponseNotFound(
             "No complete set of channels matching: {}".format(",".join(channel_ids))
@@ -642,8 +642,7 @@ def create_node(node_data, parent_node, sort_order):  # noqa: C901
                 )
 
     if len(tags) > 0:
-        node.tags = tags
-        node.save()
+        node.tags.set(tags)
 
     return node
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Uses `set` method to set tags rather than assignment
* Adds tests of tag setting via ricecooker endpoints

### Manual verification steps performed
1. Automatic tests

## References
Fixes #3199

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
