### PR TITLE
point unstable at most recent KDS

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jest-each": "^24.8.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-serializer-vue": "^2.0.2",
-    "kolibri-design-system": "git+https://github.com/learningequality/kolibri-design-system#v0.2.x",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#cfcfc2548584dcdf48426d9379fccb8f56dd6c54",
     "less": "^3.0.1",
     "less-loader": "^5.0.0",
     "mini-css-extract-plugin": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12423,23 +12423,18 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@git+https://github.com/learningequality/kolibri-design-system#v0.2.x":
-  version "0.2.2-beta4"
-  resolved "git+https://github.com/learningequality/kolibri-design-system#3288f31a56e72f257ab6cd0b9def97f323637e53"
+"kolibri-design-system@github:learningequality/kolibri-design-system#cfcfc2548584dcdf48426d9379fccb8f56dd6c54":
+  version "0.2.2-beta-2"
+  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/cfcfc2548584dcdf48426d9379fccb8f56dd6c54"
   dependencies:
-    "@babel/core" "^7.9.6"
-    "@babel/preset-env" "^7.9.6"
-    "@mdi/svg" "^5.3.45"
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"
-    material-design-icons "^3.0.1"
     popper.js "^1.14.6"
     purecss "^0.6.2"
-    svgo "^1.3.2"
     tippy.js "^4.2.1"
 
 "kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.1":


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made


point Studio `unstable` to the latest `HEAD` of KDS

## References

points to https://github.com/learningequality/kolibri-design-system/commit/cfcfc2548584dcdf48426d9379fccb8f56dd6c54

## Reviewer guidance

Upgrades KDS using the following process:

* get the most recent commit
* update package.json file
* run yarn


___
## Reviewer guidance
### How can a reviewer test these changes?


Sanity check to look for regressions


### Are there any risky areas that deserve extra testing?

I don't believe so. In the future, consulting the KDS changelog will be the appropriate way to answer this question:

https://design-system.learningequality.org/changelog/

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
