### PR TITLE
Adding the new Studio Gherkin scenarios from Notion to GitHub

### DIFF
--- a/integration_testing/features/allow-marking-as-complete.feature
+++ b/integration_testing/features/allow-marking-as-complete.feature
@@ -1,5 +1,5 @@
 Feature: Allow marking as complete
-This feature allows learners to manually mark a resource as complete in the learning platform. This option is available on all file types.
+	This feature allows learners to manually mark a resource as complete in the learning platform. This option is available on all file types.
 
 # Comment here
 
@@ -23,7 +23,6 @@ This feature allows learners to manually mark a resource as complete in the lear
 		When I click *FINISH*
 		Then I see <resource> in the topic tree
 			And I do not see an error icon
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/allow-marking-as-complete.feature
+++ b/integration_testing/features/allow-marking-as-complete.feature
@@ -1,0 +1,30 @@
+Feature: Allow marking as complete
+This feature allows learners to manually mark a resource as complete in the learning platform. This option is available on all file types.
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *Allow marking as complete* checkbox in the *Completion* section
+
+	Scenario: Toggle *Allow learners to mark as complete* setting
+		Given the *Allow marking as complete* checkbox is empty
+		When I click the *Allow marking as complete* checkbox
+		Then I see the *Allow marking as complete* is selected
+		When I click the selected *Allow marking as complete* checkbox
+		Then I see the *Allow marking as complete* is empty
+
+	Scenario: See that *Allow learners to mark as complete* is optional
+		Given the *Allow marking as complete* checkbox of <resource> is empty
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I do not see an error icon
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/allow-marking-as-complete.feature
+++ b/integration_testing/features/allow-marking-as-complete.feature
@@ -6,10 +6,7 @@ Feature: Allow marking as complete
 	Background: 
 		Given I am signed into Studio
 			And I am in an editable channel
-		When I right click <resource>
-		When I click *Edit details*
-		Then I see the edit modal for <resource>
-			And I see the *Allow marking as complete* checkbox in the *Completion* section
+			And I see the *Edit* modal for <resource>
 
 	Scenario: Toggle *Allow learners to mark as complete* setting
 		Given the *Allow marking as complete* checkbox is empty
@@ -23,7 +20,3 @@ Feature: Allow marking as complete
 		When I click *FINISH*
 		Then I see <resource> in the topic tree
 			And I do not see an error icon
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-category-field.feature
+++ b/integration_testing/features/edit-category-field.feature
@@ -114,7 +114,7 @@ Feature: Edit *Category* field
 		Then I do not see any chips in the *Category* textbox
 			And I do not see the text that I started inputting
 
-	Scenario: See that *Categoy* is optional
+	Scenario: See that *Category* is optional
 		Given the *Category* field of <resource> is empty
 		When I click *FINISH*
 		Then I see <resource> in the topic tree
@@ -122,7 +122,3 @@ Feature: Edit *Category* field
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the *Category* field is empty
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-category-field.feature
+++ b/integration_testing/features/edit-category-field.feature
@@ -1,5 +1,5 @@
 Feature: Edit *Category* field
-Across all file types. 
+	Across all file types. 
 
 # Comment here
 
@@ -122,7 +122,6 @@ Across all file types.
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the *Category* field is empty
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/edit-category-field.feature
+++ b/integration_testing/features/edit-category-field.feature
@@ -1,0 +1,129 @@
+Feature: Edit *Category* field
+Across all file types. 
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *Category* dropdown in the *Basic information* section
+
+	Scenario: View category options
+		When I click the *Category* dropdown
+		Then I see a nested checkbox list of all categories
+			And I see that children checkboxes are aligned with the text of the parent category
+		When I scroll through the category list
+		Then I see a gray divider between top-level categories
+
+	Scenario: Select first-level category option
+		Given that <first-level category> checkbox is empty
+		When I click <first-level category> 
+		Then I see that <first-level category> is determinately selected
+			And I see that children categories are not selected
+			And I see a chip with <first-level category> in the *Category* text field
+
+	Scenario: Select second-level category option
+		Given that <first-level category> checkbox is empty
+		When I select <second-level category> under <first-level category>
+		Then I see that <second-level category> is determinately selected
+			And I see that <first-level category> is determinately selected
+			And I see that children categories are not selected
+			And I see that <second-level category> is represented as a chip in the *Category* text field 
+			And I do not see <first-level category> represented as a chip in the *Category* text field
+		When I hover my mouse over the <second-level category> chip
+		Then I see *<first-level category> - <second-level category>* in a tooltip
+
+	Scenario: Select third-level category option
+		Given that <first-level category> checkbox is empty
+			And <second-level category> under <first-level category> is empty
+		When I select <third-level category> under <second-level category>
+		Then I see that <third-level category> is determinately selected
+			And I see that <second-level category> is determinately selected
+			And I see that <first-level category> is determinately selected
+			And I see that <third-level category> is represented as a chip in the *Category* text field
+			And I do not see <second-level category> represented as a chip in the *Category* text field
+			And I do not see <first-level category> represented as a chip in the *Category* text field
+		When I hover my mouse over the <third-level category> chip
+		Then I see *<first-level category> - <second-level category> - <third-level category>* in a tooltip
+
+	Scenario: Select child category while a parent category is selected
+		Given that <first-level category> checkbox is selected
+			And <first-level category> is a chip in the *Category* text field
+		When I click <second-level category> under <first-level category>
+		then I see that <second-level category> is determinately selected
+			And <first-level category> is still determinately selected
+			And I see the chip in the *Category* text field changed to <second-level category>
+			And I do not see <first-level category> as a chip in the *Category* text field
+
+	Scenario: Select a parent category while a child category is selected
+		Given that <third-level category> is selected
+			And <third-level category> is a chip in the *Category* text field
+		When I click <second-level category>, the parent of <third-level category>
+		Then I see <third-level category> is not selected
+			And I see <second-level category> is not selected
+			And I see <first-level category> is determinately selected
+			And I see <first-level category> is represented as a chip in the *Category* text field
+
+	Scenario: Select categories through text input
+		When I click on the *Category* dropdown
+		Then I see that the text input is active
+		When I start entering text
+			And the text I enter appears in the categories
+		Then I see matching options appear as a flat list
+			And I do not see nested categories
+			And I see an *X* icon on the right side of the text input
+		When I click on the <category> checkbox from the flat list
+		Then I see <category> appear as a chip in the text input
+			And I see that my text input has cleared
+			And I see the full nested category list
+
+	Scenario: No results when inputting text
+		When I click on the *Category* dropdown
+		Then I see that the text input is active
+		When I start entering text
+			And the text I enter does not appear in the categories
+		Then I see *Category not found*
+			And I do not see any selectable categories
+
+	Scenario: Chips overflow in the text field
+		When I click <X> checkboxes in the *Category* dropdown
+			And the length of the chips exceeds the width of the dropdown
+		Then I see the chips go to the next line
+			And the height of the *Category* dropdown grows to contain it
+
+	Scenario: Remove category selection
+		Given I <option> is selected in *Category*
+		When I click the selected checkbox for <option>
+		Then I see that the checkbox for <option> is empty
+			And I do not see the chip in the textbox		
+
+	Scenario: Clear all category selections
+		Given there is more than one option selected in *Category
+		When I click the *X* in the text input of *Category*
+		Then I do not see any chips in the *Category* textbox
+
+	Scenario: Clear all category selections while inputting text
+		Given there is more than one option selected in *Category*
+		When I click on *Category*
+		Then I see I can input text
+		When I start inputting text
+		When I click the *X* on the *Category* dropdown
+		Then I do not see any chips in the *Category* textbox
+			And I do not see the text that I started inputting
+
+	Scenario: See that *Categoy* is optional
+		Given the *Category* field of <resource> is empty
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I do not see an error icon
+		When I left-click <resource>
+		Then I see the previewer for <resource>
+			And I see the *Category* field is empty
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/edit-completion-field.feature
+++ b/integration_testing/features/edit-completion-field.feature
@@ -1,5 +1,5 @@
 Feature: Edit completion field
-Across all file types
+	Across all file types
 
 # Comment here
 
@@ -139,7 +139,6 @@ Across all file types
 			And I see there is no learning activity label at the top left
 			And I see the *Completion* field has a red error icon
 			And I see the message *Missing completion criteria* in red text
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/edit-completion-field.feature
+++ b/integration_testing/features/edit-completion-field.feature
@@ -139,7 +139,3 @@ Feature: Edit completion field
 			And I see there is no learning activity label at the top left
 			And I see the *Completion* field has a red error icon
 			And I see the message *Missing completion criteria* in red text
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-completion-field.feature
+++ b/integration_testing/features/edit-completion-field.feature
@@ -1,0 +1,146 @@
+Feature: Edit completion field
+Across all file types
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *Completion* section underneath the *Basic information* section
+
+	Scenario: View options for .MP4
+		Given I am viewing an .MP4 file
+		When I click the *Completion* dropdown
+		Then I see the options: *Short activity*, *Long activity*, *Reference*, and *Exact time to complete*
+
+	Scenario: View options for .PDF or .EPUB
+		Given I am viewing a .PDF or .EPUB file
+		When I click the *Completion* dropdown
+		Then I see the options: *All content viewed*, *Short activity*, *Long activity*, *Reference*, and *Exact time to complete*
+
+	Scenario: View options for .MP3
+		Given I am viewing an .MP3 file 
+		When I click the *Completion* dropdown
+		Then I see the options: *Short activity*, *Long activity*, *Reference*, and *Exact time to complete*
+
+	Scenario: View options for .ZIP
+		Given I am viewing a .ZIP
+		When I click on the *Completion* dropdown
+		Then I see the options: *Short activity*, *Long activity*, *Reference*, *Exact time to complete*
+
+	Scenario: View options for Practice resources
+		Given I am viewing an exercise
+		When I click on the *Completion* dropdown
+		Then I see the options: *Practice until goal is met*, *Short activity*, *Long activity*, *Reference*, *Exact time to complete*
+
+	Scenario: Set completion to *Short activity*
+		When I click on the *Completion* dropdown
+		When I select *Short activity*
+		Then I see *Short activity* appear in the text input
+			And I see a *Minutes* text input field appear next to *Completion*
+			And I see a slider appear next to *Minutes*
+			And I see *Minutes* is set to 10 by default
+			And I see the maximum value of the slider is 30 minutes
+			And I see the caption *(Optional) Duration until resource is marked as complete. This value will not be shown to learners*
+
+	Scenario: Adjust time for short activities
+		Given *Completion* is set to *Short activity*
+		When I adjust the slider
+		Then I see the value in the *Minutes* field change to match the slider
+		When I type in a new value into *Minutes*
+		When I lose focus on *Minutes*
+		Then I see the slider changes to match the value in *Minutes*
+		When I enter a value above 30 minutes into *Minutes*
+		Then I see the value in *Minutes* is set to 30 minutes
+			And I see the slider is set to 30 minutes
+
+	Scenario: Set completion to *Long activity*
+		When I click on the *Completion* dropdown
+		When I select *Long activity*
+		Then I see *Long activity* appear in the text input
+			And I see a *Minutes* text input field appear next to *Completion*
+			And I see a slider appear next to *Minutes*
+			And I see *Minutes* is set to 45 by default
+			And I see the maximum value of the slider is 120 minutes
+			And I see the caption *(Optional) Duration until resource is marked as complete. This value will not be shown to learners*
+
+	Scenario: Adjust time for long activities
+		Given *Completion* is set to *Long activity*
+		When I adjust the slider
+		Then I see the value in the *Minutes* field change to match the slider
+		When I type in a new value into *Minutes*
+		When I lose focus on *Minutes*
+		Then I see the slider changes to match the value in *Minutes*
+		When I enter a value above 120 minutes into *Minutes*
+		Then I see the value in *Minutes* is set to 120 minutes
+			And I see the slider is set to 120 minutes
+		When I enter a value below 45 minutes into *Minutes*
+		Then I see the value in *Minutes* is set to 45 minutes
+			And I see the slider is set to 45 minutes
+
+	Scenario: Set completion to *Reference*
+		When I click on the *Completion* dropdown
+		When I select *Reference*
+		Then I see *Reference* appear as an input for *Completion*
+			And I see the caption *Progress will not be tracked on reference material unless learners mark it as complete*
+			And I see an info icon next to the *Completion* field
+		When I hover over the info icon
+		Then I see the tooltip *Textbooks, dictionaries, indexes, and other similar resources*
+
+	Scenario: Set completion to *Exact time to complete* on .MP4 or .MOV
+		Given I am viewing an .MP4 or .MOV
+		When I click the *Completion* dropdown
+		When I select *Exact time to complete*
+		Then I see the exact duration <XX:XX> appear next to the *Completion* field as plain text
+			And I see that I cannot edit it
+
+	Scenario: Set completion to *Exact time to complete* for non- .MP4 or .MOV
+		Given I am viewing a resource that is not an .MP4 or .MOV
+		When I click the *Completion* dropdown
+		When I select *Exact time to complete*
+		Then I see a *Exact time to complete* appear as an input for *Completion*
+			And I see a *Minutes* text input field appear next to *Completion*
+			And I see it is empty by default
+		When I click the *Minutes* field
+		When I enter a whole number
+		When I lose focus on the field
+		Then I see the number has saved
+
+	Scenario: Enter whole numbers only to *Minutes* field
+		Given I can see the *Minutes* field in *Completion*
+		When I try to enter a non-numeric input or non-whole number
+		Then I see that I am blocked from entering that input
+
+	Scenario: Set completion to *Practice until goal is met*
+		Given I am viewing an exercise
+		When I click the *Completion* dropdown
+		When I click *Practice until goal is met*
+		Then I see the *Completion* field is set to *Practice until goal is met*
+			And I see an empty *Goal* text field dropdown appears next to it
+		When I click the *Goal* dropdown
+		Then I see the options: *100% correct*, *M of N*, *10 in a row*, *2 in a row*, *3 in a row*, *5 in a row*
+		When I select *M of N*
+		Then I see an empty*Correct answers needed* text field, */*, and empty *Recent answers* text field appear
+
+	Scenario: See that *Completion* field is required
+		Given the *Completion* field of <resource> is empty
+		When I click the *Completion* text field
+		When I lose focus on the *Completion* text field
+		Then I see *Completion* is in an error state
+			And I see *Completion is required*
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I see a red error icon on <resource>
+		When I left-click <resource>
+		Then I see the previewer for <resource>
+			And I see there is no learning activity label at the top left
+			And I see the *Completion* field has a red error icon
+			And I see the message *Missing completion criteria* in red text
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/edit-learnin- level-field.feature
+++ b/integration_testing/features/edit-learnin- level-field.feature
@@ -57,7 +57,3 @@ Feature: Edit *Learning level* field
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the level field is empty
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-learnin- level-field.feature
+++ b/integration_testing/features/edit-learnin- level-field.feature
@@ -1,5 +1,5 @@
 Feature: Edit *Learning level* field
-Across all file types
+	Across all file types
 
 # Comment here
 
@@ -57,7 +57,6 @@ Across all file types
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the level field is empty
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/edit-learnin- level-field.feature
+++ b/integration_testing/features/edit-learnin- level-field.feature
@@ -1,0 +1,64 @@
+Feature: Edit *Learning level* field
+Across all file types
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *Level* dropdown in the *Basic information* section
+
+	Scenario: View learning level options
+		When I click the *Level* dropdown
+		Then I see multi-select checkboxes
+			And I see the options: *Preschool/Nursery*, *Lower primary*, *Upper primary*, *Lower secondary*, *Upper secondary*, *Tertiary*, *Specialized professional training*, *All levels -- basic skills*, *All levels -- work skills*
+
+	Scenario: Select options
+		Given I see the options for *Level*
+		When I click on the checkbox for <option>
+		Then I see <option> has a determinate checkbox
+			And I see the chip for <option> appear in the textbox
+			And I see an *X* in the text field
+
+	Scenario: Remove an option
+		Given I see the options for *Level*
+			And <option> is selected
+		When I click the selected checkbox for <option>
+		Then I see that the checkbox for <option> is empty
+			And I do not see the chip in the textbox
+
+	Scenario: Remove an option through chip
+		Given I see the options for *Level*
+			And <option> is selected
+		When I click the *X* in the chip
+		Then I do not see the chip for <option> in the textbox
+			And I do not see <option> selected in the *Level* dropdown
+
+	Scenario: Clear all options in the text field
+		Given I see that several options for *Level* are selected
+		When I click the *X* in the text field
+		Then I do not see any *Level* options in the text field
+			And I do not see the *X* in the text field
+
+	Scenario: Chips overflow in the text field
+		When I click <X> checkboxes in the *Level* dropdown
+			And the length of the chips exceeds the width of the dropdown
+		Then I see the chips go to the next line
+			And the height of the *Level* dropdown grows to contain it
+
+	Scenario: See that learning level field is optional
+		Given the *Level* field of <resource> is empty
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I do not see an error icon
+		When I left-click <resource>
+		Then I see the previewer for <resource>
+			And I see the level field is empty
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/edit-learning-activity-field.feature
+++ b/integration_testing/features/edit-learning-activity-field.feature
@@ -63,7 +63,3 @@ Feature: Edit *Learning activity* field
 			And I see there is no learning activity label at the top left
 			And I see the *Learning activity* field has a red error icon
 			And I see the message *Missing learning activity* in red text
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-learning-activity-field.feature
+++ b/integration_testing/features/edit-learning-activity-field.feature
@@ -1,0 +1,70 @@
+Feature: Edit *Learning activity* field
+Across all file types
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *Learning activity* dropdown in the *Basic information* section
+
+	Scenario: View learning activity options
+		When I click the *Learning activity* dropdown
+		Then I see multi-select checkboxes
+			And I see the options: *Watch*, *Read*, *Practice*, *Explore*, *Create*, *Reflect*, *Listen*
+
+	Scenario: Select options
+		Given I see the options for *Learning activity*
+		When I click on the checkbox for <option>
+		Then I see <option> has a determinate checkbox
+			And I see the chip for <option> appear in the textbox
+			And I see an *X* in the text field
+
+	Scenario: Remove an option
+		Given I see the options for *Learning activity*
+			And <option> is selected
+		When I click the selected checkbox for <option>
+		Then I see that the checkbox for <option> is empty
+			And I do not see the chip in the textbox
+
+	Scenario: Remove an option through chip
+		Given I see the options for *Learning activity*
+			And <option> is selected
+		When I click the *X* in the chip
+		Then I do not see the chip for <option> in the textbox
+			And I do not see <option> selected in the *Learning activity* dropdown
+
+	Scenario: Clear all options in the text field
+		Given I see that several options for *Learning activity* are selected
+		When I click the *X* in the text field
+		Then I do not see any *Learning activity* options in the text field
+			And I do not see the *X* in the text field
+
+	Scenario: Chips overflow in the text field
+		When I click <X> checkboxes in the *Learning activity* dropdown
+			And the length of the chips exceeds the width of the dropdown
+		Then I see the chips go to the next line
+			And the height of the *Learning activity* dropdown grows to contain it
+
+	Scenario: See that learning activity field is required
+		Given the *Learning activity* field of <resource> is empty
+		When I click the *Learning activity* text field
+		When I lose focus on the *Learning activity* text field
+		Then I see *Learning activity* is in an error state
+			And I see *Learning activity is required*
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I see a red error icon on <resource>
+		When I left-click <resource>
+		Then I see the previewer for <resource>
+			And I see there is no learning activity label at the top left
+			And I see the *Learning activity* field has a red error icon
+			And I see the message *Missing learning activity* in red text
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/edit-learning-activity-field.feature
+++ b/integration_testing/features/edit-learning-activity-field.feature
@@ -1,5 +1,5 @@
 Feature: Edit *Learning activity* field
-Across all file types
+	Across all file types
 
 # Comment here
 
@@ -63,7 +63,6 @@ Across all file types
 			And I see there is no learning activity label at the top left
 			And I see the *Learning activity* field has a red error icon
 			And I see the message *Missing learning activity* in red text
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/edit-multiple-resources-at-the-same-time.feature
+++ b/integration_testing/features/edit-multiple-resources-at-the-same-time.feature
@@ -1,0 +1,72 @@
+Feature: Edit multiple resources at the same time in the edit modal
+Users can apply dropdown options to multiple resources at one time
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I select <X> resource checkboxes
+		When I click *Edit* in the toolbar
+		Then I see all <X> resources in the edit modal
+
+	Scenario: See which fields are hidden and shown
+		When I select more than one checkbox in the resource panel on the left
+		Then I see *Editing details for <X> resources* 
+			And I see text fields and dropdown options that are common to all <X> selected resources
+			And I do not see text fields and dropdown options that are not common to all <X> selected resources
+			And I do not see the resource renderer, *Title*, *Description*, *Preview files*, or *Thumbnail*
+
+	Scenario: View mixed settings on a multi-select dropdown
+		When I select <X> checkboxes in the resource panel on the left
+			And those <X> resources have mixed settings across different dropdown fields
+		Then I see a chip with the *Mixed* label for those dropdowns
+			And I see checkboxes are indeterminately selected
+		When I click a dropdown that has the *Mixed* label
+			Then I see an indeterminate checkbox for each option that partially applies to all <X> selected resources
+
+	Scenario: Select an indeterminate checkbox in a multi-select dropdown
+		Given <multi-select dropdown> has a *Mixed* chip
+		When I click <multi-select dropdown>
+		Then I see <option> is indeterminately selected
+		When I click <option>
+		Then I see <option> is determinately selected
+			And I see <option> is a chip in <multi-select dropdown>
+
+	Scenario: View mixed settings on a single-select dropdown
+		Given <single-select dropdown> says *Mixed*
+		When I click <single-select dropdown>
+		Then I see all options
+			And I see that none of them are selected
+		When I click <option>
+		Then I see <option> in the dropdown
+			And I see <option> is selected in the dropdown options
+
+	Scenario: View mixed settings on a checkbox
+		When I select <X> checkboxes in the resource panel on the left
+			And those <X> resources have mixed settings across checkbox settings
+			And I see that some checkboxes are indeterminate
+		When I click an indeterminate checkbox for <option>
+		Then I see the checkbox is determinate
+			And I do not see the chip with a *Mixed* label
+			And I see a chip for <option> in the dropdown
+			And I see that all <X> selected resources are applied with <option>
+
+	Scenario: Apply a setting to all selected resources
+			When I select <X> checkboxes in the resource panel on the left
+			When I open a dropdown
+			When I select <option>
+			Then I see a chip in the dropdown with <option>
+				And I see the checkbox is determinate
+
+	Scenario: Remove a setting from all resources
+		Given <option> applies to all selected resources
+			And I see a chip for <option> in <multi-select dropdown>
+		When I click *X* on the chip of <option>
+		Then I do not see the chip for <option>
+			And I see that none of the resources have <option> applied for <multi-select dropdown>
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/edit-multiple-resources-at-the-same-time.feature
+++ b/integration_testing/features/edit-multiple-resources-at-the-same-time.feature
@@ -1,5 +1,5 @@
 Feature: Edit multiple resources at the same time in the edit modal
-Users can apply dropdown options to multiple resources at one time
+	Users can apply dropdown options to multiple resources at one time
 
 # Comment here
 
@@ -65,7 +65,6 @@ Users can apply dropdown options to multiple resources at one time
 		When I click *X* on the chip of <option>
 		Then I do not see the chip for <option>
 			And I see that none of the resources have <option> applied for <multi-select dropdown>
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/edit-multiple-resources-at-the-same-time.feature
+++ b/integration_testing/features/edit-multiple-resources-at-the-same-time.feature
@@ -65,7 +65,3 @@ Feature: Edit multiple resources at the same time in the edit modal
 		When I click *X* on the chip of <option>
 		Then I do not see the chip for <option>
 			And I see that none of the resources have <option> applied for <multi-select dropdown>
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-what-you-will-need-field.feature
+++ b/integration_testing/features/edit-what-you-will-need-field.feature
@@ -57,7 +57,3 @@ Feature: Edit *What you will need* field
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the *What you will need* field is empty
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/edit-what-you-will-need-field.feature
+++ b/integration_testing/features/edit-what-you-will-need-field.feature
@@ -1,5 +1,5 @@
 Feature: Edit *What you will need* field
-Across all file types
+	Across all file types
 
 # Comment here
 
@@ -11,7 +11,7 @@ Across all file types
 		Then I see the edit modal for <resource>
 			And I see the *What you will need* dropdown in the *Basic information* section
 
-	Scenario: View 'What you will need' options
+	Scenario: View *What you will need* options
 		When I click the *What you will need* dropdown
 		Then I see multi-select checkboxes
 			And I see the options: *Teacher*, *Peers*, *Paper and pencil*, *Internet*, and *Other supplies*
@@ -57,7 +57,6 @@ Across all file types
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the *What you will need* field is empty
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/edit-what-you-will-need-field.feature
+++ b/integration_testing/features/edit-what-you-will-need-field.feature
@@ -1,0 +1,64 @@
+Feature: Edit *What you will need* field
+Across all file types
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *What you will need* dropdown in the *Basic information* section
+
+	Scenario: View 'What you will need' options
+		When I click the *What you will need* dropdown
+		Then I see multi-select checkboxes
+			And I see the options: *Teacher*, *Peers*, *Paper and pencil*, *Internet*, and *Other supplies*
+
+	Scenario: Select options
+		Given I see the options for *What you will need*
+		When I click on the checkbox for <option>
+		Then I see <option> has a determinate checkbox
+			And I see the chip for <option> appear in the textbox
+			And I see an *X* in the text field
+
+	Scenario: Remove an option
+		Given I see the options for *What you will need*
+			And <option> is selected
+		When I click the selected checkbox for <option>
+		Then I see that the checkbox for <option> is empty
+			And I do not see the chip in the textbox
+
+	Scenario: Remove an option through chip
+		Given I see the options for *What you will need*
+			And <option> is selected
+		When I click the *X* in the chip
+		Then I do not see the chip for <option> in the textbox
+			And I do not see <option> selected in the *What you will need* dropdown
+
+	Scenario: Clear all options in the text field
+		Given I see that several options for *What you will need* are selected
+		When I click the *X* in the text field
+		Then I do not see any *What you will need* options in the text field
+			And I do not see the *X* in the text field
+
+	Scenario: Chips overflow in the text field
+		When I click <X> checkboxes in the *What you will need* dropdown
+			And the length of the chips exceeds the width of the dropdown
+		Then I see the chips go to the next line
+			And the height of the *What you will need* dropdown grows to contain it
+
+	Scenario: See that *What you will need* field is optional
+		Given the *What you will need* field of <resource> is empty
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I do not see an error icon
+		When I left-click <resource>
+		Then I see the previewer for <resource>
+			And I see the *What you will need* field is empty
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/new-layout-in-the-edit-modal.feature
+++ b/integration_testing/features/new-layout-in-the-edit-modal.feature
@@ -55,7 +55,3 @@ Feature: New layout in the edit modal
 			And I see a *Completion* section underneath the *Assessment options* section
 			And I see a *For beginners* checkbox in the Audience section
 			And I see an *Accessibility* section underneath the *Audience* section
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/new-layout-in-the-edit-modal.feature
+++ b/integration_testing/features/new-layout-in-the-edit-modal.feature
@@ -1,0 +1,62 @@
+Feature: New layout in the edit modal
+User can see new fields: learning level, learning activity, what you will need, duration, completion, for beginners, accessibility, and category
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+
+	Scenario: View .PDF/.EPUB layout
+		When I right click a .PDF or .EPUB resource
+		Then I see an options menu for that .PDF or .EPUB
+		When I click *Edit details*
+		Then I see *Title*, *Description*, *Learning activity*, *Level*, *What you will need*, *Tags*, and *Category* dropdowns under the *Basic information* section
+			And I see a *Completion* section underneath the *Basic information* section
+			And I see a *For beginners* checkbox in the Audience section
+			And I see an *Accessibility* section underneath the *Audience* section 
+
+Scenario: View .MP3 layout
+		When I right click an .MP3 resource
+		Then I see an options menu for that .MP3
+		When I click *Edit details*
+		Then I see *Title*, *Description*, *Learning activity*, *Level*, *What you will need*, *Tags*, and *Category* dropdowns under the *Basic information* section
+			And I see a *Completion* section underneath the *Basic information* section
+			And I see a *For beginners* checkbox in the Audience section
+			And I see *Captions and subtitles* underneath the *Source* section
+
+Scenario: View .MP4 / .MOV layout
+		When I right click an .MP4 or .MOV resource
+		Then I see an options menu for that .MP4 or .MOV
+		When I click *Edit details*
+		Then I see *Title*, *Description*, *Learning activity*, *Level*, *What you will need*, *Tags*, and *Category* dropdowns under the *Basic information* section
+			And I see a *Completion* section underneath the *Basic information* section
+			And I see a *Completion* dropdown under the *Completion* section
+			And I see *Allow learners to mark as complete* under the *Completion* section
+			And I see a *For beginners* checkbox in the Audience section
+			And I see an *Accessibility* section underneath the *Audience* section
+
+Scenario: View *Practice* resource layout
+		When I right click a *Practice* resource
+		Then I see an options menu for that *Practice* resource
+		When I click *Edit details*
+		Then I see *Title*, *Description*, *Learning activity*, *Level*, *What you will need*, *Tags*, and *Category* dropdowns under the *Basic information* section
+			And I see an *Assessment options* section underneath the *Basic information* section
+			And I see a *Completion* section underneath the *Assessment options* section
+			And I see a *For beginners* checkbox in the Audience section
+			And I see an *Accessibility* section underneath the *Audience* section
+
+Scenario: View .ZIP resource layout
+		When I right click a *.ZIP* resource
+		Then I see an options menu for that *.ZIP* resource
+		When I click *Edit details*
+		Then I see *Title*, *Description*, *Learning activity*, *Level*, *What you will need*, *Tags*, and *Category* dropdowns under the *Basic information* section
+			And I see an *Assessment options* section underneath the *Basic information* section
+			And I see a *Completion* section underneath the *Assessment options* section
+			And I see a *For beginners* checkbox in the Audience section
+			And I see an *Accessibility* section underneath the *Audience* section
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/new-layout-in-the-edit-modal.feature
+++ b/integration_testing/features/new-layout-in-the-edit-modal.feature
@@ -1,5 +1,5 @@
 Feature: New layout in the edit modal
-User can see new fields: learning level, learning activity, what you will need, duration, completion, for beginners, accessibility, and category
+	User can see new fields: learning level, learning activity, what you will need, duration, completion, for beginners, accessibility, and category
 
 # Comment here
 
@@ -16,7 +16,7 @@ User can see new fields: learning level, learning activity, what you will need, 
 			And I see a *For beginners* checkbox in the Audience section
 			And I see an *Accessibility* section underneath the *Audience* section 
 
-Scenario: View .MP3 layout
+	Scenario: View .MP3 layout
 		When I right click an .MP3 resource
 		Then I see an options menu for that .MP3
 		When I click *Edit details*
@@ -25,7 +25,7 @@ Scenario: View .MP3 layout
 			And I see a *For beginners* checkbox in the Audience section
 			And I see *Captions and subtitles* underneath the *Source* section
 
-Scenario: View .MP4 / .MOV layout
+	Scenario: View .MP4 / .MOV layout
 		When I right click an .MP4 or .MOV resource
 		Then I see an options menu for that .MP4 or .MOV
 		When I click *Edit details*
@@ -36,7 +36,7 @@ Scenario: View .MP4 / .MOV layout
 			And I see a *For beginners* checkbox in the Audience section
 			And I see an *Accessibility* section underneath the *Audience* section
 
-Scenario: View *Practice* resource layout
+	Scenario: View *Practice* resource layout
 		When I right click a *Practice* resource
 		Then I see an options menu for that *Practice* resource
 		When I click *Edit details*
@@ -46,7 +46,7 @@ Scenario: View *Practice* resource layout
 			And I see a *For beginners* checkbox in the Audience section
 			And I see an *Accessibility* section underneath the *Audience* section
 
-Scenario: View .ZIP resource layout
+	Scenario: View .ZIP resource layout
 		When I right click a *.ZIP* resource
 		Then I see an options menu for that *.ZIP* resource
 		When I click *Edit details*
@@ -55,7 +55,6 @@ Scenario: View .ZIP resource layout
 			And I see a *Completion* section underneath the *Assessment options* section
 			And I see a *For beginners* checkbox in the Audience section
 			And I see an *Accessibility* section underneath the *Audience* section
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/new-metadata-defaults-while-uploading-or-creating-new-files.feature
+++ b/integration_testing/features/new-metadata-defaults-while-uploading-or-creating-new-files.feature
@@ -1,5 +1,5 @@
 Feature: New metadata defaults while uploading or creating new files
-User uploads files and sees which new metadata fields are and aren't set by default
+	User uploads files and sees which new metadata fields are and aren't set by default
 
 # Comment here
 
@@ -72,7 +72,6 @@ User uploads files and sees which new metadata fields are and aren't set by defa
 			And I see *Completion* is empty
 			And I see *Accessibility* checkboxes are unchecked
 			And I see *Category* is empty
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/new-metadata-defaults-while-uploading-or-creating-new-files.feature
+++ b/integration_testing/features/new-metadata-defaults-while-uploading-or-creating-new-files.feature
@@ -1,0 +1,79 @@
+Feature: New metadata defaults while uploading or creating new files
+User uploads files and sees which new metadata fields are and aren't set by default
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I click the *ADD* button
+		When I select *Upload files*
+		Then I see the *Upload files* page
+
+	Scenario: Upload .PDF or .EPUB
+		When I upload <.PDF or .EPUB>
+		Then I see the edit modal for <.PDF or .EPUB>
+			And I see upload of <.PDF or .EPUB> is in progress
+			And I see *Level* is empty
+			And I see *Learning activity* is set to *Read*
+			And I see *What you will need* is empty
+			And I see *Allow marking as complete* is empty
+			And I see *Completion* is set to *All content viewed*
+			And I see *Accessibility* checkboxes are unchecked
+			And I see *Category* is empty
+
+	Scenario: Upload .MP3
+		When I upload <.MP3>
+		Then I see the edit modal for <.MP3>
+			And I see upload of <.MP3> is in progress
+			And I see *Level* is empty
+			And I see *Learning activity* is set to *Listen*
+			And I see *What you will need* is empty
+			And I see *Allow marking as complete* is empty
+			And I see *Completion* is set to *Exact time to complete*
+			And I see *Exact time to complete* is set to the exact duration of <.MP3>
+			And I see *Accessibility* checkboxes are unchecked
+			And I see *Category* is empty
+
+	Scenario: Upload .MP4 or .MOV
+		When I upload <.MP4 or .MOV>
+		Then I see the edit modal for <.MP4 or .MOV>
+			And I see upload of <.MP4 or .MOV> is in progress
+			And I see *Level* is empty
+			And I see *Learning activity* is set to *Watch*
+			And I see *What you will need* is empty
+			And I see *Allow marking as complete* is empty
+			And I see *Completion* is set to *Exact time to complete*
+			And I see *Exact time to complete* is set to the exact duration of <.MP4 or .MOV>
+			And I see *Accessibility* checkboxes are unchecked
+			And I see *Category* is empty
+
+	Scenario: Upload .ZIP
+		When I upload <.ZIP>
+		Then I see the edit modal for <.ZIP>
+			And I see upload of <.ZIP> is in progress
+			And I see *Level* is empty
+			And I see *Learning activity* is empty
+			And I see *What you will need* is empty
+			And I see *Allow marking as complete* is empty
+			And I see *Completion* is empty
+			And I see *Accessibility* checkboxes are unchecked
+			And I see *Category* is empty
+
+	Scenario: Create new Practice resource
+		Given I am in an editable channel
+		When I click *ADD*
+		When I click *New exercise*
+		Then I see the edit modal for the exercise
+			And I see *Level* is empty
+			And I see *Learning activity* is set to *Practice*
+			And I see *What you will need* is empty
+			And I see *Allow marking as complete* is empty
+			And I see *Completion* is empty
+			And I see *Accessibility* checkboxes are unchecked
+			And I see *Category* is empty
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/new-metadata-defaults-while-uploading-or-creating-new-files.feature
+++ b/integration_testing/features/new-metadata-defaults-while-uploading-or-creating-new-files.feature
@@ -72,7 +72,3 @@ Feature: New metadata defaults while uploading or creating new files
 			And I see *Completion* is empty
 			And I see *Accessibility* checkboxes are unchecked
 			And I see *Category* is empty
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/view-new-metadata-in-previewers-across-studio.feature
+++ b/integration_testing/features/view-new-metadata-in-previewers-across-studio.feature
@@ -1,0 +1,49 @@
+Feature: View new metadata in previewers across Studio
+How the new metadata is laid out on previewers
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+
+	Scenario: View .PDF or .EPUB previewer
+		When I left-click a .PDF or .EPUB
+		Then I see the previewer panel
+			And I see a learning activity label
+			And I see text fields for: *Level*, *Learning activity*, *Completion*, *Category*, and *Accessibility*
+
+	Scenario: View .MP3 previewer
+		When I left-click an .MP3
+		Then I see the previewer panel
+			And I see a learning activity label
+			And I see text fields for: *Level*, *Learning activity*, *Completion*, *Category*, and *Captions and subtitles*
+
+	Scenario: View .MP4 or .MOV previewer
+		When I left-click a .MP4 or .MOV
+		Then I see the previewer panel
+			And I see a learning activity label
+			And I see text fields for: *Level*, *Learning activity*, *Completion*, *Category*, and *Accessibility*
+
+	Scenario: View Practice previewer
+		When I left-click an exercise
+		Then I see the previewer panel
+			And I see a learning activity label
+			And I see text fields for: *Level*, *Learning activity*, *Completion*, *Category*, and *Accessibility*
+
+	Scenario: View previewer with multiple activities
+		Given a resource has multiple learning activities set
+		When I left-click the resource
+		Then I see the previewer panel
+			And I see multiple learning activity labels
+
+	Scenario: View previewer with empty fields
+		Given <resource> has empty <metadata> field
+		When I left-click <resource>
+		Then I see the previewer panel
+			And I see there is a *–* in the field
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/view-new-metadata-in-previewers-across-studio.feature
+++ b/integration_testing/features/view-new-metadata-in-previewers-across-studio.feature
@@ -1,5 +1,5 @@
 Feature: View new metadata in previewers across Studio
-How the new metadata is laid out on previewers
+	How the new metadata is laid out on previewers
 
 # Comment here
 
@@ -42,7 +42,6 @@ How the new metadata is laid out on previewers
 		When I left-click <resource>
 		Then I see the previewer panel
 			And I see there is a *–* in the field
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/view-new-metadata-in-previewers-across-studio.feature
+++ b/integration_testing/features/view-new-metadata-in-previewers-across-studio.feature
@@ -42,7 +42,3 @@ Feature: View new metadata in previewers across Studio
 		When I left-click <resource>
 		Then I see the previewer panel
 			And I see there is a *–* in the field
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/view-new-metadata-in-the-channel-details-modal.feature
+++ b/integration_testing/features/view-new-metadata-in-the-channel-details-modal.feature
@@ -1,0 +1,34 @@
+Feature: View new metadata in the channel details modal
+
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel, <channel>
+		When I click on the info icon next to the <channel> label in the app bar
+		Then I see the channel details modal for <channel>
+
+	Scenario: View total resources
+		Given there are resources for all learning activity types in <channel>
+			And some are marked with *Multiple activities*
+		Then I see the new icons and labels
+			And I see the number of resources for each learning activity
+			And I see they are ordered from most frequent at the top of the list to least frequent at the bottom of the list
+
+	Scenario: View levels in the channel
+		Given there are resources marked with different learning levels
+		Then I see a list of levels that appear in the channel
+			And I see that the list is comma-separated
+			And I see it is ordered from most frequent levels first to least frequent levels last
+	
+	Scenario: View categories in the channel
+		Given there are resources marked with different categories
+		Then I see a list of categories that appear in the channel
+			And I see that the list is comma-separated
+			And I see it is ordered from most frequent categories first to least frequent categories last
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/view-new-metadata-in-the-channel-details-modal.feature
+++ b/integration_testing/features/view-new-metadata-in-the-channel-details-modal.feature
@@ -28,7 +28,6 @@ Feature: View new metadata in the channel details modal
 			And I see that the list is comma-separated
 			And I see it is ordered from most frequent categories first to least frequent categories last
 
-
 Examples:
 | ???      | ??? | 
 | ?????!?! |

--- a/integration_testing/features/view-new-metadata-in-the-channel-details-modal.feature
+++ b/integration_testing/features/view-new-metadata-in-the-channel-details-modal.feature
@@ -27,7 +27,3 @@ Feature: View new metadata in the channel details modal
 		Then I see a list of categories that appear in the channel
 			And I see that the list is comma-separated
 			And I see it is ordered from most frequent categories first to least frequent categories last
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/view-new-metadata-on-cards-and-list-items-in-the-studio-topic-tree-view.feature
+++ b/integration_testing/features/view-new-metadata-on-cards-and-list-items-in-the-studio-topic-tree-view.feature
@@ -1,0 +1,46 @@
+Feature: View new metadata on cards and list items in the Studio topic tree view
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+
+	Scenario: See new metadata for .pdf, .epub, .mp3, .mp4, .mov, .zip
+		Given *View* is set to *Default view*
+			And <resource> has <categories>, <learning activity>, and <levels> options set
+		Then I see <categories>, <learning activity>, and <levels> on the <resource> in the topic tree
+			And I see the thumbnail, description, and title
+
+	Scenario: See new metadata for exercises
+		Given *View* is set to *Default view*
+			And <exercise> has <categories>, <learning activity>, and <levels> options set
+		Then I see <categories>, <learning activity>, and <levels> on the <resource> in the topic tree
+			And I see the thumbnail, description, title, and number of questions
+
+	Scenario: See metadata for *Comfortable view*
+		Given *View* is set to *Comfortable view*
+		Then I see the title, thumbnail, and learning activity
+			And I do not see any other metadata
+
+	Scenario: See metadata for *Compact view*
+		Given *View* is set to *Compact view*
+		Then I see The title and learning activity
+			And I do not see any other metadata
+
+	Scenario: See metadata for .pdf, .epub, .mp3, .mp4, .mov, .zip while importing from a channel
+		Given *View* is set to *Default view* 
+			 And <resource> has <categories>, <learning activity>, and <levels> options set
+		Then I see <categories>, <learning activity>, and <levels> on the <resource> in the topic tree
+			And I see the thumbnail, description, and title
+
+	Scenario: See metadata for exercises while importing from a channle
+		Given *View* is set to *Default view*
+			And <resource> has <categories>, <learning activity>, and <levels> options set
+		Then I see <categories>, <learning activity>, and <levels> on the <resource> in the topic tree
+			And I see the thumbnail, description, and title
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/view-new-metadata-on-cards-and-list-items-in-the-studio-topic-tree-view.feature
+++ b/integration_testing/features/view-new-metadata-on-cards-and-list-items-in-the-studio-topic-tree-view.feature
@@ -39,7 +39,3 @@ Feature: View new metadata on cards and list items in the Studio topic tree view
 			And <resource> has <categories>, <learning activity>, and <levels> options set
 		Then I see <categories>, <learning activity>, and <levels> on the <resource> in the topic tree
 			And I see the thumbnail, description, and title
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/view-new-metadata-on-cards-and-list-items-in-the-studio-topic-tree-view.feature
+++ b/integration_testing/features/view-new-metadata-on-cards-and-list-items-in-the-studio-topic-tree-view.feature
@@ -40,7 +40,6 @@ Feature: View new metadata on cards and list items in the Studio topic tree view
 		Then I see <categories>, <learning activity>, and <levels> on the <resource> in the topic tree
 			And I see the thumbnail, description, and title
 
-
 Examples:
 | ???      | ??? | 
 | ?????!?! |

--- a/integration_testing/features/wip-edit-accessibility-field.feature
+++ b/integration_testing/features/wip-edit-accessibility-field.feature
@@ -1,5 +1,5 @@
 Feature: Edit *Accessibility* field
-Across all file types
+	Across all file types
 
 # Comment here
 
@@ -83,7 +83,6 @@ Across all file types
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the *Accessibility* field is empty
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/wip-edit-accessibility-field.feature
+++ b/integration_testing/features/wip-edit-accessibility-field.feature
@@ -1,0 +1,90 @@
+Feature: Edit *Accessibility* field
+Across all file types
+
+# Comment here
+
+	Background: 
+		Given I am signed into Studio
+			And I am in an editable channel
+		When I right click <resource>
+		When I click *Edit details*
+		Then I see the edit modal for <resource>
+			And I see the *Accessibility* section underneath the *Audience* section
+
+	Scenario: View options for .MP4
+		Given I am viewing an .MP4 in the edit modal
+		Then I see a checkbox that says *Has sign language captions*
+			And I see a checkbox that says *Has audio descriptions*
+
+	Scenario: View tooltips for .MP4
+		Given I am viewing an .MP4 in the edit modal
+		When I hover my mouse over the info icon for *Has sign language captions*
+		Then I see *text*
+		When I hover my mouse over the info icon for *Has audio descriptions*
+		Then I see *text*
+
+	Scenario: View options for .PDF or .EPUB
+		Given I am viewing a .PDF or .EPUB in the edit modal
+		Then I see a checkbox that says *Has alternative text description for images*
+			And I see a checkbox that says *Has high contrast display for low vision*
+			And I see a checkbox that says *Tagged PDF*
+
+	Scenario: View tooltips for .PDF or .EPUB
+		Given I am viewing a .PDF or .EPUB in the edit modal
+		When I hover my mouse over the info icon for *Has alternative text description for images*
+		Then I see *text*
+		When I hover my mouse over the info icon for *Has high contrast display for low vision*
+		Then I see *text*
+		When I hover my mouse over the info icon for *Tagged PDF*
+		Then I see *text*
+
+	Scenario: View options for .MP3
+		Given I am viewing a .MP3 in the edit modal
+		Then I see a *Captions and subtitles* section underneath the *Source* section
+
+	Scenario: View tooltips for .MP3
+		Given I am viewing an .MP3 in the edit modal
+		When I hover my mouse over the info icon for *Captions and subtitles*
+		Then I see *Supported formats: vtt*
+
+	Scenario: View options for .ZIP
+		Given I am viewing a .ZIP in the edit modal
+		Then I see a checkbox that says *Has alternative text description for images*
+			And I see a checkbox that says *Has high contrast display for low vision*
+
+	Scenario: View tooltips for .ZIP
+		Given I am viewing a .ZIP in the edit modal
+		When I hover my mouse over the info icon for *Has alternative text description for images*
+		Then I see *text*
+		When I hover my mouse over the info icon for *Has high contrast display for low vision*
+		Then I see *text*
+
+	Scenario: View options for Exercises
+		Given I am viewing an Exercise in the edit modal
+		Then I see a checkbox that says *Has alternative text description for images*
+
+	Scenario: View tooltips for Practice resources
+		Given I am viewing an Exercise in the edit modal
+		When I over my mouse over the info icon for *Has alternative text description for images*
+		Then I see *text*
+
+	Scenario: Select and deselect accessibility options
+		Given that <resource> has checkboxes in the *Accessibility* section
+		When I click <option> under *Accessibility*
+		Then I see the checkbox is selected
+		When I click <option> while it is selected
+		Then I see the checkbox is empty
+
+	Scenario: See that accessibility field is optional
+		Given the *Accessibility* field of <resource> is empty
+		When I click *FINISH*
+		Then I see <resource> in the topic tree
+			And I do not see an error icon
+		When I left-click <resource>
+		Then I see the previewer for <resource>
+			And I see the *Accessibility* field is empty
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |

--- a/integration_testing/features/wip-edit-accessibility-field.feature
+++ b/integration_testing/features/wip-edit-accessibility-field.feature
@@ -83,7 +83,3 @@ Feature: Edit *Accessibility* field
 		When I left-click <resource>
 		Then I see the previewer for <resource>
 			And I see the *Accessibility* field is empty
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/wip-toggle-make-this-a-quiz-in-assessment-options.feature
+++ b/integration_testing/features/wip-toggle-make-this-a-quiz-in-assessment-options.feature
@@ -13,7 +13,3 @@ Feature: Toggle *Make this a quiz* in assessment options of a Practice resource
 
 	Scenario: Toggle *Make this a quiz* when a completion option is set
 		When I 
-
-Examples:
-| ???      | ??? | 
-| ?????!?! |

--- a/integration_testing/features/wip-toggle-make-this-a-quiz-in-assessment-options.feature
+++ b/integration_testing/features/wip-toggle-make-this-a-quiz-in-assessment-options.feature
@@ -1,6 +1,5 @@
 Feature: Toggle *Make this a quiz* in assessment options of a Practice resource
 
-
 # Comment here
 
 	Background: 
@@ -14,7 +13,6 @@ Feature: Toggle *Make this a quiz* in assessment options of a Practice resource
 
 	Scenario: Toggle *Make this a quiz* when a completion option is set
 		When I 
-
 
 Examples:
 | ???      | ??? | 

--- a/integration_testing/features/wip-toggle-make-this-a-quiz-in-assessment-options.feature
+++ b/integration_testing/features/wip-toggle-make-this-a-quiz-in-assessment-options.feature
@@ -1,0 +1,21 @@
+Feature: Toggle *Make this a quiz* in assessment options of a Practice resource
+
+
+# Comment here
+
+	Background: 
+		Given I 
+
+	Scenario: View *Make this a quiz* option
+		When I 
+
+	Scenario: Toggle *Make this a quiz*
+		When I 
+
+	Scenario: Toggle *Make this a quiz* when a completion option is set
+		When I 
+
+
+Examples:
+| ???      | ??? | 
+| ?????!?! |


### PR DESCRIPTION
New feature files for:
- New layout in the edit modal
- Edit learning level field
- Edit learning activity field
- Edit 'what you will need' field
- Allow marking as complete
- [WIP] Edit accessibility field
- Edit completion field
- Edit category field
- [WIP] Toggle *Make this a quiz* in assessment options of a Practice resource
- New metadata defaults while uploading or creating new files
- Edit multiple resources at the same time in the edit modal
- View new metadata in previewers across Studio
- View new metadata on cards and list items across Studio
- View new metadata in the channel details modal

