### PR TITLE
Handle a ref being undefined during computed prop computation.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/ResizableNavigationDrawer.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ResizableNavigationDrawer.vue
@@ -85,7 +85,7 @@
         return this.temporary ? this.maxWidth : this.width;
       },
       drawerElement() {
-        return this.$refs.drawer.$el;
+        return this.$refs.drawer && this.$refs.drawer.$el;
       },
       isRight() {
         return this.$isRTL ? !this.right : this.right;
@@ -96,9 +96,11 @@
       this.throttledUpdateWidth = animationThrottle((...args) => updateWidth(...args));
 
       this.$nextTick(() => {
-        const drawerBorder = this.drawerElement.querySelector('.v-navigation-drawer__border');
-        drawerBorder.addEventListener('mousedown', this.handleMouseDown, false);
-        document.addEventListener('mouseup', this.handleMouseUp, false);
+        if (this.drawerElement) {
+          const drawerBorder = this.drawerElement.querySelector('.v-navigation-drawer__border');
+          drawerBorder.addEventListener('mousedown', this.handleMouseDown, false);
+          document.addEventListener('mouseup', this.handleMouseUp, false);
+        }
       });
     },
     methods: {
@@ -135,7 +137,9 @@
         });
 
         if (event.offsetX < 12) {
-          this.drawerElement.style.transition = 'initial';
+          if (this.drawerElement) {
+            this.drawerElement.style.transition = 'initial';
+          }
           document.addEventListener('mousemove', this.resize, false);
         }
       },
@@ -147,8 +151,9 @@
         this.dragging = false;
         this.throttledUpdateWidth.cancel();
         this.updateWidth(event.clientX);
-
-        this.drawerElement.style.transition = '';
+        if (this.drawerElement) {
+          this.drawerElement.style.transition = '';
+        }
 
         document.body.style.cursor = '';
         document.body.style.pointerEvents = 'unset';


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Handles a ref being undefined when a computed prop is first calculated
* Adds extra defensive checks in case it happens after mounting

### Manual verification steps performed
1. Add a topic
2. Confirm no error from ResizableNavigationDrawer that cannot read `$el of undefined`

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
