### PR TITLE
Make randomize default to true in the frontend

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -343,10 +343,10 @@
     };
   }
 
-  function generateExtraFieldsGetterSetter(key) {
+  function generateExtraFieldsGetterSetter(key, defaultValue) {
     return {
       get() {
-        return this.getExtraFieldsValueFromNodes(key);
+        return this.getExtraFieldsValueFromNodes(key, defaultValue);
       },
       set(value) {
         this.updateExtraFields({ [key]: value });
@@ -415,7 +415,7 @@
       /* FORM FIELDS */
       title: generateGetterSetter('title'),
       description: generateGetterSetter('description'),
-      randomizeOrder: generateExtraFieldsGetterSetter('randomize'),
+      randomizeOrder: generateExtraFieldsGetterSetter('randomize', true),
       author: generateGetterSetter('author'),
       provider: generateGetterSetter('provider'),
       aggregator: generateGetterSetter('aggregator'),
@@ -621,14 +621,14 @@
         let results = uniq(this.nodes.map(node => node[key] || null));
         return getValueFromResults(results);
       },
-      getExtraFieldsValueFromNodes(key) {
+      getExtraFieldsValueFromNodes(key, defaultValue = null) {
         if (
           Object.prototype.hasOwnProperty.call(this.diffTracker, 'extra_fields') &&
           Object.prototype.hasOwnProperty.call(this.diffTracker.extra_fields, key)
         ) {
           return this.diffTracker.extra_fields[key];
         }
-        let results = uniq(this.nodes.map(node => node.extra_fields[key] || null));
+        let results = uniq(this.nodes.map(node => node.extra_fields[key] || defaultValue));
         return getValueFromResults(results);
       },
       getPlaceholder(field) {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* If `randomize` is undefined on an Exercise ContentNode's extra_fields, the publishing task defaults to set it to true
* In the frontend if it is undefined, it shows it as unchecked in the interface
* This brings the frontend inline with the backend

### Manual verification steps performed
1. Create a new exercise
2. Observe that the Randomize question order for learners checkbox is checked
3. Go into the IndexedDB contentnode table and search for the id of this new exercise
4. Observe that extra_fields is still an empty object

### Screenshots (if applicable)
![Screenshot from 2021-08-03 16-35-18](https://user-images.githubusercontent.com/1680573/128099450-555c16df-70f9-41c2-ba6e-8a12fb7d63bf.png)

## References
Fixes #3244

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
