### PR TITLE
[hotfixes] Configure task behavior to acknowledge after execution to trigger requeuing when interrupted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dummyusers:
 	cd contentcuration/ && python manage.py loaddata contentcuration/fixtures/admin_user_token.json
 
 prodceleryworkers:
-	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3 --task-events --without-mingle --without-gossip
+	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3 --task-events
 
 prodcelerydashboard:
 	# connect to the celery dashboard by visiting http://localhost:5555

--- a/contentcuration/contentcuration/utils/celery/tasks.py
+++ b/contentcuration/contentcuration/utils/celery/tasks.py
@@ -76,6 +76,11 @@ class CeleryTask(Task):
     # custom task option
     track_progress = False
 
+    # ensure our tasks are restarted if they're interrupted
+    acks_late = True
+    acks_on_failure_or_timeout = True
+    reject_on_worker_lost = True
+
     _progress_tracker = None
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):


### PR DESCRIPTION
## Summary
*Testing on hotfixes separately*
### Description of the change(s) you made
- Adds celery task options that will cause interrupted tasks to be requeued
- Adds celery app method for querying what's in the queue
- Removes flags added in https://github.com/learningequality/studio/pull/1519

### Manual verification steps performed
1. Step 1
2. Step 2
3. ...

### Logging snapshots
When a worker is forcibly interrupted, it should restore (unacknowledged) tasks to the queue:
```
[2021-09-23 16:22:57,214: INFO/MainProcess] Connected to redis://localhost:6379/0
[2021-09-23 16:22:57,223: INFO/MainProcess] celery@phlack ready.
[2021-09-23 16:22:57,233: INFO/MainProcess] Received task: calculate_user_storage_task[69d10852-22ea-48a0-809d-d97ade8a2218]  ETA:[2021-09-23 14:32:37.734031-07:53] 
[2021-09-23 16:23:16,978: INFO/MainProcess] Received task: export_channel_task[1789ac915aca4519bf04a8c7755f5efc]  
^C
worker: Hitting Ctrl+C again will terminate all running tasks!

worker: Warm shutdown (MainProcess)
^C
worker: Cold shutdown (MainProcess)
[2021-09-23 17:12:01,685: WARNING/MainProcess] Restoring 2 unacknowledged message(s)
```

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1) Add a `time.sleep(10000)` to a task such as the publish task
2) Initiate publishing of a channel
3) Start the celery workers
4) Observe the workers should start the task
5) Send signal to terminate workers twice: `Ctrl+C`
6) Observe during worker shutdown you should see a message like `Restoring 1 unacknowledged message(s)`; other incomplete scheduled tasks should be included such as tasks with an ETA
7) Start the celery workers again
8) Observe celery should restart the publishing task

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
https://docs.celeryproject.org/en/v4.4.7/userguide/configuration.html#std:setting-task_acks_late
https://docs.celeryproject.org/en/v4.4.7/faq.html#faq-acks-late-vs-retry
Querying celery queue directly: `redis-cli LRANGE celery 0 -1`

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
