### PR TITLE
fix: don't publish tags greater than 30 chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,12 @@ docs/_build/
 # PyBuilder
 target/
 
-# virtualenv
+# virtualenv, pipenv
+.env
 venv
 .venv
 Pipfile
+Pipfile.lock
 
 Thumbs.db
 .DS_Store

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -633,7 +633,7 @@ class PermissionCTE(With):
         queryset = model.objects.filter(user_id=user_id)\
             .annotate(
                 tree_id=Unnest(ArrayRemove(Array(*self.tree_id_fields), None), output_field=models.IntegerField())
-            )
+        )
         super(PermissionCTE, self).__init__(queryset=queryset.values("user_id", "channel_id", "tree_id"), **kwargs)
 
     @classmethod
@@ -1016,7 +1016,7 @@ class ChannelSet(models.Model):
 
 class ContentTag(models.Model):
     id = UUIDField(primary_key=True, default=uuid.uuid4)
-    tag_name = models.CharField(max_length=50)
+    tag_name = models.CharField(max_length=30)
     channel = models.ForeignKey('Channel', related_name='tags', blank=True, null=True, db_index=True, on_delete=models.SET_NULL)
     objects = CustomManager()
 
@@ -2095,7 +2095,7 @@ class PrerequisiteContentRelationship(models.Model):
             raise IntegrityError('Cannot self reference as prerequisite.')
         # immediate cyclic exception
         if PrerequisiteContentRelationship.objects.using(self._state.db) \
-                        .filter(target_node=self.prerequisite, prerequisite=self.target_node):
+                .filter(target_node=self.prerequisite, prerequisite=self.target_node):
             raise IntegrityError(
                 'Note: Prerequisite relationship is directional! %s and %s cannot be prerequisite of each other!'
                 % (self.target_node, self.prerequisite))
@@ -2128,7 +2128,7 @@ class RelatedContentRelationship(models.Model):
             raise IntegrityError('Cannot self reference as related.')
         # handle immediate cyclic
         if RelatedContentRelationship.objects.using(self._state.db) \
-                        .filter(contentnode_1=self.contentnode_2, contentnode_2=self.contentnode_1):
+                .filter(contentnode_1=self.contentnode_2, contentnode_2=self.contentnode_1):
             return  # silently cancel the save
         super(RelatedContentRelationship, self).save(*args, **kwargs)
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1016,7 +1016,7 @@ class ChannelSet(models.Model):
 
 class ContentTag(models.Model):
     id = UUIDField(primary_key=True, default=uuid.uuid4)
-    tag_name = models.CharField(max_length=30)
+    tag_name = models.CharField(max_length=50)
     channel = models.ForeignKey('Channel', related_name='tags', blank=True, null=True, db_index=True, on_delete=models.SET_NULL)
     objects = CustomManager()
 

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -70,6 +70,13 @@ class ExportChannelTestCase(StudioTestCase):
         new_video.parent = new_node
         new_video.save()
 
+        # Add a node with tags greater than 30 chars to ensure they get excluded.
+        new_video = create_node({'kind_id': 'video', 'tags': [{'tag_name': 'kolbasdasdasrissadasdwzxcztudio'}, {'tag_name': 'kolbasdasdasrissadasdwzxcztudi'},
+                                {'tag_name': 'kolbasdasdasrissadasdwzxc'}], 'title': 'kolibri tag test', 'children': []})
+        new_video.complete = True
+        new_video.parent = self.content_channel.main_tree
+        new_video.save()
+
         set_channel_icon_encoding(self.content_channel)
         self.tempdb = create_content_database(self.content_channel, True, None, True)
 
@@ -119,6 +126,14 @@ class ExportChannelTestCase(StudioTestCase):
 
         for node in incomplete_nodes:
             assert kolibri_nodes.filter(pk=node.node_id).count() == 0
+
+    def test_tags_greater_than_30_excluded(self):
+        tag_node = kolibri_models.ContentNode.objects.filter(title='kolibri tag test').first()
+        published_tags = tag_node.tags.all()
+
+        assert published_tags.count() == 2
+        for t in published_tags:
+            assert len(t.tag_name) <= 30
 
     def test_contentnode_channel_id_data(self):
         channel = kolibri_models.ChannelMetadata.objects.first()

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -110,11 +110,6 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         invalid_copyright_holder["title"] = "invalid_copyright_holder"
         invalid_copyright_holder["copyright_holder"] = ""
 
-        # Node with tag greater than 30 characters
-        invalid_tag_length = self._make_node_data()
-        invalid_tag_length["title"] = "invalid_tag_length"
-        invalid_tag_length["tags"] = ["abcd abcd abcd abcd abcd abcd", "abcde abcd abcd abcd abcd abcd", "abcdef abcd abcd abcd abcd abcd"]
-
         self.sample_data = {
             "root_id": self.root_node.id,
             "content_data": [
@@ -122,7 +117,6 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                 invalid_title_node,
                 invalid_license_description,
                 invalid_copyright_holder,
-                invalid_tag_length,
             ],
         }
         self.resp = self.admin_client().post(
@@ -184,10 +178,23 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         self.assertFalse(node_3.complete)
 
     def test_tag_greater_than_30_chars_excluded(self):
-        node = ContentNode.objects.get(title="invalid_tag_length")
-        tags = node.tags.all()
-        for t in tags:
-            assert len(t.tag_name) <= 30
+        # Node with tag greater than 30 characters
+        invalid_tag_length = self._make_node_data()
+        invalid_tag_length["title"] = "invalid_tag_length"
+        invalid_tag_length["tags"] = ["kolibri studio, kolibri studio!"]
+
+        test_data = {
+            "root_id": self.root_node.id,
+            "content_data": [
+                invalid_tag_length,
+            ],
+        }
+
+        response = self.admin_client().post(
+            reverse_lazy("api_add_nodes_to_tree"), data=test_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, 400, response.content)
 
 
 class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -61,6 +61,7 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
             "source_domain": random_data.source_domain,
             "source_id": random_data.source_id,
             "author": random_data.author,
+            "tags": ["oer", "edtech"],
             "files": [
                 {
                     "size": fileobj.file_size,
@@ -109,6 +110,11 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         invalid_copyright_holder["title"] = "invalid_copyright_holder"
         invalid_copyright_holder["copyright_holder"] = ""
 
+        # Node with tag greater than 30 characters
+        invalid_tag_length = self._make_node_data()
+        invalid_tag_length["title"] = "invalid_tag_length"
+        invalid_tag_length["tags"] = ["abcd abcd abcd abcd abcd abcd", "abcde abcd abcd abcd abcd abcd", "abcdef abcd abcd abcd abcd abcd"]
+
         self.sample_data = {
             "root_id": self.root_node.id,
             "content_data": [
@@ -116,6 +122,7 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                 invalid_title_node,
                 invalid_license_description,
                 invalid_copyright_holder,
+                invalid_tag_length,
             ],
         }
         self.resp = self.admin_client().post(
@@ -175,6 +182,12 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         self.assertFalse(node_1.complete)
         self.assertFalse(node_2.complete)
         self.assertFalse(node_3.complete)
+
+    def test_tag_greater_than_30_chars_excluded(self):
+        node = ContentNode.objects.get(title="invalid_tag_length")
+        tags = node.tags.all()
+        for t in tags:
+            assert len(t.tag_name) <= 30
 
 
 class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -1367,6 +1367,22 @@ class CRUDTestCase(StudioAPITestCase):
             .exists()
         )
 
+    def test_contentnode_tag_greater_than_30_chars(self):
+        user = testdata.user()
+        tag = "kolibri studio, kolibri studio!"
+
+        self.client.force_authenticate(user=user)
+        contentnode = self.contentnode_metadata
+        contentnode["tags"] = {
+            tag: True,
+        }
+
+        response = self.client.post(
+            reverse("contentnode-list"), contentnode, format="json",
+        )
+
+        self.assertEqual(response.status_code, 400, response.content)
+
     def test_update_contentnode(self):
         user = testdata.user()
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -646,7 +646,8 @@ def map_tags_to_node(kolibrinode, ccnode):
 
     for tag in ccnode.tags.all():
         t, _new = kolibrimodels.ContentTag.objects.get_or_create(pk=tag.pk, tag_name=tag.tag_name)
-        tags_to_add.append(t)
+        if len(t.tag_name) <= 30:
+            tags_to_add.append(t)
 
     kolibrinode.tags.set(tags_to_add)
     kolibrinode.save()

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -7,6 +7,7 @@ from distutils.version import LooseVersion
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
 from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseForbidden
@@ -291,6 +292,8 @@ def api_add_nodes_to_tree(request):
         })
     except ContentNode.DoesNotExist:
         return HttpResponseNotFound("No content matching: {}".format(parent_id))
+    except ValidationError as e:
+        return HttpResponseBadRequest(content=str(e))
     except KeyError:
         return HttpResponseBadRequest("Required attribute missing from data: {}".format(data))
     except Exception as e:
@@ -637,13 +640,16 @@ def create_node(node_data, parent_node, sort_order):  # noqa: C901
         role_visibility=node_data.get('role') or roles.LEARNER,
         complete=is_complete,
     )
+
     tags = []
     channel = node.get_channel()
     if "tags" in node_data:
         tag_data = node_data["tags"]
         if tag_data is not None:
             for tag in tag_data:
-                if len(tag) <= 30:
+                if len(tag) > 30:
+                    raise ValidationError("tag is greater than 30 characters")
+                else:
                     tags.append(
                         ContentTag.objects.get_or_create(tag_name=tag, channel=channel)[0]
                     )

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -643,9 +643,10 @@ def create_node(node_data, parent_node, sort_order):  # noqa: C901
         tag_data = node_data["tags"]
         if tag_data is not None:
             for tag in tag_data:
-                tags.append(
-                    ContentTag.objects.get_or_create(tag_name=tag, channel=channel)[0]
-                )
+                if len(tag) <= 30:
+                    tags.append(
+                        ContentTag.objects.get_or_create(tag_name=tag, channel=channel)[0]
+                    )
 
     if len(tags) > 0:
         node.tags.set(tags)

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -300,6 +300,12 @@ class ContentNodeSerializer(BulkModelSerializer):
         list_serializer_class = ContentNodeListSerializer
         nested_writes = True
 
+    def validate(self, data):
+        for tag in data["tags"]:
+            if len(tag.tag_name) > 30:
+                raise ValidationError("tag is greater than 30 characters")
+        return data
+
     def create(self, validated_data):
         # Creating a new node, by default put it in the orphanage on initial creation.
         if "parent" not in validated_data:

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -301,9 +301,11 @@ class ContentNodeSerializer(BulkModelSerializer):
         nested_writes = True
 
     def validate(self, data):
-        for tag in data["tags"]:
-            if len(tag.tag_name) > 30:
-                raise ValidationError("tag is greater than 30 characters")
+        tags = data.get("tags")
+        if tags is not None:
+            for tag in tags:
+                if len(tag) > 30:
+                    raise ValidationError("tag is greater than 30 characters")
         return data
 
     def create(self, validated_data):


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Tags greater than 30 characters won't get published after we merge this PR.

## References

Closes https://github.com/learningequality/studio/issues/3296.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
