### PR TITLE
Don't use git:// protocol for unauthenticated github access.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.1
     hooks:
     -   id: trailing-whitespace


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Changes protocol for precommit hooks to prevent issues caused by https://github.blog/2021-09-01-improving-git-protocol-security-github/
