### PR TITLE
Error when clicking the Finish or Close button 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -66,7 +66,7 @@
         </ToolBar>
         <VContainer fluid>
           <VTabsItems v-model="currentTab">
-            <VTabItem :key="tabs.DETAILS" ref="detailswindow" :value="tabs.DETAILS" lazy>
+            <VTabItem :key="tabs.DETAILS" ref="detailswindow" :value="tabs.DETAILS">
               <VAlert v-if="nodeIds.length > 1" :value="true" type="info" color="primary" outline>
                 {{ countText }}
               </VAlert>
@@ -247,12 +247,7 @@
        * @public
        */
       immediateSaveAll: function() {
-        if (this.$refs.detailsTabView) {
-          return this.$refs.detailsTabView.immediateSaveAll();
-        } else {
-          /* eslint-disable-next-line no-console */
-          console.error('imediateSaveAll was not passed, detailsTabView is not found');
-        }
+        return this.$refs.detailsTab.immediateSaveAll();
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -245,11 +245,14 @@
       },
       /*
        * @public
-       * reaches into Details Tab to run save of diffTracker
-       * before the validation pop up is executed
        */
       immediateSaveAll: function() {
-        return this.$refs.detailsTab.immediateSaveAll();
+        if (this.$refs.detailsTabView) {
+          return this.$refs.detailsTabView.immediateSaveAll();
+        } else {
+          /* eslint-disable-next-line no-console */
+          console.error('imediateSaveAll was not passed, detailsTabView is not found');
+        }
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR fixes #3153 though it doesn't explain the underlying code that makes the bug properly. 
<!-- Briefly summarize your changes in 1-2 sentences here. -->
After trying to narrow down the issue for a while, and consulting Marcella on it, I discovered that the ImmediateSave all function can't be called since details tab is not loaded, that is blocking the save or exit functionality of the View.

I tried multiple solutions to this issue, tested why it wasn't showing up, and upon consulting Marcella she suggested we add another check in EditView to see if details tab exists pre function call. that resolved the issue.

### Manual verification steps performed
1. Opened all possible combination of details tab editing and related view editing and clicked exit at all possible steps.

### Does this introduce any tech-debt items?
We need to find the main reason details tab is not loaded when it's active in EditView, in EditModal.
___
## Reviewer guidance
### How can a reviewer test these changes?

1. Go to https://hotfixes.studio.learningequality.org/en/accounts/#/ and sign in.
2. Click on a channel to go to the channel editor and select the Edit details option for a resource.
3. Click the Related tab and add a previous and/or a next step.
4. Click the Finish button or the Close icon.

The bug appeared whenever there instance was called and an item was added or removed from a previous next step. 



### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->


Testing:
- [x] Code is clean and well-commented

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
