### PR TITLE
Draggable resize

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -23,7 +23,6 @@
                 <VListTile
                   class="content-item py-1"
                   :class="{ hover, selected }"
-                  :style="{ 'padding-left': indentPadding }"
                   inactive
                 >
                   <VListTileAction class="action-col">
@@ -283,7 +282,7 @@
   }
 
   /deep/ .v-list__tile {
-    padding-left: 11px;
+    padding-left: 43px;
   }
 
   /deep/ .v-list__tile__title {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -16,6 +16,7 @@
             <DraggableItem
               :draggableMetadata="draggableMetadata"
               :dropEffect="dropEffectAndAllowed"
+              :style="{ 'cursor': 'default' }"
             >
               <DraggableHandle
                 :effectAllowed="dropEffectAndAllowed"
@@ -23,6 +24,7 @@
                 <VListTile
                   class="content-item py-1"
                   :class="{ hover, selected }"
+                  :style="{ 'padding-left': indentPadding }"
                   inactive
                 >
                   <VListTileAction class="action-col">
@@ -240,7 +242,6 @@
   .v-list__tile {
     width: 100%;
     max-width: 100%;
-    cursor: pointer;
     transition: background-color ease 0.3s;
   }
 
@@ -282,7 +283,8 @@
   }
 
   /deep/ .v-list__tile {
-    padding-left: 43px;
+    padding-left: 11px;
+    cursor: pointer;
   }
 
   /deep/ .v-list__tile__title {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
I've implemented a reduced cursor as to not confuse the user
### Manual verification steps performed
1. Tested on english, it works now as Blaine suggester, On Arabic there is an issue.
2. Step 2
3. ...

### Does this introduce any tech-debt items?
We need to clear the LTR issues with the clipboard but those are complex and need a different PR
___
## Reviewer guidance
### How can a reviewer test these changes?
Open Studio, go to a Channel, copy something to the clipboard with at least 2 levels, and mouseover the part infront of the checkbox

## Comments
This is a solution that is suggested by the comment. 
My other course of action was moving the padding to the child component of List_node but the issue is that the child component is created by Vuetify ?. I think. it requires to be fixed proper to make the entire row draggable again. 
That would require extensive right to left language fixes as well. 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [x] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md


Resolves #3183