### PR TITLE
Add error handling in updateTaskList to reduce constant logging of 403s

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import sortBy from 'lodash/sortBy';
 import { Task } from 'shared/data/resources';
 import { TABLE_NAMES, CHANGE_TYPES } from 'shared/data';
+import urls from 'shared/urls';
 
 const DEFAULT_CHECK_INTERVAL = 5000;
 const RUNNING_TASK_INTERVAL = 2000;
@@ -63,7 +64,7 @@ export default {
       } else {
         //  for cases where this.$router doesn't exist when user is signed out,
         // use window.Urls to redirect to login
-        window.location.href = window.Urls.login();
+        window.location.href = urls.login();
       }
     },
   },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -57,7 +57,8 @@ export default {
           .catch(e => {
             // if not authorized, redirect to login screen
             if (e.response.status === 403) {
-              return (window.location.href = urls.login());
+              window.location.href = urls.login();
+              return;
             }
             store.dispatch('activateTaskUpdateTimer');
           });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -57,7 +57,7 @@ export default {
           .catch(e => {
             // if not authorized, redirect to login screen
             if (e.response.status === 403) {
-              this.$router.push('/');
+              return (window.location.href = urls.login());
             }
             store.dispatch('activateTaskUpdateTimer');
           });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -47,14 +47,24 @@ export default {
       return Task.deleteModel(task.task_id).then(() => store.dispatch('activateTaskUpdateTimer'));
     },
     updateTaskList(store) {
-      return Task.where({ channel: store.rootState.currentChannel.currentChannelId })
-        .then(tasks => {
-          store.commit('SET_ASYNC_TASKS', tasks);
-          store.dispatch('activateTaskUpdateTimer');
-        })
-        .catch(() => {
-          store.dispatch('activateTaskUpdateTimer');
-        });
+      if (store.rootGetters.loggedIn) {
+        return Task.where({ channel: store.rootState.currentChannel.currentChannelId })
+          .then(tasks => {
+            store.commit('SET_ASYNC_TASKS', tasks);
+            store.dispatch('activateTaskUpdateTimer');
+          })
+          .catch(e => {
+            // if not authorized, redirect to login screen
+            if (e.response.status === 403) {
+              this.$router.push('/');
+            }
+            store.dispatch('activateTaskUpdateTimer');
+          });
+      } else {
+        //  for cases where this.$router doesn't exist when user is signed out,
+        // use window.Urls to redirect to login
+        window.location.href = window.Urls.login();
+      }
     },
   },
   mutations: {


### PR DESCRIPTION
### Description of the change(s) you made

Fixes #3291

Adds two conditions to manage 403 errors -- one when the router is available, and one when it is not


### Manual verification steps performed/Reviewer guidance
1. Sign in and open 2 tabs in studio
2. Navigate to the channel editor
3. Sign out in one tab 
4. The other tab should sign out and redirect to the login screen also (it might be a slight lag) and neither console should register any 403 errors


### Are there any risky areas that deserve extra testing?
Any conditions I have missed?


PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
