### PR TITLE
fix: override exported content nodes duration to completion criteria threshold

### DIFF
--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -77,6 +77,20 @@ class ExportChannelTestCase(StudioTestCase):
         new_video.parent = self.content_channel.main_tree
         new_video.save()
 
+        # Add a node to test completion criteria.
+        extra_fields = {
+            "options": {
+                "completion_criteria": {
+                    "model": "time",
+                    "threshold": 20
+                }
+            }
+        }
+        new_video = create_node({'kind_id': 'video', 'title': 'Completion criteria test', 'extra_fields': extra_fields, 'children': []})
+        new_video.complete = True
+        new_video.parent = self.content_channel.main_tree
+        new_video.save()
+
         set_channel_icon_encoding(self.content_channel)
         self.tempdb = create_content_database(self.content_channel, True, None, True)
 
@@ -134,6 +148,13 @@ class ExportChannelTestCase(StudioTestCase):
         assert published_tags.count() == 2
         for t in published_tags:
             assert len(t.tag_name) <= 30
+
+    def test_duration_override_on_completion_criteria_time(self):
+        completion_criteria_node = kolibri_models.ContentNode.objects.filter(title='Completion criteria test').first()
+        non_completion_criteria_node = kolibri_models.ContentNode.objects.filter(title='kolibri tag test').first()
+
+        assert completion_criteria_node.duration == 20
+        assert non_completion_criteria_node.duration == 100
 
     def test_contentnode_channel_id_data(self):
         channel = kolibri_models.ChannelMetadata.objects.first()

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -144,11 +144,13 @@ def node(data, parent=None):
             content_id=data.get('content_id') or data['node_id'],
             sort_order=data.get('sort_order', 1),
             complete=True,
+            extra_fields=data.get('extra_fields'),
         )
         new_node.save()
         video_file = fileobj_video(contents=b"Video File")
         video_file.contentnode = new_node
         video_file.preset_id = format_presets.VIDEO_HIGH_RES
+        video_file.duration = 100
         video_file.save()
 
     # Create exercises

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -232,14 +232,13 @@ def create_bare_contentnode(ccnode, default_language, channel_id, channel_name):
         options = ccnode.extra_fields['options']
 
     duration = None
-    if ccnode.kind_id in [content_kinds.AUDIO, content_kinds.VIDEO]:
-        # aggregate duration from associated files, choosing maximum if there are multiple, like hi and lo res videos.
-        duration = ccnode.files.aggregate(duration=Max("duration")).get("duration")
-
     ccnode_completion_criteria = options.get("completion_criteria")
     if ccnode_completion_criteria:
         if ccnode_completion_criteria["model"] == completion_criteria.TIME or ccnode_completion_criteria["model"] == completion_criteria.APPROX_TIME:
             duration = ccnode_completion_criteria["threshold"]
+    elif ccnode.kind_id in [content_kinds.AUDIO, content_kinds.VIDEO]:
+        # aggregate duration from associated files, choosing maximum if there are multiple, like hi and lo res videos.
+        duration = ccnode.files.aggregate(duration=Max("duration")).get("duration")
 
     kolibrinode, is_new = kolibrimodels.ContentNode.objects.update_or_create(
         pk=ccnode.node_id,

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -239,7 +239,7 @@ def create_bare_contentnode(ccnode, default_language, channel_id, channel_name):
     ccnode_completion_criteria = options.get("completion_criteria")
     if ccnode_completion_criteria:
         if ccnode_completion_criteria["model"] == completion_criteria.TIME or ccnode_completion_criteria["model"] == completion_criteria.APPROX_TIME:
-            duration = completion_criteria["threshold"]
+            duration = ccnode_completion_criteria["threshold"]
 
     kolibrinode, is_new = kolibrimodels.ContentNode.objects.update_or_create(
         pk=ccnode.node_id,

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -236,7 +236,7 @@ def create_bare_contentnode(ccnode, default_language, channel_id, channel_name):
     if ccnode_completion_criteria:
         if ccnode_completion_criteria["model"] == completion_criteria.TIME or ccnode_completion_criteria["model"] == completion_criteria.APPROX_TIME:
             duration = ccnode_completion_criteria["threshold"]
-    elif ccnode.kind_id in [content_kinds.AUDIO, content_kinds.VIDEO]:
+    if duration is None and ccnode.kind_id in [content_kinds.AUDIO, content_kinds.VIDEO]:
         # aggregate duration from associated files, choosing maximum if there are multiple, like hi and lo res videos.
         duration = ccnode.files.aggregate(duration=Max("duration")).get("duration")
 


### PR DESCRIPTION
## Summary
When a node's completion criteria has a `model` of either `time` or `approx_time`, the exported `ContentNode` created during channel publishing is set to have the `threshold` written to the `duration` field. 

## Reviewer guidance
Does this PR performs the expected overriding behaviour?   

## References
Closes https://github.com/learningequality/studio/issues/3322.

## Contributor's Checklist
**PR process:**

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

**Studio-specifc:**
- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


**Testing:**
- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests

## Reviewer's Checklist
**This section is for reviewers to fill out.**
- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md