### PR TITLE
Import constants from le-utils and add metadata translation mixin

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -1,10 +1,10 @@
 import featureFlagsSchema from 'static/feature_flags.json';
+
 export { default as LearningActivities } from 'kolibri-constants/labels/LearningActivities';
-export {default as CompletionCriteriaModels } from 'kolibri-constants/CompletionCriteria';
+export { default as CompletionCriteriaModels } from 'kolibri-constants/CompletionCriteria';
 export { default as ContentLevel } from 'kolibri-constants/labels/Levels';
 export { default as Categories } from 'kolibri-constants/labels/Subjects';
 export { default as AccessibilityCategories } from 'kolibri-constants/labels/AccessibilityCategories';
-
 
 export const ContentDefaults = {
   author: 'author',

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -1,4 +1,10 @@
 import featureFlagsSchema from 'static/feature_flags.json';
+export { default as LearningActivities } from 'kolibri-constants/labels/LearningActivities';
+export {default as CompletionCriteriaModels } from 'kolibri-constants/CompletionCriteria';
+export { default as ContentLevel } from 'kolibri-constants/labels/Levels';
+export { default as Categories } from 'kolibri-constants/labels/Subjects';
+export { default as AccessibilityCategories } from 'kolibri-constants/labels/AccessibilityCategories';
+
 
 export const ContentDefaults = {
   author: 'author',

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -191,7 +191,7 @@ export const constantsTranslationMixin = {
   },
 };
 
-// METADA STRINGS AND RELATED MIXIN
+// METADATA STRINGS AND RELATED MIXIN
 
 export const metadataStrings = createTranslator('CommonMetadataStrings', {
   // Titles/Headers

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -191,6 +191,473 @@ export const constantsTranslationMixin = {
   },
 };
 
+// METADA STRINGS AND RELATED MIXIN
+
+
+
+export const metadataStrings = createTranslator('CommonMetadataStrings', {
+
+  // Titles/Headers
+
+  learningActivity: {
+    message: 'Learning Activity',
+    context: 'A title for the category of education material interaction, i.e. watch, read, listen',
+  },
+  completion: {
+    message: 'Completion',
+    context: 'A title for the metadata that explains when an activity is finished',
+  },
+  duration: {
+    message: 'Duration',
+    context: 'A title for the metadata that explains how long an activity will take',
+  },
+  category: {
+    message: 'Category',
+    context: 'A title for the metadata that explains the subject matter of an activity',
+  },
+  // Learning Activities
+  all: {
+    message: 'All',
+    context: 'A label for everything in the group of activities.',
+  },
+  watch: {
+    message: 'Watch',
+    context:
+      'Resource and filter label for the type of learning activity with video. Translate as a VERB',
+  },
+  create: {
+    message: 'Create',
+    context: 'Resource and filter label for the type of learning activity. Translate as a VERB',
+  },
+  read: {
+    message: 'Read',
+    context:
+      'Resource and filter label for the type of learning activity with documents. Translate as a VERB',
+  },
+  practice: {
+    message: 'Practice',
+    context:
+      'Resource and filter label for the type of learning activity with questions and answers. Translate as a VERB',
+  },
+  reflect: {
+    message: 'Reflect',
+    context: 'Resource and filter label for the type of learning activity. Translate as a VERB',
+  },
+  listen: {
+    message: 'Listen',
+    context:
+      'Resource and filter label for the type of learning activity with audio. Translate as a VERB',
+  },
+  explore: {
+    message: 'Explore',
+    context: 'Resource and filter label for the type of learning activity. Translate as a VERB',
+  },
+
+  // Library Categories
+  school: {
+    message: 'School',
+    context: 'Category type.',
+  },
+  basicSkills: {
+    message: 'Basic skills',
+    context:
+      'Category type. Basic skills refer to learning resources focused on aspects like literacy, numeracy and digital literacy.',
+  },
+  work: {
+    message: 'Work',
+    context:
+      'Top level category group that contains resources for acquisition of professional skills.',
+  },
+  dailyLife: {
+    message: 'Daily life',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Everyday_life',
+  },
+  forTeachers: {
+    message: 'For teachers',
+    context: 'Category type',
+  },
+
+  // School Categories
+  mathematics: {
+    message: 'Mathematics',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Mathematics',
+  },
+  sciences: {
+    message: 'Sciences',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Science',
+  },
+  socialSciences: {
+    message: 'Social sciences',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Social_science',
+  },
+  arts: {
+    message: 'Arts',
+    context: 'Refers to a category group type. See https://en.wikipedia.org/wiki/The_arts',
+  },
+  computerScience: {
+    message: 'Computer science',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Computer_science',
+  },
+  languageLearning: {
+    message: 'Language learning',
+    context: 'Category type.',
+  },
+  history: {
+    message: 'History',
+    context: 'Category type.',
+  },
+  readingAndWriting: {
+    message: 'Reading and writing',
+    context: 'School subject category',
+  },
+
+  // Mathematics Subcategories
+  arithmetic: {
+    message: 'Arithmetic',
+    context: 'Math category type. See https://en.wikipedia.org/wiki/Arithmetic',
+  },
+  algebra: {
+    message: 'Algebra',
+    context: 'A type of math category. See https://en.wikipedia.org/wiki/Algebra',
+  },
+  geometry: {
+    message: 'Geometry',
+    context: 'Category type.',
+  },
+  calculus: {
+    message: 'Calculus',
+    context: 'Math category type. https://en.wikipedia.org/wiki/Calculus',
+  },
+  statistics: {
+    message: 'Statistics',
+    context: 'A math category. See https://en.wikipedia.org/wiki/Statistics',
+  },
+
+  // Sciences Subcategories
+  biology: {
+    message: 'Biology',
+    context: 'Science category type. See https://en.wikipedia.org/wiki/Biology',
+  },
+  chemistry: {
+    message: 'Chemistry',
+    context: 'Science category type. See https://en.wikipedia.org/wiki/Chemistry',
+  },
+  physics: {
+    message: 'Physics',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Physics.',
+  },
+  earthScience: {
+    message: 'Earth science',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Earth_science',
+  },
+  astronomy: {
+    message: 'Astronomy',
+    context: 'Science category type. See https://en.wikipedia.org/wiki/Astronomy',
+  },
+
+  //  Literature Subcategories
+  literature: {
+    message: 'Literature',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Literature',
+  },
+  readingComprehension: {
+    message: 'Reading comprehension',
+    context: 'Category type.',
+  },
+  writing: {
+    message: 'Writing',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Writing',
+  },
+  logicAndCriticalThinking: {
+    message: 'Logic and critical thinking',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Critical_thinking',
+  },
+
+  // Social Sciences Subcategories
+  politicalScience: {
+    message: 'Political science',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Political_science.',
+  },
+  sociology: {
+    message: 'Sociology',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Sociology',
+  },
+  anthropology: {
+    message: 'Anthropology',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Anthropology',
+  },
+  civicEducation: {
+    message: 'Civic education',
+    context:
+      'Category type. Civic education is the study of the rights and obligations of citizens in society. See https://en.wikipedia.org/wiki/Civics',
+  },
+
+  // Arts Subcategories = {
+  visualArt: {
+    message: 'Visual art',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Visual_arts',
+  },
+  music: {
+    message: 'Music',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Music',
+  },
+  dance: {
+    message: 'Dance',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Dance',
+  },
+  drama: {
+    message: 'Drama',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Drama',
+  },
+
+  //  Computer Science Subcategories
+  programming: {
+    message: 'Programming',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Computer_programming',
+  },
+  mechanicalEngineering: {
+    message: 'Mechanical engineering',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Mechanical_engineering.',
+  },
+  webDesign: {
+    message: 'Web design',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Web_design',
+  },
+
+  // Basic Skills
+  literacy: {
+    message: 'Literacy',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Literacy',
+  },
+  numeracy: {
+    message: 'Numeracy',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Numeracy',
+  },
+  digitialLiteracy: {
+    message: 'Digital literacy',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Digital_literacy',
+  },
+  learningSkills: {
+    message: 'Learning skills',
+    context:
+      'A category label and type of basic skill.\nhttps://en.wikipedia.org/wiki/Study_skills',
+  },
+
+  // Work Categories
+  professionalSkills: {
+    message: 'Professional skills',
+    context: 'Category type. Refers to skills that are related to a profession or a job.',
+  },
+  technicalAndVocationalTraining: {
+    message: 'Technical and vocational training',
+    context:
+      'A level of education. See https://en.wikipedia.org/wiki/TVET_(Technical_and_Vocational_Education_and_Training)',
+  },
+
+  //  VocationalSubcategories
+  softwareToolsAndTraining: {
+    message: 'Software tools and training',
+    context: 'Subcategory type for technical and vocational training.',
+  },
+  skillsTraining: {
+    message: 'Skills training',
+    context: 'Subcategory type for technical and vocational training.',
+  },
+  industryAndSectorSpecific: {
+    message: 'Industry and sector specific',
+    context: 'Subcategory type for technical and vocational training.',
+  },
+
+  // Daily Life Categories
+  publicHealth: {
+    message: 'Public health',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Public_health.',
+  },
+  entrepreneurship: {
+    message: 'Entrepreneurship',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Entrepreneurship',
+  },
+  financialLiteracy: {
+    message: 'Financial literacy',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Financial_literacy',
+  },
+  currentEvents: {
+    message: 'Current events',
+    context:
+      "Category type. Could also be translated as 'News'. See https://en.wikipedia.org/wiki/News",
+  },
+  environment: {
+    message: 'Environment',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Environmental_studies',
+  },
+  mediaLiteracy: {
+    message: 'Media literacy',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Media_literacy',
+  },
+  diversity: {
+    message: 'Diversity',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Diversity_(politics)',
+  },
+  mentalHealth: {
+    message: 'Mental health',
+    context: 'Category type. See https://en.wikipedia.org/wiki/Mental_health',
+  },
+
+  // Teacher-Specific Categories
+  guides: {
+    message: 'Guides',
+    context:
+      'Category label in the Kolibri resources library; refers to any guide-type material for teacher professional development.',
+  },
+  lessonPlans: {
+    message: 'Lesson plans',
+    context:
+      'Category label in the Kolibri resources library; refers to lesson planning materials for teachers.',
+  },
+
+  // Resources Needed Categories = {
+  ForBeginners: {
+    message: 'For beginners',
+    context: 'Filter option and a label for the resources in the Kolibri Library.',
+  },
+  ToUseWithTeachersAndPeers: {
+    message: 'To use with teachers and peers',
+    context:
+      "'Peers' in this context refers to classmates or other learners who are interacting with Kolibri.",
+  },
+  ToUseWithPaperAndPencil: {
+    message: 'To use with paper and pencil',
+    context: 'Refers to a filter for resources.\n',
+  },
+  NeedsInternet: {
+    message: 'That need internet connection',
+    context: 'Refers to a filter for resources.',
+  },
+  NeedsMaterials: {
+    message: 'That need other materials',
+    context: 'Refers to a filter for resources.\n',
+  },
+
+  // Accessibility category name
+  accessibility: {
+    message: 'Accessibility',
+    context:
+      'Allows the user to filter for all the resources with accessibility features for learners with disabilities.',
+  },
+  // Accessibility Categories
+  signLanguage: {
+    message: 'Has sign language captions',
+    context:
+      'https://en.wikipedia.org/wiki/Sign_language\nhttps://en.wikipedia.org/wiki/List_of_sign_languages\nWherever communities of deaf people exist, sign languages have developed as useful means of communication, and they form the core of local Deaf cultures. Although signing is used primarily by the deaf and hard of hearing, it is also used by hearing individuals, such as those unable to physically speak, those who have trouble with spoken language due to a disability or condition (augmentative and alternative communication), or those with deaf family members, such as children of deaf adults. ',
+  },
+  audioDescription: {
+    message: 'Has audio descriptions',
+    context:
+      'Content has narration used to provide information surrounding key visual elements for the benefit of blind and visually impaired users.\nhttps://en.wikipedia.org/wiki/Audio_description',
+  },
+  taggedPdf: {
+    message: 'Tagged PDF',
+    context:
+      'A tagged PDF includes hidden accessibility markups (tags) that make the document accessible to those who use screen readers and other assistive technology (AT).\n\nhttps://taggedpdf.com/what-is-a-tagged-pdf/',
+  },
+  altText: {
+    message: 'Has alternative text description for images',
+    context:
+      'Alternative text, or alt text, is a written substitute for an image. It is used to describe information being provided by an image, graph, or any other visual element on a web page. It provides information about the context and function of an image for people with varying degrees of visual and cognitive impairments. When a screen reader encounters an image, it will read aloud the alternative text.\nhttps://www.med.unc.edu/webguide/accessibility/alt-text/',
+  },
+  highContrast: {
+    message: 'Has high contrast display for low vision',
+    context:
+      "Accessibility filter used to search for resources that have high contrast color themes for users with low vision ('display' refers to digital content, not the hardware like screens or monitors).\nhttps://veroniiiica.com/2019/10/25/high-contrast-color-schemes-low-vision/",
+  },
+  captionsSubtitles: {
+    message: 'Has captions or subtitles',
+    context:
+      'Accessibility filter to search for video and audio resources that have text captions for users who are deaf or hard of hearing.\nhttps://www.w3.org/WAI/media/av/captions/',
+  },
+
+  // Used to categorize the level or audience of content
+  // ContentLevels
+  level: {
+    message: 'Level',
+    context: 'Refers to the educational learning level, such a preschool, primary, secondary, etc.'
+  },
+  preschool: {
+    message: 'Preschool',
+    context:
+      'Refers to a level of education offered to children before they begin compulsory education at primary school.\n\nSee https://en.wikipedia.org/wiki/Preschool',
+  },
+  lowerPrimary: {
+    message: 'Lower primary',
+    context:
+      'Refers to a level of learning. Approximately corresponds to the first half of primary school.',
+  },
+  upperPrimary: {
+    message: 'Upper primary',
+    context:
+      'Refers to a level of education. Approximately corresponds to the second half of primary school.\n',
+  },
+  lowerSecondary: {
+    message: 'Lower secondary',
+    context:
+      'Refers to a level of learning. Approximately corresponds to the first half of secondary school (high school).',
+  },
+  upperSecondary: {
+    message: 'Upper secondary',
+    context:
+      'Refers to a level of education. Approximately corresponds to the second half of secondary school.',
+  },
+  tertiary: {
+    message: 'Tertiary',
+    context: 'A level of education. See https://en.wikipedia.org/wiki/Tertiary_education',
+  },
+  specializedProfessionalTraining: {
+    message: 'Specialized professional training',
+    context: 'Level of education that refers to training for a profession (job).',
+  },
+  allLevelsBasicSkills: {
+    message: 'All levels -- basic skills',
+    context: 'Refers to a type of educational level.',
+  },
+  allLevelsWorkSkills: {
+    message: 'All levels -- work skills',
+    context: 'Refers to a type of educational level.',
+  },
+
+  browseChannel: {
+    message: 'Browse channel',
+    context: 'Heading on page where a user can browse the content within a channel',
+  },
+  topicLabel: {
+    message: 'Folder',
+    context:
+      'A collection of resources and other subfolders within a channel. Nested folders allow a channel to be organized as a tree or hierarchy.',
+  },
+  readReference: {
+    message: 'Reference',
+    context:
+      "Label displayed for the 'Read' learning activity, used instead of the time duration information, to indicate a resource that may not need sequential reading from the beginning to the end. Similar concept as the 'reference' books in the traditional library, that the user just  'consults', and does not read from cover to cover.",
+  },
+  shortActivity: {
+    message: 'Short activity',
+    context: 'Label with time estimation for learning activities that take less than 30 minutes.',
+  },
+  longActivity: {
+    message: 'Long activity',
+    context: 'Label with time estimation for learning activities that take more than 30 minutes.',
+  },
+
+
+})
+
+export const metadataTranslationMixin = {
+  methods: {
+    translateMetadataString(string) {
+      return metadataStrings.$tr(string);
+    }
+  }
+}
+
 /**
  * jayoshih: using a mixin to handle this to handle the translations
  *           and handle cases where user opens page at a component

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -193,10 +193,7 @@ export const constantsTranslationMixin = {
 
 // METADA STRINGS AND RELATED MIXIN
 
-
-
 export const metadataStrings = createTranslator('CommonMetadataStrings', {
-
   // Titles/Headers
 
   learningActivity: {
@@ -580,7 +577,7 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
   // ContentLevels
   level: {
     message: 'Level',
-    context: 'Refers to the educational learning level, such a preschool, primary, secondary, etc.'
+    context: 'Refers to the educational learning level, such a preschool, primary, secondary, etc.',
   },
   preschool: {
     message: 'Preschool',
@@ -646,17 +643,15 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
     message: 'Long activity',
     context: 'Label with time estimation for learning activities that take more than 30 minutes.',
   },
-
-
-})
+});
 
 export const metadataTranslationMixin = {
   methods: {
     translateMetadataString(string) {
       return metadataStrings.$tr(string);
-    }
-  }
-}
+    },
+  },
+};
 
 /**
  * jayoshih: using a mixin to handle this to handle the translations


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Imports the metadata constants from `le-utils` and adds the strings from metadata that were used in kolibri. 


### Manual verification steps performed
Referenced both the constants and some strings to make sure they were available in vue files and was able to access both.


### Does this introduce any tech-debt items?
Does adding this in the existing translation mixin file make sense, or would it be better to create a separate file for this? (Originally I added it separately, but then I thought that might be more confusing, if it was the only thing that was handled differently).

### Contributor's Checklist

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
