### PR TITLE
Update completion criteria validator after breaking out mastery schema

### DIFF
--- a/contentcuration/contentcuration/constants/completion_criteria.py
+++ b/contentcuration/contentcuration/constants/completion_criteria.py
@@ -1,7 +1,24 @@
-import jsonschema
 from django.core.exceptions import ValidationError
+from jsonschema import RefResolver
+from jsonschema.exceptions import best_match
+from jsonschema.validators import validator_for
 from le_utils.constants import completion_criteria
 from le_utils.constants import content_kinds
+from le_utils.constants import mastery_criteria
+
+
+def _build_validator():
+    """
+    Builds the validator, once, for the completion criteria schema and includes the external mastery criteria schema
+    :rtype: jsonschema.Draft7Validator|jsonschema.validators.Validator
+    """
+    cls = validator_for(completion_criteria.SCHEMA)
+    validator = cls(completion_criteria.SCHEMA)
+    validator.resolver.store.update(RefResolver.from_schema(mastery_criteria.SCHEMA).store)
+    return validator
+
+
+validator = _build_validator()
 
 
 def validate(data, kind=None):
@@ -14,10 +31,9 @@ def validate(data, kind=None):
     if isinstance(data, (dict,)) and not data:
         return
 
-    try:
-        jsonschema.validate(instance=data, schema=completion_criteria.SCHEMA)
-    except jsonschema.ValidationError as e:
-        raise ValidationError("Completion criteria does not conform to schema") from e
+    error = best_match(validator.iter_errors(data))
+    if error is not None:
+        raise ValidationError("Completion criteria does not conform to schema") from error
 
     model = data.get("model")
     if kind is None or model is None:

--- a/contentcuration/contentcuration/constants/completion_criteria.py
+++ b/contentcuration/contentcuration/constants/completion_criteria.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from jsonschema import RefResolver
-from jsonschema.exceptions import best_match
 from jsonschema.validators import validator_for
 from le_utils.constants import completion_criteria
 from le_utils.constants import content_kinds
@@ -31,9 +30,24 @@ def validate(data, kind=None):
     if isinstance(data, (dict,)) and not data:
         return
 
-    error = best_match(validator.iter_errors(data))
-    if error is not None:
-        raise ValidationError("Completion criteria does not conform to schema") from error
+    error_descriptions = []
+    # @see https://python-jsonschema.readthedocs.io/en/latest/errors/
+    for error in validator.iter_errors(data):
+        if error.cause:
+            # documentation says this will only be set on FormatChecker errors
+            error_descriptions.append(error.cause)
+        elif error.absolute_path:
+            # if there's a path to a field, we can give a specific error
+            json_path = ".".join(error.absolute_path)
+            error_descriptions.append(ValidationError("{} {}".format(json_path, error.message)))
+        else:
+            # without a path, likely top-level validation error, e.g. `anyOf` conditions
+            error_descriptions.append(ValidationError("object doesn't satisfy '{}' conditions".format(error.validator)))
+
+    if error_descriptions:
+        e = ValidationError("Completion criteria doesn't conform to schema")
+        e.error_list.extend(error_descriptions)
+        raise e
 
     model = data.get("model")
     if kind is None or model is None:

--- a/contentcuration/contentcuration/frontend/shared/leUtils/CompletionCriteria.js
+++ b/contentcuration/contentcuration/frontend/shared/leUtils/CompletionCriteria.js
@@ -1,4 +1,5 @@
 import CompletionCriteriaModels, { SCHEMA } from 'kolibri-constants/CompletionCriteria';
+import { SCHEMA as MASTERY_SCHEMA } from 'kolibri-constants/MasteryCriteria';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import { compile } from 'shared/utils/jsonSchema';
 import { ValidationErrors } from 'shared/constants';
@@ -6,7 +7,7 @@ import { ValidationErrors } from 'shared/constants';
 /**
  * @type {Function<boolean>|ValidateFunction}
  */
-const _validate = compile(SCHEMA);
+const _validate = compile(SCHEMA, [MASTERY_SCHEMA]);
 
 /**
  * @param {Object} criteria

--- a/contentcuration/contentcuration/frontend/shared/utils/jsonSchema.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/jsonSchema.js
@@ -9,6 +9,21 @@ const ajv = new Ajv({
   ],
 });
 
-export function compile(schema) {
-  return ajv.compile(schema);
+/**
+ * Compiles the AJV instance with a JSON schema to get a validation function
+ *
+ * @param {Object} schema
+ * @param {Object[]} dependentSchemas
+ * @return {ValidateFunction<bool>}
+ */
+export function compile(schema, dependentSchemas = null) {
+  let instance = ajv;
+  // Add dependent schemas to local instance
+  if (dependentSchemas) {
+    instance = dependentSchemas.reduce(
+      (instance, dependentSchema) => instance.addSchema(dependentSchema),
+      instance
+    );
+  }
+  return instance.compile(schema);
 }

--- a/contentcuration/contentcuration/tests/test_completion_criteria.py
+++ b/contentcuration/contentcuration/tests/test_completion_criteria.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 from le_utils.constants import completion_criteria
 from le_utils.constants import content_kinds
+from le_utils.constants import mastery_criteria
 
 from contentcuration.constants.completion_criteria import validate
 
@@ -13,12 +14,16 @@ class CompletionCriteriaTestCase(SimpleTestCase):
     def test_validate__success__empty(self):
         validate({})
 
-    def test_validate__fail(self):
-        with self.assertRaises(ValidationError):
+    def test_validate__fail__model(self):
+        with self.assertRaisesRegex(ValidationError, "model 'does not exist' is not one of"):
             validate({"model": "does not exist"})
 
+    def test_validate__fail__threshold(self):
+        with self.assertRaisesRegex(ValidationError, "object doesn't satisfy 'anyOf' conditions"):
+            validate({"model": completion_criteria.PAGES, "threshold": "not a number"})
+
     def test_validate__content_kind(self):
-        with self.assertRaises(ValidationError):
-            validate({"model": completion_criteria.PAGES}, kind=content_kinds.EXERCISE)
-        with self.assertRaises(ValidationError):
-            validate({"model": completion_criteria.MASTERY}, kind=content_kinds.DOCUMENT)
+        with self.assertRaisesRegex(ValidationError, "is invalid for content kind"):
+            validate({"model": completion_criteria.PAGES, "threshold": 1}, kind=content_kinds.EXERCISE)
+        with self.assertRaisesRegex(ValidationError, "is invalid for content kind"):
+            validate({"model": completion_criteria.MASTERY, "threshold": {"mastery_model": mastery_criteria.DO_ALL}}, kind=content_kinds.DOCUMENT)

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "intl": "1.2.5",
     "jquery": "^2.2.4",
     "jspdf": "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
-    "kolibri-constants": "^0.1.39",
+    "kolibri-constants": "^0.1.40",
     "kolibri-tools": "^0.14.5-dev.4",
     "lodash": "^4.17.21",
     "material-icons": "0.3.1",

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ djangorestframework==3.12.4
 psycopg2-binary==2.8.6
 django-js-reverse==0.9.1
 django-registration==3.1.2
-le-utils==0.1.39
+le-utils==0.1.40
 gunicorn==19.6.0
 django-postmark==0.1.6
 jsonfield==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ jsonschema==3.2.0
     # via -r requirements.in
 kombu==4.6.11
     # via celery
-le-utils==0.1.39
+le-utils==0.1.40
     # via -r requirements.in
 newrelic==6.2.0.156
     # via -r requirements.in

--- a/yarn.lock
+++ b/yarn.lock
@@ -12316,10 +12316,10 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-kolibri-constants@^0.1.39:
-  version "0.1.39"
-  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.39.tgz#f91ec1cf19d5043a46b81580da19e1ccedaa39b8"
-  integrity sha512-6tqli9wb7N7cxQFFT4IEWFUUWTnU96+zVPJG+F2/AIwPFVSmEJdqVh/p+syfDUwqQe8eDxbdd4e+ZSC+cEcxuw==
+kolibri-constants@^0.1.40:
+  version "0.1.40"
+  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.40.tgz#ea75e7ce9716a027638c4ac6db73867bc04d1858"
+  integrity sha512-264LtFuLoQ15GbZKxWnMcl+uDovzj75GWopnW40ixAVMERrmhSIGuSl1wID9IVOyT788xLQCPhcIqOP5LmDA9A==
 
 "kolibri-design-system@github:learningequality/kolibri-design-system#c2acc3fd19cee52ccd2a17fa8d2b10cddb2b3d63":
   version "1.3.0"


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
- Upgrades `le-utils` [with changes](https://github.com/learningequality/le-utils/pull/103) that allow percentages for the threshold of the pages model
- Updates completion criteria validation after breaking out the mastery schema into standalone file

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
Are the tests satisfactory?

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
https://github.com/learningequality/le-utils/pull/103

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [X] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
