### PR TITLE
fix: use the jspdf https url instead of git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "i18n-iso-countries": "^5.1.0",
     "intl": "1.2.5",
     "jquery": "^2.2.4",
-    "jspdf": "git://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
+    "jspdf": "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "kolibri-constants": "^0.1.39",
     "kolibri-tools": "^0.14.5-dev.4",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12205,9 +12205,9 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-"jspdf@git://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e":
+"jspdf@https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e":
   version "2.1.1"
-  resolved "git://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e"
+  resolved "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e"
   dependencies:
     atob "^2.1.2"
     btoa "^1.2.1"


### PR DESCRIPTION
git:// started failing recently, and no docker build can happen



## Summary
### Description of the change(s) you made

Github recently deprecated the git:// url for pulling in dependencies. We still have jsPDF using that git:// url, so docker builds on all branches should be failing.

[Unstable failed build](https://console.cloud.google.com/cloud-build/builds;region=global/6d35b777-c535-4d98-a341-4f085409bdb9?project=contentworkshop-159920)

[Hotfixes failed build](https://console.cloud.google.com/cloud-build/builds;region=global/6d35b777-c535-4d98-a341-4f085409bdb9?project=contentworkshop-159920)

This fix simply changes the git:// url to an https:// url. And builds are now succeeding on my end!


### Manual verification steps performed

Run a docker build:
```bash
docker build -f k8s/images/app/Dockerfile .
```

