### PR TITLE
fix(admin): custom admin permission class

### DIFF
--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -20,9 +20,7 @@ from le_utils.constants import roles
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
-from rest_framework.permissions import IsAdminUser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import CharField
@@ -52,6 +50,7 @@ from contentcuration.viewsets.common import SQSum
 from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.utils import generate_update_event
+from contentcuration.viewsets.user import IsAdminUser
 
 
 class ChannelListPagination(ValuesViewsetPageNumberPagination):

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -48,8 +48,7 @@ class IsAdminUser(BasePermission):
         try:
             return request.user and request.user.is_admin
         except AttributeError:
-            perm = False
-        return False
+            return False
 
 
 class UserListPagination(ValuesViewsetPageNumberPagination):

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -16,7 +16,7 @@ from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import FilterSet
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.permissions import IsAdminUser
+from rest_framework.permissions import BasePermission
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -37,6 +37,15 @@ from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import VIEWER_M2M
+
+
+class IsAdminUser(BasePermission):
+    """
+    Our custom permission to check admin authorization.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_admin)
 
 
 class UserListPagination(ValuesViewsetPageNumberPagination):

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -49,7 +49,7 @@ class IsAdminUser(BasePermission):
             return request.user and request.user.is_admin
         except AttributeError:
             perm = False
-        return bool(perm)
+        return False
 
 
 class UserListPagination(ValuesViewsetPageNumberPagination):

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -46,7 +46,7 @@ class IsAdminUser(BasePermission):
 
     def has_permission(self, request, view):
         try:
-            perm = request.user and request.user.is_admin
+            return request.user and request.user.is_admin
         except AttributeError:
             perm = False
         return bool(perm)

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -45,7 +45,11 @@ class IsAdminUser(BasePermission):
     """
 
     def has_permission(self, request, view):
-        return bool(request.user and request.user.is_admin)
+        try:
+            perm = request.user and request.user.is_admin
+        except AttributeError:
+            perm = False
+        return bool(perm)
 
 
 class UserListPagination(ValuesViewsetPageNumberPagination):


### PR DESCRIPTION

## Summary
When admins were added, on our backend we were setting `is_admin=True` but DRF checks against `is_staff` so this PR implements a custom `IsAdminUser` DRF permission class to fix the issue.  


## Manual verification steps performed
1. Log in as admin user `a@a.com` on studio from the `unstable` branch. 
2. Add `user@b.com` or any other user as an admin. 
3. Log out and log in as `user@b.com`. 
4. Open `Administration`: http://localhost:8080/en/administration. Open networks tab on dev console, you'll see 403 errors. 
5. Now, on switching to this PR's branch, the above issue is fixed. The `Administration` view is fully functional.      

## Reviewer guidance
Now when we add admins do they get expected access?

## References
Closes https://github.com/learningequality/studio/issues/3348. 

## Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests

## Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
