### PR TITLE
Edit modal - add accessibility field

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -15,7 +15,12 @@
         >
           <template #label>
             <span class="text-xs-left">{{ accessibilityItem.label }}</span>
-            <HelpTooltip :text="$tr(accessibilityItem.help)" bottom class="px-2" />
+            <HelpTooltip
+              :text="$tr(accessibilityItem.help)"
+              bottom
+              class="px-2"
+              data-test="accessibility-tooltip"
+            />
           </template>
         </Checkbox>
       </VFlex>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -88,7 +88,7 @@
       altText: `Alternative text is provided for visual content (e.g., via the HTML alt attribute).`,
       audioDescription: `Audio descriptions are available (e.g., via an HTML5 track element with kind="descriptions")`,
       highContrast: `Content meets the visual contrast threshold set out in WCAG Success Criteria 1.4.6`,
-      signLanguage: `Synchronized sign language intepretation is available for audio and video content. The value may be extended by adding an ISO 639 sign language code. For example, /sgn-en-us for American Sign Language.`,
+      signLanguage: `Synchronized sign language intepretation is available for audio and video content.`,
       taggedPdf: `The structures in a PDF have been tagged to improve the navigation of the content.`,
       /* eslint-enable kolibri/vue-no-unused-translations */
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -12,6 +12,7 @@
           :value="accessibilityItem.value"
           :label="accessibilityItem.label"
           color="primary"
+          :data-test="`checkbox-${accessibilityItem.label}`"
         >
           <template #label>
             <span class="text-xs-left">{{ accessibilityItem.label }}</span>
@@ -19,7 +20,7 @@
               :text="$tr(accessibilityItem.help)"
               bottom
               class="px-2"
-              data-test="accessibility-tooltip"
+              :data-test="`tooltip-${accessibilityItem.label}`"
             />
           </template>
         </Checkbox>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -1,0 +1,94 @@
+<template>
+
+  <div>
+    <VLayout row wrap>
+      <VFlex
+        v-for="(accessibilityItem, index) in showCorrectAccessibilityList"
+        :key="index"
+        xs12
+      >
+        <Checkbox
+          v-model="accessibility"
+          :value="accessibilityItem.value"
+          :label="accessibilityItem.label"
+          color="primary"
+        >
+          <template #label>
+            <span class="text-xs-left">{{ accessibilityItem.label }}</span>
+            <HelpTooltip :text="$tr(accessibilityItem.help)" bottom class="px-2" />
+          </template>
+        </Checkbox>
+      </VFlex>
+    </VLayout>
+
+  </div>
+
+</template>
+
+<script>
+
+  import { camelCase } from 'lodash';
+  import { AccessibilityCategories, AccessibilityCategoriesMap } from 'shared/constants';
+  import Checkbox from 'shared/views/form/Checkbox';
+  import HelpTooltip from 'shared/views/HelpTooltip';
+  import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
+
+  export default {
+    name: 'AccessibilityOptions',
+    components: {
+      Checkbox,
+      HelpTooltip,
+    },
+    mixins: [constantsTranslationMixin, metadataTranslationMixin],
+    props: {
+      kind: {
+        type: String,
+        default: '',
+      },
+      value: {
+        type: Array,
+        default: () => [],
+      },
+    },
+    computed: {
+      accessibility: {
+        get() {
+          return this.value;
+        },
+        set(value) {
+          return this.$emit('input', value);
+        },
+      },
+      /**
+       * List of accessibility options for all content kinds except for audio
+       */
+      showCorrectAccessibilityList() {
+        return Object.keys(AccessibilityCategories)
+          .filter(key => AccessibilityCategoriesMap[this.kind].includes(key))
+          .map(key => {
+            return {
+              label: this.translateMetadataString(camelCase(key)),
+              value: AccessibilityCategories[key],
+              help: camelCase(key),
+            };
+          });
+      },
+    },
+    $trs: {
+      /* eslint-disable kolibri/vue-no-unused-translations */
+      /**
+       * Strings for the help tooltips
+       */
+      altText: `Alternative text is provided for visual content (e.g., via the HTML alt attribute).`,
+      audioDescription: `Audio descriptions are available (e.g., via an HTML5 track element with kind="descriptions")`,
+      highContrast: `Content meets the visual contrast threshold set out in WCAG Success Criteria 1.4.6`,
+      signLanguage: `Synchronized sign language intepretation is available for audio and video content. The value may be extended by adding an ISO 639 sign language code. For example, /sgn-en-us for American Sign Language.`,
+      taggedPdf: `The structures in a PDF have been tagged to improve the navigation of the content.`,
+      /* eslint-enable kolibri/vue-no-unused-translations */
+    },
+  };
+
+</script>
+<style lang="scss">
+
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -391,7 +391,7 @@
     return {
       get() {
         const value = this.getValueFromNodes(key);
-        return Object.keys(value).filter(k => value[k]);
+        return Object.keys(value);
       },
       set(value) {
         const newMap = {};

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -163,6 +163,21 @@
         </VFlex>
       </VLayout>
 
+      <!-- Accessibility section -->
+      <VLayout row wrap class="section">
+        <template v-if="requiresAccessibility">
+          <VFlex xs12>
+            <h1 class="subheading">
+              {{ translateMetadataString('accessibility') }}
+            </h1>
+            <AccessibilityOptions
+              v-model="accessibility"
+              :checked="accessibility"
+              :kind="firstNode.kind"
+            />
+          </VFlex>
+        </template>
+      </VLayout>
 
       <!-- Source section -->
       <VLayout row wrap class="section">
@@ -288,6 +303,15 @@
           <SubtitlesList :nodeId="firstNode.id" />
         </VFlex>
       </VLayout>
+
+      <!-- Audio accessibility section -->
+      <VLayout row wrap class="section">
+        <template v-if="audioAccessibility">
+          <VFlex xs12>
+            <SubtitlesList :nodeId="firstNode.id" />
+          </VFlex>
+        </template>
+      </VLayout>
     </VForm>
   </div>
 
@@ -303,6 +327,7 @@
   import FileUpload from '../../views/files/FileUpload';
   import SubtitlesList from '../../views/files/supplementaryLists/SubtitlesList';
   import { isImportedContent, importedChannelLink } from '../../utils';
+  import AccessibilityOptions from './AccessibilityOptions.vue';
   import {
     getTitleValidators,
     getCopyrightHolderValidators,
@@ -318,6 +343,7 @@
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import { NEW_OBJECT, FeatureFlagKeys, ContentModalities } from 'shared/constants';
   import { validate as validateCompletionCriteria } from 'shared/leUtils/CompletionCriteria';
+  import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
 
   // Define an object to act as the place holder for non unique values.
   const nonUniqueValue = {};
@@ -355,6 +381,28 @@
     };
   }
 
+  /**
+   * This function is used to generate getter/setters for new metadata fields that are boolean maps:
+   * - `grade_levels` (sometimes referred to as `content_levels`)
+   * - `learner_needs` (resources needed)
+   * - `accessibility_labels` (accessibility options)
+   */
+  function generateNestedNodesGetterSetter(key) {
+    return {
+      get() {
+        const value = this.getValueFromNodes(key);
+        return Object.keys(value).filter(k => value[k]);
+      },
+      set(value) {
+        const newMap = {};
+        for (let label of value) {
+          newMap[label] = true;
+        }
+        this.update({ [key]: newMap });
+      },
+    };
+  }
+
   export default {
     name: 'DetailsTabView',
     components: {
@@ -367,7 +415,9 @@
       SubtitlesList,
       ContentNodeThumbnail,
       Checkbox,
+      AccessibilityOptions,
     },
+    mixins: [constantsTranslationMixin, metadataTranslationMixin],
     props: {
       nodeIds: {
         type: Array,
@@ -413,6 +463,12 @@
       importedChannelName() {
         return this.firstNode.original_channel_name;
       },
+      requiresAccessibility() {
+        return this.nodes.every(node => node.kind !== ContentKindsNames.AUDIO);
+      },
+      audioAccessibility() {
+        return this.oneSelected && this.firstNode.kind === 'audio';
+      },
       /* FORM FIELDS */
       title: generateGetterSetter('title'),
       description: generateGetterSetter('description'),
@@ -438,6 +494,7 @@
       },
       role: generateGetterSetter('role_visibility'),
       language: generateGetterSetter('language'),
+      accessibility: generateNestedNodesGetterSetter('accessibility_labels'),
       mastery_model() {
         return this.getExtraFieldsValueFromNodes('mastery_model');
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
@@ -5,15 +5,14 @@ import AccessibilityOptions from '../AccessibilityOptions.vue';
 
 Vue.use(Vuetify);
 
-describe('AccessibilityOptions', () => {;
-
+describe('AccessibilityOptions', () => {
   it('smoke test', () => {
-      const wrapper = shallowMount(AccessibilityOptions, {
-        propsData: {
-          kind: 'document',
-        },
-      });
-      expect(wrapper.isVueInstance()).toBe(true);
+    const wrapper = shallowMount(AccessibilityOptions, {
+      propsData: {
+        kind: 'document',
+      },
+    });
+    expect(wrapper.isVueInstance()).toBe(true);
   });
 
   it('should display the correct list of accessibility options if resource is a document', () => {
@@ -23,8 +22,12 @@ describe('AccessibilityOptions', () => {;
       },
     });
 
-    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(true);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(true);
+    expect(
+      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+    ).toBe(true);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
+      true
+    );
     expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(true);
     expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
     expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
@@ -37,8 +40,12 @@ describe('AccessibilityOptions', () => {;
       },
     });
 
-    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(false);
+    expect(
+      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+    ).toBe(false);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
+      false
+    );
     expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
     expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(true);
     expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(true);
@@ -51,8 +58,12 @@ describe('AccessibilityOptions', () => {;
       },
     });
 
-    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(true);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(false);
+    expect(
+      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+    ).toBe(true);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
+      false
+    );
     expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
     expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
     expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
@@ -65,8 +76,12 @@ describe('AccessibilityOptions', () => {;
       },
     });
 
-    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(true);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(true);
+    expect(
+      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+    ).toBe(true);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
+      true
+    );
     expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
     expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
     expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
@@ -81,5 +96,4 @@ describe('AccessibilityOptions', () => {;
 
     expect(wrapper.find('[data-test="accessibility-tooltip"]').exists()).toBe(true);
   });
-
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
@@ -23,14 +23,14 @@ describe('AccessibilityOptions', () => {
     });
 
     expect(
-      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
     ).toBe(true);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
-      true
-    );
-    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(true);
-    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
+    expect(
+      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
+    ).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
   });
 
   it('should display the correct list of accessibility options if resource is a video', () => {
@@ -41,14 +41,14 @@ describe('AccessibilityOptions', () => {
     });
 
     expect(
-      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
     ).toBe(false);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
-      false
-    );
-    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(true);
-    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(true);
+    expect(
+      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
+    ).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(true);
   });
 
   it('should display the correct list of accessibility options if resource is an exercise/practice', () => {
@@ -59,14 +59,14 @@ describe('AccessibilityOptions', () => {
     });
 
     expect(
-      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
     ).toBe(true);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
-      false
-    );
-    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
+    expect(
+      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
+    ).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
   });
 
   it('should display the correct list of accessibility options if resource is html5/zip', () => {
@@ -77,23 +77,40 @@ describe('AccessibilityOptions', () => {
     });
 
     expect(
-      wrapper.find('[aria-label="Has alternative text description for images"]').exists()
+      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
     ).toBe(true);
-    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(
-      true
-    );
-    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
+    expect(
+      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
+    ).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
   });
 
-  it('should display tooltip', () => {
+  it('should render appropriate tooltips along with the checkbox', () => {
     const wrapper = mount(AccessibilityOptions, {
       propsData: {
         kind: 'document',
       },
     });
 
-    expect(wrapper.find('[data-test="accessibility-tooltip"]').exists()).toBe(true);
+    expect(
+      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-test="tooltip-Has alternative text description for images"]').exists()
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-test="tooltip-Has high contrast display for low vision"]').exists()
+    ).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-Tagged PDF"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="tooltip-Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="tooltip-Has audio descriptions"]').exists()).toBe(false);
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
@@ -1,0 +1,85 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import { shallowMount, mount } from '@vue/test-utils';
+import AccessibilityOptions from '../AccessibilityOptions.vue';
+
+Vue.use(Vuetify);
+
+describe('AccessibilityOptions', () => {;
+
+  it('smoke test', () => {
+      const wrapper = shallowMount(AccessibilityOptions, {
+        propsData: {
+          kind: 'document',
+        },
+      });
+      expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('should display the correct list of accessibility options if resource is a document', () => {
+    const wrapper = mount(AccessibilityOptions, {
+      propsData: {
+        kind: 'document',
+      },
+    });
+
+    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
+  });
+
+  it('should display the correct list of accessibility options if resource is a video', () => {
+    const wrapper = mount(AccessibilityOptions, {
+      propsData: {
+        kind: 'video',
+      },
+    });
+
+    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(true);
+  });
+
+  it('should display the correct list of accessibility options if resource is an exercise/practice', () => {
+    const wrapper = mount(AccessibilityOptions, {
+      propsData: {
+        kind: 'exercise',
+      },
+    });
+
+    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
+  });
+
+  it('should display the correct list of accessibility options if resource is html5/zip', () => {
+    const wrapper = mount(AccessibilityOptions, {
+      propsData: {
+        kind: 'html5',
+      },
+    });
+
+    expect(wrapper.find('[aria-label="Has alternative text description for images"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Has high contrast display for low vision"').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="Tagged PDF"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has sign language captions"]').exists()).toBe(false);
+    expect(wrapper.find('[aria-label="Has audio descriptions"]').exists()).toBe(false);
+  });
+
+  it('should display tooltip', () => {
+    const wrapper = mount(AccessibilityOptions, {
+      propsData: {
+        kind: 'document',
+      },
+    });
+
+    expect(wrapper.find('[data-test="accessibility-tooltip"]').exists()).toBe(true);
+  });
+
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/detailsTabView.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/detailsTabView.spec.js
@@ -60,6 +60,7 @@ describe.skip('detailsTabView', () => {
     wrapper = makeWrapper();
   });
   describe('on render', () => {
+    // TODO: add defaults for 'accessibility' field
     it('all fields should match node field values', () => {
       let keys = [
         'language',

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -211,7 +211,6 @@ function generateContentNodeData({
   prerequisite = NOVALUE,
   complete = NOVALUE,
   accessibility_labels = NOVALUE,
-
 } = {}) {
   const contentNodeData = {};
   if (title !== NOVALUE) {
@@ -248,8 +247,8 @@ function generateContentNodeData({
     contentNodeData.provider = provider;
   }
   /*
-  * New metadata fields
-  */
+   * New metadata fields
+   */
   if (accessibility_labels !== NOVALUE) {
     contentNodeData.accessibility_labels = accessibility_labels;
   }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -177,6 +177,7 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     parent,
     ...contentDefaults,
     role_visibility: contentDefaults.role_visibility || RolesNames.LEARNER,
+    accessibility_labels: {},
     ...payload,
   };
 
@@ -209,6 +210,8 @@ function generateContentNodeData({
   extra_fields = NOVALUE,
   prerequisite = NOVALUE,
   complete = NOVALUE,
+  accessibility_labels = NOVALUE,
+
 } = {}) {
   const contentNodeData = {};
   if (title !== NOVALUE) {
@@ -244,6 +247,13 @@ function generateContentNodeData({
   if (provider !== NOVALUE) {
     contentNodeData.provider = provider;
   }
+  /*
+  * New metadata fields
+  */
+  if (accessibility_labels !== NOVALUE) {
+    contentNodeData.accessibility_labels = accessibility_labels;
+  }
+
   if (extra_fields !== NOVALUE) {
     contentNodeData.extra_fields = contentNodeData.extra_fields || {};
     if (extra_fields.mastery_model) {

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -175,3 +175,11 @@ export const FeatureFlagKeys = Object.keys(FeatureFlagsSchema.properties).reduce
 export const ContentModalities = {
   QUIZ: 'QUIZ',
 };
+
+export const AccessibilityCategoriesMap = {
+  // Note: audio is not included, as it is rendered in the UI differently.
+  document: ['ALT_TEXT', 'HIGH_CONTRAST', 'TAGGED_PDF'],
+  video: ['SIGN_LANGUAGE', 'AUDIO_DESCRIPTION'],
+  exercise: ['ALT_TEXT'],
+  html5: ['ALT_TEXT', 'HIGH_CONTRAST'],
+};

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -647,10 +647,35 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
 
 export const metadataTranslationMixin = {
   methods: {
-    translateMetadataString(string) {
-      return metadataStrings.$tr(string);
+    translateMetadataString(key) {
+      if (nonconformingKeys[key]) {
+        return metadataStrings.$tr(nonconformingKeys[key]);
+      }
+      return metadataStrings.$tr(key);
     },
   },
+};
+
+/**
+ * An object mapping ad hoc keys (like those to be passed to CommonMetadataStrings()) which do not
+ * conform to the expectations. Examples:
+ *
+ * - Misspelling of the key in CommonMetadataStrings but a kolibri-constant used to access it is
+ *   spelled correctly and will not map.
+ * - Keys were defined and string-froze which are not camelCase.
+ * - Keys which, when _.camelCase()'ed will not result in a valid key, requiring manual mapping
+ */
+const nonconformingKeys = {
+  PEOPLE: 'ToUseWithTeachersAndPeers',
+  PAPER_PENCIL: 'ToUseWithPaperAndPencil',
+  INTERNET: 'NeedsInternet',
+  MATERIALS: 'NeedsMaterials',
+  FOR_BEGINNERS: 'ForBeginners',
+  digitalLiteracy: 'digitialLiteracy',
+  BASIC_SKILLS: 'allLevelsBasicSkills',
+  FOUNDATIONS: 'basicSkills',
+  toolsAndSoftwareTraining: 'softwareToolsAndTraining',
+  foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
 };
 
 /**


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Add metadata, strings, tests for accessibility field in the edit modal (`DetailsTabView`)

### Manual verification steps performed
1. Go to the edit modal
2. Look for the new "Accessibility" section below "Audience"
3. Make sure the checkboxes are visually working 
4. Use the network tab in developer tools and check in the `/sync` endpoint that the checked items are being sent in as `true` when checked and the key is removed when a checkbox is unchecked

### Screenshots (if applicable)
<img width="1100" alt="Screen Shot 2022-04-13 at 10 14 10 PM" src="https://user-images.githubusercontent.com/13563002/163318238-b2b6e0fc-7b0b-4531-9c41-f6f39d14fe1b.png">


### Does this introduce any tech-debt items?
This is the first of the new metadata fields to be included in the edit modal.
___
## Reviewer guidance
### How can a reviewer test these changes?
Run the tests:
- For `AccessibilityOptions` component using `yarn run test-jest contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js`

Manually (see also the [Gherkin stories for Accessibility here](https://www.notion.so/learningequality/Studio-gherkin-stories-6bb841246d4e4afd958f074226fa8f19)):
1. Log in to Studio
2. Go to the edit modal
3. Look for the new "Accessibility" section below "Audience"
4. Make sure the checkboxes are visually working (they seem to be a bit slow, so any suggestions here appreciated)
5. After checking and unchecking the boxes, click on "Finish" and go back in to edit the resource to make sure what you checked and unchecked are correctly displayed.
6. Make sure to test this with the different resource kinds (video, audio, documents, html5/zip, practice/exercises) and check that what is rendered matches the designs in [Figma](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=3495%3A0)
7. Make sure that when hovering over the help icon, the longer description appears
8. Use the network tab in developer tools and check in the `/sync` endpoint that the checked items are being sent in as `true` when checked and the key is removed when a checkbox is unchecked:
```
accessibility_labels: {
  some_string: true,
}
```

## References
- [Figma design for this feature](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=3495%3A0)
- [Gherkin stories for this feature](https://www.notion.so/learningequality/Studio-gherkin-stories-6bb841246d4e4afd958f074226fa8f19)
- Addresses #3205 

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

Studio-specifc:

- [x] All user-facing strings are translated properly
- [x] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [x] All UI components are LTR and RTL compliant
- [x] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)

Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
