### PR TITLE
Actually use diffTracker values for display to the user.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -690,20 +690,31 @@
         return value !== nonUniqueValue;
       },
       getValueFromNodes(key) {
-        if (Object.prototype.hasOwnProperty.call(this.diffTracker, key)) {
-          return this.diffTracker[key];
-        }
-        let results = uniq(this.nodes.map(node => node[key] || null));
+        const results = uniq(
+          this.nodes.map(node => {
+            if (Object.prototype.hasOwnProperty.call(this.diffTracker[node.id] || {}, key)) {
+              return this.diffTracker[node.id][key];
+            }
+            return node[key] || null;
+          })
+        );
         return getValueFromResults(results);
       },
       getExtraFieldsValueFromNodes(key, defaultValue = null) {
-        if (
-          Object.prototype.hasOwnProperty.call(this.diffTracker, 'extra_fields') &&
-          Object.prototype.hasOwnProperty.call(this.diffTracker.extra_fields, key)
-        ) {
-          return this.diffTracker.extra_fields[key];
-        }
-        let results = uniq(this.nodes.map(node => node.extra_fields[key] || defaultValue));
+        const results = uniq(
+          this.nodes.map(node => {
+            if (
+              Object.prototype.hasOwnProperty.call(
+                this.diffTracker[node.id] || {},
+                'extra_fields'
+              ) &&
+              Object.prototype.hasOwnProperty.call(this.diffTracker[node.id].extra_fields, key)
+            ) {
+              return this.diffTracker[node.id].extra_fields[key];
+            }
+            return node.extra_fields[key] || defaultValue;
+          })
+        );
         return getValueFromResults(results);
       },
       getPlaceholder(field) {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Makes the use of the diffTracker to generate getter values actually find the values in the diffTracker (where they are keyed by node id, and then the key for the property) rather than just keying directly by the property
* This should fix the apparent editing lag that was observed by @sairina in her recently merged #3366 
* This issue was originally introduced in https://github.com/learningequality/studio/pull/2443/commits/599e338e7965e677c3a2470b027f47d76a84b5d8

### Manual verification steps performed
1. Check an accessibility checkbox
2. See it be immediately checked

