### PR TITLE
Edit modal - add "Category" field to "Basic information" section

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -13,7 +13,7 @@
       multiple
       item-value="value"
       item-text="text"
-      @click:clear="item => remove(item.value)"
+      @click:clear="$nextTick(() => removeAll())"
     >
       <template v-slot:selection="data">
         <VTooltip bottom>
@@ -175,6 +175,9 @@
       },
       remove(item) {
         this.selected = this.selected.filter(i => !i.startsWith(item));
+      },
+      removeAll() {
+        this.selected = [];
       },
       tooltipHelper(id) {
         return this.displayFamilyTree(dropdown, id)

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -1,0 +1,246 @@
+<template>
+
+  <div id="app">
+    <VAutocomplete
+      v-model="selected"
+      :items="categoriesList"
+      :searchInput.sync="categoryText"
+      :label="translateMetadataString('category')"
+      box
+      clearable
+      chips
+      deletableChips
+      multiple
+      item-value="value"
+      item-text="text"
+    >
+
+      <template v-slot:selection="data">
+        <VTooltip bottom>
+          <template v-slot:activator="{ on, attrs }">
+            <VChip
+              v-bind="attrs"
+              close
+              v-on="on"
+              @input="remove(data.item)"
+            >
+              {{ data.item.text }}
+            </VChip>
+          </template>
+          <div>
+            <div>{{ tooltipHelper(data.item.value) }}</div>
+          </div>
+        </VTooltip>
+      </template>
+
+      <template v-slot:no-data>
+        <VListTile v-if="categoryText && categoryText.trim()">
+          <VListTileContent>
+            <VListTileTitle>
+              {{ $tr('noCategoryFoundText', { text: categoryText.trim() }) }}
+            </VListTileTitle>
+          </VListTileContent>
+        </VListTile>
+      </template>
+
+      <template v-slot:item="{ item }">
+        <!--
+          `@click.stop` to prevent from propagating
+          checkboxes updates to VAutocomplete automatically
+          so that we can use our own handlers instead
+        -->
+        <div style="width: 100%; height: 100%;" aria-hidden="true">
+          <VDivider v-if="!item.value.includes('.')" />
+          <KCheckbox
+            v-model="selected"
+            :checked="dropdownSelected.includes(item.value)"
+            :label="item.text"
+            :value="item.value"
+            style="margin-top: 10px"
+            :style="treeItemStyle(item)"
+            :ripple="false"
+            @click.stop
+          />
+        </div>
+      </template>
+    </VAutocomplete>
+  </div>
+
+</template>
+
+<script>
+
+  import { camelCase } from 'lodash';
+  import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
+  import { Categories, CategoriesLookup } from 'shared/constants';
+
+  const availablePaths = {};
+  const categoriesObj = {};
+  const dropdown = [];
+
+  Object.assign(availablePaths, CategoriesLookup);
+
+  /*
+   * This is used to create the categories object from which the dropdown list is generated
+   * and is the same as this to make sure the order in Kolibri and Studio are the same:
+   * https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/learn/assets/
+   *   src/views/CategorySearchModal/CategorySearchOptions.vue#L73
+   */
+  for (let subjectKey of Object.entries(Categories)
+    .sort((a, b) => a[1].length - b[1].length)
+    .map(a => a[0])) {
+    const ids = Categories[subjectKey].split('.');
+
+    let path = '';
+    let nested = categoriesObj;
+    for (let fragment of ids) {
+      path += fragment;
+      if (availablePaths[path]) {
+        const nestedKey = CategoriesLookup[path];
+        if (!nested[nestedKey]) {
+          nested[nestedKey] = {
+            value: path,
+            nested: {},
+          };
+        }
+        nested = nested[nestedKey].nested;
+        path += '.';
+      } else {
+        break;
+      }
+    }
+  }
+
+  const flattenCategories = obj => {
+    Object.keys(obj).forEach(key => {
+      if (key !== 'value' && key !== 'nested') {
+        dropdown.push({
+          text: key,
+          value: obj[key]['value'],
+        });
+      }
+      if (typeof obj[key] === 'object') {
+        flattenCategories(obj[key]);
+      }
+    });
+    return dropdown;
+  };
+
+  const findFamilyTreeIds = value => {
+    const family = [];
+    let familyMember = value;
+    while (familyMember) {
+      family.push(familyMember);
+      familyMember = familyMember.includes('.')
+        ? familyMember.substring(0, familyMember.lastIndexOf('.'))
+        : null;
+    }
+    return family;
+  };
+
+  function displayFamilyTree(nodes, id) {
+    return nodes.filter(node => findFamilyTreeIds(id).includes(node.value));
+  }
+
+  export default {
+    name: 'CategoryOptions',
+    mixins: [constantsTranslationMixin, metadataTranslationMixin],
+    props: {
+      value: {
+        type: Array,
+        default: () => [],
+      },
+    },
+    data() {
+      return {
+        categoryText: null,
+        chipsSelected: [],
+        dropdownSelected: [],
+        nested: true,
+      };
+    },
+    computed: {
+      categoriesList() {
+        flattenCategories(categoriesObj);
+        return dropdown.map(category => {
+          return {
+            ...category,
+            text: this.translateMetadataString(camelCase(category.text)),
+            level: this.findDepth(Categories[category.text]),
+          };
+        });
+      },
+      selected: {
+        get() {
+          return this.value;
+        },
+        set(value) {
+          let items = value.map(item => item);
+          let addedItem = items[items.length - 1];
+
+          let parents = findFamilyTreeIds(addedItem).filter(
+            familyMember => familyMember !== addedItem
+          );
+
+          // If removing an item
+          if (this.chipsSelected.length > items.length) {
+            this.chipsSelected = items;
+            this.dropdownSelected = [...value, ...parents];
+          } else {
+            // If the addedItem is already something checked in the dropdown
+            if (this.dropdownSelected.includes(addedItem)) {
+              this.dropdownSelected = this.dropdownSelected.filter(
+                item => !item.includes(addedItem)
+              );
+              this.chipsSelected = this.dropdownSelected;
+            } else {
+              // If adding a brand new item
+              this.dropdownSelected = [...items, ...parents];
+
+              // If selecting a child item when parent is checked
+              if (items.filter(item => parents.indexOf(item) !== -1)) {
+                this.chipsSelected = items.filter(item => parents.indexOf(item) === -1);
+              } else {
+                this.chipsSelected = items;
+              }
+            }
+          }
+
+          this.$emit('input', this.chipsSelected);
+        },
+      },
+    },
+    watch: {
+      categoryText(val) {
+        return !val ? (this.nested = true) : (this.nested = false);
+      },
+    },
+    methods: {
+      treeItemStyle(item) {
+        return this.nested ? { paddingLeft: `${item.level * 24}px` } : {};
+      },
+      remove(item) {
+        this.chipsSelected.splice(this.chipsSelected.indexOf(item.id), 1);
+      },
+      tooltipHelper(id) {
+        return displayFamilyTree(dropdown, id)
+          .map(node => this.translateMetadataString(camelCase(node.text)))
+          .join(' - ');
+      },
+      findDepth(val) {
+        return val.split('.').length - 1;
+      },
+    },
+    $trs: {
+      noCategoryFoundText: 'Category not found',
+    },
+  };
+
+</script>
+<style lang="less" scoped>
+
+  /deep/ .v-list__tile {
+    flex-wrap: wrap;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -187,9 +187,13 @@
       displayFamilyTree(nodes, id) {
         return nodes.filter(node => this.findFamilyTreeIds(id).includes(node.value));
       },
-      findFamilyTreeIds(value) {
+      /**
+       * @param {String} id The id of the selected category
+       * @returns {Array} An array of all ids of the family beginning with the selected category
+       */
+      findFamilyTreeIds(id) {
         const family = [];
-        let familyMember = value;
+        let familyMember = id;
         while (familyMember) {
           family.push(familyMember);
           familyMember = familyMember.includes('.')

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -61,18 +61,21 @@
             >
               <!-- Learning activity -->
               <LearningActivityOptions
+                id="learning_activities"
                 ref="learning_activities"
                 v-model="contentLearningActivities"
                 @focus="trackClick('Learning activities')"
               />
               <!-- Level -->
               <LevelsOptions
+                id="levels"
                 ref="contentLevel"
                 v-model="contentLevel"
                 @focus="trackClick('Levels dropdown')"
               />
               <!-- What you will need -->
               <ResourcesNeededOptions
+                id="resources_needed"
                 ref="resourcesNeeded"
                 v-model="resourcesNeeded"
                 @focus="trackClick('What you will need')"
@@ -178,6 +181,7 @@
           </h1>
           <!-- Language -->
           <LanguageDropdown
+            id="language"
             ref="language"
             v-model="language"
             class="mb-2"
@@ -191,6 +195,7 @@
           <!-- Visibility -->
           <VisibilityDropdown
             v-if="allResources"
+            id="role_visibility"
             ref="role_visibility"
             v-model="role"
             :placeholder="getPlaceholder('role')"
@@ -301,6 +306,7 @@
 
             <!-- License -->
             <LicenseDropdown
+              id="license"
               ref="license"
               v-model="licenseItem"
               :required="isUnique(license) && isUnique(license_description) && !disableAuthEdits"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -106,6 +106,8 @@
               </VCombobox>
             </VFlex>
           </VLayout>
+          <!-- Category -->
+          <CategoryOptions ref="categories" v-model="categories" />
         </VFlex>
       </VLayout>
 
@@ -366,6 +368,7 @@
   import LevelsOptions from './LevelsOptions.vue';
   import ResourcesNeededOptions from './ResourcesNeededOptions.vue';
   import LearningActivityOptions from './LearningActivityOptions.vue';
+  import CategoryOptions from './CategoryOptions.vue';
 
   import {
     getTitleValidators,
@@ -459,6 +462,7 @@
       LevelsOptions,
       ResourcesNeededOptions,
       LearningActivityOptions,
+      CategoryOptions,
     },
     mixins: [constantsTranslationMixin, metadataTranslationMixin],
     props: {
@@ -541,7 +545,7 @@
       contentLevel: generateNestedNodesGetterSetter('grade_levels'),
       resourcesNeeded: generateNestedNodesGetterSetter('learner_needs'),
       contentLearningActivities: generateNestedNodesGetterSetter('learning_activities'),
-
+      categories: generateNestedNodesGetterSetter('categories'),
       mastery_model() {
         return this.getExtraFieldsValueFromNodes('mastery_model');
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
@@ -10,7 +10,7 @@
     multiple
     deletableChips
     :rules="learningActivityRules"
-    attach="learning_activities"
+    attach="#learning_activities"
   />
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
@@ -10,7 +10,7 @@
     :label="translateMetadataString('level')"
     multiple
     deletableChips
-    attach="contentLevel"
+    attach="#levels"
   />
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -10,7 +10,7 @@
     multiple
     deletableChips
     clearable
-    attach="resourcesNeeded"
+    attach="#resources_needed"
   />
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/categoryOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/categoryOptions.spec.js
@@ -294,130 +294,23 @@ describe('CategoryOptions', () => {
   });
 
   describe('interactions', () => {
-    it('when user checks an item, only that item is added to the chips', () => {
+    it('when user checks an item, that is emitted to the parent component', () => {
       const wrapper = shallowMount(CategoryOptions);
-      const items = ['PbGoe2MV'];
-      const item = 'PbGoe2MV';
-      wrapper.vm.handleCheckboxItem(item, items);
+      const item = 'abcd';
+      wrapper.vm.$emit = jest.fn();
+      wrapper.vm.add(item);
 
-      expect(wrapper.vm.chipsSelected).toEqual(items);
+      expect(wrapper.vm.$emit.mock.calls[0][0]).toBe('input');
+      expect(wrapper.vm.$emit.mock.calls[0][1]).toEqual([item]);
     });
-    it('when user checks a grandchild item, that item and all its parents are added to the dropdown', () => {
+    it('when user unchecks an item, that is emitted to the parent component', () => {
       const wrapper = shallowMount(CategoryOptions);
-      const items = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW'];
-      const item = 'd&WXdXWF.e#RTW9E#.8ZoaPsVW';
-      const expectedDropdown = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'd&WXdXWF.e#RTW9E#', 'd&WXdXWF'];
-      wrapper.vm.handleCheckboxItem(item, items);
+      const item = 'defj';
+      wrapper.vm.$emit = jest.fn();
+      wrapper.vm.remove(item);
 
-      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
-    });
-    it('when user unchecks a grandchild item that has a sibling, only that item is removed from the chips', () => {
-      const wrapper = shallowMount(CategoryOptions, {
-        data() {
-          return {
-            chipsSelected: [
-              'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
-              'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
-              'd&WXdXWF.5QAjgfv7.BUMJJBnS',
-              'd&WXdXWF.5QAjgfv7.XsWznP4o',
-            ],
-          };
-        },
-      });
-      const items = [
-        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
-        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
-        'd&WXdXWF.5QAjgfv7.BUMJJBnS',
-      ];
-      const item = 'd&WXdXWF.5QAjgfv7.BUMJJBnS';
-      const expectedChips = [
-        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
-        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
-        'd&WXdXWF.5QAjgfv7.BUMJJBnS',
-      ];
-      const expectedDropdown = [
-        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
-        'd&WXdXWF.e#RTW9E#',
-        'd&WXdXWF',
-        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
-        'd&WXdXWF.5QAjgfv7.BUMJJBnS',
-        'd&WXdXWF.5QAjgfv7',
-      ];
-      wrapper.vm.handleCheckboxItem(item, items);
-
-      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
-      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
-    });
-    it('when user unchecks a grandchild item that has no siblings and its parents have siblings, that item and its parent are removed from the chips ', () => {
-      const wrapper = shallowMount(CategoryOptions, {
-        data() {
-          return {
-            chipsSelected: [
-              'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
-              'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
-              'd&WXdXWF.5QAjgfv7.BUMJJBnS',
-            ],
-          };
-        },
-      });
-      const items = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'd&WXdXWF.e#RTW9E#.CfnlTDZ#'];
-      const item = 'd&WXdXWF.e#RTW9E#.CfnlTDZ#';
-      const expectedChips = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'd&WXdXWF.e#RTW9E#.CfnlTDZ#'];
-      const expectedDropdown = [
-        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
-        'd&WXdXWF.e#RTW9E#',
-        'd&WXdXWF',
-        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
-      ];
-      wrapper.vm.handleCheckboxItem(item, items);
-
-      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
-      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
-    });
-    it('when user unchecks a grandchild item that has no siblings and its parents have no siblings, that item, its parent, and the root are removed from the chips ', () => {
-      const wrapper = shallowMount(CategoryOptions, {
-        data() {
-          return { chipsSelected: ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'BCG3&slG.wZ3EAedB'] };
-        },
-      });
-      const items = ['BCG3&slG.wZ3EAedB'];
-      const item = 'BCG3&slG.wZ3EAedB';
-      const expectedChips = ['BCG3&slG.wZ3EAedB'];
-      const expectedDropdown = ['BCG3&slG.wZ3EAedB', 'BCG3&slG'];
-      wrapper.vm.handleCheckboxItem(item, items);
-
-      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
-      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
-    });
-    it('when user unchecks an item that has children and its parents have no siblings, that item and all its children are removed from the chips ', () => {
-      const wrapper = shallowMount(CategoryOptions, {
-        data() {
-          return { chipsSelected: ['d&WXdXWF.5QAjgfv7.BUMJJBnS'] };
-        },
-      });
-      const items = ['d&WXdXWF.5QAjgfv7.BUMJJBnS', 'd&WXdXWF'];
-      const item = 'd&WXdXWF';
-      const expectedChips = [];
-      const expectedDropdown = [];
-      wrapper.vm.handleCheckboxItem(item, items);
-
-      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
-      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
-    });
-    it('when user checks grandchild of parent after parent item has already been checked, the grandchild replaces the parent chip', () => {
-      const wrapper = shallowMount(CategoryOptions, {
-        data() {
-          return { chipsSelected: ['d&WXdXWF'] };
-        },
-      });
-      const items = ['d&WXdXWF', 'd&WXdXWF.5QAjgfv7.XsWznP4o'];
-      const item = 'd&WXdXWF.5QAjgfv7.XsWznP4o';
-      const expectedChips = ['d&WXdXWF.5QAjgfv7.XsWznP4o'];
-      const expectedDropdown = ['d&WXdXWF.5QAjgfv7.XsWznP4o', 'd&WXdXWF.5QAjgfv7', 'd&WXdXWF'];
-      wrapper.vm.handleCheckboxItem(item, items);
-
-      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
-      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+      expect(wrapper.vm.$emit.mock.calls[0][0]).toBe('input');
+      expect(wrapper.vm.$emit.mock.calls[0][1]).toEqual([]);
     });
   });
 
@@ -425,12 +318,12 @@ describe('CategoryOptions', () => {
     it('in the autocomplete bar, the chip is removed when user clicks on its close button', () => {
       const wrapper = shallowMount(CategoryOptions, {
         data() {
-          return { chipsSelected: ['remove me', 'abc', 'def', 'abc.'] };
+          return { selected: ['remove me', 'abc', 'def', 'abc.'] };
         },
       });
-      const originalChipsLength = wrapper.vm.chipsSelected.length;
+      const originalChipsLength = wrapper.vm.selected.length;
       wrapper.vm.remove('remove me');
-      const chips = wrapper.vm.chipsSelected;
+      const chips = wrapper.vm.selected;
 
       expect(chips.length).toEqual(originalChipsLength - 1);
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/categoryOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/categoryOptions.spec.js
@@ -1,0 +1,438 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import { shallowMount } from '@vue/test-utils';
+import CategoryOptions from '../CategoryOptions.vue';
+
+Vue.use(Vuetify);
+
+const testDropdown = [
+  {
+    text: 'DAILY_LIFE',
+    value: 'PbGoe2MV',
+  },
+  {
+    text: 'CURRENT_EVENTS',
+    value: 'PbGoe2MV.J7CU1IxN',
+  },
+  {
+    text: 'DIVERSITY',
+    value: 'PbGoe2MV.EHcbjuKq',
+  },
+  {
+    text: 'ENTREPRENEURSHIP',
+    value: 'PbGoe2MV.kyxTNsRS',
+  },
+  {
+    text: 'ENVIRONMENT',
+    value: 'PbGoe2MV.tS7WKnZ7',
+  },
+  {
+    text: 'FINANCIAL_LITERACY',
+    value: 'PbGoe2MV.HGIc9sZq',
+  },
+  {
+    text: 'MEDIA_LITERACY',
+    value: 'PbGoe2MV.UOTL#KIV',
+  },
+  {
+    text: 'MENTAL_HEALTH',
+    value: 'PbGoe2MV.d8&gCo2N',
+  },
+  {
+    text: 'PUBLIC_HEALTH',
+    value: 'PbGoe2MV.kivAZaeX',
+  },
+  {
+    text: 'FOR_TEACHERS',
+    value: 'ziJ6PCuU',
+  },
+  {
+    text: 'GUIDES',
+    value: 'ziJ6PCuU.RLfhp37t',
+  },
+  {
+    text: 'LESSON_PLANS',
+    value: 'ziJ6PCuU.lOBPr5ix',
+  },
+  {
+    text: 'FOUNDATIONS',
+    value: 'BCG3&slG',
+  },
+  {
+    text: 'DIGITAL_LITERACY',
+    value: 'BCG3&slG.wZ3EAedB',
+  },
+  {
+    text: 'FOUNDATIONS_LOGIC_AND_CRITICAL_THINKING',
+    value: 'BCG3&slG.0&d0qTqS',
+  },
+  {
+    text: 'LEARNING_SKILLS',
+    value: 'BCG3&slG.fP2j70bj',
+  },
+  {
+    text: 'LITERACY',
+    value: 'BCG3&slG.HLo9TbNq',
+  },
+  {
+    text: 'NUMERACY',
+    value: 'BCG3&slG.Tsyej9ta',
+  },
+  {
+    text: 'SCHOOL',
+    value: 'd&WXdXWF',
+  },
+  {
+    text: 'ARTS',
+    value: 'd&WXdXWF.5QAjgfv7',
+  },
+  {
+    text: 'DANCE',
+    value: 'd&WXdXWF.5QAjgfv7.BUMJJBnS',
+  },
+  {
+    text: 'DRAMA',
+    value: 'd&WXdXWF.5QAjgfv7.XsWznP4o',
+  },
+  {
+    text: 'MUSIC',
+    value: 'd&WXdXWF.5QAjgfv7.u0aKjT4i',
+  },
+  {
+    text: 'VISUAL_ART',
+    value: 'd&WXdXWF.5QAjgfv7.4LskOFXj',
+  },
+  {
+    text: 'COMPUTER_SCIENCE',
+    value: 'd&WXdXWF.e#RTW9E#',
+  },
+  {
+    text: 'MECHANICAL_ENGINEERING',
+    value: 'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+  },
+  {
+    text: 'PROGRAMMING',
+    value: 'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+  },
+  {
+    text: 'WEB_DESIGN',
+    value: 'd&WXdXWF.e#RTW9E#.P7s8FxQ8',
+  },
+  {
+    text: 'HISTORY',
+    value: 'd&WXdXWF.zWtcJ&F2',
+  },
+  {
+    text: 'LANGUAGE_LEARNING',
+    value: 'd&WXdXWF.JDUfJNXc',
+  },
+  {
+    text: 'MATHEMATICS',
+    value: 'd&WXdXWF.qs0Xlaxq',
+  },
+  {
+    text: 'ALGEBRA',
+    value: 'd&WXdXWF.qs0Xlaxq.0t5msbL5',
+  },
+  {
+    text: 'ARITHMETIC',
+    value: 'd&WXdXWF.qs0Xlaxq.nG96nHDc',
+  },
+  {
+    text: 'CALCULUS',
+    value: 'd&WXdXWF.qs0Xlaxq.8rJ57ht6',
+  },
+  {
+    text: 'GEOMETRY',
+    value: 'd&WXdXWF.qs0Xlaxq.lb7ELcK5',
+  },
+  {
+    text: 'STATISTICS',
+    value: 'd&WXdXWF.qs0Xlaxq.jNm15RLB',
+  },
+  {
+    text: 'READING_AND_WRITING',
+    value: 'd&WXdXWF.kHKJ&PbV',
+  },
+  {
+    text: 'LITERATURE',
+    value: 'd&WXdXWF.kHKJ&PbV.DJLBbaEk',
+  },
+  {
+    text: 'LOGIC_AND_CRITICAL_THINKING',
+    value: 'd&WXdXWF.kHKJ&PbV.YMBXStib',
+  },
+  {
+    text: 'READING_COMPREHENSION',
+    value: 'd&WXdXWF.kHKJ&PbV.r7RxB#9t',
+  },
+  {
+    text: 'WRITING',
+    value: 'd&WXdXWF.kHKJ&PbV.KFJOCr&6',
+  },
+  {
+    text: 'SCIENCES',
+    value: 'd&WXdXWF.i1IdaNwr',
+  },
+  {
+    text: 'ASTRONOMY',
+    value: 'd&WXdXWF.i1IdaNwr.mjSF4QlF',
+  },
+  {
+    text: 'BIOLOGY',
+    value: 'd&WXdXWF.i1IdaNwr.uErN4PdS',
+  },
+  {
+    text: 'CHEMISTRY',
+    value: 'd&WXdXWF.i1IdaNwr.#r5ocgid',
+  },
+  {
+    text: 'EARTH_SCIENCE',
+    value: 'd&WXdXWF.i1IdaNwr.zbDzxDE7',
+  },
+  {
+    text: 'PHYSICS',
+    value: 'd&WXdXWF.i1IdaNwr.r#wbt#jF',
+  },
+  {
+    text: 'SOCIAL_SCIENCES',
+    value: 'd&WXdXWF.K80UMYnW',
+  },
+  {
+    text: 'ANTHROPOLOGY',
+    value: 'd&WXdXWF.K80UMYnW.ViBlbQR&',
+  },
+  {
+    text: 'CIVIC_EDUCATION',
+    value: 'd&WXdXWF.K80UMYnW.F863vKiF',
+  },
+  {
+    text: 'POLITICAL_SCIENCE',
+    value: 'd&WXdXWF.K80UMYnW.K72&pITr',
+  },
+  {
+    text: 'SOCIOLOGY',
+    value: 'd&WXdXWF.K80UMYnW.75WBu1ZS',
+  },
+  {
+    text: 'WORK',
+    value: 'l7DsPDlm',
+  },
+  {
+    text: 'PROFESSIONAL_SKILLS',
+    value: 'l7DsPDlm.#N2VymZo',
+  },
+  {
+    text: 'TECHNICAL_AND_VOCATIONAL_TRAINING',
+    value: 'l7DsPDlm.ISEXeZt&',
+  },
+  {
+    text: 'INDUSTRY_AND_SECTOR_SPECIFIC',
+    value: 'l7DsPDlm.ISEXeZt&.pRvOzJTE',
+  },
+  {
+    text: 'SKILLS_TRAINING',
+    value: 'l7DsPDlm.ISEXeZt&.&1WpYE&n',
+  },
+  {
+    text: 'TOOLS_AND_SOFTWARE_TRAINING',
+    value: 'l7DsPDlm.ISEXeZt&.1JfIbP&N',
+  },
+];
+
+describe('CategoryOptions', () => {
+  it('smoke test', () => {
+    const wrapper = shallowMount(CategoryOptions);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+  it('emits expected data', () => {
+    const wrapper = shallowMount(CategoryOptions);
+    const value = 'string';
+    wrapper.vm.$emit('input', value);
+
+    expect(wrapper.emitted().input).toBeTruthy();
+    expect(wrapper.emitted().input.length).toBe(1);
+    expect(wrapper.emitted().input[0]).toEqual([value]);
+  });
+  const expectedFamilyTree = [
+    { text: 'SCHOOL', value: 'd&WXdXWF' },
+    { text: 'ARTS', value: 'd&WXdXWF.5QAjgfv7' },
+    { text: 'DANCE', value: 'd&WXdXWF.5QAjgfv7.BUMJJBnS' },
+  ];
+
+  describe('display', () => {
+    it('has a tooltip that displays the tree for value of an item', () => {
+      const wrapper = shallowMount(CategoryOptions);
+      const item = 'd&WXdXWF.5QAjgfv7.BUMJJBnS'; // 'Dance'
+      const expectedToolTip = 'School - Arts - Dance';
+
+      expect(wrapper.vm.tooltipHelper(item)).toEqual(expectedToolTip);
+    });
+    it(`dropdown has 'levels' key necessary to display the nested structure of categories`, () => {
+      const wrapper = shallowMount(CategoryOptions);
+      const dropdown = wrapper.vm.categoriesList;
+      const everyCategoryHasLevelsKey = dropdown.every(item => 'level' in item);
+
+      expect(everyCategoryHasLevelsKey).toBeTruthy();
+    });
+  });
+
+  describe('nested family structure', () => {
+    it('can display all the ids of family tree of an item', () => {
+      const wrapper = shallowMount(CategoryOptions);
+      const item = 'd&WXdXWF.5QAjgfv7.BUMJJBnS'; //'Dance'
+      const expectedFamilyTreeIds = expectedFamilyTree.map(item => item.value);
+
+      expect(wrapper.vm.findFamilyTreeIds(item).sort()).toEqual(expectedFamilyTreeIds.sort());
+    });
+    it('can display array of objects of family tree of an item', () => {
+      const wrapper = shallowMount(CategoryOptions);
+      const item = 'd&WXdXWF.5QAjgfv7.BUMJJBnS'; //'Dance'
+
+      expect(wrapper.vm.displayFamilyTree(testDropdown, item)).toEqual(expectedFamilyTree);
+    });
+  });
+
+  describe('interactions', () => {
+    it('when user checks an item, only that item is added to the chips', () => {
+      const wrapper = shallowMount(CategoryOptions);
+      const items = ['PbGoe2MV'];
+      const item = 'PbGoe2MV';
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.chipsSelected).toEqual(items);
+    });
+    it('when user checks a grandchild item, that item and all its parents are added to the dropdown', () => {
+      const wrapper = shallowMount(CategoryOptions);
+      const items = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW'];
+      const item = 'd&WXdXWF.e#RTW9E#.8ZoaPsVW';
+      const expectedDropdown = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'd&WXdXWF.e#RTW9E#', 'd&WXdXWF'];
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+    });
+    it('when user unchecks a grandchild item that has a sibling, only that item is removed from the chips', () => {
+      const wrapper = shallowMount(CategoryOptions, {
+        data() {
+          return {
+            chipsSelected: [
+              'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+              'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+              'd&WXdXWF.5QAjgfv7.BUMJJBnS',
+              'd&WXdXWF.5QAjgfv7.XsWznP4o',
+            ],
+          };
+        },
+      });
+      const items = [
+        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+        'd&WXdXWF.5QAjgfv7.BUMJJBnS',
+      ];
+      const item = 'd&WXdXWF.5QAjgfv7.BUMJJBnS';
+      const expectedChips = [
+        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+        'd&WXdXWF.5QAjgfv7.BUMJJBnS',
+      ];
+      const expectedDropdown = [
+        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+        'd&WXdXWF.e#RTW9E#',
+        'd&WXdXWF',
+        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+        'd&WXdXWF.5QAjgfv7.BUMJJBnS',
+        'd&WXdXWF.5QAjgfv7',
+      ];
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
+      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+    });
+    it('when user unchecks a grandchild item that has no siblings and its parents have siblings, that item and its parent are removed from the chips ', () => {
+      const wrapper = shallowMount(CategoryOptions, {
+        data() {
+          return {
+            chipsSelected: [
+              'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+              'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+              'd&WXdXWF.5QAjgfv7.BUMJJBnS',
+            ],
+          };
+        },
+      });
+      const items = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'd&WXdXWF.e#RTW9E#.CfnlTDZ#'];
+      const item = 'd&WXdXWF.e#RTW9E#.CfnlTDZ#';
+      const expectedChips = ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'd&WXdXWF.e#RTW9E#.CfnlTDZ#'];
+      const expectedDropdown = [
+        'd&WXdXWF.e#RTW9E#.8ZoaPsVW',
+        'd&WXdXWF.e#RTW9E#',
+        'd&WXdXWF',
+        'd&WXdXWF.e#RTW9E#.CfnlTDZ#',
+      ];
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
+      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+    });
+    it('when user unchecks a grandchild item that has no siblings and its parents have no siblings, that item, its parent, and the root are removed from the chips ', () => {
+      const wrapper = shallowMount(CategoryOptions, {
+        data() {
+          return { chipsSelected: ['d&WXdXWF.e#RTW9E#.8ZoaPsVW', 'BCG3&slG.wZ3EAedB'] };
+        },
+      });
+      const items = ['BCG3&slG.wZ3EAedB'];
+      const item = 'BCG3&slG.wZ3EAedB';
+      const expectedChips = ['BCG3&slG.wZ3EAedB'];
+      const expectedDropdown = ['BCG3&slG.wZ3EAedB', 'BCG3&slG'];
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
+      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+    });
+    it('when user unchecks an item that has children and its parents have no siblings, that item and all its children are removed from the chips ', () => {
+      const wrapper = shallowMount(CategoryOptions, {
+        data() {
+          return { chipsSelected: ['d&WXdXWF.5QAjgfv7.BUMJJBnS'] };
+        },
+      });
+      const items = ['d&WXdXWF.5QAjgfv7.BUMJJBnS', 'd&WXdXWF'];
+      const item = 'd&WXdXWF';
+      const expectedChips = [];
+      const expectedDropdown = [];
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
+      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+    });
+    it('when user checks grandchild of parent after parent item has already been checked, the grandchild replaces the parent chip', () => {
+      const wrapper = shallowMount(CategoryOptions, {
+        data() {
+          return { chipsSelected: ['d&WXdXWF'] };
+        },
+      });
+      const items = ['d&WXdXWF', 'd&WXdXWF.5QAjgfv7.XsWznP4o'];
+      const item = 'd&WXdXWF.5QAjgfv7.XsWznP4o';
+      const expectedChips = ['d&WXdXWF.5QAjgfv7.XsWznP4o'];
+      const expectedDropdown = ['d&WXdXWF.5QAjgfv7.XsWznP4o', 'd&WXdXWF.5QAjgfv7', 'd&WXdXWF'];
+      wrapper.vm.handleCheckboxItem(item, items);
+
+      expect(wrapper.vm.chipsSelected.length).toEqual(expectedChips.length);
+      expect(wrapper.vm.dropdownSelected.length).toEqual(expectedDropdown.length);
+    });
+  });
+
+  describe('close button on chip interactions', () => {
+    it('in the autocomplete bar, the chip is removed when user clicks on its close button', () => {
+      const wrapper = shallowMount(CategoryOptions, {
+        data() {
+          return { chipsSelected: ['remove me', 'abc', 'def', 'abc.'] };
+        },
+      });
+      const originalChipsLength = wrapper.vm.chipsSelected.length;
+      wrapper.vm.remove('remove me');
+      const chips = wrapper.vm.chipsSelected;
+
+      expect(chips.length).toEqual(originalChipsLength - 1);
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -181,6 +181,7 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     grade_levels: {},
     learner_needs: {},
     learning_activities: {},
+    categories: {},
     ...payload,
   };
 
@@ -217,6 +218,7 @@ function generateContentNodeData({
   grade_levels = NOVALUE,
   learner_needs = NOVALUE,
   learning_activities = NOVALUE,
+  categories = NOVALUE,
 } = {}) {
   const contentNodeData = {};
   if (title !== NOVALUE) {
@@ -266,6 +268,9 @@ function generateContentNodeData({
   }
   if (learning_activities !== NOVALUE) {
     contentNodeData.learning_activities = learning_activities;
+  }
+  if (categories !== NOVALUE) {
+    contentNodeData.categories = categories;
   }
 
   if (extra_fields !== NOVALUE) {

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -1,3 +1,5 @@
+import invert from 'lodash/invert';
+import Subjects from 'kolibri-constants/labels/Subjects';
 import featureFlagsSchema from 'static/feature_flags.json';
 
 export { default as LearningActivities } from 'kolibri-constants/labels/LearningActivities';
@@ -7,6 +9,8 @@ export { default as Categories } from 'kolibri-constants/labels/Subjects';
 export { default as AccessibilityCategories } from 'kolibri-constants/labels/AccessibilityCategories';
 export { default as ContentLevels } from 'kolibri-constants/labels/Levels';
 export { default as ResourcesNeededTypes } from 'kolibri-constants/labels/Needs';
+
+export const CategoriesLookup = invert(Subjects);
 
 export const ContentDefaults = {
   author: 'author',

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -674,6 +674,8 @@ const nonconformingKeys = {
   BASIC_SKILLS: 'allLevelsBasicSkills',
   FOUNDATIONS: 'basicSkills',
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
+  toolsAndSoftwareTraining: 'softwareToolsAndTraining',
+  foundations: 'basicSkills',
 
   /*
    * TODO: the following are in ResourcesNeededTypes map from le-utils, but not in Kolibri,

--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -20,7 +20,7 @@
     :menu-props="menuProps"
     :multiple="multiple"
     :chips="multiple"
-    attach="language"
+    attach="#language"
     @change="input = ''"
     @focus="$emit('focus')"
   >

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -18,7 +18,7 @@
         menu-props="offsetY"
         class="ma-0"
         box
-        attach="license"
+        attach="#license"
         @focus="$emit('focus')"
       >
         <template #append-outer>

--- a/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
@@ -14,7 +14,7 @@
       :rules="rules"
       menu-props="offsetY"
       box
-      attach="role_visibility"
+      attach="#role_visibility"
       @focus="$emit('focus')"
     >
       <template v-slot:append-outer>


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

- Add category field to edit modal
- Add tests for category field component
- Commit history will be cleaned, and needs to be rebased after #3370 is merged

### Manual verification steps performed
1. Checked to see if behavior of the checkboxes in the dropdown and the chips work appropriately
2. Checked for data to be sent correctly to the backend
3. Checked to see if tests passed

### Screenshots
|Chip and dropdown|
|--|
|<img width="973" alt="Screen Shot 2022-04-25 at 9 01 30 PM" src="https://user-images.githubusercontent.com/13563002/165218847-a1be2e0d-a77f-4e09-9584-a2757da71162.png">|

|Chip overflow|
|--|
|<img width="973" alt="Screen Shot 2022-04-25 at 9 02 03 PM" src="https://user-images.githubusercontent.com/13563002/165218694-96883e6b-c225-4640-8482-bcbe1d972cf0.png">|

### Does this introduce any tech-debt items?
The code is pretty spaghetti-ish and could use some refactoring, particularly around the behaviors of the dropdown. It should, however, currently satisfy what is needed for an MVP. We can file follow-up issues to fix. This is a continuation of this issue https://github.com/learningequality/studio/issues/3205
___
## Reviewer guidance
### How can a reviewer test these changes?
- Any feedback on the tests would be very helpful. I'm not sure the best way to test the data being passed in (yet)
- Manual QA will be very important! I've tried to capture as many of the interactions as I could think of below

### Are there any risky areas that deserve extra testing?
It is very important to refer to the Gherkin stories and the Figma designs. There are additional scenarios that should be tested that are not described in the scenarios or in the Figma designs, but should be noted (I may also be missing some):

**There are grandparents, parents, and children items**
- Check any item with no children
  - dropdown: only that item should be checked
  - chips: only that item should appear
- Check a parent item with no children
  - dropdown: that item and the grandparent should be checked
  - chips: only that item should appear
- Check any item with children
  - dropdown: that item and its parents should be checked
  - chips: only that item should appear
- Check any item, and then check its child
  - dropdown: that item and its parents should be checked
  - chips: that item should be replaced with its child

- Uncheck any child with no siblings and its parent has no siblings checked
  - dropdown: that item and all its parents should be unchecked
  - chips: remove it from chips
- Uncheck any child with no siblings but its parent has siblings checked
  - dropdown: that item and its immediate parent should be unchecked
  - chips: remove it from chips
- Uncheck any child with siblings and its parent has no siblings checked
  - dropdown: only that item should be unchecked
  - chips: remove that item from chips
- Uncheck any child with siblings and its parent has siblings checked
  - dropdown: only that item should be unchecked
  - chips: remove that item from chips
- Uncheck a parent with checked children
  - dropdown: remove that parent and its checked children
  - chips: remove the child chip

## References
- [Figma design for this feature](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=1764%3A88434)
- [Gherkin stories for this feature](https://www.notion.so/learningequality/Studio-gherkin-stories-6bb841246d4e4afd958f074226fa8f19)
- Addresses https://github.com/learningequality/studio/issues/3205

----

### Contributor's Checklist
PR process:
- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?

Studio-specifc:
- [x] All user-facing strings are translated properly
- [x] All UI components are LTR and RTL compliant
- [x] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)

Testing:
- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
