### PR TITLE
Fix nested field updates and metadata label updates

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -634,6 +634,26 @@ class SyncTestCase(StudioAPITestCase):
         with self.assertRaises(KeyError):
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"]
 
+    def test_update_contentnode_remove_from_extra_fields_nested(self):
+        user = testdata.user()
+        metadata = self.contentnode_db_metadata
+        metadata["extra_fields"] = {
+            "options": {
+                "modality": "QUIZ",
+            },
+        }
+        contentnode = models.ContentNode.objects.create(**metadata)
+        self.client.force_authenticate(user=user)
+        # Remove extra_fields.options.modality
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.options.modality": None})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        with self.assertRaises(KeyError):
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["modality"]
+
     def test_update_contentnode_add_multiple_metadata_labels(self):
         user = testdata.user()
 

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -271,6 +271,17 @@ class TagField(DotPathValueMixin, DictField):
     pass
 
 
+class MetadataLabelBooleanField(BooleanField):
+    def bind(self, field_name, parent):
+        # By default the bind method of the Field class sets the source_attrs to field_name.split(".").
+        # As we have literal field names that include "." we need to override this behavior.
+        # Otherwise it will attempt to set the source_attrs to a nested path, assuming that it is a source path,
+        # not a materialized path. This probably means that it was a bad idea to use "." in the materialized path,
+        # but alea iacta est.
+        super(MetadataLabelBooleanField, self).bind(field_name, parent)
+        self.source_attrs = [self.source]
+
+
 class MetadataLabelsField(JSONFieldDictSerializer):
     def __init__(self, choices, *args, **kwargs):
         self.choices = choices
@@ -280,8 +291,9 @@ class MetadataLabelsField(JSONFieldDictSerializer):
     def get_fields(self):
         fields = {}
         for label_id, label_name in self.choices:
-            field = BooleanField(required=False, label=label_name, allow_null=True)
+            field = MetadataLabelBooleanField(required=False, label=label_name, allow_null=True)
             fields[label_id] = field
+
         return fields
 
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Previous attempts to make dot path updates work as intended did not properly carry out deletes when `None` was passed
* The use of dot paths in the materialized paths in nested metadata labels caused incorrect processing of nested metadata labels
* Fixes and adds tests for both of these.
