### PR TITLE
Attach menus to their parents

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
@@ -10,6 +10,7 @@
     multiple
     deletableChips
     :rules="learningActivityRules"
+    attach="learning_activities"
   />
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
@@ -10,6 +10,7 @@
     :label="translateMetadataString('level')"
     multiple
     deletableChips
+    attach="contentLevel"
   />
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -10,6 +10,7 @@
     multiple
     deletableChips
     clearable
+    attach="resourcesNeeded"
   />
 
 </template>

--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -20,6 +20,7 @@
     :menu-props="menuProps"
     :multiple="multiple"
     :chips="multiple"
+    attach="language"
     @change="input = ''"
     @focus="$emit('focus')"
   >

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -18,6 +18,7 @@
         menu-props="offsetY"
         class="ma-0"
         box
+        attach="license"
         @focus="$emit('focus')"
       >
         <template #append-outer>

--- a/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
@@ -14,6 +14,7 @@
       :rules="rules"
       menu-props="offsetY"
       box
+      attach="role_visibility"
       @focus="$emit('focus')"
     >
       <template v-slot:append-outer>


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Attaches menus in `VSelect` components to their parents.

### Screenshots
![2022-04-28 15 04 44](https://user-images.githubusercontent.com/13563002/165855512-699d8367-e1ff-4989-af52-45cbb00799d6.gif)

___
## Reviewer guidance
### How can a reviewer test these changes?
Manual QA on these fields to make sure they all stay with their parent when you scroll outside of the dropdown menu.


### Are there any risky areas that deserve extra testing?
Look for edge cases - like what happens when we scroll to the top and bottom of the screen - and note in a follow-up issue.

## References
As seen in [this comment](https://github.com/learningequality/studio/pull/3376#pullrequestreview-956328982) 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
