### PR TITLE
Fix two previously unreported bugs in nested updates to extra_fields

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -638,6 +638,20 @@ class SyncTestCase(StudioAPITestCase):
         with self.assertRaises(KeyError):
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"]
 
+    def test_update_contentnode_add_to_extra_fields_nested(self):
+        user = testdata.user()
+        metadata = self.contentnode_db_metadata
+        contentnode = models.ContentNode.objects.create(**metadata)
+        self.client.force_authenticate(user=user)
+        # Add extra_fields.options.modality
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.options.modality": "QUIZ"})],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["modality"], "QUIZ")
+
     def test_update_contentnode_remove_from_extra_fields_nested(self):
         user = testdata.user()
         metadata = self.contentnode_db_metadata

--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -176,7 +176,7 @@ class JSONFieldDictSerializer(DotPathValueMixin, serializers.Serializer):
             elif hasattr(self.fields[key], "update"):
                 # If the nested field has an update method (e.g. a nested serializer),
                 # call the update value so that we can do any recursive updates
-                self.fields[key].update(instance[key], validated_data[key])
+                instance[key] = self.fields[key].update(instance.get(key, {}), validated_data[key])
             else:
                 # Otherwise, just update the value
                 instance[key] = validated_data[key]

--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -149,7 +149,10 @@ class DotPathValueMixin(object):
                 # with the value of the child field.
                 # N.B. the get_value method expects a dictionary that references the field's name
                 # not just the value.
-                value[keys[0]] = fields[keys[0]].get_value({keys[0]: {keys[1]: html_value[key]}})
+                nested_value = fields[keys[0]].get_value({keys[0]: {keys[1]: html_value[key]}})
+                if keys[0] not in value:
+                    value[keys[0]] = {}
+                value[keys[0]].update(nested_value)
                 if key in value:
                     del value[key]
             else:


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes a bug whereby if the 'options' key or any other subkey of extra_fields did not exist, it would break upon assignment of a sub key
* Fixes a bug where completion criteria would not get updated inside the options object by ensuring that the writable keys are explicitly described on a serializer - there's some slight redundancy as a result
* Creates regression tests for the two bugs above

