### PR TITLE
Fix partial updating of completion criteria

### DIFF
--- a/contentcuration/contentcuration/tests/test_serializers.py
+++ b/contentcuration/contentcuration/tests/test_serializers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
 from django.test.testcases import SimpleTestCase
 
@@ -37,11 +38,19 @@ class ExtraFieldsOptionsSerializerTestCase(SimpleTestCase):
 
     def test_completion_criteria__valid(self):
         self.data.update(completion_criteria={"model": "time", "threshold": 10, "learner_managed": True})
-        self.assertTrue(self.serializer.is_valid())
+        serializer = self.serializer
+        serializer.is_valid()
+        try:
+            serializer.update({}, serializer.validated_data)
+        except ValidationError:
+            self.fail("Completion criteria should be valid")
 
     def test_completion_criteria__invalid(self):
         self.data.update(completion_criteria={"model": "time", "threshold": "test"})
-        self.assertFalse(self.serializer.is_valid())
+        serializer = self.serializer
+        serializer.is_valid()
+        with self.assertRaises(ValidationError):
+            serializer.update({}, serializer.validated_data)
 
 
 class ContentNodeSerializerTestCase(BaseAPITestCase):

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -708,6 +708,40 @@ class SyncTestCase(StudioAPITestCase):
         self.assertEqual(c.extra_fields["options"]["completion_criteria"]["model"], completion_criteria.TIME)
         self.assertEqual(c.extra_fields["options"]["completion_criteria"]["threshold"], 10)
 
+    def test_update_contentnode_update_options_completion_criteria_threshold_only(self):
+        user = testdata.user()
+        metadata = self.contentnode_db_metadata
+        metadata["extra_fields"] = {
+            "options": {
+                "completion_criteria": {
+                    "model": completion_criteria.TIME,
+                    "threshold": 5,
+                }
+            },
+        }
+        contentnode = models.ContentNode.objects.create(**metadata)
+        self.client.force_authenticate(user=user)
+        # Change extra_fields.options.completion_criteria.model
+        # and extra_fields.options.completion_criteria.threshold
+        response = self.client.post(
+            self.sync_url,
+            [
+                generate_update_event(
+                    contentnode.id,
+                    CONTENTNODE,
+                    {
+                        "extra_fields.options.completion_criteria.threshold": 10
+                    }
+                )
+            ],
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        c = models.ContentNode.objects.get(id=contentnode.id)
+
+        self.assertEqual(c.extra_fields["options"]["completion_criteria"]["model"], completion_criteria.TIME)
+        self.assertEqual(c.extra_fields["options"]["completion_criteria"]["threshold"], 10)
+
     def test_update_contentnode_add_multiple_metadata_labels(self):
         user = testdata.user()
 

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -271,10 +271,10 @@ class CompletionCriteriaSerializer(JSONFieldDictSerializer):
     model = CharField()
     learner_managed = BooleanField(required=False)
 
-    def to_internal_value(self, data):
-        output = super().to_internal_value(data)
-        completion_criteria_validator.validate(output)
-        return output
+    def update(self, instance, validated_data):
+        instance = super(CompletionCriteriaSerializer, self).update(instance, validated_data)
+        completion_criteria_validator.validate(instance)
+        return instance
 
 
 class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
#3382 did a lot of good things, but failed to account for partial updates of completion criteria - as such, the validation happens prematurely, so that if a change is just made to the threshold, and not the model, validation will fail because threshold is missing from the update.

This defers validation until after the instance has been updated in memory, and runs validation then, before any save has happened, therefore triggering a validation error and preventing incorrect data from being saved.

### Manual verification steps performed
1. Wrote regression test.
2. Saw that it failed.
3. Made it pass.
4. Rejoiced.

