### PR TITLE
fix: use https url for jsPDF

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "html2canvas": "^1.0.0-rc.5",
     "i18n-iso-countries": "^5.1.0",
     "jquery": "^2.2.4",
-    "jspdf": "git://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
+    "jspdf": "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "jszip": "^2.5.0",
     "jszip-utils": "0.0.2",
     "kolibri-tools": "^0.14.5-dev.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12320,9 +12320,9 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-"jspdf@git://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e":
+"jspdf@https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e":
   version "2.1.1"
-  resolved "git://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e"
+  resolved "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e"
   dependencies:
     atob "^2.1.2"
     btoa "^1.2.1"


### PR DESCRIPTION
Backport of #3349, to get hotfixes builds working again.