### PR TITLE
Add regression test for and fix issue with localizing numbers in JSON.

### DIFF
--- a/contentcuration/contentcuration/templates/perseus/input_question.json
+++ b/contentcuration/contentcuration/templates/perseus/input_question.json
@@ -3,8 +3,8 @@
         "content": "{{ question | jsonify  }}\n\n[[☃ numeric-input 1]]",
         "images": {{% for image in question_images %}
             "{{ image.name }}": {
-                "width": {{ image.width }},
-                "height": {{ image.height }}
+                "width": {{ image.width|safe }},
+                "height": {{ image.height|safe }}
             }{% if forloop.last %}{% else %},{% endif %}
         {% endfor %}},
         "widgets":  {
@@ -59,8 +59,8 @@
             "widgets":{},
             "images":{{% for image in hint.images %}
                 "{{ image.name }}": {
-                    "width": {{ image.width }},
-                    "height": {{ image.height }}
+                    "width": {{ image.width|safe }},
+                    "height": {{ image.height|safe }}
                 }{% if forloop.last %}{% else %},{% endif %}
             {% endfor %}},
             "content":"{{hint.hint | jsonify  }}",

--- a/contentcuration/contentcuration/templates/perseus/multiple_selection.json
+++ b/contentcuration/contentcuration/templates/perseus/multiple_selection.json
@@ -3,8 +3,8 @@
         "content": "{{ question | jsonify   }}\n\n[[☃ radio 1]]",
         "images": {{% for image in question_images %}
             "{{ image.name }}": {
-                "width": {{ image.width }},
-                "height": {{ image.height }}
+                "width": {{ image.width|safe }},
+                "height": {{ image.height|safe }}
             }{% if forloop.last %}{% else %},{% endif %}
         {% endfor %}},
         "widgets": {
@@ -18,8 +18,8 @@
                             "content": "{{ answer.answer | jsonify   }}",
                             "images":{{% for image in answer.images %}
                                 "{{ image.name }}": {
-                                    "width": {{ image.width }},
-                                    "height": {{ image.height }}
+                                    "width": {{ image.width|safe }},
+                                    "height": {{ image.height|safe }}
                                 }{% if forloop.last %}{% else %},{% endif %}
                             {% endfor %}}
                         }{% if forloop.last %}{% else %},{% endif %}
@@ -57,8 +57,8 @@
             "widgets":{},
             "images":{{% for image in hint.images %}
                 "{{ image.name }}": {
-                    "width": {{ image.width }},
-                    "height": {{ image.height }}
+                    "width": {{ image.width|safe }},
+                    "height": {{ image.height|safe }}
                 }{% if forloop.last %}{% else %},{% endif %}
             {% endfor %}},
             "content":"{{hint.hint | jsonify  }}",


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Prevents Django templates that generate JSON from applying i18n to numbers that should be in JSON format.


### Manual verification steps performed
1. Add an image with decimal dimensions to existing test
2. Run test in "es-es" that uses a non-decimal point separator
3. Confirm that fix produces valid JSON

## References
Fixes #3341