### PR TITLE
Set complete marking on nodes created by ricecooker

### DIFF
--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -4,6 +4,7 @@ Tests for contentcuration.views.internal functions.
 """
 import json
 import uuid
+from unittest import skipIf
 
 from django.db import connections
 from django.urls import reverse_lazy
@@ -195,6 +196,7 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                 values[0]: True
             })
 
+    @skipIf(True, "Disable until we mark nodes as incomplete rather than just warn")
     def test_invalid_nodes_are_not_complete(self):
         node_0 = ContentNode.objects.get(title=self.title)
         node_1 = ContentNode.objects.get(description="invalid_title_node")

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -53,6 +53,7 @@ from contentcuration.utils.garbage_collect import get_deleted_chefs_root
 from contentcuration.utils.nodes import map_files_to_assessment_item
 from contentcuration.utils.nodes import map_files_to_node
 from contentcuration.utils.nodes import map_files_to_slideshow_slide_item
+from contentcuration.utils.sentry import report_exception
 from contentcuration.utils.tracing import trace
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.utils import generate_publish_event
@@ -555,6 +556,20 @@ def create_channel(channel_data, user):
     return channel  # Return new channel
 
 
+class IncompleteNodeError(Exception):
+    """
+    Used to track incomplete nodes from ricecooker. We don't raise this error,
+    just feed it to Sentry for reporting.
+    """
+
+    def __init__(self, node, errors):
+        self.message = (
+            "Node {} had the following errors: {}".format(node, ",".join(errors))
+        )
+
+        super(IncompleteNodeError, self).__init__(self.message)
+
+
 @trace
 def convert_data_to_nodes(user, content_data, parent_node):
     """ Parse dict and create nodes accordingly """
@@ -596,10 +611,16 @@ def convert_data_to_nodes(user, content_data, parent_node):
                             user, new_node, slides, node_data["files"]
                         )
 
-                    new_node.mark_complete()
+                    # Wait until after files have been set on the node to check for node completeness
+                    # as some node kinds are counted as incomplete if they lack a default file.
+                    completion_errors = new_node.mark_complete()
 
-                    if not new_node.complete:
-                        new_node.save()
+                    if completion_errors:
+                        try:
+                            # we need to raise it to get Python to fill out the stack trace.
+                            raise IncompleteNodeError(new_node, completion_errors)
+                        except IncompleteNodeError as e:
+                            report_exception(e)
 
                     # Track mapping between newly created node and node id
                     root_mapping.update({node_data["node_id"]: new_node.pk})


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Creates a `mark_complete` method for ContentNode
* Includes all criteria from the `mark_incomplete` management command
* Applies at the end of node creation
* Creates tests for the various conditions

## References
Fixes #2806

## Comments
Not entirely sure how we should audit this - we definitely had some issues with the mark_incomplete management command when we ran it on historic data - but I don't have a strong sense of how much of that was affecting cheffed channels.
