### PR TITLE
Consolidate mastery criteria

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -15,6 +15,7 @@ from django_concurrent_tests.helpers import call_concurrently
 from django_concurrent_tests.helpers import make_concurrent_calls
 from le_utils.constants import completion_criteria
 from le_utils.constants import content_kinds
+from le_utils.constants import exercises
 from le_utils.constants import roles
 from le_utils.constants.labels.accessibility_categories import ACCESSIBILITYCATEGORIESLIST
 from le_utils.constants.labels.subjects import SUBJECTSLIST
@@ -587,36 +588,113 @@ class SyncTestCase(StudioAPITestCase):
             models.ContentNode.objects.get(id=contentnode.id).title, new_title
         )
 
+    def test_update_extra_fields_completion_criteria_set(self):
+        user = testdata.user()
+        metadata = self.contentnode_db_metadata
+        metadata["extra_fields"] = {
+            "options": {
+                "threshold": {
+                    "m": 3,
+                    "n": 6,
+                    "mastery_model": exercises.M_OF_N,
+                },
+                "model": completion_criteria.MASTERY,
+            }
+        }
+        contentnode = models.ContentNode.objects.create(**metadata)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {
+                "extra_fields.options.completion_criteria.threshold.m": 4,
+                "extra_fields.options.completion_criteria.threshold.n": 8,
+                "extra_fields.options.completion_criteria.threshold.mastery_model": exercises.M_OF_N,
+                "extra_fields.options.completion_criteria.model": completion_criteria.MASTERY}
+            )],
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], 4
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], 8
+        )
+
+    def test_update_extra_fields_completion_criteria_unset(self):
+        user = testdata.user()
+        metadata = self.contentnode_db_metadata
+        metadata["extra_fields"] = {
+            "m": 3,
+            "n": 5,
+            "mastery_model": exercises.M_OF_N,
+        }
+        contentnode = models.ContentNode.objects.create(**metadata)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(
+            self.sync_url,
+            [generate_update_event(contentnode.id, CONTENTNODE, {
+                "extra_fields.options.completion_criteria.threshold.m": 4,
+                "extra_fields.options.completion_criteria.threshold.n": 6,
+                "extra_fields.options.completion_criteria.threshold.mastery_model": exercises.M_OF_N,
+                "extra_fields.options.completion_criteria.model": completion_criteria.MASTERY}
+            )],
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"], 3
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["n"], 5
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["mastery_model"], exercises.M_OF_N
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], 4
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], 6
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["mastery_model"], exercises.M_OF_N
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["model"], completion_criteria.MASTERY
+        )
+
     def test_update_contentnode_extra_fields(self):
         user = testdata.user()
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
 
-        # Update extra_fields.m
+        # Update m and n fields
         m = 5
+        n = 10
         self.client.force_authenticate(user=user)
+
         response = self.client.post(
             self.sync_url,
-            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.m": m})],
+            [generate_update_event(contentnode.id, CONTENTNODE, {
+                "extra_fields.options.completion_criteria.threshold.m": m,
+                "extra_fields.options.completion_criteria.threshold.n": n,
+                "extra_fields.options.completion_criteria.threshold.mastery_model": exercises.M_OF_N,
+                "extra_fields.options.completion_criteria.model": completion_criteria.MASTERY}
+            )],
             format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"], m
         )
 
-        # Update extra_fields.m
-        n = 10
-        response = self.client.post(
-            self.sync_url,
-            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.n": n})],
-            format="json",
-        )
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"], m
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], m
         )
         self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["n"], n
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], n
         )
 
         # Update extra_fields.randomize
@@ -628,10 +706,10 @@ class SyncTestCase(StudioAPITestCase):
         )
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"], m
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], m
         )
         self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["n"], n
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], n
         )
         self.assertEqual(
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["randomize"], randomize
@@ -641,19 +719,30 @@ class SyncTestCase(StudioAPITestCase):
         user = testdata.user()
         metadata = self.contentnode_db_metadata
         metadata["extra_fields"] = {
-            "m": 5,
+            "options": {
+                "threshold": {
+                    "m": 5,
+                    "n": None,
+                    "mastery_model": exercises.M_OF_N,
+                },
+                "model": completion_criteria.MASTERY,
+            }
         }
         contentnode = models.ContentNode.objects.create(**metadata)
         self.client.force_authenticate(user=user)
-        # Remove extra_fields.m
+        # Remove m from extra_fields
         response = self.client.post(
             self.sync_url,
-            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.m": None})],
+            [generate_update_event(contentnode.id, CONTENTNODE, {
+                "extra_fields.options.completion_criteria.threshold.m": None,
+                "extra_fields.options.completion_criteria.threshold.n": None,
+                "extra_fields.options.completion_criteria.threshold.mastery_model": exercises.M_OF_N,
+                "extra_fields.options.completion_criteria.model": completion_criteria.MASTERY}
+            )],
             format="json",
         )
         self.assertEqual(response.status_code, 200, response.content)
-        with self.assertRaises(KeyError):
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["m"]
+        self.assertEqual(models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], None)
 
     def test_update_contentnode_add_to_extra_fields_nested(self):
         user = testdata.user()

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -400,6 +400,35 @@ class ContentNodeViewSetTestCase(StudioAPITestCase):
         self.assertEqual(response.data["extra_fields"]["options"]["completion_criteria"]["threshold"]["mastery_model"], exercises.M_OF_N)
         self.assertEqual(response.data["extra_fields"]["options"]["completion_criteria"]["model"], completion_criteria.MASTERY)
 
+    def test_consolidate_extra_fields_with_mastrey_model_none(self):
+
+        user = testdata.user()
+        channel = testdata.channel()
+        channel.public = True
+        channel.save()
+        contentnode = models.ContentNode.objects.create(
+            title="Aron's cool contentnode",
+            id=uuid.uuid4().hex,
+            kind_id=content_kinds.EXERCISE,
+            description="coolest contentnode this side of the Pacific",
+            parent_id=channel.main_tree_id,
+            extra_fields={
+                "options": {
+                    "m": None,
+                    "n": None,
+                    "mastery_model": None,
+                }
+            }
+        )
+
+        self.client.force_authenticate(user=user)
+        with self.settings(TEST_ENV=False):
+            response = self.client.get(
+                self.viewset_url(pk=contentnode.id), format="json",
+            )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.data["extra_fields"]["options"], {})
+
 
 class SyncTestCase(StudioAPITestCase):
     @property

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -374,17 +374,15 @@ class ContentNodeViewSetTestCase(StudioAPITestCase):
         channel.public = True
         channel.save()
         contentnode = models.ContentNode.objects.create(
-            title="Aron's cool contentnode",
+            title="Ozer's cool contentnode",
             id=uuid.uuid4().hex,
             kind_id=content_kinds.EXERCISE,
             description="coolest contentnode this side of the Pacific",
             parent_id=channel.main_tree_id,
             extra_fields={
-                "options": {
-                    "m": 3,
-                    "n": 6,
-                    "mastery_model": exercises.M_OF_N,
-                }
+                "m": 3,
+                "n": 6,
+                "mastery_model": exercises.M_OF_N,
             }
         )
 
@@ -410,14 +408,13 @@ class ContentNodeViewSetTestCase(StudioAPITestCase):
             title="Aron's cool contentnode",
             id=uuid.uuid4().hex,
             kind_id=content_kinds.EXERCISE,
-            description="coolest contentnode this side of the Pacific",
+            description="India is the hottest country in the world",
             parent_id=channel.main_tree_id,
             extra_fields={
-                "options": {
-                    "m": None,
-                    "n": None,
-                    "mastery_model": None,
-                }
+
+                "m": None,
+                "n": None,
+                "mastery_model": None,
             }
         )
 
@@ -427,7 +424,7 @@ class ContentNodeViewSetTestCase(StudioAPITestCase):
                 self.viewset_url(pk=contentnode.id), format="json",
             )
         self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual(response.data["extra_fields"]["options"], {})
+        self.assertEqual(response.data["extra_fields"], {})
 
 
 class SyncTestCase(StudioAPITestCase):

--- a/contentcuration/contentcuration/utils/db_tools.py
+++ b/contentcuration/contentcuration/utils/db_tools.py
@@ -158,6 +158,7 @@ def create_exercise(title, parent, license_id, description="", user=None, empty=
         "m": 3,
         "n": 5,
     }
+
     exercise = ContentNode.objects.create(
         title=title,
         description=description,

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -452,9 +452,9 @@ def get_title(item):
 def consolidate_extra_fields(item):
     extra_fields = item.get("extra_fields")
     if item["kind"] == content_kinds.EXERCISE:
-        m = extra_fields.get("options", {}).pop("m", None)
-        n = extra_fields.get("options", {}).pop("n", None)
-        mastery_model = extra_fields.get("options", {}).pop("mastery_model", None)
+        m = extra_fields.pop("m", None)
+        n = extra_fields.pop("n", None)
+        mastery_model = extra_fields.pop("mastery_model", None)
         if not extra_fields.get("options", {}).get("completion_criteria", {}) and mastery_model is not None:
             extra_fields["options"] = extra_fields.get("options", {})
             extra_fields["options"]["completion_criteria"] = {

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -453,9 +453,9 @@ def get_title(item):
 def consolidate_extra_fields(item):
     extra_fields = item.get("extra_fields")
     if item["kind"] == content_kinds.EXERCISE:
-        m = extra_fields.pop("m", None)
-        n = extra_fields.pop("n", None)
-        mastery_model = extra_fields.pop("mastery_model", None)
+        m = extra_fields.get("options", {}).pop("m", None)
+        n = extra_fields.get("options", {}).pop("n", None)
+        mastery_model = extra_fields.get("options", {}).pop("mastery_model", None)
         if not extra_fields.get("options", {}).get("completion_criteria", {}):
             extra_fields["options"] = extra_fields.get("options", {})
             extra_fields["options"]["completion_criteria"] = {

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -260,7 +260,6 @@ class ThresholdField(Field):
 
     def to_internal_value(self, data):
         try:
-            print(data)
             data = int(data)
         except(ValueError, TypeError):
             pass

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -35,6 +35,7 @@ from rest_framework.serializers import BooleanField
 from rest_framework.serializers import CharField
 from rest_framework.serializers import ChoiceField
 from rest_framework.serializers import DictField
+from rest_framework.serializers import Field
 from rest_framework.serializers import ValidationError
 from rest_framework.viewsets import ViewSet
 
@@ -73,8 +74,6 @@ from contentcuration.viewsets.sync.constants import TASK_ID
 from contentcuration.viewsets.sync.utils import generate_delete_event
 from contentcuration.viewsets.sync.utils import generate_update_event
 from contentcuration.viewsets.sync.utils import log_sync_exception
-# from le_utils.constants import exercises
-# from rest_framework.serializers import IntegerField
 
 
 channel_query = Channel.objects.filter(main_tree__tree_id=OuterRef("tree_id"))
@@ -255,15 +254,15 @@ class ContentNodeListSerializer(BulkListSerializer):
         return all_objects
 
 
-class ThresholdField(CharField):
+class ThresholdField(Field):
     def to_representation(self, value):
         return value
 
     def to_internal_value(self, data):
-        data = super(ThresholdField, self).to_internal_value(data)
         try:
+            print(data)
             data = int(data)
-        except ValueError:
+        except(ValueError, TypeError):
             pass
         return data
 
@@ -454,10 +453,10 @@ def get_title(item):
 def consolidate_extra_fields(item):
     extra_fields = item.get("extra_fields")
     if item["kind"] == content_kinds.EXERCISE:
-        m = extra_fields.pop("m")
-        n = extra_fields.pop("n")
-        mastery_model = extra_fields.pop("mastery_model")
-        if not extra_fields.get("options").get("completion_criteria"):
+        m = extra_fields.pop("m", None)
+        n = extra_fields.pop("n", None)
+        mastery_model = extra_fields.pop("mastery_model", None)
+        if not extra_fields.get("options", {}).get("completion_criteria", {}):
             extra_fields["options"] = extra_fields.get("options", {})
             extra_fields["options"]["completion_criteria"] = {
                 "threshold": {

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -455,7 +455,7 @@ def consolidate_extra_fields(item):
         m = extra_fields.get("options", {}).pop("m", None)
         n = extra_fields.get("options", {}).pop("n", None)
         mastery_model = extra_fields.get("options", {}).pop("mastery_model", None)
-        if not extra_fields.get("options", {}).get("completion_criteria", {}):
+        if not extra_fields.get("options", {}).get("completion_criteria", {}) and mastery_model is not None:
             extra_fields["options"] = extra_fields.get("options", {})
             extra_fields["options"]["completion_criteria"] = {
                 "threshold": {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Removed m n and mastery_model from ExtraFieldsSerializer.
- Added callable consolidate_extra_fields function to consolidate previous mastrey criteria 
- Changed unit tests
- Created new tests for set and unset completion_criteria cases.

### Manual verification steps performed
1. Ran all tests related to contentnode

## Comments
- Needs more robust validation in def to_internal_value function (we need to create a new issue for this)

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
