### PR TITLE
Add threshold field validation and properly handle updates to mastery models in all scenarios

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -575,7 +575,7 @@ class SyncTestCase(StudioAPITestCase, SyncTestMixin):
             models.ContentNode.objects.get(id=contentnode.id).title, new_title
         )
 
-    def test_update_contentnode_extra_fields(self):
+    def test_update_contentnode_exercise_mastery_model(self):
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
 
         # Update m and n fields
@@ -598,18 +598,75 @@ class SyncTestCase(StudioAPITestCase, SyncTestMixin):
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], n
         )
 
+    def test_update_contentnode_exercise_mastery_model_partial(self):
+        data = self.contentnode_db_metadata
+        data["extra_fields"] = {
+            "options": {
+                "completion_criteria": {
+                    "threshold": {
+                        "m": 5,
+                        "n": 10,
+                        "mastery_model": exercises.M_OF_N,
+                    },
+                    "model": completion_criteria.MASTERY,
+                }
+            }
+        }
+        contentnode = models.ContentNode.objects.create(**data)
+
+        # Update m and n fields
+        m = 4
+        response = self.sync_changes(
+            [generate_update_event(contentnode.id, CONTENTNODE, {
+                "extra_fields.options.completion_criteria.threshold.m": m,
+            }, channel_id=self.channel.id)],
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], m
+        )
+
+    def test_update_contentnode_exercise_mastery_model_old(self):
+        data = self.contentnode_db_metadata
+        data["extra_fields"] = {
+            "m": 5,
+            "n": 10,
+            "mastery_model": exercises.M_OF_N,
+        }
+
+        contentnode = models.ContentNode.objects.create(**data)
+
+        # Update m and n fields
+        m = 4
+        response = self.sync_changes(
+            [generate_update_event(contentnode.id, CONTENTNODE, {
+                "extra_fields.options.completion_criteria.threshold.m": m,
+            }, channel_id=self.channel.id)],
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], m
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], 10
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["mastery_model"], exercises.M_OF_N
+        )
+        self.assertEqual(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["model"], completion_criteria.MASTERY
+        )
+
+    def test_update_contentnode_extra_fields(self):
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
         # Update extra_fields.randomize
         randomize = True
         response = self.sync_changes(
             [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.randomize": randomize}, channel_id=self.channel.id)],
         )
         self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["m"], m
-        )
-        self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).extra_fields["options"]["completion_criteria"]["threshold"]["n"], n
-        )
         self.assertEqual(
             models.ContentNode.objects.get(id=contentnode.id).extra_fields["randomize"], randomize
         )

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -283,6 +283,25 @@ class CompletionCriteriaSerializer(JSONFieldDictSerializer):
         return instance
 
 
+def _migrate_extra_fields(extra_fields):
+    if not isinstance(extra_fields, dict):
+        return extra_fields
+    m = extra_fields.pop("m", None)
+    n = extra_fields.pop("n", None)
+    mastery_model = extra_fields.pop("mastery_model", None)
+    if not extra_fields.get("options", {}).get("completion_criteria", {}) and mastery_model is not None:
+        extra_fields["options"] = extra_fields.get("options", {})
+        extra_fields["options"]["completion_criteria"] = {
+            "threshold": {
+                "m": m,
+                "n": n,
+                "mastery_model": mastery_model,
+            },
+            "model": completion_criteria.MASTERY,
+        }
+    return extra_fields
+
+
 class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
     modality = ChoiceField(choices=(("QUIZ", "Quiz"),), allow_null=True, required=False)
     completion_criteria = CompletionCriteriaSerializer(required=False)
@@ -291,6 +310,10 @@ class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
 class ExtraFieldsSerializer(JSONFieldDictSerializer):
     randomize = BooleanField()
     options = ExtraFieldsOptionsSerializer(required=False)
+
+    def update(self, instance, validated_data):
+        instance = _migrate_extra_fields(instance)
+        return super(ExtraFieldsSerializer, self).update(instance, validated_data)
 
 
 class TagField(DotPathValueMixin, DictField):
@@ -453,19 +476,7 @@ def get_title(item):
 def consolidate_extra_fields(item):
     extra_fields = item.get("extra_fields")
     if item["kind"] == content_kinds.EXERCISE:
-        m = extra_fields.pop("m", None)
-        n = extra_fields.pop("n", None)
-        mastery_model = extra_fields.pop("mastery_model", None)
-        if not extra_fields.get("options", {}).get("completion_criteria", {}) and mastery_model is not None:
-            extra_fields["options"] = extra_fields.get("options", {})
-            extra_fields["options"]["completion_criteria"] = {
-                "threshold": {
-                    "m": m,
-                    "n": n,
-                    "mastery_model": mastery_model,
-                },
-                "model": completion_criteria.MASTERY,
-            }
+        extra_fields = _migrate_extra_fields(extra_fields)
 
     return extra_fields
 

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -258,8 +258,15 @@ class ThresholdField(Field):
         try:
             data = int(data)
         except(ValueError, TypeError):
-            pass
+            if not isinstance(data, (str, dict)):
+                self.fail("Must be either an integer, string or dictionary")
         return data
+
+    def update(self, instance, validated_data):
+        if isinstance(instance, dict) and isinstance(validated_data, dict):
+            instance.update(validated_data)
+            return instance
+        return validated_data
 
 
 class CompletionCriteriaSerializer(JSONFieldDictSerializer):


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds some simple validation for the threshold field to ensure it is either a string, integer coerceable or dict.
* Ensures that updates to the `threshold` key of `completion_criteria` can be made granularly when `threshold` is an object
* For example, just updating the `m` value of an `m of n` mastery model
* Ensures that partial updates to extra fields that contain the old way of encoding mastery model (at the top level) successfully write the entire representation into the completion criteria format.
* Adds regression tests for both scenarios
