### PR TITLE
Add stream parsing fallback for duration setting.

### DIFF
--- a/contentcuration/contentcuration/management/commands/set_file_duration.py
+++ b/contentcuration/contentcuration/management/commands/set_file_duration.py
@@ -14,7 +14,7 @@ logging = logmodule.getLogger('command')
 CHUNKSIZE = 10000
 
 
-def extract_duration_of_media(f_in):
+def extract_duration_of_media(f_in, extension):
     """
     For more details on these commands, refer to the ffmpeg Wiki:
     https://trac.ffmpeg.org/wiki/FFprobeTips#Formatcontainerduration
@@ -30,6 +30,8 @@ def extract_duration_of_media(f_in):
             "default=noprint_wrappers=1:nokey=1",
             "-loglevel",
             "panic",
+            "-f",
+            extension,
             "-"
         ],
         stdin=f_in,
@@ -95,7 +97,7 @@ class Command(BaseCommand):
                     continue
                 try:
                     with file.file_on_disk.open() as f:
-                        duration = extract_duration_of_media(f)
+                        duration = extract_duration_of_media(f, file.file_format.extension)
                     if duration:
                         updated_count += File.objects.filter(checksum=file.checksum, preset_id__in=MEDIA_PRESETS).update(duration=duration)
                 except FileNotFoundError:

--- a/contentcuration/contentcuration/management/commands/set_file_duration.py
+++ b/contentcuration/contentcuration/management/commands/set_file_duration.py
@@ -36,8 +36,7 @@ def extract_duration_of_media(f_in):
     )
     result = result.decode("utf-8").strip()
     try:
-        # return int(float(result))
-        raise ValueError
+        return int(float(result))
     except ValueError:
         # This can happen if ffprobe returns N/A for the duration
         # So instead we try to stream the entire file to get the value


### PR DESCRIPTION
Adds a fallback using ffmpeg in cases where the container header parsing with ffprobe does not produce a valid value.

This is somewhat intensive as it actually decodes the entire stream in order to get the duration, but should be relatively foolproof.