### PR TITLE
Exclude dependency presets from listings.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
@@ -108,7 +108,10 @@
         return this.getContentNodeFiles(this.nodeId);
       },
       presets() {
-        return FormatPresetsList.filter(p => p.kind_id === this.node.kind);
+        // Explicitly exclude any 'dependency' presets for now
+        return FormatPresetsList.filter(
+          p => p.kind_id === this.node.kind && !p.id.includes('dependency')
+        );
       },
       fileCount() {
         return this.primaryFileMapping.filter(item => item.file && !item.file.error).length;


### PR DESCRIPTION
Excludes any presets for 'dependency' presets from listings - these are only used for ricecooker nodes, so can be safely excluded from the UI for now.

Screenshot:

![Screenshot from 2022-07-05 17-19-54](https://user-images.githubusercontent.com/1680573/177437417-3da3da5d-4c51-4ded-bfb5-bfa28b9b8060.png)

Fixes #3439