### PR TITLE
Add a conditional check for if user is an admin for channel sharing

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -156,6 +156,9 @@
     computed: {
       ...mapState(['currentLanguage']),
       ...mapGetters('channel', ['getChannel']),
+      ...mapState({
+        user: state => state.session.currentUser,
+      }),
       channel() {
         return this.getChannel(this.channelId) || {};
       },
@@ -338,8 +341,9 @@
         return new Promise((resolve, reject) => {
           // Check if we already have the channel locally
           if (this.getChannel(channelId)) {
-            // Don't allow view-only channels
-            if (this.getChannel(channelId).edit) {
+            // Don't allow view-only channels,
+            // but allow admins to access
+            if (this.getChannel(channelId).edit || this.user.is_admin) {
               resolve();
             } else {
               this.$store.dispatch('errors/handleGenericError', {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Updates the `verifyChannel` function to have an alternate condition for if a user is an admin (and thus should be able to share the channel, even if they don't have explicitly set editor permissions)

### Manual verification steps performed
1. Created channel UserA 
2. Signed in as admin a@a.com
3. Accessed this channel through admin panel under "Users" tabs
4. Shared channel - it now works! 

### Screenshots (if applicable)

https://user-images.githubusercontent.com/17235236/177856888-cdf8b3b6-8fd7-43a3-aaf7-cc419ad97e07.mp4



### Does this introduce any tech-debt items?
I do not think so!

___
## Reviewer guidance
### How can a reviewer test these changes?
See manual verification above


## References
Fixes #3258 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
