### PR TITLE
Fix default upload duration being shown in raw seconds

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -86,12 +86,12 @@
       },
       duration: {
         type: Number,
-        default: 0,
+        default: null,
       },
     },
     data() {
       return {
-        defaultUploadTime: this.duration,
+        defaultUploadTime: this.duration || `17:12`,
       };
     },
     computed: {
@@ -168,14 +168,18 @@
         this.$emit('input', this.convertToSeconds(value));
       },
       convertToHHMMSS(totalSeconds) {
-        const hours = Math.floor(totalSeconds / 3600)
-          .toString()
-          .padStart(2, 0);
-        const minutes = Math.floor((totalSeconds % 3600) / 60)
-          .toString()
-          .padStart(2, 0);
-        const seconds = ((totalSeconds % 3600) % 60).toString().padStart(2, 0);
-        return `${hours}:${minutes}:${seconds}`;
+        if (totalSeconds !== null && Number.isInteger(totalSeconds)) {
+          const hours = Math.floor(totalSeconds / 3600)
+            .toString()
+            .padStart(2, 0);
+          const minutes = Math.floor((totalSeconds % 3600) / 60)
+            .toString()
+            .padStart(2, 0);
+          const seconds = ((totalSeconds % 3600) % 60).toString().padStart(2, 0);
+          return `${hours}:${minutes}:${seconds}`;
+        } else {
+          return totalSeconds;
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -6,7 +6,7 @@
         v-if="audioVideoUpload && selectedDuration === 'exactTime'"
         class="defaultUpload md2 sm3"
       >
-        {{ defaultUploadTime }}
+        {{ convertToHHMMSS(defaultUploadTime) }}
       </VFlex>
       <VFlex
         v-else-if="selectedDuration === 'shortActivity' || selectedDuration === 'longActivity'"
@@ -166,6 +166,16 @@
       },
       handleInput(value) {
         this.$emit('input', this.convertToSeconds(value));
+      },
+      convertToHHMMSS(totalSeconds) {
+        const hours = Math.floor(totalSeconds / 3600)
+          .toString()
+          .padStart(2, 0);
+        const minutes = Math.floor((totalSeconds % 3600) / 60)
+          .toString()
+          .padStart(2, 0);
+        const seconds = ((totalSeconds % 3600) % 60).toString().padStart(2, 0);
+        return `${hours}:${minutes}:${seconds}`;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -86,12 +86,12 @@
       },
       duration: {
         type: Number,
-        default: null,
+        default: 0,
       },
     },
     data() {
       return {
-        defaultUploadTime: this.duration || `17:12`,
+        defaultUploadTime: this.duration,
       };
     },
     computed: {


### PR DESCRIPTION
## Summary
This PR fixes the default upload duration being shown in raw seconds. Now, we show the `duration` in `HH:MM:SS` format.

## Screenshots (if applicable)
**Before:**
![image](https://user-images.githubusercontent.com/26724128/181917512-b9cbb70d-444f-4c26-b8b9-d745131e6a88.png)

**After:**
![image](https://user-images.githubusercontent.com/26724128/181917571-78df39c5-c560-4761-a2f2-ee43a7dd4cb7.png)

___
## Reviewer guidance
1. Sign up with a@a.com.
2. Start editing a sample video file.
3. Observe the time shown beside "Completion -> Duration" field when "Exact time to complete" is selected.

## References

Closes https://github.com/learningequality/studio/issues/3465.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
