### PR TITLE
Feat change log broadcasting

### DIFF
--- a/contentcuration/contentcuration/apps.py
+++ b/contentcuration/contentcuration/apps.py
@@ -8,6 +8,8 @@ class ContentConfig(AppConfig):
     name = 'contentcuration'
 
     def ready(self):
+        # signals for websockets
+        import contentcuration.viewsets.websockets.signals
         # see note in the celery_signals.py file for why we import here.
         import contentcuration.utils.celery.signals  # noqa
 

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -6,6 +6,7 @@ from mock import patch
 
 from contentcuration.models import Change
 from contentcuration.tests import testdata
+from contentcuration.tests.base import BucketTestMixin
 from contentcuration.tests.viewsets.base import generate_create_event
 from contentcuration.tests.viewsets.base import generate_update_event
 from contentcuration.viewsets.sync.constants import BOOKMARK
@@ -13,14 +14,18 @@ from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 
 
-class ChangeSignalTestCase(TestCase):
+class ChangeSignalTestCase(TestCase, BucketTestMixin):
     def setUp(self):
         call_command("loadconstants")
+        if not self.persist_bucket:
+            self.create_bucket()
         self.user = testdata.user("mrtest@testy.com")
         self.channel = testdata.channel()
         self.channel.editors.add(self.user)
 
     def tearDown(self):
+        if not self.persist_bucket:
+            self.delete_bucket()
         self.user.delete()
 
     @property

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -1,0 +1,117 @@
+import uuid
+
+from django.core.management import call_command
+from django.test import TestCase
+from mock import patch
+
+from contentcuration.models import Change
+from contentcuration.tests import testdata
+from contentcuration.tests.viewsets.base import generate_create_event
+from contentcuration.tests.viewsets.base import generate_update_event
+from contentcuration.viewsets.sync.constants import BOOKMARK
+from contentcuration.viewsets.sync.constants import CHANNEL
+from contentcuration.viewsets.sync.constants import EDITOR_M2M
+
+
+class ChangeSignalTestCase(TestCase):
+    def setUp(self):
+        call_command("loadconstants")
+        self.user = testdata.user("mrtest@testy.com")
+        self.channel = testdata.channel()
+        self.channel.editors.add(self.user)
+
+    def tearDown(self):
+        self.user.delete()
+
+    @property
+    def channel_metadata(self):
+        return {
+            "name": "ozer's cool channel",
+            "id": uuid.uuid4().hex,
+            "description": "coolest channel that side of the Pacific",
+        }
+
+    @property
+    def bookmark_metadata(self):
+        return {
+            "channel": self.channel.id,
+        }
+
+    @patch('contentcuration.viewsets.websockets.signals.broadcast_new_change_model')
+    def test_change_signal_handler(self, mock_signal):
+        """
+        Test if signal is getting triggered when an change object gets created.
+        """
+        self.client.force_login(self.user)
+        new_name = "This is not the old name"
+        Change.create_change(generate_update_event(self.channel.id, CHANNEL, {"name": new_name}, channel_id=self.channel.id))
+        assert mock_signal.call_count == 1
+
+    @patch('contentcuration.viewsets.websockets.signals.async_to_sync')
+    @patch('contentcuration.viewsets.websockets.signals.get_channel_layer')
+    def test_signal_handler_channel_specific_changes(self, mock_get_channel_layer, mock_async_to_sync):
+        """
+        Test changes that are specific to channel(change channel name) only.
+        """
+        new_name = "This is not the old name"
+        change_obj = Change.create_change(generate_update_event(self.channel.id, CHANNEL, {"name": new_name}, channel_id=self.channel.id))
+
+        change_serialized = Change.serialize(change_obj)
+
+        channel_layer = mock_get_channel_layer.return_value
+        mock_async_to_sync.assert_called_once_with(channel_layer.group_send)
+        async_mock_return_value = mock_async_to_sync.return_value
+        async_mock_return_value.assert_called_once_with(self.channel.id, {
+            'type': 'broadcast_changes',
+            'change': change_serialized
+        })
+
+    @patch('contentcuration.viewsets.websockets.signals.async_to_sync')
+    @patch('contentcuration.viewsets.websockets.signals.get_channel_layer')
+    def test_signal_handler_user_specific_changes(self, mock_get_channel_layer, mock_async_to_sync):
+        """
+        Test changes that are specific to user(bookmarks) only.
+        """
+        self.client.force_login(user=self.user)
+        bookmark = self.bookmark_metadata
+        change_obj = Change.create_change(generate_create_event(
+            bookmark["channel"],
+            BOOKMARK,
+            bookmark,
+            user_id=self.user.id,
+        ))
+        change_serialized = Change.serialize(change_obj)
+        channel_layer = mock_get_channel_layer.return_value
+        mock_async_to_sync.assert_called_with(channel_layer.group_send)
+        async_mock_return_value = mock_async_to_sync.return_value
+        async_mock_return_value.assert_called_with(self.user.id, {
+            'type': 'broadcast_changes',
+            'change': change_serialized
+        })
+
+    @patch('contentcuration.viewsets.websockets.signals.async_to_sync')
+    @patch('contentcuration.viewsets.websockets.signals.get_channel_layer')
+    def test_signal_handler_user_channel_common_changes(self, mock_get_channel_layer, mock_async_to_sync):
+        """
+        Test changes that are common to both channel and user(invitations).
+        """
+        editor = self.user
+        self.client.force_login(self.user)
+        change_obj = Change.create_change(generate_create_event([editor.id, self.channel.id], EDITOR_M2M, {}, channel_id=self.channel.id, user_id=editor.id))
+        change_serialized = Change.serialize(change_obj)
+        channel_layer = mock_get_channel_layer.return_value
+        mock_async_to_sync.assert_called_with(channel_layer.group_send)
+        async_mock_return_value = mock_async_to_sync.return_value
+        async_mock_return_value.assert_called_with(editor.id, {
+            'type': 'broadcast_changes',
+            'change': change_serialized
+        })
+        assert 2 == mock_async_to_sync.call_count
+        async_mock_return_value.assert_any_call(self.channel.id, {
+            'type': 'broadcast_changes',
+            'change': change_serialized
+        })
+        async_mock_return_value.assert_any_call(editor.id, {
+            'type': 'broadcast_changes',
+            'change': change_serialized
+        })

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -89,7 +89,7 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         channel_layer = mock_get_channel_layer.return_value
         mock_async_to_sync.assert_called_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
-        async_mock_return_value.assert_called_with(self.user.id, {
+        async_mock_return_value.assert_called_with(str(self.user.id), {
             'type': 'broadcast_changes',
             'change': change_serialized
         })
@@ -107,7 +107,7 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         channel_layer = mock_get_channel_layer.return_value
         mock_async_to_sync.assert_called_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
-        async_mock_return_value.assert_called_with(editor.id, {
+        async_mock_return_value.assert_called_with(str(editor.id), {
             'type': 'broadcast_changes',
             'change': change_serialized
         })
@@ -116,7 +116,7 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
             'type': 'broadcast_changes',
             'change': change_serialized
         })
-        async_mock_return_value.assert_any_call(editor.id, {
+        async_mock_return_value.assert_any_call(str(editor.id), {
             'type': 'broadcast_changes',
             'change': change_serialized
         })

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -44,7 +44,7 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         """
         Test changes that are specific to channel(change channel name) only.
         """
-        change_serialized = create_channel_specific_change_object(self.channel)
+        change_serialized = create_channel_specific_change_object(self.user, self.channel)
         channel_layer = mock_get_channel_layer.return_value
         mock_async_to_sync.assert_called_once_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
@@ -61,9 +61,9 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         """
         change_serialized = create_user_specific_change_object(self.user, self.channel)
         channel_layer = mock_get_channel_layer.return_value
-        mock_async_to_sync.assert_called_with(channel_layer.group_send)
+        mock_async_to_sync.assert_called_once_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
-        async_mock_return_value.assert_called_with(str(self.user.id), {
+        async_mock_return_value.assert_called_once_with(str(self.user.id), {
             'type': 'broadcast_changes',
             'change': change_serialized
         })
@@ -77,12 +77,9 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         editor = self.user
         change_serialized = create_channel_user_common_change_object(editor, self.channel)
         channel_layer = mock_get_channel_layer.return_value
+        assert 2 == mock_async_to_sync.call_count
         mock_async_to_sync.assert_called_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
-        async_mock_return_value.assert_called_with(str(editor.id), {
-            'type': 'broadcast_changes',
-            'change': change_serialized
-        })
         assert 2 == mock_async_to_sync.call_count
         async_mock_return_value.assert_any_call(self.channel.id, {
             'type': 'broadcast_changes',
@@ -101,10 +98,10 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         """
         change_serialized = create_errored_change_object(self.user, self.channel)
         channel_layer = mock_get_channel_layer.return_value
-        mock_async_to_sync.assert_called_with(channel_layer.group_send)
+        mock_async_to_sync.assert_called_once_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
         assert 1 == mock_async_to_sync.call_count
-        async_mock_return_value.assert_any_call(str(self.user.id), {
+        async_mock_return_value.assert_called_once_with(str(self.user.id), {
             'type': 'broadcast_changes',
             'errored': change_serialized
         })

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -5,11 +5,11 @@ from mock import patch
 from contentcuration.models import Change
 from contentcuration.tests import testdata
 from contentcuration.tests.base import BucketTestMixin
+from contentcuration.tests.utils.websocket_helper import create_channel_specific_change_object
+from contentcuration.tests.utils.websocket_helper import create_channel_user_common_change_object
+from contentcuration.tests.utils.websocket_helper import create_errored_change_object
+from contentcuration.tests.utils.websocket_helper import create_user_specific_change_object
 from contentcuration.tests.viewsets.base import generate_update_event
-from contentcuration.utils.websocket_helper import create_channel_specific_change_object
-from contentcuration.utils.websocket_helper import create_channel_user_common_change_object
-from contentcuration.utils.websocket_helper import create_errored_change_object
-from contentcuration.utils.websocket_helper import create_user_specific_change_object
 from contentcuration.viewsets.sync.constants import CHANNEL
 
 

--- a/contentcuration/contentcuration/tests/test_websocket_consumer.py
+++ b/contentcuration/contentcuration/tests/test_websocket_consumer.py
@@ -14,7 +14,6 @@ os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
 
 class WebsocketTestCase(TransactionTestCase):
-
     def setUp(self):
         call_command("loadconstants")
         self.user = testdata.user("mrtest@testy.com")

--- a/contentcuration/contentcuration/tests/utils/websocket_helper.py
+++ b/contentcuration/contentcuration/tests/utils/websocket_helper.py
@@ -12,25 +12,6 @@ from contentcuration.viewsets.sync.constants import CONTENTNODE
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 
 
-class NoneCreatedByIdError(Exception):
-    """
-    Use to log change object whose created_by_id is set to none. We don't raise this error,
-    just feed it to Sentry for reporting.
-    """
-
-    def __init__(self, instance):
-
-        self.change_object = instance
-        message = (
-            "The change object did not have a created_by_id {}"
-        )
-        self.message = message.format(
-            instance.pk
-        )
-
-        super(NoneCreatedByIdError, self).__init__(self.message)
-
-
 def bookmark_metadata(channel):
     return {
         "channel": channel.id,

--- a/contentcuration/contentcuration/tests/utils/websocket_helper.py
+++ b/contentcuration/contentcuration/tests/utils/websocket_helper.py
@@ -25,7 +25,7 @@ class NoneCreatedByIdError(Exception):
             "The change object did not have a created_by_id {}"
         )
         self.message = message.format(
-            instance.__dict__
+            instance.pk
         )
 
         super(NoneCreatedByIdError, self).__init__(self.message)

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -374,7 +374,6 @@ class ContentNodeViewSetTestCase(StudioAPITestCase):
                 self.viewset_url(pk=contentnode.id), format="json",
             )
         self.assertEqual(response.status_code, 200, response.content)
-        print(response.data["extra_fields"])
         self.assertEqual(response.data["extra_fields"]["options"]["completion_criteria"]["threshold"]["m"], 3)
         self.assertEqual(response.data["extra_fields"]["options"]["completion_criteria"]["threshold"]["n"], 6)
         self.assertEqual(response.data["extra_fields"]["options"]["completion_criteria"]["threshold"]["mastery_model"], exercises.M_OF_N)

--- a/contentcuration/contentcuration/utils/websocket_helper.py
+++ b/contentcuration/contentcuration/utils/websocket_helper.py
@@ -1,0 +1,71 @@
+import uuid
+
+from le_utils.constants import content_kinds
+
+from contentcuration import models
+from contentcuration.models import Change
+from contentcuration.tests.viewsets.base import generate_create_event
+from contentcuration.tests.viewsets.base import generate_update_event
+from contentcuration.viewsets.sync.constants import BOOKMARK
+from contentcuration.viewsets.sync.constants import CHANNEL
+from contentcuration.viewsets.sync.constants import CONTENTNODE
+from contentcuration.viewsets.sync.constants import EDITOR_M2M
+
+
+def bookmark_metadata(channel):
+    return {
+        "channel": channel.id,
+    }
+
+
+def contentnode_db_metadata(channel):
+    return {
+        "title": "Aron's cool contentnode",
+        "id": uuid.uuid4().hex,
+        "kind_id": content_kinds.VIDEO,
+        "description": "coolest contentnode this side of the Pacific",
+        "parent_id": channel.main_tree_id,
+    }
+
+
+def create_user_specific_change_object(user, channel):
+    bookmark = bookmark_metadata(channel)
+    change_obj = Change.create_change(generate_create_event(
+        bookmark["channel"],
+        BOOKMARK,
+        bookmark,
+        user_id=user.id,
+    ))
+    change_obj.applied = True
+    change_obj.save()
+    change_serialized = Change.serialize(change_obj)
+    return change_serialized
+
+
+def create_channel_specific_change_object(channel):
+    new_name = "This is not the old name"
+    change_obj = Change.create_change(generate_update_event(channel.id, CHANNEL, {"name": new_name}, channel_id=channel.id))
+    change_obj.applied = True
+    change_obj.save()
+    change_serialized = Change.serialize(change_obj)
+    return change_serialized
+
+
+def create_channel_user_common_change_object(user, channel):
+    editor = user
+    change_obj = Change.create_change(generate_create_event([editor.id, channel.id], EDITOR_M2M, {}, channel_id=channel.id, user_id=editor.id))
+    change_obj.applied = True
+    change_obj.save()
+    change_serialized = Change.serialize(change_obj)
+    return change_serialized
+
+
+def create_errored_change_object(user, channel):
+    contentnode = models.ContentNode.objects.create(**contentnode_db_metadata(channel))
+    tag = "howzat!"
+    change_obj = Change.create_change(generate_update_event(contentnode.id, CONTENTNODE, {
+        "tags": [tag]}, channel_id=channel.id), created_by_id=user.id)
+    change_obj.errored = True
+    change_obj.save()
+    change_serialized = Change.serialize(change_obj)
+    return change_serialized

--- a/contentcuration/contentcuration/utils/websocket_helper.py
+++ b/contentcuration/contentcuration/utils/websocket_helper.py
@@ -12,6 +12,25 @@ from contentcuration.viewsets.sync.constants import CONTENTNODE
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 
 
+class NoneCreatedByIdError(Exception):
+    """
+    Use to log change object whose created_by_id. We don't raise this error,
+    just feed it to Sentry for reporting.
+    """
+
+    def __init__(self, instance):
+
+        self.change_object = instance
+        message = (
+            "The change object did not have a created_by_id {}"
+        )
+        self.message = message.format(
+            instance.__dict__
+        )
+
+        super(NoneCreatedByIdError, self).__init__(self.message)
+
+
 def bookmark_metadata(channel):
     return {
         "channel": channel.id,
@@ -35,16 +54,16 @@ def create_user_specific_change_object(user, channel):
         BOOKMARK,
         bookmark,
         user_id=user.id,
-    ))
+    ), created_by_id=user.id)
     change_obj.applied = True
     change_obj.save()
     change_serialized = Change.serialize(change_obj)
     return change_serialized
 
 
-def create_channel_specific_change_object(channel):
+def create_channel_specific_change_object(user, channel):
     new_name = "This is not the old name"
-    change_obj = Change.create_change(generate_update_event(channel.id, CHANNEL, {"name": new_name}, channel_id=channel.id))
+    change_obj = Change.create_change(generate_update_event(channel.id, CHANNEL, {"name": new_name}, channel_id=channel.id), created_by_id=user.id)
     change_obj.applied = True
     change_obj.save()
     change_serialized = Change.serialize(change_obj)
@@ -53,7 +72,8 @@ def create_channel_specific_change_object(channel):
 
 def create_channel_user_common_change_object(user, channel):
     editor = user
-    change_obj = Change.create_change(generate_create_event([editor.id, channel.id], EDITOR_M2M, {}, channel_id=channel.id, user_id=editor.id))
+    change_obj = Change.create_change(generate_create_event([editor.id, channel.id], EDITOR_M2M, {},
+                                                            channel_id=channel.id, user_id=editor.id), created_by_id=user.id)
     change_obj.applied = True
     change_obj.save()
     change_serialized = Change.serialize(change_obj)

--- a/contentcuration/contentcuration/utils/websocket_helper.py
+++ b/contentcuration/contentcuration/utils/websocket_helper.py
@@ -14,7 +14,7 @@ from contentcuration.viewsets.sync.constants import EDITOR_M2M
 
 class NoneCreatedByIdError(Exception):
     """
-    Use to log change object whose created_by_id. We don't raise this error,
+    Use to log change object whose created_by_id is set to none. We don't raise this error,
     just feed it to Sentry for reporting.
     """
 

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -111,15 +111,15 @@ class SyncConsumer(WebsocketConsumer):
         # Changes that cannot be made
         disallowed_changes = []
         for c in changes:
-            if c.get("channel_id") is None and c.get("user_id") == self.user_id:
+            if c.get("channel_id") is None and c.get("user_id") == user_id:
                 user_only_changes.append(c)
             elif c.get("channel_id") in allowed_ids:
                 channel_changes.append(c)
             else:
                 disallowed_changes.append(c)
-        change_models = Change.create_changes(user_only_changes + channel_changes, created_by_id=self.user_id, session_key=self.session_key)
+        change_models = Change.create_changes(user_only_changes + channel_changes, created_by_id=user_id, session_key=session_key)
         if user_only_changes:
-            get_or_create_async_task("apply_user_changes", self.user, user_id=self.user_id)
+            get_or_create_async_task("apply_user_changes", self.user, user_id=user_id)
         for channel_id in allowed_ids:
             get_or_create_async_task("apply_channel_changes", self.user, channel_id=channel_id)
         allowed_changes = [{"rev": c.client_rev, "server_rev": c.server_rev} for c in change_models]

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -129,8 +129,10 @@ class SyncConsumer(WebsocketConsumer):
             'response_payload': response_payload
         }))
 
-    # Receive message from room group
     def broadcast_changes(self, event):
+        """
+        Receive message events sent to the subscribed groups from our Django signal handlers, and relay the messages to the frontend
+        """
         change = event['change']
 
         # Send message to WebSocket

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -1,9 +1,15 @@
+import logging as logger
+
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from contentcuration.models import Change
+from contentcuration.utils.sentry import report_exception
+from contentcuration.utils.websocket_helper import NoneCreatedByIdError
+
+logging = logger.getLogger(__name__)
 
 
 @receiver(post_save, sender=Change, weak=False)
@@ -19,12 +25,18 @@ def broadcast_new_change_model(instance):
 
     # name of indiviual_user group
     indiviual_room_group_name = instance.user_id
-    print("DEBUG", instance.errored)
-    print("DEBUG", instance.__dict__)
+
+    if(instance.created_by_id is None):
+        try:
+            raise NoneCreatedByIdError(instance)
+        except NoneCreatedByIdError as e:
+            report_exception(e)
+        return
+
     # if the change object is errored then we broadcast the info back to indiviual user
     if instance.errored:
         async_to_sync(channel_layer.group_send)(
-            str(instance.created_by_id or ""),
+            str(instance.created_by_id),
             {
                 'type': 'broadcast_changes',
                 'errored': serialized_change_object
@@ -34,7 +46,7 @@ def broadcast_new_change_model(instance):
         # if the change is related to channel we broadcast changes to channel group
         if not indiviual_room_group_name and room_group_name:
             async_to_sync(channel_layer.group_send)(
-                str(room_group_name or ""),
+                str(room_group_name),
                 {
                     'type': 'broadcast_changes',
                     'change': serialized_change_object
@@ -43,7 +55,7 @@ def broadcast_new_change_model(instance):
         # if the change is only related to indiviual user
         elif indiviual_room_group_name and not room_group_name:
             async_to_sync(channel_layer.group_send)(
-                str(indiviual_room_group_name or ""),
+                str(indiviual_room_group_name),
                 {
                     'type': 'broadcast_changes',
                     'change': serialized_change_object
@@ -52,14 +64,14 @@ def broadcast_new_change_model(instance):
         # if the change is realted to both user and channel then we will broadcast to both of the groups
         elif indiviual_room_group_name and room_group_name:
             async_to_sync(channel_layer.group_send)(
-                str(room_group_name or ""),
+                str(room_group_name),
                 {
                     'type': 'broadcast_changes',
                     'change': serialized_change_object
                 }
             )
             async_to_sync(channel_layer.group_send)(
-                str(indiviual_room_group_name or ""),
+                str(indiviual_room_group_name),
                 {
                     'type': 'broadcast_changes',
                     'change': serialized_change_object

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -15,9 +15,13 @@ def broadcast_new_change_model(instance):
     channel_layer = get_channel_layer()
     serialized_change_object = Change.serialize(instance)
     # Name of channel group
-    room_group_name = instance.channel_id
+    room_group_name = str(instance.channel_id or "dummy")
+
     # name of indiviual_user group
-    indiviual_room_group_name = instance.user_id
+    indiviual_room_group_name = str(instance.user_id or "dummy")
+
+    print("DEBUG", room_group_name)
+    print("DEBUG", indiviual_room_group_name)
 
     # if the change object is errored then we broadcast the info back to indiviual user
     if instance.errored:

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -31,6 +31,7 @@ def broadcast_new_change_model(instance):
             raise NoneCreatedByIdError(instance)
         except NoneCreatedByIdError as e:
             report_exception(e)
+        logging.error("Missing expected Change.created_by_id")
         return
 
     # if the change object is errored then we broadcast the info back to indiviual user

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -15,18 +15,15 @@ def broadcast_new_change_model(instance):
     channel_layer = get_channel_layer()
     serialized_change_object = Change.serialize(instance)
     # Name of channel group
-    room_group_name = str(instance.channel_id or "dummy")
+    room_group_name = instance.channel_id
 
     # name of indiviual_user group
-    indiviual_room_group_name = str(instance.user_id or "dummy")
-
-    print("DEBUG", room_group_name)
-    print("DEBUG", indiviual_room_group_name)
+    indiviual_room_group_name = instance.user_id
 
     # if the change object is errored then we broadcast the info back to indiviual user
     if instance.errored:
         async_to_sync(channel_layer.group_send)(
-            instance.created_by_id,
+            str(instance.created_by_id or ""),
             {
                 'type': 'broadcast_changes',
                 'errored': serialized_change_object
@@ -36,7 +33,7 @@ def broadcast_new_change_model(instance):
     # if the change is related to channel we broadcast changes to channel group
     if not indiviual_room_group_name and room_group_name:
         async_to_sync(channel_layer.group_send)(
-            room_group_name,
+            str(room_group_name or ""),
             {
                 'type': 'broadcast_changes',
                 'change': serialized_change_object
@@ -45,7 +42,7 @@ def broadcast_new_change_model(instance):
     # if the change is only related to indiviual user
     elif indiviual_room_group_name and not room_group_name:
         async_to_sync(channel_layer.group_send)(
-            indiviual_room_group_name,
+            str(indiviual_room_group_name or ""),
             {
                 'type': 'broadcast_changes',
                 'change': serialized_change_object
@@ -54,14 +51,14 @@ def broadcast_new_change_model(instance):
     # if the change is realted to both user and channel then we will broadcast to both of the groups
     elif indiviual_room_group_name and room_group_name:
         async_to_sync(channel_layer.group_send)(
-            room_group_name,
+            str(room_group_name or ""),
             {
                 'type': 'broadcast_changes',
                 'change': serialized_change_object
             }
         )
         async_to_sync(channel_layer.group_send)(
-            indiviual_room_group_name,
+            str(indiviual_room_group_name or ""),
             {
                 'type': 'broadcast_changes',
                 'change': serialized_change_object

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -11,9 +11,22 @@ def broadcast_new_change_model(sender, instance, created, **kwargs):
     channel_layer = get_channel_layer()
     print(instance.__dict__)
     serialized_change_object = Change.serialize(instance)
+    # Name of channel group
     room_group_name = instance.channel_id
+    # name of indiviual_user group
     indiviual_room_group_name = instance.user_id
-    # if the change is only related to user we broadcast changes only to user
+
+    # if the change object is errored then we broadcast the info back to indiviual user
+    if instance.errored is True:
+        async_to_sync(channel_layer.group_send)(
+            instance.created_by_id,
+            {
+                'type': 'broadcast_changes',
+                'errored': serialized_change_object
+            }
+        )
+
+    # if the change is related to channel we broadcast changes to channel group
     if not indiviual_room_group_name and room_group_name:
         async_to_sync(channel_layer.group_send)(
             room_group_name,
@@ -22,6 +35,7 @@ def broadcast_new_change_model(sender, instance, created, **kwargs):
                 'change': serialized_change_object
             }
         )
+    # if the change is only related to indiviual user
     elif indiviual_room_group_name and not room_group_name:
         async_to_sync(channel_layer.group_send)(
             indiviual_room_group_name,
@@ -30,11 +44,19 @@ def broadcast_new_change_model(sender, instance, created, **kwargs):
                 'change': serialized_change_object
             }
         )
-
-    async_to_sync(channel_layer.group_send)(
-        room_group_name,
-        {
-            'type': 'broadcast_changes',
-            'change': serialized_change_object
-        }
-    )
+    # if the change is realted to both user and channel then we will broadcast to both of the groups
+    elif indiviual_room_group_name and room_group_name:
+        async_to_sync(channel_layer.group_send)(
+            room_group_name,
+            {
+                'type': 'broadcast_changes',
+                'change': serialized_change_object
+            }
+        )
+        async_to_sync(channel_layer.group_send)(
+            indiviual_room_group_name,
+            {
+                'type': 'broadcast_changes',
+                'change': serialized_change_object
+            }
+        )

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -7,9 +7,12 @@ from contentcuration.models import Change
 
 
 @receiver(post_save, sender=Change, weak=False)
-def broadcast_new_change_model(sender, instance, created, **kwargs):
+def broadcast_new_change_model_handler(sender, instance, created, **kwargs):
+    broadcast_new_change_model(instance)
+
+
+def broadcast_new_change_model(instance):
     channel_layer = get_channel_layer()
-    print(instance.__dict__)
     serialized_change_object = Change.serialize(instance)
     # Name of channel group
     room_group_name = instance.channel_id
@@ -17,7 +20,7 @@ def broadcast_new_change_model(sender, instance, created, **kwargs):
     indiviual_room_group_name = instance.user_id
 
     # if the change object is errored then we broadcast the info back to indiviual user
-    if instance.errored is True:
+    if instance.errored:
         async_to_sync(channel_layer.group_send)(
             instance.created_by_id,
             {

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -19,7 +19,8 @@ def broadcast_new_change_model(instance):
 
     # name of indiviual_user group
     indiviual_room_group_name = instance.user_id
-
+    print("DEBUG", instance.errored)
+    print("DEBUG", instance.__dict__)
     # if the change object is errored then we broadcast the info back to indiviual user
     if instance.errored:
         async_to_sync(channel_layer.group_send)(
@@ -29,38 +30,38 @@ def broadcast_new_change_model(instance):
                 'errored': serialized_change_object
             }
         )
-
-    # if the change is related to channel we broadcast changes to channel group
-    if not indiviual_room_group_name and room_group_name:
-        async_to_sync(channel_layer.group_send)(
-            str(room_group_name or ""),
-            {
-                'type': 'broadcast_changes',
-                'change': serialized_change_object
-            }
-        )
-    # if the change is only related to indiviual user
-    elif indiviual_room_group_name and not room_group_name:
-        async_to_sync(channel_layer.group_send)(
-            str(indiviual_room_group_name or ""),
-            {
-                'type': 'broadcast_changes',
-                'change': serialized_change_object
-            }
-        )
-    # if the change is realted to both user and channel then we will broadcast to both of the groups
-    elif indiviual_room_group_name and room_group_name:
-        async_to_sync(channel_layer.group_send)(
-            str(room_group_name or ""),
-            {
-                'type': 'broadcast_changes',
-                'change': serialized_change_object
-            }
-        )
-        async_to_sync(channel_layer.group_send)(
-            str(indiviual_room_group_name or ""),
-            {
-                'type': 'broadcast_changes',
-                'change': serialized_change_object
-            }
-        )
+    if instance.applied:
+        # if the change is related to channel we broadcast changes to channel group
+        if not indiviual_room_group_name and room_group_name:
+            async_to_sync(channel_layer.group_send)(
+                str(room_group_name or ""),
+                {
+                    'type': 'broadcast_changes',
+                    'change': serialized_change_object
+                }
+            )
+        # if the change is only related to indiviual user
+        elif indiviual_room_group_name and not room_group_name:
+            async_to_sync(channel_layer.group_send)(
+                str(indiviual_room_group_name or ""),
+                {
+                    'type': 'broadcast_changes',
+                    'change': serialized_change_object
+                }
+            )
+        # if the change is realted to both user and channel then we will broadcast to both of the groups
+        elif indiviual_room_group_name and room_group_name:
+            async_to_sync(channel_layer.group_send)(
+                str(room_group_name or ""),
+                {
+                    'type': 'broadcast_changes',
+                    'change': serialized_change_object
+                }
+            )
+            async_to_sync(channel_layer.group_send)(
+                str(indiviual_room_group_name or ""),
+                {
+                    'type': 'broadcast_changes',
+                    'change': serialized_change_object
+                }
+            )

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -1,0 +1,40 @@
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from contentcuration.models import Change
+
+
+@receiver(post_save, sender=Change, weak=False)
+def broadcast_new_change_model(sender, instance, created, **kwargs):
+    channel_layer = get_channel_layer()
+    print(instance.__dict__)
+    serialized_change_object = Change.serialize(instance)
+    room_group_name = instance.channel_id
+    indiviual_room_group_name = instance.user_id
+    # if the change is only related to user we broadcast changes only to user
+    if not indiviual_room_group_name and room_group_name:
+        async_to_sync(channel_layer.group_send)(
+            room_group_name,
+            {
+                'type': 'broadcast_changes',
+                'change': serialized_change_object
+            }
+        )
+    elif indiviual_room_group_name and not room_group_name:
+        async_to_sync(channel_layer.group_send)(
+            indiviual_room_group_name,
+            {
+                'type': 'broadcast_changes',
+                'change': serialized_change_object
+            }
+        )
+
+    async_to_sync(channel_layer.group_send)(
+        room_group_name,
+        {
+            'type': 'broadcast_changes',
+            'change': serialized_change_object
+        }
+    )

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -6,10 +6,28 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from contentcuration.models import Change
-from contentcuration.tests.utils.websocket_helper import NoneCreatedByIdError
 from contentcuration.utils.sentry import report_exception
 
 logging = logger.getLogger(__name__)
+
+
+class NoneCreatedByIdError(Exception):
+    """
+    Use to log change object whose created_by_id is set to none. We don't raise this error,
+    just feed it to Sentry for reporting.
+    """
+
+    def __init__(self, instance):
+
+        self.change_object = instance
+        message = (
+            "The change object did not have a created_by_id {}"
+        )
+        self.message = message.format(
+            instance.pk
+        )
+
+        super(NoneCreatedByIdError, self).__init__(self.message)
 
 
 @receiver(post_save, sender=Change, weak=False)

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -6,8 +6,8 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from contentcuration.models import Change
+from contentcuration.tests.utils.websocket_helper import NoneCreatedByIdError
 from contentcuration.utils.sentry import report_exception
-from contentcuration.utils.websocket_helper import NoneCreatedByIdError
 
 logging = logger.getLogger(__name__)
 
@@ -26,7 +26,7 @@ def broadcast_new_change_model(instance):
     # name of indiviual_user group
     indiviual_room_group_name = instance.user_id
 
-    if(instance.created_by_id is None):
+    if instance.created_by_id is None:
         try:
             raise NoneCreatedByIdError(instance)
         except NoneCreatedByIdError as e:


### PR DESCRIPTION
## Summary
Added mechanism to broadcast change object model via Django signals.
### Description of the change(s) you made
Added the following features:
1. Signals on save of Change object.
2. Broadcast changes to frontend once signal gets triggered.
3. Test the signals and its decision tree.

### Manual verification steps performed
1. Ran all tests

### Are there any risky areas that deserve extra testing?
The create_changes function(applies changes in bulk) does not use the save method so the signal will not be triggered but it won't matter in our case as told by @rtibbles sir.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
