### PR TITLE
Use Vuetify's lazy attribute to delay mounting of DOM nodes

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelActionsDropdown.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelActionsDropdown.vue
@@ -42,7 +42,7 @@
       confirmButtonText="Delete"
       @confirm="softDeleteHandler"
     />
-    <VMenu offset-y>
+    <Menu>
       <template #activator="{ on }">
         <VBtn v-bind="$attrs" v-on="on">
           actions
@@ -108,7 +108,7 @@
           </VListTile>
         </template>
       </VList>
-    </VMenu>
+    </Menu>
 
   </div>
 

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
@@ -10,7 +10,7 @@
           <Checkbox v-model="selected" />
         </VFlex>
         <VFlex shrink>
-          <VTooltip v-if="channel.public && !channel.deleted" bottom z-index="200">
+          <VTooltip v-if="channel.public && !channel.deleted" bottom z-index="200" lazy>
             <template #activator="{ on }">
               <span class="px-1 py-2" v-on="on">
                 <Icon color="light-green accent-4">

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/EmailUsersDialog.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/EmailUsersDialog.vue
@@ -30,7 +30,7 @@
                 :delimit="false"
               >
                 <template #item="{ item }">
-                  <VTooltip bottom>
+                  <VTooltip bottom lazy>
                     <template #activator="{ on }">
                       <VChip
                         small

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserActionsDropdown.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserActionsDropdown.vue
@@ -36,7 +36,7 @@
       v-model="emailDialog"
       :query="{ ids: [userId] }"
     />
-    <VMenu offsetY>
+    <Menu>
       <template #activator="{ on }">
         <VBtn v-bind="$attrs" v-on="on">
           Actions
@@ -88,7 +88,7 @@
           </VListTile>
         </template>
       </VList>
-    </VMenu>
+    </Menu>
   </div>
 
 </template>

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
@@ -10,7 +10,7 @@
           <Checkbox v-model="selected" />
         </VFlex>
         <VFlex shrink>
-          <VTooltip v-if="user.is_admin" bottom z-index="200">
+          <VTooltip v-if="user.is_admin" bottom z-index="200" lazy>
             <template #activator="{ on }">
               <span class="px-1 py-2" v-on="on">
                 <Icon color="light-green accent-4">

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
@@ -33,11 +33,10 @@
     <td>{{ user.email }}</td>
     <td style="min-width: 175px;">
       <!-- Using VMenu instead of VEditDialog to have more control over actions -->
-      <VMenu
+      <Menu
         v-if="user.is_active"
         v-model="showStorage"
         :close-on-content-click="false"
-        offset-y
       >
         <template #activator="{ on }">
           {{ formatFileSize(user.disk_space) }}
@@ -57,7 +56,7 @@
             />
           </VCardText>
         </VCard>
-      </VMenu>
+      </Menu>
       <span v-else>Inactive</span>
     </td>
     <td>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
@@ -42,6 +42,7 @@
                 <VTooltip
                   bottom
                   :disabled="!isListItemDisabled(childNode)"
+                  lazy
                 >
                   <template #activator="{ on }">
                     <span

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
@@ -65,7 +65,7 @@
                     </span>
                   </template>
 
-                  <VTooltip v-else top>
+                  <VTooltip v-else top lazy>
                     <template #activator="{ on }">
                       <Icon class="red--text" v-on="on">
                         error

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemToolbar.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemToolbar.vue
@@ -6,7 +6,7 @@
       :key="`${action}-${idx}`"
       class="toolbar-item"
     >
-      <VTooltip top>
+      <VTooltip top lazy>
         <template #activator="{ on }">
           <VBtn
             icon

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeChangedIcon.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeChangedIcon.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span v-if="message">
-    <VTooltip bottom>
+    <VTooltip bottom lazy>
       <template #activator="{ on }">
         <Icon color="greenSuccess" small v-on="on">
           {{ showFilled ? 'lens' : 'trip_origin' }}

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute>
+  <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute lazy>
     <VCard>
       <slot>
         <ContentNodeOptions :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute lazy>
+  <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute>
     <VCard>
       <slot>
         <ContentNodeOptions :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -48,7 +48,7 @@
 
         <template #actions-end>
           <VListTileAction :aria-hidden="!active" class="action-icon px-1">
-            <Menu v-model="activated">
+            <Menu v-model="activated" lazy>
               <template #activator="{ on }">
                 <IconButton
                   icon="optionsVertical"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -48,7 +48,7 @@
 
         <template #actions-end>
           <VListTileAction :aria-hidden="!active" class="action-icon px-1">
-            <Menu v-model="activated" lazy>
+            <Menu v-model="activated">
               <template #activator="{ on }">
                 <IconButton
                   icon="optionsVertical"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -99,9 +99,7 @@
                     </span>
                     <span v-if="(isTopic && node.coach_count) || isCoach">
                       <!-- for each learning activity -->
-
-
-                      <VTooltip bottom>
+                      <VTooltip bottom lazy>
                         <template #activator="{ on }">
                           <div style="display: inline-block;" v-on="on">
                             <Icon

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
@@ -7,7 +7,7 @@
     </span>
   </span>
   <span v-else-if="error" class="mx-2">
-    <VTooltip bottom>
+    <VTooltip bottom lazy>
       <template #activator="{ on }">
         <Icon color="red" v-on="on">
           error
@@ -17,7 +17,7 @@
     </VTooltip>
   </span>
   <span v-else-if="warning" class="mx-2">
-    <VTooltip bottom>
+    <VTooltip bottom lazy>
       <template #activator="{ on }">
         <Icon color="amber" v-on="on">
           warning

--- a/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesList/RelatedResourcesList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/RelatedResourcesList/RelatedResourcesList.vue
@@ -33,7 +33,7 @@
         </VListTileContent>
 
         <VListTileAction>
-          <VTooltip bottom>
+          <VTooltip bottom lazy>
             <template #activator="{ on }">
               <VBtn
                 icon

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -104,7 +104,7 @@
           />
           <VCard v-else-if="isResource && !isExercise" class="preview-error" flat>
             <VLayout align-center justify-center fill-height>
-              <VTooltip bottom>
+              <VTooltip bottom lazy>
                 <template #activator="{ on }">
                   <Icon color="red" v-on="on">
                     error

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -67,7 +67,7 @@
                       </VBtn>
                     </VFlex>
                     <VFlex shrink class="px-1">
-                      <VTooltip :disabled="!hasTitle(node)" bottom open-delay="500">
+                      <VTooltip :disabled="!hasTitle(node)" bottom open-delay="500" lazy>
                         <template #activator="{ on }">
                           <Icon v-on="on">
                             {{ node.resource_count ? "folder" : "folder_open" }}

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -18,7 +18,7 @@
       @click:clear="$nextTick(() => removeAll())"
     >
       <template #selection="data">
-        <VTooltip bottom>
+        <VTooltip bottom lazy>
           <template #activator="{ on, attrs }">
             <VChip v-bind="attrs" close v-on="on" @input="remove(data.item.value)">
               {{ data.item.text }}

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditListItem.vue
@@ -33,7 +33,7 @@
             error
           </Icon>
         </div>
-        <VTooltip v-else-if="erroredFiles.length" top>
+        <VTooltip v-else-if="erroredFiles.length" top lazy>
           <template #activator="{ on }">
             <Icon color="red" v-on="on">
               error

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -19,7 +19,7 @@
               @click="trackTab('Details')"
             >
               {{ $tr(tabs.DETAILS) }}
-              <VTooltip v-if="!areDetailsValid || !areFilesValid" top>
+              <VTooltip v-if="!areDetailsValid || !areFilesValid" top lazy>
                 <template #activator="{ on }">
                   <Icon color="red" dark small class="ml-2" v-on="on">
                     error
@@ -37,7 +37,7 @@
               @click="trackTab('Questions')"
             >
               {{ $tr(tabs.QUESTIONS) }}
-              <VTooltip v-if="!areAssessmentItemsValid" top>
+              <VTooltip v-if="!areAssessmentItemsValid" top lazy>
                 <template #activator="{ on }">
                   <Icon color="red" dark v-on="on">
                     error

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -28,7 +28,7 @@
               {{ languageName }}
             </span>
             <span v-if="node.coach_count || isCoach">
-              <VTooltip bottom>
+              <VTooltip bottom lazy>
                 <template #activator="{ on }">
                   <div class="my-1" style="display: inline-block;" v-on="on">
                     <Icon

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -47,7 +47,7 @@
       <OfflineText indicator />
       <ProgressModal />
       <div v-if="errorsInChannel && canEdit" class="mx-1">
-        <VTooltip bottom>
+        <VTooltip bottom lazy>
           <template #activator="{ on }">
             <div class="amber--text title" style="width: max-content;" v-on="on">
               {{ $formatNumber(errorsInChannel) }}
@@ -63,7 +63,7 @@
         <span v-if="canManage && isRicecooker" class="font-weight-bold grey--text subheading">
           {{ $tr('apiGenerated') }}
         </span>
-        <VTooltip v-if="canManage" bottom attach="body">
+        <VTooltip v-if="canManage" bottom attach="body" lazy>
           <template #activator="{ on }">
             <!-- Need to wrap in div to enable tooltip when button is disabled -->
             <div style="height: 100%;" v-on="on">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -48,7 +48,7 @@
 
     <VCard v-else class="message-card" flat>
       <VLayout align-center justify-center fill-height data-test="not-supported">
-        <VTooltip bottom>
+        <VTooltip bottom lazy>
           <template #activator="{ on }">
             <Icon color="grey lighten-2" large v-on="on">
               visibility_off

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUpload.vue
@@ -23,7 +23,7 @@
         <div class="preview-wrapper">
           <VCard v-if="!primaryFileCount" flat class="mb-2 message-card">
             <VLayout align-center justify-center fill-height>
-              <VTooltip bottom>
+              <VTooltip bottom lazy>
                 <template #activator="{ on }">
                   <Icon color="red" v-on="on">
                     error

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelInvitation.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelInvitation.vue
@@ -8,7 +8,7 @@
 
       <template>
         <VListTileAction>
-          <VTooltip bottom>
+          <VTooltip bottom lazy>
             <template #activator="{ on }">
               <VBtn
                 icon
@@ -25,7 +25,7 @@
           </VTooltip>
         </VListTileAction>
         <VListTileAction>
-          <VTooltip bottom>
+          <VTooltip bottom lazy>
             <template #activator="{ on }">
               <VBtn
                 icon

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -63,7 +63,7 @@
               {{ $tr('unpublishedText') }}
             </VCardText>
           </VFlex>
-          <VTooltip bottom>
+          <VTooltip bottom lazy>
             <template #activator="{ on }">
               <Icon
                 v-if="allowEdit && hasUnpublishedChanges"

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
@@ -17,7 +17,7 @@
     @change="languageInput = ''"
   >
     <template #selection="{ item }">
-      <VTooltip bottom>
+      <VTooltip bottom lazy>
         <template #activator="{ on }">
           <VChip class="ma-1" v-on="on">
             <div class="text-truncate">
@@ -31,7 +31,7 @@
     <template #item="{ item }">
       <Checkbox :key="item.id" :input-value="value" :value="item.id" class="mt-0">
         <template #label>
-          <VTooltip bottom>
+          <VTooltip bottom lazy>
             <template #activator="{ on }">
               <div class="text-truncate" style="width: 250px;" v-on="on">
                 {{ item.name }}

--- a/contentcuration/contentcuration/frontend/shared/views/HelpTooltip.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/HelpTooltip.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VTooltip maxWidth="150px" v-bind="$attrs">
+  <VTooltip maxWidth="150px" v-bind="$attrs" lazy>
     <template #activator="{ on }">
       <Icon color="primary" :small="small" v-on="on">
         {{ icon }}

--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -25,7 +25,7 @@
     @focus="$emit('focus')"
   >
     <template #item="{ item }">
-      <VTooltip bottom>
+      <VTooltip bottom lazy>
         <template #activator="{ on }">
           <span class="text-truncate" v-on="on">{{ languageText(item) }}</span>
         </template>

--- a/contentcuration/contentcuration/frontend/shared/views/Menu.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Menu.vue
@@ -23,6 +23,10 @@
         type: Boolean,
         default: true,
       },
+      lazy: {
+        type: Boolean,
+        default: true,
+      },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },
   };

--- a/contentcuration/contentcuration/frontend/shared/views/OfflineText.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/OfflineText.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VFadeTransition v-if="offline && !libraryMode" data-test="text">
-    <VTooltip v-if="indicator" bottom z-index="300">
+    <VTooltip v-if="indicator" bottom z-index="300" lazy>
       <template #activator="{ on }">
         <div class="px-4" v-on="on">
           <Icon class="mx-2">

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -186,7 +186,7 @@
       <DetailsRow :label="$tr('licensesLabel')">
         <template #default>
           <template v-if="!printing">
-            <VTooltip v-for="license in details.licenses" :key="license" top>
+            <VTooltip v-for="license in details.licenses" :key="license" top lazy>
               <template #activator="{ on }">
                 <VChip class="tag" v-on="on">
                   {{ translateConstant(license) }}

--- a/contentcuration/contentcuration/frontend/shared/views/files/FileStatus.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/FileStatus.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <VTooltip v-if="hasErrors" top>
+    <VTooltip v-if="hasErrors" top lazy>
       <template #activator="{ on }">
         <Icon color="red" :large="large" v-on="on">
           error


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updated all `<VTooltip>` usages to use `lazy` setting which delays their mount to the DOM until they need to be
- Updated our `<Menu>` component to also default `lazy` setting 
- Overall, this reduced the attached DOM nodes by around 1000 nodes for a particular channel

### Manual verification steps performed
1. Open the channel edit page
2. Hover over <kbd>Publish</kbd> or any icons and verify their tooltips show
3. Right click on content nodes and ensure the context menu shows correctly
4. Click the kebab menu on content nodes and ensure those menus show correctly

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Below are screenshots of the Chrome performance monitor for the same channel on production vs locally with these changes. I left the channel open at the root to get a baseline on each. You can see there are less DOM nodes in the Elements tab.
| Production | Dev (w/o changes) | Dev (w/ changes) |
| --- | --- | --- |
| ![studio-prod](https://user-images.githubusercontent.com/819838/183108889-9d5254f2-776d-499c-b6ca-6d0de3309b2b.png) | ![Screenshot from 2022-08-05 08-27-02](https://user-images.githubusercontent.com/819838/183110015-f8ef2fda-4287-4871-ad29-c668e7ff97a5.png) | ![Screenshot from 2022-08-05 08-15-52](https://user-images.githubusercontent.com/819838/183108929-de940ecb-55a7-40eb-b317-f7cd534cf3a3.png) |

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- See manual verification steps

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
- Comparatively in development, this did reduce the JS Heap Size, but overall the Heap Size is greater than production

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
