### PR TITLE
Use individual lodash imports as lodash does not allow tree shaking.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -193,7 +193,7 @@
 <script>
 
   import { mapActions } from 'vuex';
-  import { camelCase } from 'lodash';
+  import camelCase from 'lodash/camelCase';
   import ContentNodeValidator from '../ContentNodeValidator';
   import ContentNodeChangedIcon from '../ContentNodeChangedIcon';
   import TaskProgress from '../../views/progress/TaskProgress';

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -326,7 +326,7 @@
 
   import sortBy from 'lodash/sortBy';
   import { mapActions, mapGetters } from 'vuex';
-  import { camelCase } from 'lodash';
+  import camelCase from 'lodash/camelCase';
   import { isImportedContent, importedChannelLink } from '../utils';
   import FilePreview from '../views/files/FilePreview';
   import { ContentLevel, Categories, AccessibilityCategories } from '../../shared/constants';

--- a/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
@@ -43,7 +43,7 @@
 
 <script>
 
-  import { camelCase } from 'lodash';
+  import camelCase from 'lodash/camelCase';
   import { LearningActivities } from '../constants';
   import { getLearningActivityIcon } from 'shared/vuetify/icons';
   import { metadataTranslationMixin } from 'shared/mixins';

--- a/contentcuration/contentcuration/frontend/shared/vuetify/icons.js
+++ b/contentcuration/contentcuration/frontend/shared/vuetify/icons.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import vuetifyIcons from 'vuetify/lib/components/Vuetify/mixins/icons';
-import { camelCase } from 'lodash';
+import camelCase from 'lodash/camelCase';
 import CollapseAllIcon from '../views/icons/CollapseAllIcon';
 import IndicatorIcon from '../views/icons/IndicatorIcon';
 import LightBulbIcon from '../views/icons/LightBulbIcon';


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Replaces destructured imports from lodash with imports from specific lodash submodules to prevent entire lodash code being included in the build.

Should reduce build size somewhat, and seems to reduce the memory usage growth over time of the devserver.
