### PR TITLE
Resolve remaining issues with dropdown positioning and broken help tooltips

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -16,6 +16,7 @@
         >
           <template #label>
             <span class="text-xs-left">{{ accessibilityItem.label }}</span>
+            &nbsp;
             <HelpTooltip
               :text="$tr(accessibilityItem.help)"
               bottom

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -10,6 +10,7 @@
       </VFlex>
       <VFlex
         v-else-if="selectedDuration === 'shortActivity' || selectedDuration === 'longActivity'"
+        class="activity-duration-container"
         md3
         sm3
       >
@@ -19,6 +20,8 @@
           box
           :label="$tr('minutesRequired')"
           :items="availableNumbers"
+          :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+          attach=".activity-duration-container"
         />
       </VFlex>
       <VFlex v-else md3 sm3>
@@ -192,7 +195,11 @@
   };
 
 </script>
-<style lang="scss" scoped>
+<style lang="less" scoped>
+
+  .activity-duration-container {
+    position: relative;
+  }
 
   .defaultUpload {
     margin: 0.8em;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -20,7 +20,7 @@
           box
           :label="$tr('minutesRequired')"
           :items="availableNumbers"
-          :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+          :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
           attach=".activity-duration-container"
         />
       </VFlex>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div id="app">
+  <div class="category-container">
     <VAutocomplete
       :value="selected"
       :items="categoriesList"
@@ -13,6 +13,8 @@
       multiple
       item-value="value"
       item-text="text"
+      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      attach=".category-container"
       @click:clear="$nextTick(() => removeAll())"
     >
       <template #selection="data">
@@ -39,7 +41,7 @@
       </template>
 
       <template #item="{ item }">
-        <div style="width: 100%; height: 100%" aria-hidden="true">
+        <div style="width: 100%; height: 100%">
           <VDivider v-if="!item.value.includes('.')" />
           <KCheckbox
             :checked="dropdownSelected[item.value]"
@@ -214,8 +216,16 @@
 </script>
 <style lang="less" scoped>
 
+  .category-container {
+    position: relative;
+  }
+
   /deep/ .v-list__tile {
     flex-wrap: wrap;
+  }
+
+  /deep/ div[role="listitem"]:first-child hr {
+    display: none;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -13,7 +13,7 @@
       multiple
       item-value="value"
       item-text="text"
-      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
       attach=".category-container"
       @click:clear="$nextTick(() => removeAll())"
     >
@@ -224,7 +224,7 @@
     flex-wrap: wrap;
   }
 
-  /deep/ div[role="listitem"]:first-child hr {
+  /deep/ div[role='listitem']:first-child hr {
     display: none;
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -4,7 +4,7 @@
     <!-- Layout when practice quizzes are enabled -->
     <VLayout v-if="hideCompletionDropdown" xs6 md6>
       <!-- "Completion" dropdown menu  -->
-      <VFlex xs6 md6 class="pr-2">
+      <VFlex xs6 md6 class="pr-2 completion-container">
         <VSelect
           ref="completion"
           v-model="completionDropdown"
@@ -13,6 +13,8 @@
           :label="translateMetadataString('completion')"
           :required="required"
           :rules="completionRules"
+          :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+          attach=".completion-container"
           @focus="trackClick('Completion')"
         />
       </VFlex>
@@ -58,7 +60,7 @@
     </VLayout>
 
     <VLayout row wrap>
-      <VFlex xs6 md6 class="pr-2">
+      <VFlex xs6 md6 class="pr-2 completion-duration-container">
         <VSelect
           v-if="!hideDurationDropdown"
           ref="duration"
@@ -68,6 +70,8 @@
           :label="translateMetadataString('duration')"
           :required="required"
           :rules="durationRules"
+          :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+          attach=".completion-duration-container"
           @focus="trackClick('Duration')"
         />
       </VFlex>
@@ -876,5 +880,8 @@
   };
 
 </script>
-<style lang="scss">
+<style lang="less" scoped>
+  .completion-container, .completion-duration-container {
+    position: relative;
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -4,7 +4,7 @@
     <!-- Layout when practice quizzes are enabled -->
     <VLayout v-if="hideCompletionDropdown" xs6 md6>
       <!-- "Completion" dropdown menu  -->
-      <VFlex xs6 md6 class="pr-2 completion-container">
+      <VFlex xs6 md6 class="completion-container pr-2">
         <VSelect
           ref="completion"
           v-model="completionDropdown"
@@ -13,7 +13,7 @@
           :label="translateMetadataString('completion')"
           :required="required"
           :rules="completionRules"
-          :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+          :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
           attach=".completion-container"
           @focus="trackClick('Completion')"
         />
@@ -60,7 +60,7 @@
     </VLayout>
 
     <VLayout row wrap>
-      <VFlex xs6 md6 class="pr-2 completion-duration-container">
+      <VFlex xs6 md6 class="completion-duration-container pr-2">
         <VSelect
           v-if="!hideDurationDropdown"
           ref="duration"
@@ -70,7 +70,7 @@
           :label="translateMetadataString('duration')"
           :required="required"
           :rules="durationRules"
-          :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+          :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
           attach=".completion-duration-container"
           @focus="trackClick('Duration')"
         />
@@ -881,7 +881,10 @@
 
 </script>
 <style lang="less" scoped>
-  .completion-container, .completion-duration-container {
+
+  .completion-container,
+  .completion-duration-container {
     position: relative;
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
@@ -1,17 +1,20 @@
 <template>
 
-  <VSelect
-    v-model="learningActivity"
-    :items="learningActivities"
-    box
-    chips
-    clearable
-    :label="translateMetadataString('learningActivity')"
-    multiple
-    deletableChips
-    :rules="learningActivityRules"
-    attach="#learning_activities"
-  />
+  <div class="learning-activity-container">
+    <VSelect
+      v-model="learningActivity"
+      :items="learningActivities"
+      box
+      chips
+      clearable
+      :label="translateMetadataString('learningActivity')"
+      multiple
+      deletableChips
+      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :rules="learningActivityRules"
+      :attach="$attrs.id ? `#${$attrs.id}` : '.learning-activity-container'"
+    />
+  </div>
 
 </template>
 
@@ -53,5 +56,8 @@
   };
 
 </script>
-<style lang="scss">
+<style lang="less" scoped>
+  .learning-activity-container {
+    position: relative;
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
@@ -10,7 +10,7 @@
       :label="translateMetadataString('learningActivity')"
       multiple
       deletableChips
-      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
       :rules="learningActivityRules"
       :attach="$attrs.id ? `#${$attrs.id}` : '.learning-activity-container'"
     />
@@ -57,7 +57,9 @@
 
 </script>
 <style lang="less" scoped>
+
   .learning-activity-container {
     position: relative;
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
@@ -11,7 +11,7 @@
       :label="translateMetadataString('level')"
       multiple
       deletableChips
-      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
       :attach="$attrs.id ? `#${$attrs.id}` : '.levels-container'"
     />
   </div>
@@ -74,4 +74,5 @@
   .levels-container {
     position: relative;
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
@@ -1,17 +1,20 @@
 <template>
 
-  <VSelect
-    ref="level"
-    v-model="level"
-    :items="levels"
-    box
-    chips
-    clearable
-    :label="translateMetadataString('level')"
-    multiple
-    deletableChips
-    attach="#levels"
-  />
+  <div class="levels-container">
+    <VSelect
+      ref="level"
+      v-model="level"
+      :items="levels"
+      box
+      chips
+      clearable
+      :label="translateMetadataString('level')"
+      multiple
+      deletableChips
+      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :attach="$attrs.id ? `#${$attrs.id}` : '.levels-container'"
+    />
+  </div>
 
 </template>
 
@@ -66,6 +69,9 @@
   };
 
 </script>
-<style lang="scss">
+<style lang="less" scoped>
 
+  .levels-container {
+    position: relative;
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -1,17 +1,20 @@
 <template>
 
-  <VSelect
-    ref="need"
-    v-model="need"
-    :items="resources"
-    box
-    chips
-    :label="$tr('resourcesNeededLabel')"
-    multiple
-    deletableChips
-    clearable
-    attach="#resources_needed"
-  />
+  <div class="resources-needed-container">
+    <VSelect
+      ref="need"
+      v-model="need"
+      :items="resources"
+      box
+      chips
+      :label="$tr('resourcesNeededLabel')"
+      multiple
+      deletableChips
+      clearable
+      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :attach="$attrs.id ? `#${$attrs.id}` : '.resources-needed-container'"
+    />
+  </div>
 
 </template>
 
@@ -73,5 +76,8 @@
   };
 
 </script>
-<style lang="scss">
+<style lang="less">
+  .resources-needed-container {
+    position: relative;
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -11,7 +11,7 @@
       multiple
       deletableChips
       clearable
-      :menu-props="{offsetY: true, lazy: true, zIndex: 4}"
+      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
       :attach="$attrs.id ? `#${$attrs.id}` : '.resources-needed-container'"
     />
   </div>
@@ -77,7 +77,9 @@
 
 </script>
 <style lang="less">
+
   .resources-needed-container {
     position: relative;
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/learningActivityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/learningActivityOptions.spec.js
@@ -20,10 +20,12 @@ describe('LearningActivityOptions', () => {
     expect(wrapper.isVueInstance()).toBe(true);
   });
 
-  it('number of items in the dropdown should be equal to number of items available in ', () => {
-    const wrapper = shallowMount(LearningActivityOptions);
+  it('number of items in the dropdown should be equal to number of items available in ', async () => {
+    const wrapper = makeWrapper([]);
+    await wrapper.find('.v-input__slot').trigger('click');
+
     const numberOfDropdownItems = Object.keys(LearningActivities).length;
-    const dropdownItems = wrapper.attributes()['items'].split(',').length;
+    const dropdownItems = wrapper.find('.v-list').element.children.length;
 
     expect(dropdownItems).toBe(numberOfDropdownItems);
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/levelsOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/levelsOptions.spec.js
@@ -21,10 +21,12 @@ describe('LevelsOptions', () => {
     expect(wrapper.isVueInstance()).toBe(true);
   });
 
-  it('number of items in the dropdown should be equal to number of items available in ContentLevels', () => {
-    const wrapper = shallowMount(LevelsOptions);
+  it('number of items in the dropdown should be equal to number of items available in ContentLevels', async () => {
+    const wrapper = makeWrapper([]);
+    await wrapper.find('.v-input__slot').trigger('click');
+
     const numberOfAvailableLevels = Object.keys(ContentLevels).length;
-    const dropdownItems = wrapper.attributes()['items'].split(',').length;
+    const dropdownItems = wrapper.find('.v-list').element.children.length;
 
     expect(dropdownItems).toBe(numberOfAvailableLevels);
   });

--- a/contentcuration/contentcuration/frontend/shared/views/HelpTooltip.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/HelpTooltip.vue
@@ -1,8 +1,8 @@
 <template>
 
   <VTooltip maxWidth="150px" v-bind="$attrs">
-    <template #activator>
-      <Icon color="primary" :small="small">
+    <template #activator="{ on }">
+      <Icon color="primary" :small="small" v-on="on">
         {{ icon }}
       </Icon>
     </template>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="license-container">
     <VLayout class="license-dropdown" row align-center>
       <VSelect
         ref="license"
@@ -15,10 +15,10 @@
         :readonly="readonly"
         :rules="licenseRules"
         :placeholder="placeholder"
-        menu-props="offsetY"
+        :menu-props="{offsetY: true, lazy: true, top: true, zIndex: 4}"
         class="ma-0"
         box
-        attach="#license"
+        :attach="$attrs.id ? `#${$attrs.id}` : '.license-container'"
         @focus="$emit('focus')"
       >
         <template #append-outer>
@@ -178,3 +178,9 @@
   };
 
 </script>
+
+<style lang="less" scoped>
+  .license-container {
+    position: relative;
+  }
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -15,7 +15,7 @@
         :readonly="readonly"
         :rules="licenseRules"
         :placeholder="placeholder"
-        :menu-props="{offsetY: true, lazy: true, top: true, zIndex: 4}"
+        :menu-props="{ offsetY: true, lazy: true, top: true, zIndex: 4 }"
         class="ma-0"
         box
         :attach="$attrs.id ? `#${$attrs.id}` : '.license-container'"
@@ -180,7 +180,9 @@
 </script>
 
 <style lang="less" scoped>
+
   .license-container {
     position: relative;
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VLayout grid wrap align-center>
+  <VLayout grid wrap align-center class="role-visibility-container">
     <VSelect
       ref="visibility"
       v-model="role"
@@ -12,9 +12,9 @@
       :readonly="readonly"
       :required="required"
       :rules="rules"
-      menu-props="offsetY"
+      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
       box
-      attach="#role_visibility"
+      :attach="$attrs.id ? `#${$attrs.id}` : '.role-visibility-container'"
       @focus="$emit('focus')"
     >
       <template #append-outer>
@@ -136,6 +136,10 @@
     margin-left: 5px;
     font-size: 12pt;
     vertical-align: text-top;
+  }
+
+  .role-visibility-container {
+    position: relative;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/licenseDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/licenseDropdown.spec.js
@@ -27,7 +27,8 @@ describe('licenseDropdown', () => {
   });
 
   describe('on load', () => {
-    it.each(LicensesList)('%s license option should be an option to select', license => {
+    it.each(LicensesList)('%s license option should be an option to select', async license => {
+      await wrapper.find('.v-input__slot').trigger('click');
       expect(wrapper.find('.v-list').text()).toContain(license.license_name);
     });
     it.each(LicensesList)(

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/visibilityDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/visibilityDropdown.spec.js
@@ -25,7 +25,8 @@ describe('visibilityDropdown', () => {
   });
 
   describe('on load', () => {
-    it.each(RolesArray)('all visibility options should be an option to select', role => {
+    it.each(RolesArray)('all visibility options should be an option to select', async role => {
+      await wrapper.find('.v-input__slot').trigger('click');
       expect(wrapper.find('.v-list').text()).toContain(constantStrings.$tr(role));
     });
     it.each(RolesArray)('should render according to visibility prop %s', visibility => {


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updates attachment of menus to not use ID's defined outside of the component
- Updates all edit modal menus to use parent attachment pattern, to display below the field, to not show above edit modal toolbar when scrolling, and to be lazily loaded
- Updates the license dropdown to always show above the field, because it's the last field and generally showing below would cause overflow
- Fixes broken help tooltips in the edit modal

### Manual verification steps performed
1. Open to edit a resource
2. Use any and all fields with dropdowns
3. Verify the dropdown shows below the field, except for the License field where it should show above
4. Ensure the fields still operate appropriately
5. Scroll while a dropdown is open, and ensure it remains in place relative to the field

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Since this affects nearly every field in the edit modal, I didn't take screenshots-- that would be a lot of before and after screenshots

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
Check out the changes and use the edit modal


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3467
Fixes https://github.com/learningequality/studio/issues/3381

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
