### PR TITLE
Always use the channel title for the first breadcrumb

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -5,11 +5,11 @@
     <VToolbar dense color="transparent" flat>
       <slot name="action"></slot>
       <Breadcrumbs :items="ancestors" class="mx-1 px-2 py-0">
-        <template #item="{ item, isLast }">
+        <template #item="{ item, isFirst, isLast }">
           <!-- Current item -->
           <VLayout v-if="isLast" align-center row>
             <VFlex class="font-weight-bold text-truncate" shrink :class="getTitleClass(item)">
-              {{ getTitle(item) }}
+              {{ isFirst ? currentChannel.name : getTitle(item) }}
             </VFlex>
             <Menu v-if="item.displayNodeOptions">
               <template #activator="{ on }">
@@ -23,7 +23,7 @@
             </Menu>
           </VLayout>
           <span v-else class="grey--text" :class="getTitleClass(item)">
-            {{ getTitle(item) }}
+            {{ isFirst ? currentChannel.name : getTitle(item) }}
           </span>
         </template>
       </Breadcrumbs>

--- a/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
@@ -47,6 +47,7 @@
         name="item"
         :item="item"
         :index="index"
+        :isFirst="index === 0"
         :isLast="index === breadcrumbs.length - 1"
       ></slot>
     </VBreadcrumbsItem>

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -703,7 +703,6 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
         "tags": "content_tags",
         "kind": "kind__kind",
         "thumbnail_src": retrieve_thumbail_src,
-        "title": get_title,
         "parent": "parent_id",
         "grade_levels": partial(dict_if_none, field_name="grade_levels"),
         "resource_types": partial(dict_if_none, field_name="resource_types"),

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -469,11 +469,6 @@ def retrieve_thumbail_src(item):
     return None
 
 
-def get_title(item):
-    # If it's the root, use the channel name (should be original channel name)
-    return item["title"] if item["parent_id"] else item["original_channel_name"]
-
-
 def consolidate_extra_fields(item):
     extra_fields = item.get("extra_fields")
     if item["kind"] == content_kinds.EXERCISE:


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- When changing the title of a channel, the name in the breadcrumbs wasn't updating because that was saved into the content node table of IndexedDB with the channel's original title. Instead of having that require updating in IndexedDB, I've simply removed that functionality and made the first breadcrumb always use the channel's name

### Manual verification steps performed
1. Open a channel for editing
2. Click to edit the channel details
3. Update the channel's name
4. Save the changes
5. Verify the breadcrumbs have also been updated

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3295

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
