### PR TITLE
Update browserslist to exclude IE and other low usage browsers

### DIFF
--- a/.github/workflows/deploytest.yml
+++ b/.github/workflows/deploytest.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["**.py", "requirements.txt", ".github/workflows/deploytest.yml", "**.vue", "**.js", "yarn.lock"]'
+          paths: '["**.py", "requirements.txt", ".github/workflows/deploytest.yml", "**.vue", "**.js", "yarn.lock", "package.json"]'
   build_assets:
     name: Build frontend assets
     needs: pre_job

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
   },
   "browserslist": [
     "> 1%",
-    "last 2 versions",
     "Firefox ESR"
   ]
 }


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Removes the 'last 2 versions' requirement from our browserslist

Changes our resolved supported browsers from:
```
and_chr 101
and_ff 100
and_qq 10.4
and_uc 12.12
android 101
baidu 7.12
bb 10
bb 7
chrome 101
chrome 100
edge 101
edge 100
firefox 101
firefox 100
firefox 91
ie 11
ie 10
ie_mob 11
ie_mob 10
ios_saf 15.4
ios_saf 15.2-15.3
kaios 2.5
op_mini all
op_mob 64
op_mob 12.1
opera 86
opera 85
safari 15.5
safari 15.4
samsung 16.0
samsung 15.0
```
to:
```
and_chr 101
chrome 100
chrome 99
edge 100
firefox 99
firefox 91
ios_saf 15.4
ios_saf 15.2-15.3
ios_saf 14.5-14.8
op_mini all
safari 15.4
samsung 16.0
```
