### PR TITLE
Migrate to using the Sentry browser/vue library, Stop relying on Raven.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,7 @@ esLintConfig.globals = {
   MathQuill: false,
   HandlebarsIntl: false,
   MathJax: false,
-  Sentry: false,
   jest: false,
-  Raven: false,
 };
 esLintConfig.settings['import/resolver']['webpack'] = { config: 'webpack.config.js'};
 

--- a/contentcuration/contentcuration/frontend/shared/client.js
+++ b/contentcuration/contentcuration/frontend/shared/client.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import qs from 'qs';
+import * as Sentry from '@sentry/vue';
 
 export function paramsSerializer(params) {
   // Do custom querystring stingifying to comma separate array params
@@ -83,9 +84,8 @@ client.interceptors.response.use(
       // In dev build log warnings to console for developer use
       console.warn('AJAX Request Error: ' + message); // eslint-disable-line no-console
       console.warn('Error data: ' + JSON.stringify(extraData)); // eslint-disable-line no-console
-    }
-    if (window.Raven && window.Raven.captureMessage) {
-      window.Raven.captureMessage(message, {
+    } else {
+      Sentry.captureMessage(message, {
         extra: extraData,
       });
     }

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -28,53 +28,7 @@
         {% block variables %}
         {% endblock variables %}
         {% cache 60 head_cache %}
-        <!--[if lt IE 9]>
-            <script src="{% static "js/html5shiv.js" %}"></script>
-        <![endif] -->
-        <!-- make sure configuring Sentry is one of the very first things we do in order to catch the most errors. -->
 
-        <!-- for some reason, load raven commmand doesn't actually load the raven JS library, so do so here
-             TODO: Should we install and bundle this as a dep using yarn?
-        -->
-        {%  if not debug %}
-        <script
-          src="https://browser.sentry-cdn.com/5.10.2/bundle.min.js"
-          integrity="sha384-ssBfXiBvlVC7bdA/VX03S88B5MwXQWdnpJRbUYFPgswlOBwETwTp6F3SMUNpo9M9"
-          crossorigin="anonymous">
-        </script>
-        <script>
-            // Ignore errors when CloudFlare-AlwaysOnline is in the user agent as these are errors serving
-            // the offline version and I don't think we can fix or reproduce these easily.
-            // Fix taken from here: https://github.com/getsentry/sentry-javascript/issues/617#issuecomment-227562203
-            if (window.Sentry) {
-              Sentry.init({ dsn: 'https://e4b21baeb7a044b885464d2af687fb73@sentry.io/1252819',
-                // onunhandledrejection reports just give us a dump of the Promise.reject object, and we often
-                // get another error report with more useful data anyway, so ignore these for now.
-                // They are most commonly triggered by a 500 response from an API endpoint call.
-                integrations: [new Sentry.Integrations.GlobalHandlers({ onerror: true, onunhandledrejection: false})],
-                beforeSend: function(event) {
-                  var isCloudFlare = /^(.*CloudFlare-AlwaysOnline.*)$/.test(window.navigator.userAgent);
-                  if (isCloudFlare) {
-                      return null;
-                  }
-
-                  return event;
-                },
-                // If there are errors that are known bugs in third-party libs or are clearly harmless,
-                // add them here to reduce sentry noise.
-                ignoreErrors: [
-                  // These appear to be errors in Summernote, but we have yet to reproduce. Although we get a lot
-                  // of Sentry reports with these errors, they lack a stack trace, and we also have not yet gotten
-                  // any user reports of this problem. For the moment, silence them so that they don't drown out
-                  // other errors. We may wish to remove these once we resolve the other errors.
-                  'IndexSizeError: Failed to execute \'setStart\' on \'Range\'',
-                  'IndexSizeError: Failed to execute \'setEnd\' on \'Range\'',
-                  'IndexSizeError: Index or size is negative or greater than the allowed amount',
-                ]
-              });
-            }
-        </script>
-        {% endif %}
         <link rel="shortcut icon" href="{% static 'img/logo.ico' %}">
 
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "homepage": "https://github.com/learningequality/studio#readme",
   "dependencies": {
-    "@sentry/vue": "^7.9.0",
+    "@sentry/vue": "^7.11.1",
     "@toast-ui/editor": "^2.3.1",
     "ajv": "^8.9.0",
     "axios": "^0.21.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "homepage": "https://github.com/learningequality/studio#readme",
   "dependencies": {
-    "@sentry/browser": "^7.9.0",
+    "@sentry/vue": "^7.9.0",
     "@toast-ui/editor": "^2.3.1",
     "ajv": "^8.9.0",
     "axios": "^0.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,63 +1600,63 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sentry/browser@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.9.0.tgz#eb9aeebfd5fb758e484ebdc6ab420a2a620219bb"
-  integrity sha512-R0/EatdSBPZ+orsD5Mu/Gq8XmEfr/KCzJv05S35GVPDkIgczIJ2AYlHgchnEO0m63jDFyWLzUteQmPZ3pao9PQ==
+"@sentry/browser@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.11.1.tgz#377d417e833ef54c78a93ef720a742bda5022625"
+  integrity sha512-k2XHuzPfnm8VJPK5eWd1+Y5VCgN42sLveb8Qxc3prb5PSL416NWMLZaoB7RMIhy430fKrSFiosnm6QDk2M6pbA==
   dependencies:
-    "@sentry/core" "7.9.0"
-    "@sentry/types" "7.9.0"
-    "@sentry/utils" "7.9.0"
+    "@sentry/core" "7.11.1"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
     tslib "^1.9.3"
 
-"@sentry/core@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.9.0.tgz#fb9308e067a4b5794eb49f8bac303bb9c627b1a9"
-  integrity sha512-WVGd2hV7Clcpl7/GL8LsRr4Zk9o/7o4rZHfs1Qed5lMRNYcxiMwucC1CYILVpJqVfY+8vIRP9v9Ss9ta2VUikw==
+"@sentry/core@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.11.1.tgz#d68e796f3b6428aefd6086a1db00118df7a9a9e4"
+  integrity sha512-kaDSZ6VNuO4ZZdqUOOX6XM6x+kjo2bMnDQ3IJG51FPvVjr8lXYhXj1Ccxcot3pBYAIWPPby2+vNDOXllmXqoBA==
   dependencies:
-    "@sentry/hub" "7.9.0"
-    "@sentry/types" "7.9.0"
-    "@sentry/utils" "7.9.0"
+    "@sentry/hub" "7.11.1"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
     tslib "^1.9.3"
 
-"@sentry/hub@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.9.0.tgz#29d4c796006282a20e5f78a1bb156d8f5eacd772"
-  integrity sha512-KzPbGCB5mONgsXEzqHy6uOaOuqLnhmFmSpGg+M03J6UJnJaNM7nrNp80MhStmjLMq6whEYVE07DrMAn3+iaQdg==
+"@sentry/hub@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.11.1.tgz#1749b2b102ea1892ff388d65d66d3b402b393958"
+  integrity sha512-M6ClgdXdptS0lUBKB5KpXXe2qMQhsoiEN2pEGRI6+auqhfHCUQB1ZXsfjiOYexKC9fwx7TyFyZ9Jcaf2DTxEhw==
   dependencies:
-    "@sentry/types" "7.9.0"
-    "@sentry/utils" "7.9.0"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
     tslib "^1.9.3"
 
-"@sentry/types@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.9.0.tgz#8fa952865fda76f7c7c7fc6c84043979a22043ae"
-  integrity sha512-VGnUgELVMpGJCYW1triO+5XSyaPjB2Zu6esUgbb8iJ5bi+OWtxklixXgwhdaTb0FDzmRL/T/pckmrIuBTLySHQ==
+"@sentry/types@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.11.1.tgz#06e2827f6ba37159c33644208a0453b86d25e232"
+  integrity sha512-gIEhOPxC2cjrxQ0+K2SFJ1P6e/an5osSxVc9OOtekN28eHtVsXFCLB8XVWeNQnS7N2VkrVrkqORMBz1kvIcvVQ==
 
-"@sentry/utils@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.9.0.tgz#497c41efe1b32974208ca68570e42c853b874f77"
-  integrity sha512-4f9TZvAVopgG7Lp1TcPSekSX1Ashk68Et4T8Y+60EVX5se19i0hpytbHWWwrXSrb3w0KpGANk0byoZkdaTgkYA==
+"@sentry/utils@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.11.1.tgz#1635c5b223369d9428bc83c9b8908c9c3287ee10"
+  integrity sha512-tRVXNT5O9ilkV31pyHeTqA1PcPQfMV/2OR6yUYM4ah+QVISovC0f0ybhByuH5nYg6x/Gsnx1o7pc8L1GE3+O7A==
   dependencies:
-    "@sentry/types" "7.9.0"
+    "@sentry/types" "7.11.1"
+    tslib "^1.9.3"
+
+"@sentry/vue@^7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-7.11.1.tgz#dc3a1d4868a3400222053465dac154a9e30aedce"
+  integrity sha512-4RiaMbvGITpKpnzJBixCR874HjYCmK11yt9YRt/rwXE185TKCVyq54h+57l3680WgNz4MU9oI+PF6C/1E/LfXg==
+  dependencies:
+    "@sentry/browser" "7.11.1"
+    "@sentry/core" "7.11.1"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
     tslib "^1.9.3"
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.28"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.28.tgz#15aa0b416f82c268b1573ab653e4413c965fe794"
   integrity sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==
-
-"@sentry/vue@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-7.9.0.tgz#63752b08ef6e3313f0828080641f6df0b9ceef61"
-  integrity sha512-oHTNc31xfOqxASEQXzZ9LxN2cbKlhQNuaLQZEG4W/3mEWwJM/TLwd/0pWQPUmUQDuQlxTb56hEqCbaCPNTOPqw==
-  dependencies:
-    "@sentry/browser" "7.9.0"
-    "@sentry/core" "7.9.0"
-    "@sentry/types" "7.9.0"
-    "@sentry/utils" "7.9.0"
-    tslib "^1.9.3"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,7 +1600,7 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sentry/browser@^7.9.0":
+"@sentry/browser@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.9.0.tgz#eb9aeebfd5fb758e484ebdc6ab420a2a620219bb"
   integrity sha512-R0/EatdSBPZ+orsD5Mu/Gq8XmEfr/KCzJv05S35GVPDkIgczIJ2AYlHgchnEO0m63jDFyWLzUteQmPZ3pao9PQ==
@@ -1646,6 +1646,17 @@
   version "0.24.28"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.28.tgz#15aa0b416f82c268b1573ab653e4413c965fe794"
   integrity sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==
+
+"@sentry/vue@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-7.9.0.tgz#63752b08ef6e3313f0828080641f6df0b9ceef61"
+  integrity sha512-oHTNc31xfOqxASEQXzZ9LxN2cbKlhQNuaLQZEG4W/3mEWwJM/TLwd/0pWQPUmUQDuQlxTb56hEqCbaCPNTOPqw==
+  dependencies:
+    "@sentry/browser" "7.9.0"
+    "@sentry/core" "7.9.0"
+    "@sentry/types" "7.9.0"
+    "@sentry/utils" "7.9.0"
+    tslib "^1.9.3"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* In spite of commit comments to the contrary, we had never stopped using the long deprecated Raven sentry frontend integration
* Migrates Studio to use the `@sentry/vue` integration to better capture frontend errors
* Follows standard integration steps, but only in production builds

## References
Fixes #3497
