### PR TITLE
Update duration to check for second value in files array

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -6,7 +6,7 @@
         v-if="audioVideoUpload && selectedDuration === 'exactTime'"
         class="defaultUpload md2 sm3"
       >
-        {{ convertToHHMMSS(defaultUploadTime) }}
+        {{ convertToHHMMSS(duration || `00:00`) }}
       </VFlex>
       <VFlex
         v-else-if="selectedDuration === 'shortActivity' || selectedDuration === 'longActivity'"
@@ -91,11 +91,6 @@
         type: Number,
         default: null,
       },
-    },
-    data() {
-      return {
-        defaultUploadTime: this.duration || `17:12`,
-      };
     },
     computed: {
       showRequiredLabel() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -642,18 +642,13 @@
         return (this.firstNode && this.getContentNodeFiles(this.firstNode.id)) || [];
       },
       fileDuration() {
-        let audioVideoFiles;
-        if (this.firstNode.kind === 'audio' || this.firstNode.kind === 'video') {
-          audioVideoFiles = this.nodeFiles.filter(
-            file => file.file_format === 'mp4' || file.file_format === 'mp3'
-          );
-          if (audioVideoFiles && audioVideoFiles[1]) {
-            return audioVideoFiles[1].duration;
-          } else if (audioVideoFiles && audioVideoFiles[0]) {
-            return audioVideoFiles[0].duration;
-          } else {
-            return null;
-          }
+        if (
+          this.firstNode.kind === ContentKindsNames.AUDIO ||
+          this.firstNode.kind === ContentKindsNames.VIDEO
+        ) {
+          // return the last item in the array
+          const file = this.nodeFiles[this.nodeFiles.length - 1];
+          return file.duration;
         } else {
           return null;
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -642,10 +642,18 @@
         return (this.firstNode && this.getContentNodeFiles(this.firstNode.id)) || [];
       },
       fileDuration() {
+        let audioVideoFiles;
         if (this.firstNode.kind === 'audio' || this.firstNode.kind === 'video') {
-          return this.nodeFiles.filter(
+          audioVideoFiles = this.nodeFiles.filter(
             file => file.file_format === 'mp4' || file.file_format === 'mp3'
-          )[0].duration;
+          );
+          if (audioVideoFiles && audioVideoFiles[1]) {
+            return audioVideoFiles[1].duration;
+          } else if (audioVideoFiles && audioVideoFiles[0]) {
+            return audioVideoFiles[0].duration;
+          } else {
+            return null;
+          }
         } else {
           return null;
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -370,7 +370,7 @@
   import LearningActivityOptions from './LearningActivityOptions.vue';
   import CategoryOptions from './CategoryOptions.vue';
   import CompletionOptions from './CompletionOptions.vue';
-
+  import FormatPresetsMap, { FormatPresetsNames } from 'shared/leUtils/FormatPresets';
   import {
     getTitleValidators,
     getCopyrightHolderValidators,
@@ -646,8 +646,12 @@
           this.firstNode.kind === ContentKindsNames.AUDIO ||
           this.firstNode.kind === ContentKindsNames.VIDEO
         ) {
+          // filter for the correct file types,
+          // to exclude files such as subtitle or cc
+          let audioVideoFiles;
+          audioVideoFiles = this.nodeFiles.filter(file => this.allowedFileType(file));
           // return the last item in the array
-          const file = this.nodeFiles[this.nodeFiles.length - 1];
+          const file = audioVideoFiles[audioVideoFiles.length - 1];
           return file.duration;
         } else {
           return null;
@@ -736,6 +740,17 @@
       },
       isUnique(value) {
         return value !== nonUniqueValue;
+      },
+      allowedFileType(file) {
+        let allowedFileTypes = [];
+        // add the relevant format presets for audio and video
+        // high res and low res are currently the same, so only one is included
+        allowedFileTypes.push(
+          FormatPresetsMap.get(FormatPresetsNames.HIGH_RES_VIDEO).allowed_formats
+        );
+        allowedFileTypes.push(FormatPresetsMap.get(FormatPresetsNames.AUDIO).allowed_formats);
+        allowedFileTypes = allowedFileTypes.flat();
+        return allowedFileTypes.includes(file.file_format);
       },
       getValueFromNodes(key) {
         const results = uniq(

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/activityDuration.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/activityDuration.spec.js
@@ -16,33 +16,6 @@ describe('ActivityDuration', () => {
     const shortActivityMax = 30;
     const longActivityMin = 31;
     const longActivityMax = 120;
-    describe(`default state for audio/video resources`, () => {
-      it(`should display a static upload time when 'Exact time to complete' for audio/video resources as initial state`, () => {
-        const defaultValue = '17:12';
-        const wrapper = shallowMount(ActivityDuration);
-        expect(wrapper.vm.defaultUploadTime).toEqual(defaultValue);
-      });
-      it(`should display the file's time at upload when 'Exact time to complete' is chosen in Completion dropdown`, () => {
-        // TODO: defaultValue will need to be changed when file-upload-duration is implemented
-        const defaultValue = '17:12';
-        const wrapper = shallowMount(ActivityDuration, {
-          propsData: { duration: 123 },
-        });
-        expect(wrapper.props('duration')).toEqual(123);
-        expect(wrapper.vm.defaultUploadTime).not.toEqual(defaultValue);
-        expect(wrapper.vm.defaultUploadTime).toEqual(123);
-      });
-      it(`should display a "stand-in" at upload if file's time at upload is not available when 'Exact time to complete' is chosen in Completion dropdown`, () => {
-        // TODO: defaultValue will need to be changed when file-upload-duration is implemented
-        const defaultValue = '17:12';
-        const wrapper = shallowMount(ActivityDuration, {
-          propsData: { duration: null },
-        });
-        expect(wrapper.props('duration')).toEqual(null);
-        expect(wrapper.vm.defaultUploadTime).toEqual(defaultValue);
-        expect(wrapper.vm.defaultUploadTime).not.toEqual(null);
-      });
-    });
 
     describe(`convert seconds to minutes for display`, () => {
       it(`should display the seconds passed down from parent as minutes`, () => {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This updates the duration value to check for both values in the potential array (high and low resolution video), and uses the prop rather than a data calculation.

Fixes #3472

### Manual verification steps performed
1. Upload a video 
2. Ensure the duration is correctly displaying
3. Click on the file name to change the video file
4. select a different file of a different length 
5. Check to ensure that the new correct duration is now reflected

### Screenshots (if applicable)

https://user-images.githubusercontent.com/17235236/183918564-329751a6-6bb4-4740-8a29-2323761a565a.mp4


### Does this introduce any tech-debt items?
Not that I am aware of
___
## Reviewer guidance
### How can a reviewer test these changes?
You can follow the manual QA steps listed above


### Are there any risky areas that deserve extra testing?
There was one scenario that seemed a bit wonky, but I haven't be able to reproduce consistently. 
1. Video file that is the same for both high and low resolution options 
2. Replace the high resolution file following the steps above
3. The low resolution sometimes is still the other video file, and sometimes the duration still matches this. Other times, when the file is changed, the "low resolution" option from the _old_ file seems to be automatically deleted. 


## Comments
It's possible there might be edge cases I'm not thinking of, of why this solution wouldn't be a good idea? 

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
