### PR TITLE
Raise FileNotFoundError when file cannot be found on GCS.

### DIFF
--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -58,6 +58,9 @@ class GoogleCloudStorage(Storage):
         else:
             blob = blob_object
 
+        if blob is None:
+            raise FileNotFoundError("{} not found".format(name))
+
         fobj = tempfile.NamedTemporaryFile()
         blob.download_to_file(fobj)
         # flush it to disk


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Fixes [#3473](https://github.com/learningequality/studio/issues/3473)

Does this by raising `FileNotFoundError` from our GCS backend, rather than throwing an `AttributeError` because the GCS client library returned `None`.