### PR TITLE
Limit push builds to unstable, hotfixes, and master.

### DIFF
--- a/.github/workflows/deploytest.yml
+++ b/.github/workflows/deploytest.yml
@@ -1,6 +1,12 @@
 name: Build and deploy tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - unstable
+    - hotfixes
+    - master
+  pull_request:
 
 jobs:
   pre_job:

--- a/.github/workflows/frontendlint.yml
+++ b/.github/workflows/frontendlint.yml
@@ -1,6 +1,12 @@
 name: Javascript Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - unstable
+    - hotfixes
+    - master
+  pull_request:
 
 jobs:
   pre_job:

--- a/.github/workflows/frontendtest.yml
+++ b/.github/workflows/frontendtest.yml
@@ -1,6 +1,12 @@
 name: Javascript Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - unstable
+    - hotfixes
+    - master
+  pull_request:
 
 jobs:
   pre_job:

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -1,6 +1,12 @@
 name: Python tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - unstable
+    - hotfixes
+    - master
+  pull_request:
 
 jobs:
   pre_job:


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Limits the branches that get CI builds run to only our canonical branches.
Does this to prevent double builds of feature and dependabot branches on the main repo.