### PR TITLE
Fix for `grpcio` dependencies for Apple M1 computers in `readme`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ pip install -r requirements-dev.txt
 # Set up pre-commit hooks
 pre-commit install
 ```
+#### A note about dependencies on Apple Silicon M1
+If you run into an error with `pip install` related to the `grcpio` package, it is because it currently [does not support M1 with the version for `grcpio` Studio uses](https://github.com/grpc/grpc/issues/25082). In order to fix it, you will need to add the following environmental variables before running `pip install`:
+
+```
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
+export CFLAGS="-I/opt/homebrew/opt/openssl/include"
+export LDFLAGS="-L/opt/homebrew/opt/openssl/lib"
+```
 
 #### Adding or updating dependencies
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Update readme to include instructions for Apple Silicon M1 computers.
___
## Reviewer guidance
### How can a reviewer test these changes?
Make sure to update user docs if necessary.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?

----
### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md