### PR TITLE
Add 'new' to Intl.ListFormat

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -580,7 +580,7 @@
       },
       metadataListText(ids) {
         const list = ids.map(i => this.translateMetadataString(camelCase(i)));
-        const formatter = Intl.ListFormat(window.languageCode, {
+        const formatter = new Intl.ListFormat(window.languageCode, {
           style: 'narrow',
           type: 'conjunction',
         });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
At some point (I think during linting), I dropped the `new` from 
```
const formatter = new Intl.ListFormat()
```
This caused an error when rendering any lists (reported in the accessibility criteria, but I suspect it would be anywhere multiple items can be selected). 



### Manual verification steps performed
1. Add a new item (I tried this for both .mp4 and .pdf as reported in the original issue @pcenov filed)
2. Select multiple accessibility criteria
3. Open `View Detail` - the content should display and there should be no console errors.

### Screenshots (if applicable)

<img width="1434" alt="Screen Shot 2022-08-17 at 11 00 57 AM" src="https://user-images.githubusercontent.com/17235236/185175592-c43a7431-f54e-459d-84ff-b8c7ff332e2b.png">


<img width="1434" alt="Screen Shot 2022-08-17 at 11 03 41 AM" src="https://user-images.githubusercontent.com/17235236/185175620-e5f4a403-e731-4c3c-b9bc-923ca5f4941d.png">

___
## Reviewer guidance
### How can a reviewer test these changes?
See manual verification steps above

### Are there any risky areas that deserve extra testing?
I think that we should wait to consider this "done" until the issue with the chips is resolved. While on the code side, I don't see how there would be any difference, I do think it would be good to double check and make sure there isn't anything I'm not accounting for in the lists.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
