### PR TITLE
remould frontend to remove fake task object

### DIFF
--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -102,6 +102,6 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         async_mock_return_value = mock_async_to_sync.return_value
         assert 1 == mock_async_to_sync.call_count
         async_mock_return_value.assert_called_once_with(str(self.user.id), {
-            'type': 'broadcast_changes',
+            'type': 'broadcast_errors',
             'errored': change_serialized
         })

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -3,7 +3,9 @@ import traceback
 import uuid
 from contextlib import contextmanager
 
+from asgiref.sync import async_to_sync
 from celery import states
+from channels.layers import get_channel_layer
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.http import Http404
@@ -894,24 +896,70 @@ def create_change_tracker(pk, table, channel_id, user, task_name):
     # Clean up any previous tasks specific to this in case there were failures.
     meta = json.dumps(dict(pk=pk, table=table))
     TaskResult.objects.filter(channel_id=channel_id, task_name=task_name, meta=meta).delete()
+    progress = 0
+    status = states.STARTED
+
+    channel_layer = get_channel_layer()
+    room_group_name = channel_id
 
     task_id = uuid.uuid4().hex
-    task_object = TaskResult.objects.create(
-        task_id=task_id,
-        status=states.STARTED,
-        channel_id=channel_id,
-        task_name=task_name,
-        user=user,
-        meta=meta
+
+    async_to_sync(channel_layer.group_send)(
+        str(room_group_name),
+        {
+            'type': 'broadcast_tasks',
+            'tasks': {
+                'pk': pk,
+                'table': table,
+                'task_id': task_id,
+                'task_name': task_name,
+                'traceback': None,
+                'progress': progress,
+                'channel_id': channel_id,
+                'status': status,
+            }
+        }
     )
 
     def update_progress(progress=None):
         if progress:
-            task_object.progress = progress
-            task_object.save()
+            if progress == 100:
+                async_to_sync(channel_layer.group_send)(
+                    str(room_group_name),
+                    {
+                        'type': 'broadcast_tasks',
+                        'tasks': {
+                            'pk': pk,
+                            'table': table,
+                            'task_id': task_id,
+                            'task_name': task_name,
+                            'traceback': None,
+                            'progress': progress,
+                            'channel_id': channel_id,
+                            'status': states.SUCCESS,
+                        }
+                    }
+                )
+            else:
+                async_to_sync(channel_layer.group_send)(
+                    str(room_group_name),
+                    {
+                        'type': 'broadcast_tasks',
+                        'tasks': {
+                            'pk': pk,
+                            'table': table,
+                            'task_id': task_id,
+                            'task_name': task_name,
+                            'traceback': None,
+                            'progress': progress,
+                            'channel_id': channel_id,
+                            'status': status,
+                        }
+                    }
+                )
 
     Change.create_change(
-        generate_update_event(pk, table, {TASK_ID: task_object.task_id}, channel_id=channel_id), applied=True
+        generate_update_event(pk, table, {TASK_ID: task_id}, channel_id=channel_id), applied=True
     )
 
     tracker = ProgressTracker(task_id, update_progress)
@@ -919,13 +967,27 @@ def create_change_tracker(pk, table, channel_id, user, task_name):
     try:
         yield tracker
     except Exception as e:
-        task_object.status = states.FAILURE
-        task_object.traceback = e.__traceback__
-        task_object.save()
+        status = states.FAILURE
+        traceback_str = ''.join(traceback.format_tb(e.__traceback__))
+        async_to_sync(channel_layer.group_send)(
+            str(room_group_name),
+            {
+                'type': 'broadcast_tasks',
+                'tasks': {
+                    'pk': pk,
+                    'table': table,
+                    'task_id': task_id,
+                    'task_name': task_name,
+                    'traceback': traceback_str,
+                    'progress': progress,
+                    'channel_id': channel_id,
+                    'status': status,
+                }
+            }
+        )
     finally:
-        if task_object.status == states.STARTED:
+        if status == states.SUCCESS:
             # No error reported, cleanup.
             Change.create_change(
                 generate_update_event(pk, table, {TASK_ID: None}, channel_id=channel_id), applied=True
             )
-            task_object.delete()

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -969,6 +969,7 @@ def create_change_tracker(pk, table, channel_id, user, task_name):
         )
     finally:
         if status == states.STARTED:
+            progress = 100
             async_to_sync(channel_layer.group_send)(
                 str(room_group_name),
                 {

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -140,3 +140,25 @@ class SyncConsumer(WebsocketConsumer):
         self.send(text_data=json.dumps({
             'change': change
         }))
+
+    def broadcast_errors(self, event):
+        """
+        Broadcast any errors to frontend
+        """
+        error = event['errored']
+
+        # Send message to WebSocket
+        self.send(text_data=json.dumps({
+            'errored': error
+        }))
+
+    def broadcast_tasks(self, event):
+        """
+        Broadcast tasks to frontend
+        """
+        task = event['tasks']
+
+        # Send message to WebSocket
+        self.send(text_data=json.dumps({
+            'task': task
+        }))

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -44,6 +44,15 @@ def broadcast_new_change_model(instance):
     # name of indiviual_user group
     indiviual_room_group_name = instance.user_id
 
+    if instance.created_by_id is None and instance.change_type == 2 and instance.errored is True:
+        async_to_sync(channel_layer.group_send)(
+            str(room_group_name),
+            {
+                'type': 'broadcast_errors',
+                'errored': serialized_change_object
+            }
+        )
+
     if instance.created_by_id is None:
         try:
             raise NoneCreatedByIdError(instance)
@@ -57,7 +66,7 @@ def broadcast_new_change_model(instance):
         async_to_sync(channel_layer.group_send)(
             str(instance.created_by_id),
             {
-                'type': 'broadcast_changes',
+                'type': 'broadcast_errors',
                 'errored': serialized_change_object
             }
         )


### PR DESCRIPTION
## Summary
This PR implements the broadcasting of tasks using WebSockets. It removes the existing mechanism which involved fake task object that was being created. Now the task status is directly being broadcasted at the time of update and added to the TASK table of the frontend.

### Description of the change(s) you made
- Direct broadcasting of Task progress
- Delegated consumer functions for error, task, and change broadcasting.

## Reviewer guidance
### How can a reviewer test these changes?
Manually it can be checked by publishing a channel!

## Comments
contentcuration/contentcuration/tests/test_asynctask.py tests are failing with ```celery.exceptions.TimeoutError: The operation timed out``` error.

----

### Contributor's Checklist


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
