### PR TITLE
Ignore any imports of vuetify src style files to defer to our vendored css

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,8 @@ const WebpackRTLPlugin = require('kolibri-tools/lib/webpackRtlPlugin');
 
 const { InjectManifest } = require('workbox-webpack-plugin');
 
+const webpack = require('webpack');
+
 const djangoProjectDir = path.resolve('contentcuration');
 const staticFilesDir = path.resolve(djangoProjectDir, 'contentcuration', 'static');
 const srcDir = path.resolve(djangoProjectDir, 'contentcuration', 'frontend');
@@ -88,6 +90,9 @@ module.exports = (env = {}) => {
       modules: [rootNodeModules],
     },
     plugins: [
+      new webpack.IgnorePlugin({
+        resourceRegExp: /vuetify\/src\/stylus\//,
+      }),
       new BundleTracker({
         filename: path.resolve(djangoProjectDir, 'build', 'webpack-stats.json'),
       }),


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes regression from the removal of vuetify-loader whereby source styles for Vuetify were now being imported, clashing with our vendored and excluded vuetify.css
* Adds a webpack ignore plugin to ignore these imports
* Fixes RTL issues


### Manual verification steps performed
1. Switch to Arabic.
2. Confirm RTL works

### Screenshots (if applicable)
![Screenshot from 2022-08-22 17-43-34](https://user-images.githubusercontent.com/1680573/186044235-ce244fa0-5371-4d20-b0bf-23ca522cdae0.png)

## References
Fixes [#3499](https://github.com/learningequality/studio/issues/3499)
