### PR TITLE
Remove unused pycountry dependency.

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -17,7 +17,6 @@ import sys
 from datetime import timedelta
 from tempfile import gettempdir
 
-import pycountry
 from django.utils.timezone import now
 
 from contentcuration.utils.incidents import INCIDENTS
@@ -276,7 +275,6 @@ USE_TZ = True
 
 LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'locale'),
-    pycountry.LOCALES_DIR,
 )
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,6 @@ jsonfield==3.1.0
 newrelic>=2.86.3.70
 celery==5.2.7
 redis
-pycountry==22.3.5
 pathlib
 progressbar2==3.55.0
 python-postmark==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -203,8 +203,6 @@ pyasn1-modules==0.2.8
     # via
     #   google-auth
     #   oauth2client
-pycountry==22.3.5
-    # via -r requirements.in
 pycparser==2.20
     # via cffi
 pyparsing==2.4.7


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* We were adding pycountry to our locale paths
* A quick grep of the code base showed no usage of ` _(...)` `gettext` that would require strings that don't already exist in Django or are our own internal strings.

### Manual verification steps performed
Check that the server still runs fine.
Check that all language names are properly translated in the frontend language changing interfaces.