### PR TITLE
Remove deprecated Raven pip dependency.

### DIFF
--- a/contentcuration/contentcuration/views/zip.py
+++ b/contentcuration/contentcuration/views/zip.py
@@ -19,7 +19,7 @@ from django.utils.http import http_date
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic.base import View
 from le_utils.constants import exercises
-from raven.contrib.django.raven_compat.models import client
+from sentry_sdk import capture_message
 from webpack_loader.utils import get_files
 
 from contentcuration.models import generate_object_storage_name
@@ -112,7 +112,7 @@ class ZipContentView(View):
         return response
 
     @xframe_options_exempt  # noqa
-    def get(self, request, zipped_filename, embedded_filepath):
+    def get(self, request, zipped_filename, embedded_filepath):  # noqa: C901
         """
         Handles GET requests and serves a static file from within the zip file.
         """
@@ -174,7 +174,7 @@ class ZipContentView(View):
                     file_size = len(content_with_path)
         except zipfile.BadZipfile:
             just_downloaded = getattr(zf_obj, 'just_downloaded', "Unknown (Most likely local file)")
-            client.captureMessage("Unable to open zip file. File info: name={}, size={}, mode={}, just_downloaded={}".format(
+            capture_message("Unable to open zip file. File info: name={}, size={}, mode={}, just_downloaded={}".format(
                 zf_obj.name, zf_obj.size, zf_obj.mode, just_downloaded))
             return HttpResponseServerError(
                 "Attempt to open zip file failed. Please try again, and if you continue to receive this message, please check that the zip file is valid."

--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,6 @@ django-redis
 django-prometheus
 future
 sentry-sdk
-raven
 django-bulk-update
 html5lib==1.1
 pillow==9.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -227,8 +227,6 @@ pytz==2022.1
     #   django
     #   django-postmark
     #   google-api-core
-raven==6.10.0
-    # via -r requirements.in
 redis==3.5.3
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Removes the Python Raven dependency that was still being used, in favour of the sentry_sdk.

### Manual verification steps performed
I followed the migration guide here: https://docs.sentry.io/platforms/python/migration/