### PR TITLE
Update reference selection for duration for audioVideo resources

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -4,7 +4,7 @@
     <!-- Layout when practice quizzes are enabled -->
     <VLayout v-if="hideCompletionDropdown" xs6 md6>
       <!-- "Completion" dropdown menu  -->
-      <VFlex xs6 md6 class="completion-container pr-2">
+      <VFlex v-if="!audioVideoResource" xs6 md6 class="completion-container pr-2">
         <VSelect
           ref="completion"
           v-model="completionDropdown"
@@ -201,10 +201,11 @@
             return true;
           }
           return (
-            this.currentCompletionDropdown === CompletionDropdownMap.reference ||
+            (this.currentCompletionDropdown === CompletionDropdownMap.reference &&
+              !this.audioVideoResource) ||
             (this.value.model === CompletionCriteriaModels.REFERENCE &&
               !this.currentCompletionDropdown &&
-              this.audioVideoResource) ||
+              !this.audioVideoResource) ||
             //should be hidden if model is reference and we're getting this from the BE
             this.currentCompletionDropdown === CompletionDropdownMap.determinedByResource
           );
@@ -764,9 +765,8 @@
        */
       selectableDurationOptions() {
         if (
-          (this.kind === ContentKindsNames.DOCUMENT &&
-            this.currentCompletionDropdown === CompletionDropdownMap.completeDuration) ||
-          this.audioVideoResource
+          this.kind === ContentKindsNames.DOCUMENT &&
+          this.currentCompletionDropdown === CompletionDropdownMap.completeDuration
         ) {
           return this.allPossibleDurationOptions.map(model => ({
             value: model.id,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
@@ -202,7 +202,7 @@ describe('CompletionOptions', () => {
         });
       });
       describe(`audio/video`, () => {
-        it(`'Duration dropdown' is not visible and reference hint is visible when 'Reference' is selected`, () => {
+        it(`'Completion dropdown' is not visible and reference hint is visible when 'Reference' is selected`, () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
               kind: 'audio',
@@ -210,7 +210,7 @@ describe('CompletionOptions', () => {
             },
           });
           expect(wrapper.vm.showReferenceHint).toBe(true);
-          expect(wrapper.find({ ref: 'duration' }).exists()).toBe(false);
+          expect(wrapper.find({ ref: 'completion' }).exists()).toBe(false);
         });
       });
       describe(`exercise`, () => {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR makes a slight adjustment to how audio and video completion duration is handled. 

Per the spec, all four options should be available and selectable in the "duration" dropdown, and the "completion" dropdown should be hidden, with the values set in the background.
<img width="242" alt="Screen Shot 2022-08-25 at 4 28 33 PM" src="https://user-images.githubusercontent.com/17235236/186762649-f307fe37-2ab9-4240-b705-56167441c906.png">

Fixes #3527 

### Manual verification steps performed

1. Add a video file
2. See no completion dropdown
3. See "duration" dropdown with 4 selectable options
4. All 4 options, including reference, work

### Screenshots (if applicable)

https://user-images.githubusercontent.com/17235236/186763834-c9bd87cd-6e9b-4c0c-8c2f-7ca152dcd508.mp4



## Reviewer guidance
### How can a reviewer test these changes?
Please see the testing steps above. This can be done with audio and video files


### Are there any risky areas that deserve extra testing?
With manual QA, I went through other file types, and I don't believe I've caused any regressions, but I'm less familiar with the data structure than the front end, and it's possible my understanding missed some things or made assumptions about combinations that can happen that aren't always true, which could potentially result in a combination that doesn't save correctly? (I know from talking to Sairina that there are many permutations here...)


### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
