### PR TITLE
Cleanup stale files

### DIFF
--- a/contentcuration/contentcuration/management/commands/garbage_collect.py
+++ b/contentcuration/contentcuration/management/commands/garbage_collect.py
@@ -11,6 +11,7 @@ from django.core.management.base import BaseCommand
 from contentcuration.utils.garbage_collect import clean_up_contentnodes
 from contentcuration.utils.garbage_collect import clean_up_deleted_chefs
 from contentcuration.utils.garbage_collect import clean_up_feature_flags
+from contentcuration.utils.garbage_collect import clean_up_stale_files
 from contentcuration.utils.garbage_collect import clean_up_tasks
 
 
@@ -33,5 +34,7 @@ class Command(BaseCommand):
         clean_up_deleted_chefs()
         logging.info("Cleaning up feature flags")
         clean_up_feature_flags()
+        logging.info("Cleaning up stale file objects")
+        clean_up_stale_files()
         logging.info("Cleaning up tasks")
         clean_up_tasks()

--- a/contentcuration/contentcuration/tests/test_decorators.py
+++ b/contentcuration/contentcuration/tests/test_decorators.py
@@ -1,11 +1,11 @@
 import mock
 
+from contentcuration.decorators import delay_user_storage_calculation
 from contentcuration.tests.base import StudioTestCase
 from contentcuration.utils.user import calculate_user_storage
-from contentcuration.utils.user import delay_user_storage_calculation
 
 
-class UserUtilsTestCase(StudioTestCase):
+class DecoratorsTestCase(StudioTestCase):
     @mock.patch("contentcuration.utils.user.calculate_user_storage_task")
     def test_delay_storage_calculation(self, mock_task):
         @delay_user_storage_calculation

--- a/contentcuration/contentcuration/utils/garbage_collect.py
+++ b/contentcuration/contentcuration/utils/garbage_collect.py
@@ -18,11 +18,11 @@ from le_utils.constants import content_kinds
 
 from contentcuration.constants import feature_flags
 from contentcuration.db.models.functions import JSONObjectKeys
+from contentcuration.decorators import delay_user_storage_calculation
 from contentcuration.models import ContentNode
 from contentcuration.models import File
 from contentcuration.models import TaskResult
 from contentcuration.models import User
-from contentcuration.utils.user import delay_user_storage_calculation
 
 
 class DisablePostDeleteSignal(object):

--- a/contentcuration/contentcuration/utils/garbage_collect.py
+++ b/contentcuration/contentcuration/utils/garbage_collect.py
@@ -7,7 +7,9 @@ import logging
 
 from celery import states
 from django.conf import settings
+from django.db.models import OuterRef
 from django.db.models.expressions import CombinedExpression
+from django.db.models.expressions import Exists
 from django.db.models.expressions import F
 from django.db.models.expressions import Value
 from django.db.models.signals import post_delete
@@ -20,6 +22,7 @@ from contentcuration.models import ContentNode
 from contentcuration.models import File
 from contentcuration.models import TaskResult
 from contentcuration.models import User
+from contentcuration.utils.user import delay_user_storage_calculation
 
 
 class DisablePostDeleteSignal(object):
@@ -145,3 +148,20 @@ def clean_up_tasks():
         count, _ = TaskResult.objects.filter(date_done__lt=date_cutoff, status__in=states.READY_STATES).delete()
 
     logging.info("Deleted {} completed task(s) from the task table".format(count))
+
+
+@delay_user_storage_calculation
+def clean_up_stale_files(last_modified=now() - datetime.timedelta(days=30)):
+    """
+    Clean up files that aren't attached to any ContentNode, AssessmentItem, or SlideshowSlide and where
+    the modified date is older than `last_modified`
+    """
+
+    files_to_clean_up = File.objects.filter(
+        contentnode__isnull=True, assessment_item__isnull=True, slideshow_slide__isnull=True, modified__lt=last_modified
+    )
+
+    # Uses a subset of Python’s array-slicing syntax to limit deletion to 100000 files per function run
+    files_deleted, _ = File.objects.filter(Exists(files_to_clean_up.filter(pk=OuterRef('pk'))[:100000])).delete()
+
+    logging.info("Files with a modified date older than {} should be deleted. Deleted {} file(s).".format(last_modified, files_deleted))

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -40,6 +40,7 @@ from past.builtins import basestring
 from past.utils import old_div
 
 from contentcuration import models as ccmodels
+from contentcuration.decorators import delay_user_storage_calculation
 from contentcuration.statistics import record_publish_stats
 from contentcuration.utils.cache import delete_public_channel_cache_keys
 from contentcuration.utils.files import create_thumbnail_from_base64
@@ -47,7 +48,6 @@ from contentcuration.utils.files import get_thumbnail_encoding
 from contentcuration.utils.parser import extract_value
 from contentcuration.utils.parser import load_json_string
 from contentcuration.utils.sentry import report_exception
-from contentcuration.utils.user import delay_user_storage_calculation
 
 
 logmodule.basicConfig()

--- a/contentcuration/contentcuration/utils/user.py
+++ b/contentcuration/contentcuration/utils/user.py
@@ -1,38 +1,12 @@
 import logging
-from contextlib import ContextDecorator
 
-
-class DelayUserStorageCalculation(ContextDecorator):
-    """
-    Decorator class that will dedupe and delay requests to enqueue storage calculation tasks for users
-    until after the wrapped function has exited
-    """
-    depth = 0
-    queue = []
-
-    @property
-    def is_active(self):
-        return self.depth > 0
-
-    def __enter__(self):
-        self.depth += 1
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.depth -= 1
-        if not self.is_active:
-            user_ids = set(self.queue)
-            self.queue = []
-            for user_id in user_ids:
-                calculate_user_storage(user_id)
-
-
-delay_user_storage_calculation = DelayUserStorageCalculation()
+from contentcuration.tasks import calculate_user_storage_task
 
 
 def calculate_user_storage(user_id):
     """TODO: Perhaps move this to User model to avoid unnecessary User lookups"""
     from contentcuration.models import User
-    from contentcuration.tasks import calculate_user_storage_task
+    from contentcuration.decorators import delay_user_storage_calculation
 
     if delay_user_storage_calculation.is_active:
         delay_user_storage_calculation.queue.append(user_id)

--- a/contentcuration/contentcuration/utils/user.py
+++ b/contentcuration/contentcuration/utils/user.py
@@ -1,8 +1,6 @@
 import logging
 from contextlib import ContextDecorator
 
-from contentcuration.tasks import calculate_user_storage_task
-
 
 class DelayUserStorageCalculation(ContextDecorator):
     """
@@ -34,6 +32,7 @@ delay_user_storage_calculation = DelayUserStorageCalculation()
 def calculate_user_storage(user_id):
     """TODO: Perhaps move this to User model to avoid unnecessary User lookups"""
     from contentcuration.models import User
+    from contentcuration.tasks import calculate_user_storage_task
 
     if delay_user_storage_calculation.is_active:
         delay_user_storage_calculation.queue.append(user_id)

--- a/contentcuration/contentcuration/viewsets/sync/base.py
+++ b/contentcuration/contentcuration/viewsets/sync/base.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from search.viewsets.savedsearch import SavedSearchViewSet
 
-from contentcuration.utils.user import delay_user_storage_calculation
+from contentcuration.decorators import delay_user_storage_calculation
 from contentcuration.viewsets.assessmentitem import AssessmentItemViewSet
 from contentcuration.viewsets.bookmark import BookmarkViewSet
 from contentcuration.viewsets.channel import ChannelViewSet


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This PR adds a function that cleans up File objects to the garbage collection utilities. Files with no associated ContentNode AssessementItem or SlideShow will be deleted, as well as files that have not been modified since the date specified (defaults to one month ago if no date is given).

The garbage collect management command is updated to run this function for any files not modified in the last month. This PR also includes a code clean-up of the decorators.py file. Sections deleted within this file were unused.

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
Tests for this function have been added to the test_garbage_collect.py file. Tests for the deletion of files that meet the specified requirements (no ContentNode AssessementItem or SlideShow association, and have not been modified in 1 month) and the non-deletion of files that have no ContentNode AssessementItem or SlideShow association, but have been modified more recently.

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #3533 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
