### PR TITLE
Fix CLIENTID comparison with change source

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/indexedDBPlugin/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/indexedDBPlugin/index.js
@@ -2,6 +2,9 @@ import { EventEmitter } from 'events';
 import { CHANGE_TYPES } from 'shared/data';
 import { CLIENTID } from 'shared/data/db';
 
+// In the change source, the client ID should always be in the beginning
+const clientIdRegex = new RegExp(`^${CLIENTID}`);
+
 function getEventName(table, type) {
   return `${table}/${type}`;
 }
@@ -111,7 +114,7 @@ export default function IndexedDBPlugin(db, listeners = []) {
   db.on('changes', function(changes) {
     changes.forEach(function(change) {
       // Don't invoke listeners if their client originated the change
-      if (CLIENTID !== change.source) {
+      if (!clientIdRegex.test(change.source)) {
         // Always invoke the listeners with the full object representation
         // It is up to the callbacks to know how to parse this.
         const obj = Object.assign(

--- a/contentcuration/contentcuration/frontend/shared/vuex/indexedDBPlugin/index.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/indexedDBPlugin/index.spec.js
@@ -198,6 +198,7 @@ describe('IndexedDBPlugin', function() {
     const listener5 = testListener('testTableC', CHANGE_TYPES.CREATED, 'anotherVuexNamespace');
     const listener6 = testListener('testTableC', CHANGE_TYPES.UPDATED, 'anotherVuexNamespace');
     const listener7 = testListener('testTableZ', CHANGE_TYPES.CREATED);
+    const listener8 = testListener('testTableZ', CHANGE_TYPES.CREATED);
 
     listener1.addChange();
     listener2.addChange();
@@ -206,6 +207,7 @@ describe('IndexedDBPlugin', function() {
     listener5.addChange();
     listener6.addChange();
     listener7.addChange(CLIENTID);
+    listener8.addChange(`${CLIENTID}::${uuidv4()}`);
 
     const result = IndexedDBPlugin(this.db, this.listeners);
     result(this.store);
@@ -217,6 +219,7 @@ describe('IndexedDBPlugin', function() {
     listener5.assertNotCalled();
     listener6.assertNotCalled();
     listener7.assertNotCalled();
+    listener8.assertNotCalled();
 
     this.db.events.emit('changes', this.changes);
 
@@ -227,5 +230,6 @@ describe('IndexedDBPlugin', function() {
     listener5.assertCalled();
     listener6.assertCalled();
     listener7.assertNotCalled(); // from source CLIENTID
+    listener8.assertNotCalled(); // from source /^CLIENTID/
   });
 });


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
Recent changes to the frontend change event processing caused a regression when comparing whether a change came from the same client. The existing code was comparing for equality, but a change source may now only start with the `CLIENTID`.


### Manual verification steps performed
1. Add new learning activities one by one to a resource
2. Verify that after adding each, the other selected activities are not unselected

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
The symptoms of this are exactly the same when there are multiple users editing the same channel. I've added a [follow up issue](https://github.com/learningequality/studio/issues/3587) for that
___


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3511

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
