### PR TITLE
Ensure channel ID is set on move change to trash tree

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -182,6 +182,7 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     learning_activities: {},
     categories: {},
     suggested_duration: 0,
+    channel_id: channel.id,
     ...payload,
   };
 

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1274,6 +1274,24 @@ export const ContentNode = new TreeResource({
               changed: true,
             };
 
+            let channel_id = parent.channel_id;
+
+            // This should really only happen when this is a move operation to the trash tree.
+            // Other cases like copying shouldn't encounter this because they should always have the
+            // channel_id on the destination. The trash tree root node does not have the channel_id
+            // annotated on it, and using the source node's channel_id should be reliable
+            // in that case
+            if (!channel_id && node) {
+              channel_id = node.channel_id;
+
+              // The change would be disallowed anyway, so prevent the frontend from applying it
+              if (!channel_id) {
+                return Promise.reject(
+                  new Error('Missing channel_id for tree insertion change event')
+                );
+              }
+            }
+
             // Prep the change data tracked in the changes table
             const change = {
               key: payload.id,
@@ -1284,7 +1302,7 @@ export const ContentNode = new TreeResource({
               source: CLIENTID,
               table: this.tableName,
               type: isCreate ? CHANGE_TYPES.COPIED : CHANGE_TYPES.MOVED,
-              channel_id: parent.channel_id,
+              channel_id,
             };
 
             return callback({


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
The trash tree root node doesn't have `channel_id` annotated on it, so when deleting resources which moves them to the trash tree, the corresponding change event was missing the `channel_id` since it relied on the destination node having it. This updates that logic to fallback to the source node's `channel_id`, which should only ever be the case for moving to the trash tree.

This also adds the channel ID to node creation, since as a side effect, creating a new topic/folder and then immediately trying to delete it would fail given the newly added defensive check that prevents unset `channel_id` on the change objet.


### Manual verification steps performed
1. Create a topic
2. Delete a topic
3. Ensure the deletion change is `allowed` by the sync endpoint
4. Retry the above in quick succession


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3507

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
