### PR TITLE
Add a check for new entries in the changes table to ensure swift syncing of non-Dexie observable changes.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -306,6 +306,16 @@ if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
 async function handleChanges(changes) {
   changes.map(applyResourceListener);
   const syncableChanges = changes.filter(isSyncableChange);
+  // Here we are handling changes triggered by Dexie Observable
+  // this is listening to all of our IndexedDB tables, both for resources
+  // and for our special Changes table.
+  // Here we look for any newly created changes in the changes table, which may require
+  // a sync to send them to the backend - this is particularly important for
+  // MOVE, COPY, PUBLISH, and SYNC changes where we may be executing them inside an IGNORED_SOURCE
+  // because they also make UPDATE and CREATE changes that we wish to make in the client only.
+  const newChangeTableEntries = changes.some(
+    c => c.table === CHANGES_TABLE && c.type === CHANGE_TYPES.CREATED
+  );
 
   if (syncableChanges.length) {
     // Flatten any changes before we store them in the changes table
@@ -323,7 +333,7 @@ async function handleChanges(changes) {
 
   // If we detect  changes were written to the changes table
   // then we'll trigger sync
-  if (syncableChanges.length) {
+  if (syncableChanges.length || newChangeTableEntries) {
     debouncedSyncChanges();
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -313,8 +313,9 @@ async function handleChanges(changes) {
   // a sync to send them to the backend - this is particularly important for
   // MOVE, COPY, PUBLISH, and SYNC changes where we may be executing them inside an IGNORED_SOURCE
   // because they also make UPDATE and CREATE changes that we wish to make in the client only.
+  // Only do this for changes that are not marked as synced.
   const newChangeTableEntries = changes.some(
-    c => c.table === CHANGES_TABLE && c.type === CHANGE_TYPES.CREATED
+    c => c.table === CHANGES_TABLE && c.type === CHANGE_TYPES.CREATED && !c.obj.synced
   );
 
   if (syncableChanges.length) {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Currently our `handleChanges` listener only triggers a sync when changes to our IndexedDBResource tables are made that are CREATE, UPDATE, or DELETE (the change types that Dexie Observable natively creates).
* This means that our custom change operations: MOVE, COPY, PUBLISH, and SYNC, will be ignored, until the sync endpoint polling happens.
* To remedy this, this PR implements an extra check in the handleChanges listener function to look for newly created changes in our specific changes table, so that we can trigger a sync when one of our custom changes has been created.

### Manual verification steps performed
Carried out copy and move operations and confirmed that they were included in an almost immediate sync call to the backend.

### Does this introduce any tech-debt items?
I don't think so - ultimately, I think we could drop Dexie Observable and use something closer to the Dexie middleware that it is built on top of to make a more unified solution.

## References
Fixes #3586
