### PR TITLE
Update sorting of channel items and fix erroneous use of `sortBy`

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -324,6 +324,7 @@
 
 <script>
 
+  import orderBy from 'lodash/orderBy';
   import sortBy from 'lodash/sortBy';
   import { mapActions, mapGetters } from 'vuex';
   import camelCase from 'lodash/camelCase';
@@ -468,7 +469,7 @@
         return this.translateConstant(masteryModel);
       },
       sortedTags() {
-        return sortBy(this.node.tags, '-count');
+        return orderBy(this.node.tags, ['count'], ['desc']);
       },
       license() {
         return Licenses.get(this.node.license);

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -110,6 +110,7 @@
   import debounce from 'lodash/debounce';
   import difference from 'lodash/difference';
   import isEqual from 'lodash/isEqual';
+  import sortBy from 'lodash/sortBy';
   import union from 'lodash/union';
   import { RouteNames } from '../../constants';
   import CatalogFilters from './CatalogFilters';
@@ -189,7 +190,9 @@
         return RouteNames.CATALOG_DETAILS;
       },
       channels() {
-        return this.getChannels(this.page.results);
+        // Sort again by the same ordering used on the backend - name.
+        // Have to do this because of how we are getting the object data via getChannels.
+        return sortBy(this.getChannels(this.page.results), 'name');
       },
       selectedCount() {
         return this.page.count - this.excluded.length;

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -47,7 +47,7 @@
 <script>
 
   import { mapGetters, mapActions } from 'vuex';
-  import sortBy from 'lodash/sortBy';
+  import orderBy from 'lodash/orderBy';
   import { RouteNames, CHANNEL_PAGE_SIZE } from '../../constants';
   import ChannelItem from './ChannelItem';
   import LoadingText from 'shared/views/LoadingText';
@@ -83,13 +83,16 @@
         if (!channels) {
           return [];
         }
-        const sortFields = ['-modified'];
+        const sortFields = ['modified'];
+        const orderFields = ['desc'];
         if (this.listType === ChannelListTypes.PUBLIC) {
-          sortFields.unshift('-priority');
+          sortFields.unshift('priority');
+          orderFields.unshift('desc');
         }
-        return sortBy(
+        return orderBy(
           this.channels.filter(channel => channel[this.listType] && !channel.deleted),
-          sortFields
+          sortFields,
+          orderFields
         );
       },
       isEditable() {

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -274,7 +274,7 @@
 
 <script>
 
-  import sortBy from 'lodash/sortBy';
+  import orderBy from 'lodash/orderBy';
   import DetailsRow from './DetailsRow';
   import { SCALE_TEXT, SCALE, CHANNEL_SIZE_DIVISOR } from './constants';
   import {
@@ -348,7 +348,7 @@
         });
       },
       kindCount() {
-        return sortBy(this.details.kind_count, ['-count', 'kind_id']);
+        return orderBy(this.details.kind_count, ['count', 'kind_id'], ['desc', 'asc']);
       },
       createdDate() {
         return this.$formatDate(this.details.created, {
@@ -361,7 +361,7 @@
         return Object.keys(this.details).length;
       },
       sortedTags() {
-        return sortBy(this.details.tags, '-count');
+        return orderBy(this.details.tags, ['count'], ['desc']);
       },
       includesPrintable() {
         const includes = [];


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* `sortBy` was being used under the assumption that it could be passed field names prefixed with `-` to reverse the ordering. This is not the case.
* Updates these uses of `sortBy` to use `orderBy` with an additional array of `asc`/`desc` to specify the order of sorting.
* Fixes ordering on the catalog list page as the ordering from the API is lost once items are retrieved from vuex - resorts using the `name` parameter.

### Manual verification steps performed
Checked sorting by `modified` time on My Channels page.
Checked sorting on Catalog list page.

### Screenshots (if applicable)
Update to my channels - all channels shown in descending order of last modified:
![Screenshot from 2022-08-30 15-36-07](https://user-images.githubusercontent.com/1680573/187555910-d999e02e-36c9-49e9-bd33-b5499bd15602.png)

Update to catalog list - all channels now properly sorted by name when displayed:
![Screenshot from 2022-08-30 15-35-48](https://user-images.githubusercontent.com/1680573/187555976-77c3fe46-5c9f-436c-9a87-1cf008164fc5.png)

## References
Fixes #3559
Fixes #3294