### PR TITLE
Data migration updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ filedurations:
 learningactivities:
 	python contentcuration/manage.py set_default_learning_activities
 
+hascaptions:
+	python contentcuration/manage.py set_orm_based_has_captions
+
 export COMPOSE_PROJECT_NAME=studio_$(shell git rev-parse --abbrev-ref HEAD)
 
 purge-postgres:

--- a/contentcuration/contentcuration/management/commands/set_orm_based_has_captions.py
+++ b/contentcuration/contentcuration/management/commands/set_orm_based_has_captions.py
@@ -25,26 +25,25 @@ class Command(BaseCommand):
 
         logging.info("Setting 'has captions' for video kinds")
 
+        has_captions_subquery = Exists(File.objects.filter(contentnode=OuterRef("id"), language=OuterRef("language"), preset_id=format_presets.VIDEO_SUBTITLE))
         # Only try to update video nodes which have not had any accessibility labels set on them
         # this will allow this management command to be rerun and resume from where it left off
         # and also prevent stomping previous edits to the accessibility_labels field.
-        updateable_nodes = ContentNode.objects.annotate(
-            has_captions=Exists(File.objects.filter(contentnode=OuterRef("id"), language=OuterRef("language"), preset_id=format_presets.VIDEO_SUBTITLE))
-        ).filter(kind=content_kinds.VIDEO, accessibility_labels__isnull=True, has_captions=True)
+        updateable_nodes = ContentNode.objects.filter(has_captions_subquery, kind=content_kinds.VIDEO, accessibility_labels__isnull=True)
 
-        updateable_node_slice = list(updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE])
+        updateable_node_slice = updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE]
 
         count = 0
 
-        while updateable_node_slice:
-            ContentNode.objects.filter(id__in=updateable_node_slice).update(accessibility_labels={accessibility_categories.CAPTIONS_SUBTITLES: True})
-
-            this_count = len(updateable_node_slice)
+        while updateable_nodes.exists():
+            this_count = ContentNode.objects.filter(
+                id__in=updateable_node_slice
+            ).update(accessibility_labels={accessibility_categories.CAPTIONS_SUBTITLES: True})
 
             logging.info("Set has captions metadata for {} nodes".format(this_count))
 
             count += this_count
 
-            updateable_node_slice = list(updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE])
+            updateable_node_slice = updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE]
 
         logging.info('Finished setting all has captions metadata for {} nodes in {} seconds'.format(count, time.time() - start))

--- a/contentcuration/contentcuration/management/commands/set_orm_based_has_captions.py
+++ b/contentcuration/contentcuration/management/commands/set_orm_based_has_captions.py
@@ -1,0 +1,50 @@
+import logging as logmodule
+import time
+
+from django.core.management.base import BaseCommand
+from django.db.models import Exists
+from django.db.models import OuterRef
+from le_utils.constants import content_kinds
+from le_utils.constants import format_presets
+from le_utils.constants.labels import accessibility_categories
+
+from contentcuration.models import ContentNode
+from contentcuration.models import File
+
+logmodule.basicConfig(level=logmodule.INFO)
+logging = logmodule.getLogger('command')
+
+
+CHUNKSIZE = 10000
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        start = time.time()
+
+        logging.info("Setting 'has captions' for video kinds")
+
+        # Only try to update video nodes which have not had any accessibility labels set on them
+        # this will allow this management command to be rerun and resume from where it left off
+        # and also prevent stomping previous edits to the accessibility_labels field.
+        updateable_nodes = ContentNode.objects.annotate(
+            has_captions=Exists(File.objects.filter(contentnode=OuterRef("id"), language=OuterRef("language"), preset_id=format_presets.VIDEO_SUBTITLE))
+        ).filter(kind=content_kinds.VIDEO, accessibility_labels__isnull=True, has_captions=True)
+
+        updateable_node_slice = list(updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE])
+
+        count = 0
+
+        while updateable_node_slice:
+            ContentNode.objects.filter(id__in=updateable_node_slice).update(accessibility_labels={accessibility_categories.CAPTIONS_SUBTITLES: True})
+
+            this_count = len(updateable_node_slice)
+
+            logging.info("Set has captions metadata for {} nodes".format(this_count))
+
+            count += this_count
+
+            updateable_node_slice = list(updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE])
+
+        logging.info('Finished setting all has captions metadata for {} nodes in {} seconds'.format(count, time.time() - start))


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes a remaining bug with the set file duration job whereby even with a fully streamed file, the duration cannot be inferred
* Adds a management command and make file entry to infer whether video resource nodes should have the has captions metadata applied to them, and applies it

### Manual verification steps performed
1. Ran the new management command, confirmed that it added the label for a node with subtitles that matched the language of the video.
2. Ran it again and confirmed no additional nodes were updated

### Screenshots (if applicable)
First run:
```
Setting 'has captions' for video kinds
INFO:command:Setting 'has captions' for video kinds
Set has captions metadata for 1 nodes
INFO:command:Set has captions metadata for 1 nodes
Finished setting all has captions metadata for 1 nodes in 0.044237375259399414 seconds
INFO:command:Finished setting all has captions metadata for 1 nodes in 0.044237375259399414 seconds
```
Second run:
```
Setting 'has captions' for video kinds
INFO:command:Setting 'has captions' for video kinds
Finished setting all has captions metadata for 0 nodes in 0.02699899673461914 seconds
INFO:command:Finished setting all has captions metadata for 0 nodes in 0.02699899673461914 seconds
```

## References
Fixes #3577
