### PR TITLE
Add recipe for daphne server and change nginx file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-altprodserver: NUM_PROCS:=3
-altprodserver: NUM_THREADS:=5
-altprodserver: collectstatic ensurecrowdinclient downloadmessages compilemessages
+altprodserver:
+	$(MAKE) -j 2 gunicornanddapneserver
+
+gunicornanddapneserver: gunicornserver daphneserver
+
+daphneserver:
+	cd contentcuration/ && daphne -b 0.0.0.0 -p 8082 contentcuration.asgi:application
+
+gunicornserver: NUM_PROCS:=2
+gunicornserver: NUM_THREADS:=5
+gunicornserver: collectstatic ensurecrowdinclient downloadmessages compilemessages
 	cd contentcuration/ && gunicorn contentcuration.wsgi:application --timeout=4000 --error-logfile=/var/log/gunicorn-error.log --workers=${NUM_PROCS} --threads=${NUM_THREADS} --bind=0.0.0.0:8081 --pid=/tmp/contentcuration.pid --log-level=debug || sleep infinity
+
 
 contentnodegc:
 	cd contentcuration/ && python manage.py garbage_collect

--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -24,6 +24,11 @@ http {
         server 127.0.0.1:8081;
     }
 
+    # Proxy to daphne for websocket requests
+    upstream ws_server {
+        server 127.0.0.1:8082;
+    }
+
     # Allow-list filter for content catalog paths
     server {
         listen 8080;
@@ -83,6 +88,14 @@ http {
             proxy_redirect     off;
             proxy_set_header   Host $host;
         }
+
+        location /ws/ {
+           proxy_set_header Upgrade $http_upgrade;
+           proxy_set_header Connection "upgrade";
+           proxy_redirect off;
+           proxy_pass http://ws_server;
+        }
+
 
         location /content/ {
             proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
Change nginx configuration to add daphne server. Proxy pass websocket requests to Daphne.
### Description of the change(s) you made
- Created recipe for daphne server
- Reduced NUM_PROCS to two for the daphne server.
- Configured nginx file to proxy pass to daphne server for any incoming websocket request.

