### PR TITLE
adds translated user friendly string for files with no name

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -29,6 +29,7 @@
                 v-if="fileDisplay"
                 class="notranslate"
                 :text="formattedFileDisplay"
+                data-test="file-link"
                 @click="openFileDialog"
               />
               <ActionLink

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -28,7 +28,7 @@
               <ActionLink
                 v-if="fileDisplay"
                 class="notranslate"
-                :text="fileDisplay.original_filename"
+                :text="formattedFileDisplay"
                 @click="openFileDialog"
               />
               <ActionLink
@@ -133,6 +133,13 @@
         }
         return this.file;
       },
+      formattedFileDisplay() {
+        const fileName = this.fileDisplay.original_filename;
+        if (fileName === 'file' || (fileName && !fileName.length)) {
+          return this.$tr('unknownFile');
+        }
+        return fileName;
+      },
       erroredFile() {
         if (this.fileUpload && this.fileUpload.error) {
           return this.fileUpload;
@@ -166,6 +173,7 @@
       /* eslint-disable kolibri/vue-no-unused-translations */
       retryUpload: 'Retry upload',
       uploadFailed: 'Upload failed',
+      unknownFile: 'Unknown filename',
       /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadItem.vue
@@ -136,7 +136,7 @@
       },
       formattedFileDisplay() {
         const fileName = this.fileDisplay.original_filename;
-        if (fileName === 'file' || (fileName && !fileName.length)) {
+        if (fileName === 'file' || !fileName) {
           return this.$tr('unknownFile');
         }
         return fileName;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUploadItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUploadItem.spec.js
@@ -31,8 +31,14 @@ describe('fileUploadItem', () => {
   describe('render', () => {
     it("'Unknown filename' should be displayed if original_filename is 'file'", () => {
       let file = {
-        id: 'file-1',
         original_filename: 'file',
+      };
+      let wrapper = makeWrapper({}, file);
+      expect(wrapper.find('[data-test="file-link"]').text()).toBe('Unknown filename');
+    });
+    it("'Unknown filename' should be displayed if original_filename is ''", () => {
+      let file = {
+        original_filename: '',
       };
       let wrapper = makeWrapper({}, file);
       expect(wrapper.find('[data-test="file-link"]').text()).toBe('Unknown filename');

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUploadItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/fileUploadItem.spec.js
@@ -29,6 +29,22 @@ function makeWrapper(props = {}, file = {}) {
 
 describe('fileUploadItem', () => {
   describe('render', () => {
+    it("'Unknown filename' should be displayed if original_filename is 'file'", () => {
+      let file = {
+        id: 'file-1',
+        original_filename: 'file',
+      };
+      let wrapper = makeWrapper({}, file);
+      expect(wrapper.find('[data-test="file-link"]').text()).toBe('Unknown filename');
+    });
+    it("original_filename should be displayed if its value is not 'file'", () => {
+      let file = {
+        id: 'file-1',
+        original_filename: 'SomeFileName',
+      };
+      let wrapper = makeWrapper({}, file);
+      expect(wrapper.find('[data-test="file-link"]').text()).toBe('SomeFileName');
+    });
     it('should show a status error if the file has an error', () => {
       let wrapper = makeWrapper({}, { error: true });
       expect(wrapper.find('[data-test="status"]').exists()).toBe(true);


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
This pr translates the hard coded "file" name for all file uploads with no name, particularly those uploaded via `ricecooker`. The hard coded "file" remains as is on the backend, but on the frontend it is set to a translated, meaningful string("Unknown filename") to the user.


### Manual verification steps performed
1. Select a Channel>Select a Resource>Edit
2. Any file with no name should display  "file" as its name
3. If you are unable to find a resource with a file name "file", you may want run the following commands to change all system files to the name '"file". Once done with your checks, you can always rerun the database setup command to reset the database. You might want to use an isolated database for this especially if you already have imported channels you may not want to re-import
- `cd contentcuration`
- `./manage.py shell`
- `from contentcuration.models import File`
- `File.objects.update(original_filename="file")` 

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
#### Before
Please see https://github.com/learningequality/studio/issues/3017

#### After Fix(en)
![Screenshot_2022-09-05_16-32-00](https://user-images.githubusercontent.com/5203639/188486087-9709ca21-3c11-4dee-bfbc-fa79787bb7b4.png)
#### After Fix(ar) - Arabic doesn't exist so defaults to English as shown in console
![Screenshot_2022-09-05_16-35-29](https://user-images.githubusercontent.com/5203639/188486207-339b2622-fad9-4af7-8e11-be429ae06759.png)


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
No
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
Please see **Manual verification steps performed** above


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Closes https://github.com/learningequality/studio/issues/3017

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [x] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [x] If this includes an internal dependency change, a link to the diff is provided
- [x] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [x] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [x] Opportunities for using Google Analytics here are noted
- [x] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [x] All user-facing strings are translated properly
- [x] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [x] All UI components are LTR and RTL compliant
- [x] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [x] Users' storage used is recalculated properly on any changes to main tree files
- [x] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [x] Automated test coverage is satisfactory
- [x] PR is fully functional
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependency files were updated if necessary (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Contributor is in AUTHORS.md
