### PR TITLE
Feat server sync js cleanup

### DIFF
--- a/contentcuration/contentcuration/asgi.py
+++ b/contentcuration/contentcuration/asgi.py
@@ -1,8 +1,11 @@
+import django
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter
 from channels.routing import URLRouter
 
 from contentcuration.viewsets.websockets.routing import websocket_urlpatterns
+
+django.setup(set_prefix=False)
 
 application = ProtocolTypeRouter({
     "websocket":

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1,3 +1,22 @@
+import Dexie from 'dexie';
+import Mutex from 'mutex-js';
+import findIndex from 'lodash/findIndex';
+import flatMap from 'lodash/flatMap';
+import isArray from 'lodash/isArray';
+import isFunction from 'lodash/isFunction';
+import isNumber from 'lodash/isNumber';
+import isString from 'lodash/isString';
+import matches from 'lodash/matches';
+import overEvery from 'lodash/overEvery';
+import pick from 'lodash/pick';
+import sortBy from 'lodash/sortBy';
+import uniq from 'lodash/uniq';
+import uniqBy from 'lodash/uniqBy';
+import { v4 as uuidv4 } from 'uuid';
+import mergeAllChanges from './mergeChanges';
+import db, { CLIENTID, Collection, channelScope } from './db';
+import applyChanges, { applyMods, collectChanges } from './applyRemoteChanges';
+import { API_RESOURCES, INDEXEDDB_RESOURCES } from './registry';
 import {
   ACTIVE_CHANNELS,
   CHANGES_TABLE,
@@ -11,30 +30,10 @@ import {
   TABLE_NAMES,
   TASK_ID,
 } from './constants';
-import { API_RESOURCES, INDEXEDDB_RESOURCES } from './registry';
-import { NEW_OBJECT, fileErrors } from 'shared/constants';
-import applyChanges, { applyMods, collectChanges } from './applyRemoteChanges';
-import client, { paramsSerializer } from 'shared/client';
-import db, { CLIENTID, Collection, channelScope } from './db';
-
-import Dexie from 'dexie';
-import Mutex from 'mutex-js';
-import { currentLanguage } from 'shared/i18n';
-import findIndex from 'lodash/findIndex';
-import flatMap from 'lodash/flatMap';
-import isArray from 'lodash/isArray';
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
-import matches from 'lodash/matches';
-import mergeAllChanges from './mergeChanges';
-import overEvery from 'lodash/overEvery';
-import pick from 'lodash/pick';
-import sortBy from 'lodash/sortBy';
-import uniq from 'lodash/uniq';
-import uniqBy from 'lodash/uniqBy';
 import urls from 'shared/urls';
-import { v4 as uuidv4 } from 'uuid';
+import { currentLanguage } from 'shared/i18n';
+import client, { paramsSerializer } from 'shared/client';
+import { NEW_OBJECT, fileErrors } from 'shared/constants';
 
 // Number of seconds after which data is considered stale.
 const REFRESH_INTERVAL = 5;
@@ -1808,9 +1807,9 @@ export const Clipboard = new TreeResource({
 export const Task = new IndexedDBResource({
   tableName: TABLE_NAMES.TASK,
   idField: 'task_id',
-  setTask(task) {
+  setTasks(task) {
     return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
-      return this.table.Put(task);
+      return this.table.bulkPut(task);
     });
   },
 });

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -332,7 +332,12 @@ async function syncChanges() {
         handleReturnedChanges(get(response, ['data', 'changes'], [])),
         handleErrors(get(response, ['data', 'errors'], [])),
         handleSuccesses(get(response, ['data', 'successes'], [])),
-        handleMaxRevs(get(response, ['data', 'changes'], []), user.id),
+        handleMaxRevs(
+          get(response, ['data', 'changes'], [])
+            .concat(get(response, ['data', 'errors'], []))
+            .concat(get(response, ['data', 'successes'], [])),
+          user.id
+        ),
         handleTasks(get(response, ['data', 'tasks'], [])),
       ]);
     } catch (err) {
@@ -440,10 +445,8 @@ export function startSyncing() {
     }
     if (data.change) {
       try {
-        Promise.all([
-          handleReturnedChanges([data.change]),
-          handleMaxRevs([data.change], data.change.created_by_id),
-        ]);
+        handleReturnedChanges([data.change]);
+        handleMaxRevs([data.change], data.change.created_by_id);
       } catch (err) {
         console.log(err);
       }
@@ -451,6 +454,7 @@ export function startSyncing() {
     if (data.errored) {
       try {
         handleErrors([data.errored]);
+        handleMaxRevs([data.errored], data.errored.created_by_id);
       } catch (err) {
         console.log(err);
       }
@@ -458,6 +462,7 @@ export function startSyncing() {
     if (data.success) {
       try {
         handleSuccesses([data.success]);
+        handleMaxRevs([data.success], data.success.created_by_id);
       } catch (err) {
         console.log(err);
       }

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -22,7 +22,7 @@ import urls from 'shared/urls';
 
 // When this many seconds pass without a syncable
 // change being registered, sync changes!
-const SYNC_IF_NO_CHANGES_FOR = 2;
+const SYNC_IF_NO_CHANGES_FOR = 0.5;
 
 let socket;
 // Flag to check if a sync is currently active.

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -1,3 +1,15 @@
+import debounce from 'lodash/debounce';
+// import { event } from 'jquery';
+import findLastIndex from 'lodash/findLastIndex';
+import get from 'lodash/get';
+import orderBy from 'lodash/orderBy';
+import pick from 'lodash/pick';
+import uniq from 'lodash/uniq';
+import mergeAllChanges from './mergeChanges';
+import db from './db';
+import applyChanges from './applyRemoteChanges';
+import { INDEXEDDB_RESOURCES } from './registry';
+import { Channel, Session, Task } from './resources';
 import {
   ACTIVE_CHANNELS,
   CHANGES_TABLE,
@@ -6,20 +18,7 @@ import {
   IGNORED_SOURCE,
   MAX_REV_KEY,
 } from './constants';
-import { Channel, Session, Task } from './resources';
-
-import { INDEXEDDB_RESOURCES } from './registry';
-import applyChanges from './applyRemoteChanges';
 import client from 'shared/client';
-import db from './db';
-import debounce from 'lodash/debounce';
-// import { event } from 'jquery';
-import findLastIndex from 'lodash/findLastIndex';
-import get from 'lodash/get';
-import mergeAllChanges from './mergeChanges';
-import orderBy from 'lodash/orderBy';
-import pick from 'lodash/pick';
-import uniq from 'lodash/uniq';
 import urls from 'shared/urls';
 
 // When this many seconds pass without a syncable
@@ -318,8 +317,7 @@ function handleMaxRevs(response, userId) {
 }
 
 async function WebsocketSendChanges(changesToSync) {
-  const  user =  await Session.getSession();
-
+  const user = await Session.getSession();
 
   if (!user) {
     // If not logged in, nothing to do.
@@ -341,7 +339,6 @@ async function WebsocketSendChanges(changesToSync) {
   if (changes.length) {
     requestPayload.changes = changes;
   }
-
 
   if (requestPayload.changes.length != 0) {
     socket.send(
@@ -518,7 +515,7 @@ export function startSyncing() {
     const data = JSON.parse(e.data);
     console.log(data);
     if (data.task) {
-      Task.setTask(data.task);
+      Task.setTasks([data.task]);
     }
     if (data.responsePayload && data.responsePayload.allowed) {
       try {

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -490,7 +490,7 @@ let intervalTimer;
 export function startSyncing() {
   // Initiate a sync immediately in case any data
   // is left over in the database.
-
+  debouncedSyncChanges();
   const websocketUrl = new URL(
     `/ws/sync_socket/${window.CHANNEL_EDIT_GLOBAL.channel_id}/`,
     window.location.href
@@ -508,8 +508,6 @@ export function startSyncing() {
   socket.addEventListener('error', event => {
     console.log('WebSocket error: ', event);
   });
-
-  debouncedSyncChanges();
 
   socket.addEventListener('message', e => {
     const data = JSON.parse(e.data);

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -459,7 +459,7 @@ async function handleChanges(changes) {
   // MOVE, COPY, PUBLISH, and SYNC changes where we may be executing them inside an IGNORED_SOURCE
   // because they also make UPDATE and CREATE changes that we wish to make in the client only.
   // Only do this for changes that are not marked as synced.
-  const newChangeTableEntries = changes.some(
+  const newChangeTableEntries = changes.filter(
     c => c.table === CHANGES_TABLE && c.type === CHANGE_TYPES.CREATED && !c.obj.synced
   );
 
@@ -481,7 +481,7 @@ async function handleChanges(changes) {
   // then we'll trigger sync
 
   if (newChangeTableEntries.length) {
-    WebsocketSendChanges(newChangeTableEntries);
+    WebsocketSendChanges(newChangeTableEntries.map(c => c.obj));
   }
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -423,8 +423,9 @@ export function startSyncing() {
     console.log('WebSocket error: ', event);
   });
 
-  socket.addEventListener('message', e => {
+  socket.addEventListener('message', async e => {
     const data = JSON.parse(e.data);
+    const user = await Session.getSession();
     console.log(data);
     if (data.task) {
       Task.setTasks([data.task]);
@@ -446,7 +447,7 @@ export function startSyncing() {
     if (data.change) {
       try {
         handleReturnedChanges([data.change]);
-        handleMaxRevs([data.change], data.change.created_by_id);
+        handleMaxRevs([data.change], user.id);
       } catch (err) {
         console.log(err);
       }
@@ -454,7 +455,7 @@ export function startSyncing() {
     if (data.errored) {
       try {
         handleErrors([data.errored]);
-        handleMaxRevs([data.errored], data.errored.created_by_id);
+        handleMaxRevs([data.errored], user.id);
       } catch (err) {
         console.log(err);
       }
@@ -462,7 +463,7 @@ export function startSyncing() {
     if (data.success) {
       try {
         handleSuccesses([data.success]);
-        handleMaxRevs([data.success], data.success.created_by_id);
+        handleMaxRevs([data.success], user.id);
       } catch (err) {
         console.log(err);
       }

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -1,5 +1,4 @@
 import debounce from 'lodash/debounce';
-// import { event } from 'jquery';
 import findLastIndex from 'lodash/findLastIndex';
 import get from 'lodash/get';
 import orderBy from 'lodash/orderBy';
@@ -25,9 +24,6 @@ import urls from 'shared/urls';
 // change being registered, sync changes!
 const SYNC_IF_NO_CHANGES_FOR = 2;
 
-// When this many seconds pass, repoll the backend to
-// check for any updates to active channels, or the user and sync any current changes
-// const SYNC_POLL_INTERVAL = 5;
 let socket;
 // Flag to check if a sync is currently active.
 let syncActive = false;
@@ -515,16 +511,16 @@ export function startSyncing() {
     if (data.task) {
       Task.setTasks([data.task]);
     }
-    if (data.responsePayload && data.responsePayload.allowed) {
+    if (data.response_payload && data.response_payload.allowed) {
       try {
-        socketHandleAllowed(data.responsePayload.allowed);
+        socketHandleAllowed(data.response_payload.allowed);
       } catch (err) {
         console.log(err);
       }
     }
-    if (data.responsePayload && data.responsePayload.disallowed) {
+    if (data.response_payload && data.response_payload.disallowed) {
       try {
-        socketHandleDisallowed(data.responsePayload.disallowed);
+        socketHandleDisallowed(data.response_payload.disallowed);
       } catch (err) {
         console.log(err);
       }

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -8,7 +8,6 @@ import uuid
 from datetime import datetime
 
 import pytz
-from celery import states
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.base_user import BaseUserManager
@@ -2414,7 +2413,7 @@ class Change(models.Model):
         )
 
     @classmethod
-    def create_changes(cls, changes, created_by_id=None, session_key=None, applied=False):
+    def create_changes(cls, changes, created_by_id, session_key=None, applied=False):
         change_models = []
         for change in changes:
             change_models.append(cls._create_from_change(created_by_id=created_by_id, session_key=session_key, applied=applied, **change))
@@ -2423,7 +2422,7 @@ class Change(models.Model):
         return change_models
 
     @classmethod
-    def create_change(cls, change, created_by_id=None, session_key=None, applied=False):
+    def create_change(cls, change, created_by_id, session_key=None, applied=False):
         obj = cls._create_from_change(created_by_id=created_by_id, session_key=session_key, applied=applied, **change)
         obj.save()
         return obj

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -66,7 +66,6 @@ ALLOWED_HOSTS = ["*"]  # In production, we serve through a file socket, so this 
 # Application definition
 
 INSTALLED_APPS = (
-    'channels',
     'contentcuration.apps.ContentConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -87,6 +86,7 @@ INSTALLED_APPS = (
     'django_filters',
     'mathfilters',
     'django_celery_results',
+    'channels',
 )
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -46,9 +46,14 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         """
         change_serialized = create_channel_specific_change_object(self.user, self.channel)
         channel_layer = mock_get_channel_layer.return_value
-        mock_async_to_sync.assert_called_once_with(channel_layer.group_send)
+        assert 2 == mock_async_to_sync.call_count
+        mock_async_to_sync.assert_called_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
-        async_mock_return_value.assert_called_once_with(self.channel.id, {
+        async_mock_return_value.assert_any_call(str(self.user.id), {
+            'type': 'broadcast_success',
+            'success': change_serialized
+        })
+        async_mock_return_value.assert_any_call(self.channel.id, {
             'type': 'broadcast_changes',
             'change': change_serialized
         })
@@ -63,9 +68,9 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         channel_layer = mock_get_channel_layer.return_value
         mock_async_to_sync.assert_called_once_with(channel_layer.group_send)
         async_mock_return_value = mock_async_to_sync.return_value
-        async_mock_return_value.assert_called_once_with(str(self.user.id), {
-            'type': 'broadcast_changes',
-            'change': change_serialized
+        async_mock_return_value.assert_any_call(str(self.user.id), {
+            'type': 'broadcast_success',
+            'success': change_serialized
         })
 
     @patch('contentcuration.viewsets.websockets.signals.async_to_sync')
@@ -85,9 +90,9 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
             'type': 'broadcast_changes',
             'change': change_serialized
         })
-        async_mock_return_value.assert_any_call(str(editor.id), {
-            'type': 'broadcast_changes',
-            'change': change_serialized
+        async_mock_return_value.assert_any_call(str(self.user.id), {
+            'type': 'broadcast_success',
+            'success': change_serialized
         })
 
     @patch('contentcuration.viewsets.websockets.signals.async_to_sync')

--- a/contentcuration/contentcuration/tests/test_change_signals.py
+++ b/contentcuration/contentcuration/tests/test_change_signals.py
@@ -35,7 +35,7 @@ class ChangeSignalTestCase(TestCase, BucketTestMixin):
         """
         self.client.force_login(self.user)
         new_name = "This is not the old name"
-        Change.create_change(generate_update_event(self.channel.id, CHANNEL, {"name": new_name}, channel_id=self.channel.id))
+        Change.create_change(generate_update_event(self.channel.id, CHANNEL, {"name": new_name}, channel_id=self.channel.id), created_by_id=self.user.id)
         assert mock_signal.call_count == 1
 
     @patch('contentcuration.viewsets.websockets.signals.async_to_sync')

--- a/contentcuration/contentcuration/tests/test_serializers.py
+++ b/contentcuration/contentcuration/tests/test_serializers.py
@@ -148,12 +148,15 @@ class ContentDefaultsSerializerUseTestCase(BaseAPITestCase):
             nested_writes = True
 
     def test_save__create(self):
+        class request:
+            user = self.user
+        context = {"request": request}
         s = self.ChannelSerializer(
             data=dict(
                 name="New test channel",
                 description="This is the best test channel",
                 content_defaults=dict(author="Buster"),
-            )
+            ), context=context
         )
 
         self.assertTrue(s.is_valid())
@@ -164,6 +167,9 @@ class ContentDefaultsSerializerUseTestCase(BaseAPITestCase):
         self.assertEqual(defaults, c.content_defaults)
 
     def test_save__update(self):
+        class request:
+            user = self.user
+        context = {"request": request}
         c = Channel(
             name="New test channel",
             description="This is the best test channel",
@@ -172,7 +178,7 @@ class ContentDefaultsSerializerUseTestCase(BaseAPITestCase):
         c.save()
 
         s = self.ChannelSerializer(
-            c, data=dict(content_defaults=dict(license="Special Permissions"))
+            c, data=dict(content_defaults=dict(license="Special Permissions")), context=context
         )
 
         self.assertTrue(s.is_valid())

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -203,12 +203,12 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
     def save(self, **kwargs):
         instance = super(BulkModelSerializer, self).save(**kwargs)
         if "request" in self.context and not self.context["request"].user.is_anonymous:
-            user = self.context["request"].user.id
+            user = self.context["request"].user
         else:
             raise NotAuthenticated()
 
         if self.changes:
-            Change.create_changes(self.changes, applied=True, created_by_id=user)
+            Change.create_changes(self.changes, applied=True, created_by_id=user.id)
         return instance
 
 

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -490,13 +490,13 @@ class ChannelViewSet(ValuesViewset):
                             "unpublished_changes": _unpublished_changes_query(channel.id).exists()
                         }, channel_id=channel.id
                     ),
-                ], applied=True)
+                ], created_by_id=self.request.user.id, applied=True)
             except Exception:
                 Change.create_changes([
                     generate_update_event(
                         channel.id, CHANNEL, {"publishing": False, "unpublished_changes": True}, channel_id=channel.id
                     ),
-                ], applied=True)
+                ], created_by_id=self.request.user, applied=True)
                 raise
 
     def sync_from_changes(self, changes):

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -480,23 +480,22 @@ class ChannelViewSet(ValuesViewset):
                     progress_tracker=progress_tracker,
                     language=language
                 )
-                Change.create_changes([
+                Change.create_change(
                     generate_update_event(
                         channel.id, CHANNEL, {
                             "published": True,
                             "publishing": False,
                             "primary_token": channel.get_human_token().token,
-                            "last_published": channel.last_published,
-                            "unpublished_changes": _unpublished_changes_query(channel.id).exists()
+                            "last_published": str(channel.last_published),
+                            "unpublished_changes": bool(_unpublished_changes_query(channel.id).exists())
                         }, channel_id=channel.id
-                    ),
-                ], created_by_id=self.request.user.id, applied=True)
+                    ), created_by_id=self.request.user.id, applied=True)
             except Exception:
                 Change.create_changes([
                     generate_update_event(
                         channel.id, CHANNEL, {"publishing": False, "unpublished_changes": True}, channel_id=channel.id
                     ),
-                ], created_by_id=self.request.user, applied=True)
+                ], created_by_id=self.request.user.id, applied=True)
                 raise
 
     def sync_from_changes(self, changes):

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -162,3 +162,14 @@ class SyncConsumer(WebsocketConsumer):
         self.send(text_data=json.dumps({
             'task': task
         }))
+
+    def broadcast_success(self, event):
+        """
+        Broadcast success to required user
+        """
+        success = event['success']
+
+        # Send message to WebSocket
+        self.send(text_data=json.dumps({
+            'success': success
+        }))

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -76,13 +76,14 @@ class SyncConsumer(WebsocketConsumer):
         )
 
     def receive(self, text_data):
+        """
+        Executes when data is received from websocket
+        """
         from contentcuration.models import Change
         from contentcuration.models import Channel
         from contentcuration.tasks import apply_channel_changes_task
         from contentcuration.tasks import apply_user_changes_task
-        """
-        Executes when data is received from websocket
-        """
+
         response_payload = {
             "disallowed": [],
             "allowed": [],

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -4,10 +4,6 @@ import logging as logger
 from asgiref.sync import async_to_sync
 from channels.generic.websocket import WebsocketConsumer
 
-from contentcuration.models import Change
-from contentcuration.models import Channel
-from contentcuration.tasks import apply_channel_changes_task
-from contentcuration.tasks import apply_user_changes_task
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import CREATED
 
@@ -80,6 +76,10 @@ class SyncConsumer(WebsocketConsumer):
         )
 
     def receive(self, text_data):
+        from contentcuration.models import Change
+        from contentcuration.models import Channel
+        from contentcuration.tasks import apply_channel_changes_task
+        from contentcuration.tasks import apply_user_changes_task
         """
         Executes when data is received from websocket
         """

--- a/contentcuration/contentcuration/viewsets/websockets/signals.py
+++ b/contentcuration/contentcuration/viewsets/websockets/signals.py
@@ -74,6 +74,13 @@ def broadcast_new_change_model(instance):
         # if the change is related to channel we broadcast changes to channel group
         if not indiviual_room_group_name and room_group_name:
             async_to_sync(channel_layer.group_send)(
+                str(instance.created_by_id),
+                {
+                    'type': 'broadcast_success',
+                    'success': serialized_change_object
+                }
+            )
+            async_to_sync(channel_layer.group_send)(
                 str(room_group_name),
                 {
                     'type': 'broadcast_changes',
@@ -85,8 +92,8 @@ def broadcast_new_change_model(instance):
             async_to_sync(channel_layer.group_send)(
                 str(indiviual_room_group_name),
                 {
-                    'type': 'broadcast_changes',
-                    'change': serialized_change_object
+                    'type': 'broadcast_success',
+                    'success': serialized_change_object
                 }
             )
         # if the change is realted to both user and channel then we will broadcast to both of the groups
@@ -101,7 +108,7 @@ def broadcast_new_change_model(instance):
             async_to_sync(channel_layer.group_send)(
                 str(indiviual_room_group_name),
                 {
-                    'type': 'broadcast_changes',
-                    'change': serialized_change_object
+                    'type': 'broadcast_success',
+                    'success': serialized_change_object
                 }
             )


### PR DESCRIPTION
## Summary
This pr remolds the serverSync.js to fully and properly support incoming events from WebSockets. It removes the polling interval used for syncing with the backend.

### Description of the change(s) you made
- Changes ServerSync.js to add event listeners for websocket events 
- Removes polling in regular intervals 🥳🥳
- Forces created_by_id of change object to not be null
- Additional hacks around some IGNORED_SOURCE change objects


### Manual verification steps performed
Ran pytest

### Does this introduce any tech-debt items?
Some of the internal logic of Publishing is still broken. The bar always shows that we can publish even tho there are no changes made.

### Are there any risky areas that deserve extra testing?
Every thing is at risk!!!!!!


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
