### PR TITLE
Sets ‘has captions or subtitles accessibility’ label

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -337,7 +337,10 @@
       <!-- Subtitles -->
       <VLayout v-if="videoSelected" row wrap class="section">
         <VFlex xs12>
-          <SubtitlesList :nodeId="firstNode.id" />
+          <SubtitlesList
+            :nodeId="firstNode.id"
+            @addFile="subtitleFileLanguageComparison"
+          />
         </VFlex>
       </VLayout>
 
@@ -383,7 +386,7 @@
   import VisibilityDropdown from 'shared/views/VisibilityDropdown';
   import Checkbox from 'shared/views/form/Checkbox';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
-  import { NEW_OBJECT, FeatureFlagKeys } from 'shared/constants';
+  import { NEW_OBJECT, FeatureFlagKeys, AccessibilityCategories } from 'shared/constants';
   import { validate as validateCompletionCriteria } from 'shared/leUtils/CompletionCriteria';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
 
@@ -800,6 +803,12 @@
         this.$analytics.trackAction('channel_editor_modal_preview', 'Preview', {
           eventLabel: 'File',
         });
+      },
+      subtitleFileLanguageComparison(file) {
+        if (this.oneSelected && this.language === file.language) {
+          this.accessibility = [...this.accessibility, AccessibilityCategories.CAPTIONS_SUBTITLES];
+          console.log({ ...this.accessibility });
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SubtitlesList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SubtitlesList.vue
@@ -11,6 +11,7 @@
       :readonly="readonly"
       :nodeId="nodeId"
       @upload="trackUpload"
+      @addFile="addFileHandler"
     />
   </div>
 
@@ -52,6 +53,9 @@
         this.$analytics.trackAction('file_uploader', 'Upload', {
           eventLabel: 'Related file',
         });
+      },
+      addFileHandler(f) {
+        this.$emit('addFile', f);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/supplementaryLists/SupplementaryList.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VList two-line>
+  <VList>
     <SupplementaryItem
       v-for="file in files"
       :key="file.id"
@@ -18,7 +18,7 @@
       @upload="$emit('upload')"
     >
       <template #default="{ openFileDialog }">
-        <VListTile @click.stop>
+        <VListTile inactive class="languageTile py-2">
           <VListTileContent v-if="!addingFile">
             <ActionLink
               data-test="add-file"
@@ -26,10 +26,12 @@
               @click="addingFile = true"
             />
           </VListTileContent>
-          <VListTileContent v-else style="max-width: 250px; height: auto;">
+          <VListTileContent v-else class="captionLanguageDropdown">
             <LanguageDropdown
+              id="captionLanguage"
               v-model="selectedLanguage"
               data-test="select-language"
+              dropAbove
               :excludeLanguages="currentLanguages"
               hide-details
             />
@@ -117,7 +119,10 @@
     methods: {
       ...mapActions('file', ['updateFile', 'deleteFile']),
       add(file) {
-        this.makeFile(file).then(this.reset);
+        this.makeFile(file).then(f => {
+          this.$emit('addFile', f);
+          this.reset();
+        });
       },
       makeFile(file) {
         return this.updateFile({
@@ -142,3 +147,20 @@
   };
 
 </script>
+<style lang="less" scoped>
+
+  .languageTile:hover {
+    background-color: var(--v-greyBackground-base);
+  }
+
+  /deep/ .languageTile > .v-list__tile {
+    height: 56px;
+  }
+
+  .captionLanguageDropdown {
+    max-width: 250px;
+    height: auto;
+    overflow: visible;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -196,7 +196,7 @@ export const ContentModalities = {
 export const AccessibilityCategoriesMap = {
   // Note: audio is not included, as it is rendered in the UI differently.
   document: ['ALT_TEXT', 'HIGH_CONTRAST', 'TAGGED_PDF'],
-  video: ['SIGN_LANGUAGE', 'AUDIO_DESCRIPTION'],
+  video: ['SIGN_LANGUAGE', 'AUDIO_DESCRIPTION', 'CAPTIONS_SUBTITLES'],
   exercise: ['ALT_TEXT'],
   html5: ['ALT_TEXT', 'HIGH_CONTRAST'],
 };

--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -20,7 +20,7 @@
     :menu-props="menuProps"
     :multiple="multiple"
     :chips="multiple"
-    attach="#language"
+    :attach="$attrs.id ? `#${$attrs.id}` : '.language-dropdown'"
     @change="input = ''"
     @focus="$emit('focus')"
   >
@@ -73,6 +73,10 @@
         type: Boolean,
         default: false,
       },
+      dropAbove: {
+        type: Boolean,
+        default: false,
+      },
     },
     data() {
       return {
@@ -92,6 +96,7 @@
         return {
           minWidth: 300,
           maxWidth: 300,
+          top: this.dropAbove,
         };
       },
       languages() {

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -99,6 +99,7 @@ export function updateFile(context, { id, ...payload }) {
         }
       }
     }
+    return { id, ...fileData };
   });
 }
 


### PR DESCRIPTION

<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This PR checks the ‘has captions or subtitles accessibility’ label automatically if the uploaded subtitle file language is the same as the video file language. The language dropdown placement for the captions and subtitles section was previously shown underneath it but would be cut off. This PR changes the placement of the menu options to show above instead.

### Manual verification steps performed
1. Uploaded video file
2. Set the Language of the video file to English
3. Underneath Captions and subtitles, set the language of the subtitles file to English
4. Uploaded a sample subtitle file
5. Confirmed that the ‘Has captions or subtitles’ checkbox was checked

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Checked ‘Has captions or subtitles’ checkbox.
<img width="1433" alt="Screen Shot 2022-09-06 at 1 34 50 PM" src="https://user-images.githubusercontent.com/46411498/188739153-ad2c15c3-8c09-4c48-8de8-9ddd8657fe2d.png">

Previous placement for language dropdown underneath Captions and subtitles section.
<img width="1440" alt="Screen Shot 2022-09-06 at 1 51 06 PM" src="https://user-images.githubusercontent.com/46411498/188739163-57fa5e47-38f0-45c8-b4e9-19c1660613f0.png">

Updated language dropdown placement.
<img width="1435" alt="Screen Shot 2022-09-06 at 1 33 37 PM" src="https://user-images.githubusercontent.com/46411498/188739171-b21fb979-8367-4bb1-bb14-3710f188d706.png">

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Upload video file
2. Underneath Audience, set the Language of the video file
3. Underneath Captions and subtitles, set the language of the subtitles file and upload a .vtt file
4. If the subtitles file language and the video file language match, the ‘Has captions or subtitles’ checkbox should be checked.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->
Note: The ‘Has captions and subtitles’ checkbox label description needs to be updated.

Radina and Jessica agree that the label is descriptive enough and suggest removing the info icon next to the label and reordering this label to be first in the list instead since it’s expected to be the most commonly used option out of those three. 

<img width="508" alt="Accessibility" src="https://user-images.githubusercontent.com/46411498/188739114-79d953a7-34ae-444a-8f68-3dfdacd2b0db.png">

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
