### PR TITLE
Default learning activities on upload for some content kinds

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -183,6 +183,7 @@
   import SavingIndicator from './SavingIndicator';
   import EditView from './EditView';
   import EditList from './EditList';
+  import { ContentKindLearningActivityDefaults } from 'shared/leUtils/ContentKinds';
   import { fileSizeMixin, routerMixin } from 'shared/mixins';
   import FileStorage from 'shared/views/files/FileStorage';
   import MessageDialog from 'shared/views/MessageDialog';
@@ -445,6 +446,15 @@
       /* Creation actions */
       createNode(kind, payload = {}) {
         this.enableValidation(this.nodeIds);
+        // Default learning activity on upload
+        if (
+          !Object.keys(payload.learning_activities || {}).length &&
+          kind in ContentKindLearningActivityDefaults
+        ) {
+          payload.learning_activities = {
+            [ContentKindLearningActivityDefaults[kind]]: true,
+          };
+        }
         return this.createContentNode({
           kind,
           parent: this.$route.params.nodeId,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -241,7 +241,10 @@
   import Breadcrumbs from 'shared/views/Breadcrumbs';
   import Checkbox from 'shared/views/form/Checkbox';
   import { withChangeTracker } from 'shared/data/changes';
-  import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+  import {
+    ContentKindsNames,
+    ContentKindLearningActivityDefaults,
+  } from 'shared/leUtils/ContentKinds';
   import { titleMixin, routerMixin } from 'shared/mixins';
   import { COPYING_FLAG, RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
   import { DraggableTypes, DropEffect } from 'shared/mixins/draggable/constants';
@@ -438,8 +441,8 @@
         const title = detailTitle ? `${detailTitle} - ${topicTitle}` : topicTitle;
         this.updateTabTitle(this.$store.getters.appendChannelName(title));
       },
-      newContentNode(route, { kind, title }) {
-        this.createContentNode({ parent: this.topicId, kind, title }).then(newId => {
+      newContentNode(route, payload) {
+        this.createContentNode({ parent: this.topicId, ...payload }).then(newId => {
           this.$router.push({
             name: route,
             params: { detailNodeIds: newId },
@@ -458,6 +461,9 @@
         let nodeData = {
           kind: ContentKindsNames.EXERCISE,
           title: '',
+          learning_activities: {
+            [ContentKindLearningActivityDefaults[ContentKindsNames.EXERCISE]]: true,
+          },
         };
         this.newContentNode(RouteNames.ADD_EXERCISE, nodeData);
         this.trackClickEvent('Add exercise');

--- a/contentcuration/contentcuration/frontend/shared/leUtils/ContentKinds.js
+++ b/contentcuration/contentcuration/frontend/shared/leUtils/ContentKinds.js
@@ -1,3 +1,5 @@
+import LearningActivities from 'kolibri-constants/labels/LearningActivities';
+
 // Constant values for ContentKinds sorted by id
 const ContentKinds = new Set([
   'audio',
@@ -25,4 +27,10 @@ export const ContentKindsNames = {
   TOPIC: 'topic',
   VIDEO: 'video',
   ZIM: 'zim',
+};
+
+export const ContentKindLearningActivityDefaults = {
+  [ContentKindsNames.AUDIO]: LearningActivities.LISTEN,
+  [ContentKindsNames.DOCUMENT]: LearningActivities.READ,
+  [ContentKindsNames.VIDEO]: LearningActivities.WATCH,
 };

--- a/contentcuration/contentcuration/frontend/shared/leUtils/ContentKinds.js
+++ b/contentcuration/contentcuration/frontend/shared/leUtils/ContentKinds.js
@@ -33,4 +33,6 @@ export const ContentKindLearningActivityDefaults = {
   [ContentKindsNames.AUDIO]: LearningActivities.LISTEN,
   [ContentKindsNames.DOCUMENT]: LearningActivities.READ,
   [ContentKindsNames.VIDEO]: LearningActivities.WATCH,
+  [ContentKindsNames.EXERCISE]: LearningActivities.PRACTICE,
+  [ContentKindsNames.SLIDESHOW]: LearningActivities.READ,
 };


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- This PR defaults the learning activity for some content kinds when a file/node is uploaded/created

### Manual verification steps performed
1. Upload a PDF
2. Ensure that "Read" learning activity is defaulted


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3373

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
