### PR TITLE
Removes use of the clipboard-polyfill and just uses the native API instead

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/CopyToken.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/CopyToken.vue
@@ -21,8 +21,6 @@
 
 <script>
 
-  import * as clipboard from 'clipboard-polyfill';
-
   export default {
     name: 'CopyToken',
     props: {
@@ -51,7 +49,7 @@
     },
     methods: {
       copyToken() {
-        clipboard
+        navigator.clipboard
           .writeText(this.displayToken)
           .then(() => {
             let text = this.successText || this.$tr('copiedTokenId');

--- a/contentcuration/contentcuration/frontend/shared/views/errors/TechnicalTextBlock.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/TechnicalTextBlock.vue
@@ -32,8 +32,6 @@
 
 <script>
 
-  import * as clipboard from 'clipboard-polyfill';
-
   export default {
     name: 'TechnicalTextBlock',
     props: {
@@ -65,7 +63,7 @@
     },
     methods: {
       copyError() {
-        clipboard
+        navigator.clipboard
           .writeText(this.formattedText)
           .then(() => {
             this.$store.dispatch('showSnackbar', {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "ajv": "^8.9.0",
     "axios": "^0.27.2",
     "broadcast-channel": "^4.14.0",
-    "clipboard-polyfill": "^2.8.1",
     "codemirror": "5.58.2",
     "core-js": "^3.25.0",
     "dexie": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,11 +3515,6 @@ cli@0.6.x:
     exit "0.1.2"
     glob "~ 3.2.1"
 
-clipboard-polyfill@^2.8.1:
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/clipboard-polyfill/-/clipboard-polyfill-2.8.6.tgz#19d27283f11f2933bb18737263b98b8c95b5a0f7"
-  integrity sha512-kz/1ov+PXsBpGnW9XJH3dLWdYj12FpXqO89Dngm/GRPoI36E/tnYs6N0YPTEhxM9WHAlFiN5eoyIVuv5nzKXvg==
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Removes the clipboard polyfill which is only useful for browsers that we don't support anyway.

### Manual verification steps performed
1. Copy auth token from Settings page
2. Copy a channel token from channel edit page


### References

Supersedes #3582