### PR TITLE
Implement webpack performance suggestions from docs.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,10 +51,11 @@ module.exports = (env = {}) => {
       htmlScreenshot: ['./shared/utils/htmlScreenshot.js'],
     },
     output: {
-      filename: '[name]-[fullhash].js',
-      chunkFilename: '[name]-[id]-[fullhash].js',
+      filename: dev ? '[name].js' : '[name]-[fullhash].js',
+      chunkFilename: dev ? '[name]-[id].js' : '[name]-[id]-[fullhash].js',
       path: bundleOutputDir,
       publicPath: dev ? 'http://127.0.0.1:4000/dist/' : '/static/studio/',
+      pathinfo: !dev,
     },
     devServer: {
       port: 4000,
@@ -97,8 +98,8 @@ module.exports = (env = {}) => {
         filename: path.resolve(djangoProjectDir, 'build', 'webpack-stats.json'),
       }),
       new MiniCssExtractPlugin({
-        filename: '[name]-[fullhash].css',
-        chunkFilename: '[name]-[fullhash]-[id].css',
+        filename: dev ? '[name].css' :'[name]-[fullhash].css',
+        chunkFilename: dev ? '[name]-[id].css' :'[name]-[fullhash]-[id].css',
       }),
       new WebpackRTLPlugin({
         minify: false,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* [Only use full hashes for production builds.](https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling)
* [Turn off pathinfo for development.
](https://webpack.js.org/guides/build-performance/#output-without-path-info)
This seemed to slightly reduce memory usage during builds, but I couldn't get a consistent measure.

### Manual verification steps performed
1. Ran devserver, confirmed it still ran as expected.