### PR TITLE
Updates width of content library channel cards with no description to…

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -46,6 +46,7 @@
             <ChannelItem
               :channelId="item.id"
               :detailsRouteName="detailsRouteName"
+              style="flex-grow: 1; width: 100%;"
             />
           </VLayout>
         </VFlex>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div style="width: 100%;">
+  <div>
     <VCard
       class="channel my-3"
       :class="{ hideHighlight, added }"

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="channel-cards">
     <VCard
       class="channel my-3"
       :class="{ hideHighlight, added }"
@@ -430,6 +430,11 @@
 
   /deep/ .thumbnail {
     width: 100%;
+  }
+
+  .channel-cards {
+    display: inline-block;
+    min-width: 100%;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="channel-cards">
+  <div style="width: 100%;">
     <VCard
       class="channel my-3"
       :class="{ hideHighlight, added }"
@@ -430,11 +430,6 @@
 
   /deep/ .thumbnail {
     width: 100%;
-  }
-
-  .channel-cards {
-    display: inline-block;
-    min-width: 100%;
   }
 
 </style>


### PR DESCRIPTION
… fill horizontal space

<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This PR adds a channel-card class to the list of channels under content-library and sets the `display` to `inline-block` and the `min-width` to `100%`. Previously, channels without descriptions did not completely fill the horizontal space.


### Manual verification steps performed
1. Edited published channel and took away description
2. Opened Content library page where published channel will appear
3. Verified that the channel width filled the horizontal space

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Channel card layout without description:
<img width="1436" alt="Before changes" src="https://user-images.githubusercontent.com/46411498/189961571-cf1266eb-9d6e-4222-90da-cf57a2f40b0f.png">

Channel card layout with description:
<img width="1440" alt="Card with description" src="https://user-images.githubusercontent.com/46411498/189961736-61832fa5-9a4d-4273-9ae1-92a915b09757.png">

Channel card layout without description after changes:
<img width="1437" alt="Card without description" src="https://user-images.githubusercontent.com/46411498/189961838-25c3bda6-a576-4b41-9e0e-40e5182fdac6.png">

On smaller screen:

<img width="501" alt="Screen Shot 2022-09-09 at 10 06 32 AM" src="https://user-images.githubusercontent.com/46411498/189964448-2c8354a1-096d-41ab-80c1-04a0b614041e.png">

<img width="432" alt="Screen Shot 2022-09-09 at 10 20 23 AM" src="https://user-images.githubusercontent.com/46411498/189964459-54aba873-66d9-4257-9a4d-2283e1dd2f27.png">


___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Open local studio with changes from this branch.
2. Check if a published channel has a description, if so, edit out the description.
4. Open the Content library page where the published channel will appear.
5. Verify if the channel width fills the horizontal space.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes issue #3387 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
