### PR TITLE
Fixes relaying of copy/move changes with refactoring

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -1,7 +1,5 @@
 import Dexie from 'dexie';
-import flatten from 'lodash/flatten';
 import sortBy from 'lodash/sortBy';
-import uniq from 'lodash/uniq';
 import { CHANGE_TYPES, IGNORED_SOURCE, TABLE_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
@@ -17,19 +15,6 @@ export function applyMods(obj, mods) {
     }
   }
   return obj;
-}
-
-function applyUpdate(table, change) {
-  return table
-    .where(':id')
-    .equals(change.key)
-    .modify(obj => applyMods(obj, change.mods));
-}
-
-function applyCreate(table, change) {
-  return table
-    .put(change.obj, !table.schema.primKey.keyPath ? change.key : undefined)
-    .then(() => change.obj);
 }
 
 export function collectChanges(changes) {
@@ -51,76 +36,116 @@ export function collectChanges(changes) {
 }
 
 /**
- * @param {table: string, rev: Number, key: string, target: string, position: string} change
- * @return {Promise{}}
+ * @param {Object} change - The change object
+ * @param {String|Function} args[] - string table names with callback at the end
+ * @returns {Promise}
  */
+function transaction(change, ...args) {
+  const callback = args.pop();
+  const tableNames = [change.table, ...args];
+  return db.transaction('rw', tableNames, () => {
+    Dexie.currentTransaction.source = IGNORED_SOURCE;
+    return callback();
+  });
+}
+
+function applyCreate(change) {
+  return transaction(change, () => {
+    const table = db.table(change.table);
+    return table
+      .put(change.obj, !table.schema.primKey.keyPath ? change.key : undefined)
+      .then(() => change.obj);
+  });
+}
+
+function applyUpdate(change) {
+  return transaction(change, () => {
+    return db
+      .table(change.table)
+      .where(':id')
+      .equals(change.key)
+      .modify(obj => applyMods(obj, change.mods));
+  });
+}
+
+function applyDelete(change) {
+  return transaction(change, () => {
+    return db.table(change.table).delete(change.key);
+  });
+}
+
 function applyMove(change) {
   const resource = INDEXEDDB_RESOURCES[change.table];
   if (!resource || !resource.tableMove) {
-    return null;
+    return Promise.resolve();
   }
 
   const { key, target, position } = change;
   return resource.resolveTreeInsert(key, target, position, false, data => {
-    data.change.source = IGNORED_SOURCE;
-    return resource.tableMove(data);
+    return transaction(change, () => {
+      return resource.tableMove(data);
+    });
+  });
+}
+
+function applyCopy(change) {
+  const resource = INDEXEDDB_RESOURCES[change.table];
+  if (!resource || !resource.tableCopy) {
+    return Promise.resolve();
+  }
+
+  const { key, target, position, from_key } = change;
+  // copying takes the ID of the node to copy, so we use `from_key`
+  return resource.resolveTreeInsert(from_key, target, position, true, data => {
+    return transaction(change, () => {
+      // Update the ID on the payload to match the received change, since isCreate=true
+      // would generate new IDs
+      data.payload.id = key;
+      return resource.tableCopy(data);
+    });
   });
 }
 
 function applyPublish(change) {
   if (change.table !== TABLE_NAMES.CHANNEL) {
-    return null;
+    return Promise.resolve();
   }
 
-  const ContentNode = INDEXEDDB_RESOURCES[TABLE_NAMES.CONTENTNODE];
-  return ContentNode.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
-    return ContentNode.table
+  // Publish changes associate with the channel, but we open a transaction on contentnode
+  return transaction(change, TABLE_NAMES.CONTENTNODE, () => {
+    return db
+      .table(TABLE_NAMES.CONTENTNODE)
       .where({ channel_id: change.channel_id })
       .modify({ changed: false, published: true });
   });
 }
 
-/*
- * Modified from https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
+/**
+ * @see https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
+ * @return {Promise<Array>}
  */
-export default function applyChanges(changes) {
-  if (!changes.length) {
-    return Promise.resolve();
+export default async function applyChanges(changes) {
+  const results = [];
+  for (let change of sortBy(changes, ['server_rev', 'rev'])) {
+    let result;
+    if (change.type === CHANGE_TYPES.CREATED) {
+      result = await applyCreate(change);
+    } else if (change.type === CHANGE_TYPES.UPDATED) {
+      result = await applyUpdate(change);
+    } else if (change.type === CHANGE_TYPES.DELETED) {
+      result = await applyDelete(change);
+    } else if (change.type === CHANGE_TYPES.MOVED) {
+      result = await applyMove(change);
+    } else if (change.type === CHANGE_TYPES.COPIED) {
+      result = await applyCopy(change);
+    } else if (change.type === CHANGE_TYPES.PUBLISHED) {
+      result = await applyPublish(change);
+    }
+
+    if (result) {
+      results.push(result);
+    }
   }
 
-  changes = sortBy(changes, ['server_rev', 'rev']);
-
-  const table_names = uniq(changes.map(c => c.table));
-  // When changes include a publish change, add the contentnode table since `applyPublish` above
-  // needs to make updates to content nodes
-  if (
-    changes.some(c => c.type === CHANGE_TYPES.PUBLISHED) &&
-    !table_names.includes(TABLE_NAMES.CONTENTNODE)
-  ) {
-    table_names.push(TABLE_NAMES.CONTENTNODE);
-  }
-  const tables = table_names.map(table => db.table(table));
-
-  return db.transaction('rw', tables, () => {
-    Dexie.currentTransaction.source = IGNORED_SOURCE;
-    const promises = changes.map(change => {
-      const table = db.table(change.table);
-      if (change.type === CHANGE_TYPES.CREATED) {
-        return applyCreate(table, change);
-      }
-      if (change.type === CHANGE_TYPES.UPDATED) {
-        return applyUpdate(table, change);
-      }
-      if (change.type === CHANGE_TYPES.DELETED) {
-        return table.delete(change.key);
-      }
-      if (change.type === CHANGE_TYPES.MOVED) {
-        return applyMove(change);
-      }
-      if (change.type === CHANGE_TYPES.PUBLISHED) {
-        return applyPublish(change);
-      }
-    });
-    return Promise.all(promises).then(results => flatten(results).filter(Boolean));
-  });
+  return results;
 }

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -51,6 +51,7 @@ export const RELATIVE_TREE_POSITIONS = {
 // Special fields used for copying and other async tasks
 export const COPYING_FLAG = '__COPYING';
 export const TASK_ID = '__TASK_ID';
+export const LAST_FETCHED = '__last_fetch';
 
 // This constant is used for saving/retrieving a current
 // user object from the session table


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Copy and move changes would fail to be applied when relayed to other editors/browsers
- Refactors transaction handling to open a transaction when applying each type of change
  - This is likely slower but allows finer grained transaction management on per-change basis

### Manual verification steps performed
1. Open two separate browsers
2. Sign into Studio on each browser
3. Open the same channel in each browser
4. In one browser, duplicate a resource
5. In the other browser, watch for the duplicate to appear-- it should

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
To wrap up parallel websocket integration work, we may want to consider implementing a FIFO queue when receiving changes or other updates over the websocket before passing along to `applyChanges`
___
## Reviewer guidance


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3635

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
