### PR TITLE
Use the file format as the default extension in case the passed in name for the file does not have one.

### DIFF
--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -156,7 +156,7 @@ class FileViewSet(BulkDeleteMixin, BulkUpdateMixin, ReadOnlyValuesViewset):
 
         might_skip = File.objects.filter(checksum=checksum).exists()
 
-        filepath = generate_object_storage_name(checksum, filename)
+        filepath = generate_object_storage_name(checksum, filename, default_ext=file_format)
         checksum_base64 = codecs.encode(
             codecs.decode(checksum, "hex"), "base64"
         ).decode()


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes small edge case that was showing up for graphie file uploads in ricecooker
* The graphie files' original filename had no extension, so the files were being uploaded to the checksum with no file extension, and then seemed to have not been uploaded.
* This uses the supplied file_format as the default extension to prevent this.