### PR TITLE
Hide tooltip for certain accessibility options and reorder them

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -18,6 +18,7 @@
             <span class="text-xs-left">{{ accessibilityItem.label }}</span>
             &nbsp;
             <HelpTooltip
+              v-if="accessibilityItem.showTooltip"
               :text="$tr(accessibilityItem.help)"
               bottom
               class="px-2"
@@ -39,6 +40,9 @@
   import Checkbox from 'shared/views/form/Checkbox';
   import HelpTooltip from 'shared/views/HelpTooltip';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
+
+  // A list of accessibility category values for which to hide the tooltip
+  const HideTooltips = [AccessibilityCategories.CAPTIONS_SUBTITLES];
 
   export default {
     name: 'AccessibilityOptions',
@@ -70,15 +74,14 @@
        * List of accessibility options for all content kinds except for audio
        */
       showCorrectAccessibilityList() {
-        return Object.keys(AccessibilityCategories)
-          .filter(key => AccessibilityCategoriesMap[this.kind].includes(key))
-          .map(key => {
-            return {
-              label: this.translateMetadataString(camelCase(key)),
-              value: AccessibilityCategories[key],
-              help: camelCase(key),
-            };
-          });
+        return AccessibilityCategoriesMap[this.kind].map(key => {
+          return {
+            label: this.translateMetadataString(camelCase(key)),
+            value: AccessibilityCategories[key],
+            help: camelCase(key),
+            showTooltip: !HideTooltips.includes(AccessibilityCategories[key]),
+          };
+        });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
@@ -49,6 +49,8 @@ describe('AccessibilityOptions', () => {
     expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-Has captions or subtitles"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-Has captions or subtitles"]').exists()).toBe(false);
   });
 
   it('should display the correct list of accessibility options if resource is an exercise/practice', () => {

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -196,7 +196,7 @@ export const ContentModalities = {
 export const AccessibilityCategoriesMap = {
   // Note: audio is not included, as it is rendered in the UI differently.
   document: ['ALT_TEXT', 'HIGH_CONTRAST', 'TAGGED_PDF'],
-  video: ['SIGN_LANGUAGE', 'AUDIO_DESCRIPTION', 'CAPTIONS_SUBTITLES'],
+  video: ['CAPTIONS_SUBTITLES', 'AUDIO_DESCRIPTION', 'SIGN_LANGUAGE'],
   exercise: ['ALT_TEXT'],
   html5: ['ALT_TEXT', 'HIGH_CONTRAST'],
 };

--- a/integration_testing/features/wip-studio-edit-modal/wip-edit-accessibility-field.feature
+++ b/integration_testing/features/wip-studio-edit-modal/wip-edit-accessibility-field.feature
@@ -3,7 +3,7 @@ Feature: Edit *Accessibility* field
 
 # Comment here
 
-	Background: 
+	Background:
 		Given I am signed into Studio
 			And I am in an editable channel
 		When I right click <resource>
@@ -13,8 +13,9 @@ Feature: Edit *Accessibility* field
 
 	Scenario: View options for .MP4
 		Given I am viewing an .MP4 in the edit modal
-		Then I see a checkbox that says *Has sign language captions*
+		Then I see a checkbox that says *Has captions or subtitles*
 			And I see a checkbox that says *Has audio descriptions*
+			And I see a checkbox that says *Has sign language captions*
 
 	Scenario: View tooltips for .MP4
 		Given I am viewing an .MP4 in the edit modal


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
@thanksameeelian and I cohacked on this
- Hides the tooltip for the "Has captions or subtitles" accessibility option since it's self-explanatory
- Reorder the accessibility options so that "Has captions or subtitles" is first


### Manual verification steps performed
1. Clicked to 'Edit details' a video resource
2. Verified that the tooltip info icon does not show for the option
3. Verified that the option is first

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
![Screenshot from 2022-09-16 09-06-19](https://user-images.githubusercontent.com/819838/190683118-efbaf606-0d3b-4fdd-ae88-fad22f39aeb6.png)


___
## Reviewer guidance

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3610

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [X] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
