### PR TITLE
Resolve missing option labels in content library filters

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -55,8 +55,8 @@
       v-model="kinds"
       :items="kindFilterOptions"
       :label="$tr('kindLabel')"
+      item-text="text"
     />
-
 
     <!-- Language -->
     <LanguageDropdown
@@ -69,6 +69,7 @@
       v-model="licenses"
       :items="licenseOptions"
       :label="$tr('licensesLabel')"
+      item-text="text"
     />
 
     <!-- Created after -->

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilters.vue
@@ -52,6 +52,7 @@
           v-model="licenses"
           :items="licenseOptions"
           :label="$tr('licenseLabel')"
+          item-text="text"
         />
 
         <!-- Formats (attach to self to keep in notranslate class) -->
@@ -59,6 +60,7 @@
           v-model="kinds"
           :items="kindOptions"
           :label="$tr('formatLabel')"
+          item-text="text"
         />
 
         <!-- Starred -->

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -51,8 +51,7 @@
       },
       itemText: {
         type: [String, Function],
-        required: false,
-        default: '',
+        required: true,
       },
       notranslate: {
         type: Boolean,


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- @AllanOXDi and I cohacked on this
- Enforce that `<MultiSelect>` component requires the `item-text` prop to avoid using an empty string for selecting the key in the items array for option label display
- Updates other usages of the component to pass `item-text`, since they had the same issue

### Manual verification steps performed
1. Signed into Studio
2. Opened 'Content Library'
3. Clicked 'Licenses' and 'Format' fields
4. Verified that option labels were present

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
| Licenses | Formats |
| --- | --- |
| ![Screenshot from 2022-09-22 11-34-50](https://user-images.githubusercontent.com/819838/191825187-949ed217-0929-4e64-86dd-e2eaf2b72e15.png) | ![Screenshot from 2022-09-22 11-35-01](https://user-images.githubusercontent.com/819838/191825214-44e78f7e-74e9-408b-9dff-79af42f2b766.png) |

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3660

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
