### PR TITLE
Resolve issue with selection mismatch between autocomplete and checkbox

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -41,18 +41,21 @@
       </template>
 
       <template #item="{ item }">
-        <div style="width: 100%; height: 100%">
-          <VDivider v-if="!item.value.includes('.')" />
+        <VListTile
+          :value="isSelected(item.value)"
+          :class="{ parentOption: !item.value.includes('.') }"
+          @mousedown.prevent
+          @click="() => !isSelected(item.value) ? add(item.value) : remove(item.value)"
+        >
           <KCheckbox
-            :checked="dropdownSelected[item.value]"
+            :checked="isSelected(item.value)"
             :label="item.text"
             :value="item.value"
             style="margin-top: 10px"
             :style="treeItemStyle(item)"
             :ripple="false"
-            @change="checked => checked ? add(item.value) : remove(item.value)"
           />
-        </div>
+        </VListTile>
       </template>
     </VAutocomplete>
   </div>
@@ -143,19 +146,6 @@
           };
         });
       },
-      dropdownSelected() {
-        const obj = {};
-        for (let category of this.selected) {
-          const paths = category.split('.');
-          let cat = '';
-          for (let path of paths) {
-            cat += path;
-            obj[cat] = true;
-            cat += '.';
-          }
-        }
-        return obj;
-      },
       selected: {
         get() {
           return this.value;
@@ -167,16 +157,19 @@
       nested() {
         return !this.categoryText;
       },
+      isSelected() {
+        return value => this.selected.some(v => v.startsWith(value));
+      },
     },
     methods: {
       treeItemStyle(item) {
         return this.nested ? { paddingLeft: `${item.level * 24}px` } : {};
       },
-      add(item) {
-        this.selected = [...this.selected, item];
+      add(value) {
+        this.selected = [...this.selected, value];
       },
-      remove(item) {
-        this.selected = this.selected.filter(i => !i.startsWith(item));
+      remove(value) {
+        this.selected = this.selected.filter(i => !i.startsWith(value));
       },
       removeAll() {
         this.selected = [];
@@ -220,12 +213,8 @@
     position: relative;
   }
 
-  /deep/ .v-list__tile {
-    flex-wrap: wrap;
-  }
-
-  /deep/ div[role='listitem']:first-child hr {
-    display: none;
+  .parentOption:not(:first-child) {
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
   }
 
 </style>


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
The entire row of the category options select was clickable, but didn't toggle the checkbox unless you clicked the checkbox or its label directly.

### Manual verification steps performed
1. Toggle on and off category options

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
