### PR TITLE
Dropdown consolidation, layout fixes, and RTL updates

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -99,15 +99,20 @@
         <h1 class="font-weight-bold my-2 subheading">
           {{ $tr('sourceLabel') }}*
         </h1>
-        <VSelect
-          v-model="form.source"
-          :items="sourceOptions"
-          item-text="label"
-          item-value="id"
-          box
-          menu-props="offsetY"
-          :label="$tr('sourcePlaceholder')"
-        />
+        <DropdownWrapper>
+          <template #default="{ attach, menuProps }">
+            <VSelect
+              v-model="form.source"
+              :items="sourceOptions"
+              item-text="label"
+              item-value="id"
+              box
+              :menu-props="menuProps"
+              :attach="attach"
+              :label="$tr('sourcePlaceholder')"
+            />
+          </template>
+        </DropdownWrapper>
         <VSlideYTransition>
           <TextArea
             v-if="form.source === sources.ORGANIZATION"
@@ -185,10 +190,12 @@
   import Banner from 'shared/views/Banner';
   import Checkbox from 'shared/views/form/Checkbox';
   import { policies } from 'shared/constants';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'Create',
     components: {
+      DropdownWrapper,
       ImmersiveModalLayout,
       TextField,
       EmailField,

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserStorage.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserStorage.vue
@@ -16,17 +16,20 @@
           :rules="spaceRules"
         />
       </VFlex>
-      <VFlex style="max-width: 75px;">
-        <VSelect
-          v-model="unit"
-          :items="unitOptions"
-          :menuProps="{ offsetY: true }"
-          box
-          single-line
-          required
-          :rules="unitRules"
-        />
-      </VFlex>
+      <DropdownWrapper component="VFlex" style="max-width: 75px;">
+        <template #default="{ attach, menuProps }">
+          <VSelect
+            v-model="unit"
+            :items="unitOptions"
+            :attach="attach"
+            :menuProps="menuProps"
+            box
+            single-line
+            required
+            :rules="unitRules"
+          />
+        </template>
+      </DropdownWrapper>
     </VLayout>
     <VBtn
       v-if="showCancel"
@@ -55,6 +58,7 @@
   import { mapActions } from 'vuex';
   import findLastKey from 'lodash/findLastKey';
   import { ONE_B, ONE_KB, ONE_MB, ONE_GB, ONE_TB } from 'shared/constants';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const units = {
     ONE_B,
@@ -66,6 +70,7 @@
 
   export default {
     name: 'UserStorage',
+    components: { DropdownWrapper },
     props: {
       value: {
         type: Number,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemEditor/AssessmentItemEditor.vue
@@ -3,18 +3,21 @@
   <Uploader ref="uploader" :presetID="imagePreset">
     <template #default="{ handleFiles }">
       <VLayout>
-        <VFlex xs7 lg5>
-          <VSelect
-            :key="kindSelectKey"
-            :items="kindSelectItems"
-            :value="kind"
-            :label="$tr('questionTypeLabel')"
-            data-test="kindSelect"
-            :menu-props="{ offsetY: true }"
-            box
-            @input="onKindUpdate"
-          />
-        </VFlex>
+        <DropdownWrapper component="VFlex" xs7 lg5>
+          <template #default="{ attach, menuProps }">
+            <VSelect
+              :key="kindSelectKey"
+              :items="kindSelectItems"
+              :value="kind"
+              :label="$tr('questionTypeLabel')"
+              data-test="kindSelect"
+              :menu-props="menuProps"
+              :attach="attach"
+              box
+              @input="onKindUpdate"
+            />
+          </template>
+        </DropdownWrapper>
       </VLayout>
 
       <VLayout>
@@ -115,10 +118,12 @@
   import MarkdownEditor from 'shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor';
   import MarkdownViewer from 'shared/views/MarkdownEditor/MarkdownViewer/MarkdownViewer';
   import { FormatPresetsNames } from 'shared/leUtils/FormatPresets';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'AssessmentItemEditor',
     components: {
+      DropdownWrapper,
       ErrorList,
       MarkdownEditor,
       MarkdownViewer,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -10,19 +10,22 @@
       </VFlex>
       <VFlex
         v-else-if="selectedDuration === 'shortActivity' || selectedDuration === 'longActivity'"
-        class="activity-duration-container"
         md3
         sm3
       >
-        <VAutocomplete
-          v-model.number="minutes"
-          :step="increments"
-          box
-          :label="$tr('minutesRequired')"
-          :items="availableNumbers"
-          :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-          attach=".activity-duration-container"
-        />
+        <DropdownWrapper>
+          <template #default="{ attach, menuProps }">
+            <VAutocomplete
+              v-model.number="minutes"
+              :step="increments"
+              box
+              :label="$tr('minutesRequired')"
+              :items="availableNumbers"
+              :menu-props="menuProps"
+              :attach="attach"
+            />
+          </template>
+        </DropdownWrapper>
       </VFlex>
       <VFlex v-else md3 sm3>
         <VTextField
@@ -58,6 +61,7 @@
     getActivityDurationValidators,
     translateValidator,
   } from 'shared/utils/validation';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const SHORT_MIN = 1;
   const SHORT_MAX = 30;
@@ -70,6 +74,7 @@
 
   export default {
     name: 'ActivityDuration',
+    components: { DropdownWrapper },
     props: {
       selectedDuration: {
         type: String,
@@ -191,10 +196,6 @@
 
 </script>
 <style lang="less" scoped>
-
-  .activity-duration-container {
-    position: relative;
-  }
 
   .defaultUpload {
     margin: 0.8em;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -1,64 +1,66 @@
 <template>
 
-  <div class="category-container">
-    <VAutocomplete
-      :value="selected"
-      :items="categoriesList"
-      :searchInput.sync="categoryText"
-      :label="translateMetadataString('category')"
-      box
-      clearable
-      chips
-      deletableChips
-      multiple
-      item-value="value"
-      item-text="text"
-      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-      attach=".category-container"
-      @click:clear="$nextTick(() => removeAll())"
-    >
-      <template #selection="data">
-        <VTooltip bottom lazy>
-          <template #activator="{ on, attrs }">
-            <VChip v-bind="attrs" close v-on="on" @input="remove(data.item.value)">
-              {{ data.item.text }}
-            </VChip>
-          </template>
-          <div>
-            <div>{{ tooltipHelper(data.item.value) }}</div>
-          </div>
-        </VTooltip>
-      </template>
+  <DropdownWrapper>
+    <template #default="{ attach, menuProps }">
+      <VAutocomplete
+        :value="selected"
+        :items="categoriesList"
+        :searchInput.sync="categoryText"
+        :label="translateMetadataString('category')"
+        box
+        clearable
+        chips
+        deletableChips
+        multiple
+        item-value="value"
+        item-text="text"
+        :menu-props="{ ...menuProps, zIndex: 4 }"
+        :attach="attach"
+        @click:clear="$nextTick(() => removeAll())"
+      >
+        <template #selection="data">
+          <VTooltip bottom lazy>
+            <template #activator="{ on, attrs }">
+              <VChip v-bind="attrs" close v-on="on" @input="remove(data.item.value)">
+                {{ data.item.text }}
+              </VChip>
+            </template>
+            <div>
+              <div>{{ tooltipHelper(data.item.value) }}</div>
+            </div>
+          </VTooltip>
+        </template>
 
-      <template #no-data>
-        <VListTile v-if="categoryText && categoryText.trim()">
-          <VListTileContent>
-            <VListTileTitle>
-              {{ $tr('noCategoryFoundText', { text: categoryText.trim() }) }}
-            </VListTileTitle>
-          </VListTileContent>
-        </VListTile>
-      </template>
+        <template #no-data>
+          <VListTile v-if="categoryText && categoryText.trim()">
+            <VListTileContent>
+              <VListTileTitle>
+                {{ $tr('noCategoryFoundText', { text: categoryText.trim() }) }}
+              </VListTileTitle>
+            </VListTileContent>
+          </VListTile>
+        </template>
 
-      <template #item="{ item }">
-        <VListTile
-          :value="isSelected(item.value)"
-          :class="{ parentOption: !item.value.includes('.') }"
-          @mousedown.prevent
-          @click="() => !isSelected(item.value) ? add(item.value) : remove(item.value)"
-        >
-          <KCheckbox
-            :checked="isSelected(item.value)"
-            :label="item.text"
-            :value="item.value"
-            style="margin-top: 10px"
-            :style="treeItemStyle(item)"
-            :ripple="false"
-          />
-        </VListTile>
-      </template>
-    </VAutocomplete>
-  </div>
+        <template #item="{ item }">
+          <VListTile
+            :value="isSelected(item.value)"
+            :class="{ parentOption: !item.value.includes('.') }"
+            @mousedown.prevent
+            @click="() => !isSelected(item.value) ? add(item.value) : remove(item.value)"
+          >
+            <KCheckbox
+              :checked="isSelected(item.value)"
+              :label="item.text"
+              :value="item.value"
+              style="margin-top: 10px"
+              :style="treeItemStyle(item)"
+              :ripple="false"
+            />
+          </VListTile>
+        </template>
+      </VAutocomplete>
+    </template>
+  </DropdownWrapper>
 
 </template>
 
@@ -67,6 +69,7 @@
   import camelCase from 'lodash/camelCase';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
   import { Categories, CategoriesLookup } from 'shared/constants';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const availablePaths = {};
   const categoriesObj = {};
@@ -124,6 +127,7 @@
 
   export default {
     name: 'CategoryOptions',
+    components: { DropdownWrapper },
     mixins: [constantsTranslationMixin, metadataTranslationMixin],
     props: {
       value: {
@@ -208,10 +212,6 @@
 
 </script>
 <style lang="less" scoped>
-
-  .category-container {
-    position: relative;
-  }
 
   .parentOption:not(:first-child) {
     border-top: 1px solid rgba(0, 0, 0, 0.12);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -4,20 +4,22 @@
     <!-- Layout when practice quizzes are enabled -->
     <VLayout v-if="hideCompletionDropdown" xs6 md6>
       <!-- "Completion" dropdown menu  -->
-      <VFlex xs6 md6 class="completion-container pr-2">
-        <VSelect
-          ref="completion"
-          v-model="completionDropdown"
-          box
-          :items="showCorrectCompletionOptions"
-          :label="translateMetadataString('completion')"
-          :required="required"
-          :rules="completionRules"
-          :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-          attach=".completion-container"
-          @focus="trackClick('Completion')"
-        />
-      </VFlex>
+      <DropdownWrapper component="VFlex" xs6 md6 class="pr-2">
+        <template #default="{ attach, menuProps }">
+          <VSelect
+            ref="completion"
+            v-model="completionDropdown"
+            box
+            :items="showCorrectCompletionOptions"
+            :label="translateMetadataString('completion')"
+            :required="required"
+            :rules="completionRules"
+            :menu-props="menuProps"
+            :attach="attach"
+            @focus="trackClick('Completion')"
+          />
+        </template>
+      </DropdownWrapper>
       <VFlex>
         <MasteryCriteriaGoal
           v-if="showMasteryCriteriaGoalDropdown"
@@ -60,21 +62,23 @@
     </VLayout>
 
     <VLayout row wrap>
-      <VFlex xs6 md6 class="completion-duration-container pr-2">
-        <VSelect
-          v-if="!hideDurationDropdown"
-          ref="duration"
-          v-model="durationDropdown"
-          box
-          :items="selectableDurationOptions"
-          :label="translateMetadataString('duration')"
-          :required="required"
-          :rules="durationRules"
-          :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-          attach=".completion-duration-container"
-          @focus="trackClick('Duration')"
-        />
-      </VFlex>
+      <DropdownWrapper component="VFlex" xs6 md6 class="pr-2">
+        <template #default="{ attach, menuProps }">
+          <VSelect
+            v-if="!hideDurationDropdown"
+            ref="duration"
+            v-model="durationDropdown"
+            box
+            :items="selectableDurationOptions"
+            :label="translateMetadataString('duration')"
+            :required="required"
+            :rules="durationRules"
+            :menu-props="{ ...menuProps, zIndex: 4 }"
+            :attach="attach"
+            @focus="trackClick('Duration')"
+          />
+        </template>
+      </DropdownWrapper>
 
       <!-- "Activity duration" minutes input -->
       <VFlex xs6 md6>
@@ -117,6 +121,7 @@
     translateValidator,
   } from 'shared/utils/validation';
   import { metadataStrings, metadataTranslationMixin } from 'shared/mixins';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const DEFAULT_SHORT_ACTIVITY = 600;
   const DEFAULT_LONG_ACTIVITY = 3000;
@@ -132,6 +137,7 @@
   export default {
     name: 'CompletionOptions',
     components: {
+      DropdownWrapper,
       ActivityDuration,
       MasteryCriteriaMofNFields,
       MasteryCriteriaGoal,
@@ -889,10 +895,5 @@
 
 </script>
 <style lang="less" scoped>
-
-  .completion-container,
-  .completion-duration-container {
-    position: relative;
-  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -57,7 +57,6 @@
             <VFlex xs12 md6 :class="{ 'pl-2': $vuetify.breakpoint.mdAndUp }">
               <!-- Learning activity -->
               <LearningActivityOptions
-                id="learning_activities"
                 ref="learning_activities"
                 v-model="contentLearningActivities"
                 :disabled="isTopic"
@@ -65,14 +64,12 @@
               />
               <!-- Level -->
               <LevelsOptions
-                id="levels"
                 ref="contentLevel"
                 v-model="contentLevel"
                 @focus="trackClick('Levels dropdown')"
               />
               <!-- What you will need -->
               <ResourcesNeededOptions
-                id="resources_needed"
                 ref="resourcesNeeded"
                 v-model="resourcesNeeded"
                 @focus="trackClick('What you will need')"
@@ -178,7 +175,6 @@
           </h1>
           <!-- Language -->
           <LanguageDropdown
-            id="language"
             ref="language"
             v-model="language"
             class="mb-2"
@@ -192,7 +188,6 @@
           <!-- Visibility -->
           <VisibilityDropdown
             v-if="allResources"
-            id="role_visibility"
             ref="role_visibility"
             v-model="role"
             :placeholder="getPlaceholder('role')"
@@ -313,7 +308,6 @@
 
             <!-- License -->
             <LicenseDropdown
-              id="license"
               ref="license"
               v-model="licenseItem"
               :required="isUnique(license) && isUnique(license_description) && !disableAuthEdits"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LearningActivityOptions.vue
@@ -1,21 +1,23 @@
 <template>
 
-  <div class="learning-activity-container">
-    <VSelect
-      v-model="learningActivity"
-      :items="learningActivities"
-      :disabled="disabled"
-      box
-      chips
-      clearable
-      :label="translateMetadataString('learningActivity')"
-      multiple
-      deletableChips
-      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-      :rules="learningActivityRules"
-      :attach="$attrs.id ? `#${$attrs.id}` : '.learning-activity-container'"
-    />
-  </div>
+  <DropdownWrapper>
+    <template #default="{ attach, menuProps }">
+      <VSelect
+        v-model="learningActivity"
+        :items="learningActivities"
+        :disabled="disabled"
+        box
+        chips
+        clearable
+        :label="translateMetadataString('learningActivity')"
+        multiple
+        deletableChips
+        :menu-props="menuProps"
+        :rules="learningActivityRules"
+        :attach="attach"
+      />
+    </template>
+  </DropdownWrapper>
 
 </template>
 
@@ -25,9 +27,11 @@
   import { LearningActivities } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
   import { getLearningActivityValidators, translateValidator } from 'shared/utils/validation';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'LearningActivityOptions',
+    components: { DropdownWrapper },
     mixins: [constantsTranslationMixin, metadataTranslationMixin],
     props: {
       value: {
@@ -67,9 +71,5 @@
 
 </script>
 <style lang="less" scoped>
-
-  .learning-activity-container {
-    position: relative;
-  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/LevelsOptions.vue
@@ -1,20 +1,22 @@
 <template>
 
-  <div class="levels-container">
-    <VSelect
-      ref="level"
-      v-model="level"
-      :items="levels"
-      box
-      chips
-      clearable
-      :label="translateMetadataString('level')"
-      multiple
-      deletableChips
-      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-      :attach="$attrs.id ? `#${$attrs.id}` : '.levels-container'"
-    />
-  </div>
+  <DropdownWrapper>
+    <template #default="{ attach, menuProps }">
+      <VSelect
+        ref="level"
+        v-model="level"
+        :items="levels"
+        box
+        chips
+        clearable
+        :label="translateMetadataString('level')"
+        multiple
+        deletableChips
+        :menu-props="menuProps"
+        :attach="attach"
+      />
+    </template>
+  </DropdownWrapper>
 
 </template>
 
@@ -23,9 +25,11 @@
   import camelCase from 'lodash/camelCase';
   import { ContentLevels } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'LevelsOptions',
+    components: { DropdownWrapper },
     mixins: [constantsTranslationMixin, metadataTranslationMixin],
     props: {
       value: {
@@ -70,9 +74,5 @@
 
 </script>
 <style lang="less" scoped>
-
-  .levels-container {
-    position: relative;
-  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
@@ -2,24 +2,27 @@
 
   <VFlex>
     <VLayout>
-      <VFlex>
-        <VSelect
-          ref="masteryModel"
-          v-model="masteryModel"
-          :items="masteryCriteria"
-          :label="$tr('labelText')"
-          color="primary"
-          box
-          :placeholder="placeholder"
-          :required="required"
-          :readonly="readonly"
-          :disabled="disabled"
-          :rules="masteryRules"
-          menu-props="offsetY"
-          class="mb-2"
-          @focus="$emit('focus')"
-        />
-      </VFlex>
+      <DropdownWrapper component="VFlex">
+        <template #default="{ attach, menuProps }">
+          <VSelect
+            ref="masteryModel"
+            v-model="masteryModel"
+            :items="masteryCriteria"
+            :label="$tr('labelText')"
+            color="primary"
+            box
+            :placeholder="placeholder"
+            :required="required"
+            :readonly="readonly"
+            :disabled="disabled"
+            :rules="masteryRules"
+            :menu-props="menuProps"
+            :attach="attach"
+            class="mb-2"
+            @focus="$emit('focus')"
+          />
+        </template>
+      </DropdownWrapper>
     </VLayout>
   </VFlex>
 
@@ -30,9 +33,11 @@
   import { getMasteryModelValidators, translateValidator } from '../../../shared/utils/validation';
   import MasteryModels, { MasteryModelsList } from 'shared/leUtils/MasteryModels';
   import { constantsTranslationMixin } from 'shared/mixins';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'MasteryCriteriaGoal',
+    components: { DropdownWrapper },
     mixins: [constantsTranslationMixin],
     props: {
       value: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
@@ -16,7 +16,7 @@
             :readonly="readonly"
             :disabled="disabled"
             :rules="masteryRules"
-            :menu-props="menuProps"
+            :menu-props="{ ...menuProps, lazy: false }"
             :attach="attach"
             class="mb-2"
             @focus="$emit('focus')"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -1,22 +1,24 @@
 <template>
 
-  <div class="resources-needed-container">
-    <VSelect
-      ref="need"
-      v-model="need"
-      :items="resources"
-      box
-      chips
-      :label="$tr('resourcesNeededLabel')"
-      multiple
-      deletableChips
-      clearable
-      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-      :attach="$attrs.id ? `#${$attrs.id}` : '.resources-needed-container'"
-      :hint="hint"
-      persistent-hint
-    />
-  </div>
+  <DropdownWrapper>
+    <template #default="{ attach, menuProps }">
+      <VSelect
+        ref="need"
+        v-model="need"
+        :items="resources"
+        box
+        chips
+        :label="$tr('resourcesNeededLabel')"
+        multiple
+        deletableChips
+        clearable
+        :menu-props="menuProps"
+        :attach="attach"
+        :hint="hint"
+        persistent-hint
+      />
+    </template>
+  </DropdownWrapper>
 
 </template>
 
@@ -24,6 +26,7 @@
 
   import { ResourcesNeededTypes } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const dropdownItems = [
     'PEERS',
@@ -36,6 +39,7 @@
 
   export default {
     name: 'ResourcesNeededOptions',
+    components: { DropdownWrapper },
     mixins: [constantsTranslationMixin, metadataTranslationMixin],
     props: {
       value: {
@@ -73,9 +77,5 @@
 
 </script>
 <style lang="less">
-
-  .resources-needed-container {
-    position: relative;
-  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -3,7 +3,7 @@
   <VCard @click="handleClick">
     <VCardTitle>
       <VLayout row wrap>
-        <VFlex lg2 md4 sm5 xs12 class="pt-2 px-4">
+        <VFlex class="pt-2 px-4 thumbnail-column">
           <Thumbnail
             :src="node.thumbnail_src"
             :kind="node.kind"
@@ -11,7 +11,7 @@
           />
         </VFlex>
 
-        <VFlex lg10 md8 sm7 xs12 class="px-4">
+        <VFlex class="info-column px-4">
           <h3
             class="font-weight-bold mt-2 text-truncate title"
             :class="getTitleClass(node)"
@@ -204,6 +204,15 @@
 
 
 <style lang="less" scoped>
+
+  .thumbnail-column {
+    flex-basis: 33%;
+    max-width: 220px;
+  }
+
+  .info-column {
+    flex-basis: 67%;
+  }
 
   .show-more-btn {
     margin-left: -7px;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -3,16 +3,26 @@
   <VContainer class="mx-0 px-0">
     <!-- Filters -->
     <VLayout row wrap>
-      <VFlex sm6 md5 lg4 xl3 class="pr-4">
-        <VSelect
-          v-model="channelFilter"
-          :label="$tr('channelFilterLabel')"
-          :items="channelFilterOptions"
-          :menu-props="{ offsetY: true }"
-          :disabled="loading"
-          box
-        />
-      </VFlex>
+      <DropdownWrapper
+        component="VFlex"
+        sm6
+        md5
+        lg4
+        xl3
+        class="pr-4"
+      >
+        <template #default="{ attach, menuProps }">
+          <VSelect
+            v-model="channelFilter"
+            :label="$tr('channelFilterLabel')"
+            :items="channelFilterOptions"
+            :attach="attach"
+            :menu-props="menuProps"
+            :disabled="loading"
+            box
+          />
+        </template>
+      </DropdownWrapper>
       <VFlex sm6 md5 lg4 xl3 class="pr-5">
         <LanguageDropdown v-model="languageFilter" />
       </VFlex>
@@ -48,10 +58,12 @@
   import Pagination from 'shared/views/Pagination';
   import LoadingText from 'shared/views/LoadingText';
   import { constantsTranslationMixin } from 'shared/mixins';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'ChannelList',
     components: {
+      DropdownWrapper,
       ChannelInfoCard,
       LanguageDropdown,
       Pagination,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -17,7 +17,7 @@
       ></div>
     </VFadeTransition>
 
-    <VContainer fluid class="mb-5 pb-5 px-5">
+    <VContainer fluid class="mb-5 modal-container mx-0 pb-5 px-4">
       <slot :preview="handlePreview"></slot>
     </VContainer>
     <ResourceDrawer
@@ -263,5 +263,8 @@
 
 <style lang="less" scoped>
 
+  .modal-container.fluid {
+    max-width: 1200px;
+  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VContainer class="pt-3 px-0" fluid>
+  <VContainer class="pt-3 px-2" fluid>
     <VChip
       v-for="(filter, index) in currentFilters"
       :key="`search-filter-${index}`"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -9,13 +9,18 @@
     <p class="font-weight-bold grey--text mb-1">
       {{ $tr('channelsHeader') }}
     </p>
-    <VSelect
-      v-model="channelType"
-      :label="$tr('channelTypeLabel')"
-      :items="channelTypeFilterOptions"
-      box
-      :menu-props="menuProps"
-    />
+    <DropdownWrapper menuHeight="270">
+      <template #default="{ attach, menuProps }">
+        <VSelect
+          v-model="channelType"
+          :label="$tr('channelTypeLabel')"
+          :items="channelTypeFilterOptions"
+          box
+          :attach="attach"
+          :menu-props="menuProps"
+        />
+      </template>
+    </DropdownWrapper>
     <MultiSelect
       v-model="channel_id__in"
       :label="$tr('channelSourceLabel')"
@@ -65,7 +70,6 @@
     <!-- Language -->
     <LanguageDropdown
       v-model="languages"
-      drop-above
       multiple
     />
 
@@ -125,6 +129,7 @@
   import MultiSelect from 'shared/views/form/MultiSelect';
   import Checkbox from 'shared/views/form/Checkbox';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const excludedKinds = new Set(['topic', 'exercise', 'h5p', 'zim']);
   const includedKinds = ContentKindsList.filter(kind => !excludedKinds.has(kind));
@@ -132,6 +137,7 @@
   export default {
     name: 'SearchFilters',
     components: {
+      DropdownWrapper,
       MultiSelect,
       Checkbox,
       LanguageDropdown,
@@ -182,9 +188,6 @@
             value,
           };
         });
-      },
-      menuProps() {
-        return { offsetY: true, maxHeight: 270 };
       },
       licenseOptions() {
         return LicensesList.map(license => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <VNavigationDrawer permanent floating style="z-index: 0;">
+  <VNavigationDrawer
+    permanent
+    floating
+    class="import-search-filters px-2"
+  >
     <!-- Channel -->
     <p class="font-weight-bold grey--text mb-1">
       {{ $tr('channelsHeader') }}
@@ -61,6 +65,7 @@
     <!-- Language -->
     <LanguageDropdown
       v-model="languages"
+      drop-above
       multiple
     />
 
@@ -121,7 +126,7 @@
   import Checkbox from 'shared/views/form/Checkbox';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
 
-  const excludedKinds = new Set(['topic', 'exercise', 'h5p']);
+  const excludedKinds = new Set(['topic', 'exercise', 'h5p', 'zim']);
   const includedKinds = ContentKindsList.filter(kind => !excludedKinds.has(kind));
 
   export default {
@@ -225,6 +230,12 @@
 
 
 <style lang="less" scoped>
+
+  .import-search-filters {
+    z-index: 0;
+    box-sizing: border-box;
+    overflow: visible;
+  }
 
   .fieldset-reset {
     border-style: none;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -3,7 +3,7 @@
   <ImportFromChannelsModal>
     <template #default="{ preview }">
       <VSheet>
-        <div v-if="!isBrowsing" class="my-2">
+        <div v-if="!isBrowsing" class="my-2 px-2">
           <ActionLink
             :text="$tr('backToBrowseAction')"
             @click="handleBackToBrowse"
@@ -11,8 +11,8 @@
         </div>
 
         <!-- Search bar -->
-        <VLayout row wrap class="mt-4">
-          <VFlex xl4 lg5 md7 sm12>
+        <VLayout row wrap class="mt-4 px-2">
+          <VFlex style="max-width: 700px">
             <VForm ref="search" @submit.prevent="handleSearchTerm">
               <VTextField
                 v-model="searchTerm"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -4,19 +4,21 @@
     <!-- Filters -->
     <SearchFilterBar />
     <VLayout row>
-      <VFlex class="px-2" sm3>
-        <ActionLink
-          class="mb-3"
-          :text="$tr('savedSearchesLabel')"
-          @click="showSavedSearches = true"
-        />
+      <VFlex shrink>
+        <div class="px-2">
+          <ActionLink
+            class="mb-3"
+            :text="$tr('savedSearchesLabel')"
+            @click="showSavedSearches = true"
+          />
+        </div>
         <SearchFilters
           :searchResults="nodes"
         />
       </VFlex>
 
       <!-- Main area with cards -->
-      <VFlex sm9>
+      <VFlex class="pl-4">
         <VContainer v-if="loadFailed">
           <p class="text-xs-center">
             <Icon color="red">
@@ -27,9 +29,9 @@
             {{ $tr('failedToLoad') }}
           </p>
         </VContainer>
-        <VContainer v-else class="mx-0">
+        <VContainer v-else class="mx-0 px-1">
           <LoadingText v-if="loading" />
-          <VLayout v-else row align-center class="mx-4">
+          <VLayout v-else row align-center>
             <VFlex grow>
               <span class="font-weight-bold subheading">
                 {{ $tr('searchResultsCount', {
@@ -55,16 +57,17 @@
               </span>
             </VFlex>
           </VLayout>
-          <div class="px-4">
-            <VLayout v-for="node in nodes" :key="node.id" row align-center>
-              <VFlex shrink>
+          <div>
+            <VLayout v-for="node in nodes" :key="node.id" row align-center class="py-2">
+              <VFlex class="px-1" shrink>
                 <Checkbox
                   :key="`checkbox-${node.id}`"
                   :input-value="isSelected(node)"
+                  class="mt-0 pt-0"
                   @change="toggleSelected(node)"
                 />
               </VFlex>
-              <VFlex class="pa-4" grow>
+              <VFlex shrink grow style="width: 100%;">
                 <BrowsingCard
                   :node="node"
                   :inSearch="true"

--- a/contentcuration/contentcuration/frontend/shared/styles/main.less
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.less
@@ -68,6 +68,10 @@ body {
     right: auto;
     left: 16px;
   }
+
+  .v-input {
+    text-align: right;
+  }
 }
 
 /*! rtl:end:ignore */

--- a/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
@@ -124,4 +124,11 @@
     border-radius: 4px;
   }
 
+  .labeled-icon-wrapper /deep/ .icon {
+    [dir='rtl'] & {
+      right: 0;
+      left: auto;
+    }
+  }
+
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
@@ -124,11 +124,4 @@
     border-radius: 4px;
   }
 
-  .labeled-icon-wrapper /deep/ .icon {
-    [dir='rtl'] & {
-      right: 0;
-      left: auto;
-    }
-  }
-
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -1,39 +1,43 @@
 <template>
 
-  <VAutocomplete
-    v-model="language"
-    class="language-dropdown"
-    box
-    v-bind="$attrs"
-    :items="languages"
-    :label="$tr('labelText')"
-    color="primary"
-    itemValue="id"
-    :itemText="languageText"
-    autoSelectFirst
-    :allowOverflow="false"
-    clearable
-    :rules="rules"
-    :required="required"
-    :no-data-text="$tr('noDataText')"
-    :search-input.sync="input"
-    :menu-props="menuProps"
-    :multiple="multiple"
-    :chips="multiple"
-    :attach="$attrs.id ? `#${$attrs.id}` : '.language-dropdown'"
-    @change="input = ''"
-    @focus="$emit('focus')"
-  >
-    <template #item="{ item }">
-      <VTooltip bottom lazy>
-        <template #activator="{ on }">
-          <span class="text-truncate" v-on="on">{{ languageText(item) }}</span>
-        </template>
-        <span>{{ languageText(item) }}</span>
-      </VTooltip>
+  <DropdownWrapper>
+    <template #default="{ attach, menuProps }">
+      <VAutocomplete
+        v-model="language"
+        class="language-dropdown"
+        box
+        v-bind="$attrs"
+        :items="languages"
+        :label="$tr('labelText')"
+        color="primary"
+        itemValue="id"
+        :itemText="languageText"
+        autoSelectFirst
+        :allowOverflow="false"
+        clearable
+        :rules="rules"
+        :required="required"
+        :no-data-text="$tr('noDataText')"
+        :search-input.sync="input"
+        :menu-props="{ ...menuProps, maxWidth: 300 }"
+        :multiple="multiple"
+        :chips="multiple"
+        :attach="attach"
+        @change="input = ''"
+        @focus="$emit('focus')"
+      >
+        <template #item="{ item }">
+          <VTooltip bottom lazy>
+            <template #activator="{ on }">
+              <span class="text-truncate" v-on="on">{{ languageText(item) }}</span>
+            </template>
+            <span>{{ languageText(item) }}</span>
+          </VTooltip>
 
+        </template>
+      </VAutocomplete>
     </template>
-  </VAutocomplete>
+  </DropdownWrapper>
 
 </template>
 
@@ -42,9 +46,13 @@
 
   import isArray from 'lodash/isArray';
   import Languages, { LanguagesList } from 'shared/leUtils/Languages';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'LanguageDropdown',
+    components: { DropdownWrapper },
+    // $attrs are rebound to a descendent component
+    inheritAttrs: false,
     props: {
       value: {
         type: [String, Array, Object],
@@ -73,10 +81,6 @@
         type: Boolean,
         default: false,
       },
-      dropAbove: {
-        type: Boolean,
-        default: false,
-      },
     },
     data() {
       return {
@@ -91,13 +95,6 @@
         set(value) {
           this.$emit('input', value);
         },
-      },
-      menuProps() {
-        return {
-          minWidth: 300,
-          maxWidth: 300,
-          top: this.dropAbove,
-        };
       },
       languages() {
         const excludeLanguages = new Set(this.excludeLanguages);
@@ -124,11 +121,6 @@
 
 
 <style lang="less" scoped>
-
-  .language-dropdown {
-    display: inline-block;
-    width: 100%;
-  }
 
   /deep/ .v-select__selections {
     width: calc(100% - 48px);

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -1,45 +1,47 @@
 <template>
 
-  <div class="license-container">
-    <VLayout class="license-dropdown" row align-center>
-      <VSelect
-        ref="license"
-        v-model="license"
-        :items="licenses"
-        :label="$tr('licenseLabel')"
-        color="primary"
-        itemValue="id"
-        :itemText="translate"
-        :disabled="disabled"
-        :required="required"
-        :readonly="readonly"
-        :rules="licenseRules"
-        :placeholder="placeholder"
-        :menu-props="{ offsetY: true, lazy: true, top: true, zIndex: 4 }"
-        class="ma-0"
-        box
-        :attach="$attrs.id ? `#${$attrs.id}` : '.license-container'"
-        @focus="$emit('focus')"
-      >
-        <template #append-outer>
-          <InfoModal :header="$tr('licenseInfoHeader')" :items="licenses">
-            <template #header="{ item }">
-              {{ translate(item) }}
-            </template>
-            <template #description="{ item }">
-              {{ translateDescription(item) }}
-              <p v-if="item.license_url" class="mt-1">
-                <ActionLink
-                  :href="getLicenseUrl(item)"
-                  target="_blank"
-                  :text="$tr('learnMoreButton')"
-                />
-              </p>
-            </template>
-          </InfoModal>
-        </template>
-      </VSelect>
-    </VLayout>
+  <div>
+    <DropdownWrapper component="VLayout" class="license-dropdown" row align-center>
+      <template #default="{ attach, menuProps }">
+        <VSelect
+          ref="license"
+          v-model="license"
+          :items="licenses"
+          :label="$tr('licenseLabel')"
+          color="primary"
+          itemValue="id"
+          :itemText="translate"
+          :disabled="disabled"
+          :required="required"
+          :readonly="readonly"
+          :rules="licenseRules"
+          :placeholder="placeholder"
+          :menu-props="menuProps"
+          class="ma-0"
+          box
+          :attach="attach"
+          @focus="$emit('focus')"
+        >
+          <template #append-outer>
+            <InfoModal :header="$tr('licenseInfoHeader')" :items="licenses">
+              <template #header="{ item }">
+                {{ translate(item) }}
+              </template>
+              <template #description="{ item }">
+                {{ translateDescription(item) }}
+                <p v-if="item.license_url" class="mt-1">
+                  <ActionLink
+                    :href="getLicenseUrl(item)"
+                    target="_blank"
+                    :text="$tr('learnMoreButton')"
+                  />
+                </p>
+              </template>
+            </InfoModal>
+          </template>
+        </VSelect>
+      </template>
+    </DropdownWrapper>
     <VTextarea
       v-if="isCustom"
       ref="description"
@@ -72,10 +74,12 @@
   import { LicensesList } from 'shared/leUtils/Licenses';
   import { constantsTranslationMixin } from 'shared/mixins';
   import { findLicense } from 'shared/utils/helpers';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'LicenseDropdown',
     components: {
+      DropdownWrapper,
       InfoModal,
     },
     filters: {},
@@ -180,9 +184,5 @@
 </script>
 
 <style lang="less" scoped>
-
-  .license-container {
-    position: relative;
-  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/VisibilityDropdown.vue
@@ -1,52 +1,54 @@
 <template>
 
-  <VLayout grid wrap align-center class="role-visibility-container">
-    <VSelect
-      ref="visibility"
-      v-model="role"
-      :items="roles"
-      :label="$tr('labelText')"
-      :placeholder="placeholder"
-      color="primary"
-      :disabled="disabled"
-      :readonly="readonly"
-      :required="required"
-      :rules="rules"
-      :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
-      box
-      :attach="$attrs.id ? `#${$attrs.id}` : '.role-visibility-container'"
-      @focus="$emit('focus')"
-    >
-      <template #append-outer>
-        <InfoModal :header="$tr('visibilityHeader')" :items="roles">
-          <p>{{ $tr('visibilityDescription') }}</p>
-          <template #header="{ item }">
-            <span>
-              {{ item.text }}
-              <Icon v-if="roleIcon(item.value)" :color="roleColor(item.value)">
-                {{ roleIcon(item.value) }}
-              </Icon>
-            </span>
-          </template>
-          <template #description="{ item }">
-            {{ $tr(item.value) }}
-          </template>
-        </InfoModal>
-      </template>
-      <template #selection="{ item }">
-        <Icon v-if="roleIcon(item.value)" :color="roleColor(item.value)" class="pr-2">
-          {{ roleIcon(item.value) }}
-        </Icon>
-        {{ item.text }}
-      </template>
-      <template #item="{ item }">
-        <Icon v-if="roleIcon(item.value)" :color="roleColor(item.value)" class="pr-2">
-          {{ roleIcon(item.value) }}
-        </Icon>
-        {{ item.text }}
-      </template>
-    </VSelect>
-  </VLayout>
+  <DropdownWrapper component="VLayout" grid wrap align-center>
+    <template #default="{ attach, menuProps }">
+      <VSelect
+        ref="visibility"
+        v-model="role"
+        :items="roles"
+        :label="$tr('labelText')"
+        :placeholder="placeholder"
+        color="primary"
+        :disabled="disabled"
+        :readonly="readonly"
+        :required="required"
+        :rules="rules"
+        :menu-props="{ ...menuProps, zIndex: 4 }"
+        box
+        :attach="attach"
+        @focus="$emit('focus')"
+      >
+        <template #append-outer>
+          <InfoModal :header="$tr('visibilityHeader')" :items="roles">
+            <p>{{ $tr('visibilityDescription') }}</p>
+            <template #header="{ item }">
+              <span>
+                {{ item.text }}
+                <Icon v-if="roleIcon(item.value)" :color="roleColor(item.value)">
+                  {{ roleIcon(item.value) }}
+                </Icon>
+              </span>
+            </template>
+            <template #description="{ item }">
+              {{ $tr(item.value) }}
+            </template>
+          </InfoModal>
+        </template>
+        <template #selection="{ item }">
+          <Icon v-if="roleIcon(item.value)" :color="roleColor(item.value)" class="pr-2">
+            {{ roleIcon(item.value) }}
+          </Icon>
+          {{ item.text }}
+        </template>
+        <template #item="{ item }">
+          <Icon v-if="roleIcon(item.value)" :color="roleColor(item.value)" class="pr-2">
+            {{ roleIcon(item.value) }}
+          </Icon>
+          {{ item.text }}
+        </template>
+      </VSelect>
+    </template>
+  </DropdownWrapper>
 
 </template>
 
@@ -55,6 +57,7 @@
   import Roles, { RolesList } from 'shared/leUtils/Roles';
   import InfoModal from 'shared/views/InfoModal.vue';
   import { constantsTranslationMixin } from 'shared/mixins';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const roleIcons = { coach: 'local_library' };
   const roleColors = { coach: 'roleVisibilityCoach' };
@@ -62,6 +65,7 @@
   export default {
     name: 'VisibilityDropdown',
     components: {
+      DropdownWrapper,
       InfoModal,
     },
     mixins: [constantsTranslationMixin],

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharing.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelSharing.vue
@@ -26,20 +26,24 @@
             @input="error = null"
           />
         </VFlex>
-        <VFlex shrink>
-          <VSelect
-            v-model="shareMode"
-            box
-            color="primary"
-            menu-props="offsetY"
-            :items="permissions"
-            item-value="id"
-            item-text="text"
-            style="max-width: 200px;"
-            single-line
-            hide-details
-          />
-        </VFlex>
+        <DropdownWrapper component="VFlex" shrink :menuHeight="120">
+          <template #default="{ attach, menuProps }">
+            <VSelect
+              v-model="shareMode"
+              box
+              color="primary"
+              menu-props="offsetY"
+              :items="permissions"
+              item-value="id"
+              item-text="text"
+              style="max-width: 200px;"
+              single-line
+              hide-details
+              :attach="attach"
+              :menuProps="menuProps"
+            />
+          </template>
+        </DropdownWrapper>
       </VLayout>
       <VBtn color="primary" type="submit" :disabled="sharing">
         {{ $tr('inviteButton') }}
@@ -63,10 +67,12 @@
   import ChannelSharingTable from './ChannelSharingTable';
   import LoadingText from 'shared/views/LoadingText';
   import { SharingPermissions } from 'shared/constants';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   export default {
     name: 'ChannelSharing',
     components: {
+      DropdownWrapper,
       LoadingText,
       ChannelSharingTable,
     },

--- a/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
@@ -213,7 +213,7 @@
     }
 
     &.rtl-image {
-      right: 16%;
+      right: 66%;
     }
 
     .caption + & {

--- a/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
@@ -213,7 +213,7 @@
     }
 
     &.rtl-image {
-      right: 66%;
+      right: 16%;
     }
 
     .caption + & {

--- a/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/ContentDefaults.vue
@@ -41,14 +41,19 @@
         data-name="copyrightHolder"
         :label="$tr('copyrightHolder')"
       />
-      <VSelect
-        v-model="license"
-        box
-        data-name="license"
-        :items="licenseOpts"
-        :label="$tr('license')"
-        menuProps="offsetY"
-      />
+      <DropdownWrapper>
+        <template #default="{ attach, menuProps }">
+          <VSelect
+            v-model="license"
+            box
+            data-name="license"
+            :items="licenseOpts"
+            :label="$tr('license')"
+            :attach="attach"
+            :menuProps="menuProps"
+          />
+        </template>
+      </DropdownWrapper>
       <VTextarea
         v-if="isCustomLicense"
         v-model="licenseDescription"
@@ -104,6 +109,7 @@
   import { LicensesList } from 'shared/leUtils/Licenses';
   import { ContentDefaults, ContentDefaultsDefaults } from 'shared/constants';
   import { findLicense } from 'shared/utils/helpers';
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   function normalizeContentDefaults(contentDefaults) {
     return Object.entries(ContentDefaultsDefaults).reduce((normalized, [key, defaultValue]) => {
@@ -136,6 +142,7 @@
   export default {
     name: 'ContentDefaults',
     components: {
+      DropdownWrapper,
       Checkbox,
     },
     mixins: [constantsTranslationMixin],

--- a/contentcuration/contentcuration/frontend/shared/views/form/CountryField.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/CountryField.vue
@@ -1,27 +1,35 @@
 <template>
 
-  <VAutocomplete
-    v-model="locations"
-    :items="options"
-    :label="label || $tr('locationLabel')"
-    :multiple="multiple"
-    :box="box"
-    item-value="id"
-    item-text="name"
-    :required="required"
-    :rules="rules"
-    :search-input.sync="searchInput"
-    :no-data-text="$tr('noCountriesFound')"
-    :chips="multiple"
-    clearable
-    v-bind="$attrs"
-    @change="searchInput = ''"
-  />
+  <DropdownWrapper>
+    <template #default="{ attach, menuProps }">
+      <VAutocomplete
+        v-model="locations"
+        :items="options"
+        :label="label || $tr('locationLabel')"
+        :multiple="multiple"
+        :box="box"
+        item-value="id"
+        item-text="name"
+        :required="required"
+        :rules="rules"
+        :search-input.sync="searchInput"
+        :no-data-text="$tr('noCountriesFound')"
+        :chips="multiple"
+        :attach="attach"
+        :menuProps="menuProps"
+        clearable
+        v-bind="$attrs"
+        @change="searchInput = ''"
+      />
+    </template>
+  </DropdownWrapper>
 
 </template>
 
 
 <script>
+
+  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   var countries = require('i18n-iso-countries');
   countries.registerLocale(require('i18n-iso-countries/langs/en.json'));
@@ -32,6 +40,9 @@
 
   export default {
     name: 'CountryField',
+    components: { DropdownWrapper },
+    // $attrs are rebound to a descendent component
+    inheritAttrs: false,
     props: {
       value: {
         type: [String, Array],

--- a/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
@@ -1,0 +1,88 @@
+<template>
+
+  <component :is="component" :id="id" style="position: relative" v-bind="$attrs">
+    <slot name="default" :attach="`#${id}`" :menuProps="menuProps"></slot>
+  </component>
+
+</template>
+
+<script>
+
+  import { v4 as uuidv4 } from 'uuid';
+  import { animationThrottle } from 'shared/utils/helpers';
+
+  /**
+   * Wrapper component that defines an ID for using with Vuetify's `:attach` so that
+   * absolute positioned dropdowns will remain attached next to the wrapped field/component
+   */
+  export default {
+    name: 'DropdownWrapper',
+    props: {
+      id: {
+        type: String,
+        default() {
+          return `DropdownWrapper_${uuidv4()
+            .split('-')
+            .pop()}`;
+        },
+      },
+      component: {
+        type: String,
+        default: 'div',
+      },
+      menuHeight: {
+        type: Number,
+        default: 300,
+      },
+    },
+    data() {
+      return {
+        top: false,
+      };
+    },
+    computed: {
+      menuProps() {
+        return {
+          offsetY: true,
+          zIndex: 4,
+          top: this.top,
+          maxHeight: this.menuHeight,
+          lazy: true,
+        };
+      },
+    },
+    /**
+     * TODO: this logic doesn't handle if the page is resized, which could occur
+     * from viewport rotation on a tablet
+     */
+    mounted() {
+      let scrollableAncestor = this.$el;
+
+      // Go upwards in the DOM finding the nearest ancestor that's scrollable
+      // Note: it ideally it should be `<= 0` instead of `<= 1`
+      while (
+        scrollableAncestor &&
+        (scrollableAncestor.scrollHeight - scrollableAncestor.clientHeight <= 1 ||
+          !/auto|scroll/.test(window.getComputedStyle(scrollableAncestor).overflowY))
+      ) {
+        if (!scrollableAncestor.parentNode) {
+          break;
+        }
+        scrollableAncestor = scrollableAncestor.parentNode;
+      }
+
+      const scrollableBoundingRect = scrollableAncestor.getBoundingClientRect();
+
+      // Listen for scrolls and update `top` according to whether there's enough space to render
+      // the dropdown below the element
+      const scrollListener = animationThrottle(() => {
+        this.top =
+          this.$el.getBoundingClientRect().bottom + this.menuHeight > scrollableBoundingRect.bottom;
+      });
+      scrollableAncestor.addEventListener('scroll', scrollListener);
+      // call the scroll listener to initialize `top`
+      scrollListener();
+    },
+  };
+
+</script>

--- a/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
@@ -69,6 +69,11 @@
           break;
         }
         scrollableAncestor = scrollableAncestor.parentNode;
+
+        // Stop if we reach the body-- tagName is likely uppercase
+        if (/body/i.test(scrollableAncestor.tagName)) {
+          break;
+        }
       }
 
       const scrollableBoundingRect = scrollableAncestor.getBoundingClientRect();

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -1,30 +1,35 @@
 <template>
 
-  <VSelect
-    v-model="selections"
-    :items="items"
-    multiple
-    :box="box"
-    clearable
-    chips
-    :no-data-text="$tr('noItemsFound')"
-    :menu-props="menuProps"
-    v-bind="$attrs"
-    @click.stop.prevent
-  >
-    <template #selection="{ item }">
-      <VChip :class="{ notranslate }">
-        {{ getText(item) }}
-      </VChip>
-    </template>
-    <template #item="{ item, tile }">
-      <Checkbox v-bind="tile.props" class="ma-0">
-        <template #label>
-          <span :class="{ notranslate }">{{ getText(item) }}</span>
+  <DropdownWrapper :menuHeight="270">
+    <template #default="{ attach, menuProps }">
+      <VSelect
+        v-model="selections"
+        :items="items"
+        multiple
+        :box="box"
+        clearable
+        chips
+        :no-data-text="$tr('noItemsFound')"
+        :menu-props="{ ...menuProps, zIndex: 300 }"
+        :attach="attach"
+        v-bind="$attrs"
+        @click.stop.prevent
+      >
+        <template #selection="{ item }">
+          <VChip :class="{ notranslate }">
+            {{ getText(item) }}
+          </VChip>
         </template>
-      </Checkbox>
+        <template #item="{ item, tile }">
+          <Checkbox v-bind="tile.props" class="ma-0">
+            <template #label>
+              <span :class="{ notranslate }">{{ getText(item) }}</span>
+            </template>
+          </Checkbox>
+        </template>
+      </VSelect>
     </template>
-  </VSelect>
+  </DropdownWrapper>
 
 </template>
 
@@ -32,10 +37,13 @@
 <script>
 
   import Checkbox from './Checkbox';
+  import DropdownWrapper from './DropdownWrapper';
 
   export default {
     name: 'MultiSelect',
-    components: { Checkbox },
+    components: { Checkbox, DropdownWrapper },
+    // $attrs are rebound to a descendent component
+    inheritAttrs: false,
     props: {
       value: {
         type: Array,
@@ -70,9 +78,6 @@
         set(value) {
           this.$emit('input', value.filter(Boolean));
         },
-      },
-      menuProps() {
-        return { offsetY: true, maxHeight: 270, zIndex: 300 };
       },
     },
     methods: {

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -615,7 +615,7 @@ class PrerequisitesUpdateHandler(ValuesViewset):
 
 
 def dict_if_none(obj, field_name=None):
-    return obj[field_name] if obj[field_name] else {}
+    return obj[field_name] if field_name in obj and obj[field_name] else {}
 
 
 # Apply mixin first to override ValuesViewset


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Background
-  We recently switched Studio's dropdowns to `absolute` positioning instead of the `fixed` positioning
  - It relies on a selector, usually an ID, for attaching the menu, and when building reusable components the use of ID complicates things
  - Additionally, switching this caused issues with automatic placement of the dropdowns depending on its location in the viewport

### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Consolidated dropdown behavior (hopefully once and for all) using a new component that uses scoped slots to provide an `attach` attribute to Vuetify selects, autocompletes, and menus
- With the consolidated behavior in the new component, it now automates the dropdown position so that the dropdown shows above the field if there isn't sufficient space below the field
- Refactors and simplifies the layout of import search to address issues with the filter dropdowns
- Fixes RTL issues in the Language filter of the Catalog search

### Manual verification steps performed
- Verified the behavior of the dropdowns in:
  - Edit modal
  - Editing channel details
  - Signing up for a new account
  - Catalog search
  - Import search

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
| Before | After |
| --- | --- |
| ![dropdown-before](https://user-images.githubusercontent.com/819838/193125542-6435c315-9df9-430f-9cc8-f4fee4b56c08.gif) | ![dropdown](https://user-images.githubusercontent.com/819838/193125550-2b1dc465-a3f2-4150-981e-3ef4579c27dd.gif) |
| ![192760472-f7f12bb5-f70f-42e5-8d25-28243ef7c5a7](https://user-images.githubusercontent.com/819838/193125507-ea50d731-e59e-4e6d-91bd-d51f73cda085.png) | ![Screenshot from 2022-09-29 12-07-31](https://user-images.githubusercontent.com/819838/193125349-3f2268ca-f754-49fe-b9cb-824973e0ca7a.png) |
| ![Screenshot from 2022-09-22 11-08-58](https://user-images.githubusercontent.com/819838/193350642-40b3983d-0d45-4381-9707-ae710945bc35.png) | ![Screenshot from 2022-09-29 12-09-09](https://user-images.githubusercontent.com/819838/193350540-84fd7deb-30a1-4fd2-b01e-e12e087d4f08.png) |




### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
- I didn't add logic to the `<DropdownWrapper>` for handling viewport resizes
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
Much of the diff comes from wrapping templates with `<DropdownWrapper>`

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3689
Fixes https://github.com/learningequality/studio/issues/3678
Fixes https://github.com/learningequality/studio/issues/3666


## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [x] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
