### PR TITLE
Fix mastery criterion publishing

### DIFF
--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -112,7 +112,7 @@ def node_json(data):
     return node_data
 
 
-def node(data, parent=None):
+def node(data, parent=None):  # noqa: C901
     new_node = None
     # Create topics
     if 'node_id' not in data:
@@ -155,12 +155,15 @@ def node(data, parent=None):
 
     # Create exercises
     elif data['kind_id'] == "exercise":
-        extra_fields = {
-            'mastery_model': data['mastery_model'],
-            'randomize': True,
-            'm': data.get('m') or 0,
-            'n': data.get('n') or 0
-        }
+        if "extra_fields" in data:
+            extra_fields = data["extra_fields"]
+        else:
+            extra_fields = {
+                'mastery_model': data['mastery_model'],
+                'randomize': True,
+                'm': data.get('m') or 0,
+                'n': data.get('n') or 0
+            }
         new_node = cc.ContentNode(
             kind=exercise(),
             parent=parent,
@@ -174,7 +177,7 @@ def node(data, parent=None):
         )
 
         new_node.save()
-        for assessment_item in data['assessment_items']:
+        for assessment_item in data.get('assessment_items', []):
             ai = cc.AssessmentItem(
                 contentnode=new_node,
                 assessment_id=assessment_item['assessment_id'],

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -15,6 +15,7 @@ from django.core.files.storage import default_storage
 from django.db.models import Count
 from django.db.models import Sum
 from django.utils import timezone
+from le_utils.constants import completion_criteria
 from le_utils.constants import content_kinds
 from le_utils.constants import format_presets
 
@@ -427,3 +428,22 @@ def calculate_resource_size(node, force=False):
             report_exception(e)
 
     return size, False
+
+
+def migrate_extra_fields(extra_fields):
+    if not isinstance(extra_fields, dict):
+        return extra_fields
+    m = extra_fields.pop("m", None)
+    n = extra_fields.pop("n", None)
+    mastery_model = extra_fields.pop("mastery_model", None)
+    if not extra_fields.get("options", {}).get("completion_criteria", {}) and mastery_model is not None:
+        extra_fields["options"] = extra_fields.get("options", {})
+        extra_fields["options"]["completion_criteria"] = {
+            "threshold": {
+                "m": m,
+                "n": n,
+                "mastery_model": mastery_model,
+            },
+            "model": completion_criteria.MASTERY,
+        }
+    return extra_fields


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes completely wrong logic in the publish code for extracting the mastery model
* Consolidates logic from the viewset to reuse in publishing too
* Adds tests for proper publishing of both old format and new format mastery models (at top level of extra_fields, and in the completion criteria)


### Manual verification steps performed
1. Wrote a regression test, saw that it failed.
2. Fixed the behaviour.
3. Regression test passed.

Fixes #3676