### PR TITLE
Coerce all file durations with floor instead of ceil.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
@@ -92,7 +92,7 @@ export function extractMetadata(file, preset = null) {
     const mediaElement = document.createElement(isVideo ? 'video' : 'audio');
     // Add a listener to read the metadata once it has loaded.
     mediaElement.addEventListener('loadedmetadata', () => {
-      metadata.duration = Math.ceil(mediaElement.duration);
+      metadata.duration = Math.floor(mediaElement.duration);
       // Override preset based off video resolution
       if (isVideo) {
         metadata.preset =

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -426,4 +426,4 @@ class UploadFileURLTestCase(StudioAPITestCase):
         response = self.client.post(reverse("file-upload-url"), self.file, format="json",)
         self.assertEqual(response.status_code, 200)
         file = models.File.objects.get(checksum=self.file["checksum"])
-        self.assertEqual(11, file.duration)
+        self.assertEqual(10, file.duration)

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -147,7 +147,7 @@ class FileViewSet(BulkDeleteMixin, BulkUpdateMixin, ReadOnlyValuesViewset):
         if duration is not None:
             if not isinstance(duration, (int, float)):
                 return HttpResponseBadRequest(reason="File duration must be a number")
-            duration = math.ceil(duration)
+            duration = math.floor(duration)
 
         try:
             request.user.check_space(float(size), checksum)


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Uses floor instead of ceil for file durations
* Do this to ensure that duration never exceeds actual duration and makes it tricky to get full progress for duration based progress
* If ceil-ed, then users might have to skip back a second in a video in Kolibri for it to be marked as complete.


Address concerns raised here: https://github.com/learningequality/studio/pull/3317#issuecomment-1252373687