### PR TITLE
Update IndexedDB mutations

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/mutations.js
@@ -52,13 +52,9 @@ export function UPDATE_ASSESSMENTITEM_FROM_INDEXEDDB(state, { id, ...mods }) {
     state.assessmentItemsMap[contentnode] &&
     state.assessmentItemsMap[contentnode][assessment_id]
   ) {
-    state.assessmentItemsMap = {
-      ...state.assessmentItemsMap,
-      [contentnode]: {
-        ...state.assessmentItemsMap[contentnode],
-        [assessment_id]: applyMods(state.assessmentItemsMap[contentnode][assessment_id], mods),
-      },
-    };
+    Vue.set(state.assessmentItemsMap[contentnode], assessment_id, {
+      ...applyMods(state.assessmentItemsMap[contentnode][assessment_id], mods),
+    });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/mutations.js
@@ -46,8 +46,19 @@ export function UPDATE_ASSESSMENTITEM(state, assessmentItem) {
 }
 
 export function UPDATE_ASSESSMENTITEM_FROM_INDEXEDDB(state, { id, ...mods }) {
-  if (id && state.assessmentItemsMap[id]) {
-    applyMods(state.assessmentItemsMap[id], mods);
+  const [contentnode, assessment_id] = id || [null, null];
+  if (
+    id &&
+    state.assessmentItemsMap[contentnode] &&
+    state.assessmentItemsMap[contentnode][assessment_id]
+  ) {
+    state.assessmentItemsMap = {
+      ...state.assessmentItemsMap,
+      [contentnode]: {
+        ...state.assessmentItemsMap[contentnode],
+        [assessment_id]: applyMods(state.assessmentItemsMap[contentnode][assessment_id], mods),
+      },
+    };
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
@@ -16,10 +16,9 @@ export function ADD_CONTENTNODES(state, contentNodes = []) {
 
 export function UPDATE_CONTENTNODE_FROM_INDEXEDDB(state, { id, ...updates }) {
   if (id && state.contentNodesMap[id]) {
-    state.contentNodesMap = {
-      ...state.contentNodesMap,
-      [id]: applyMods(state.contentNodesMap[id], updates),
-    };
+    // Need to do object spread to return a new object for setting in the map
+    // otherwise nested changes will not trigger reactive updates
+    Vue.set(state.contentNodesMap, id, { ...applyMods(state.contentNodesMap[id], updates) });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
@@ -16,7 +16,10 @@ export function ADD_CONTENTNODES(state, contentNodes = []) {
 
 export function UPDATE_CONTENTNODE_FROM_INDEXEDDB(state, { id, ...updates }) {
   if (id && state.contentNodesMap[id]) {
-    applyMods(state.contentNodesMap[id], updates);
+    state.contentNodesMap = {
+      ...state.contentNodesMap,
+      [id]: applyMods(state.contentNodesMap[id], updates),
+    };
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/mutations.js
@@ -17,7 +17,10 @@ export function UPDATE_SAVEDSEARCH(state, search) {
 
 export function UPDATE_SAVEDSEARCH_FROM_INDEXEDDB(state, { id, ...updates }) {
   if (id && state.savedSearches[id]) {
-    applyMods(state.savedSearches[id], updates);
+    state.savedSearches = {
+      ...state.savedSearches,
+      [id]: applyMods(state.savedSearches[id], updates),
+    };
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/mutations.js
@@ -17,10 +17,7 @@ export function UPDATE_SAVEDSEARCH(state, search) {
 
 export function UPDATE_SAVEDSEARCH_FROM_INDEXEDDB(state, { id, ...updates }) {
   if (id && state.savedSearches[id]) {
-    state.savedSearches = {
-      ...state.savedSearches,
-      [id]: applyMods(state.savedSearches[id], updates),
-    };
+    Vue.set(state.savedSearches, id, { ...applyMods(state.savedSearches[id], updates) });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -39,10 +39,7 @@ export default {
     },
     UPDATE_ASYNC_TASK_FROM_INDEXEDDB(state, { task_id, ...mods }) {
       if (task_id && state.asyncTasksMap[task_id]) {
-        state.asyncTasksMap = {
-          ...state.asyncTasksMap,
-          [task_id]: applyMods(state.asyncTasksMap[task_id], mods),
-        };
+        Vue.set(state.asyncTasksMap, task_id, { ...applyMods(state.asyncTasksMap[task_id], mods) });
       }
     },
     REMOVE_ASYNC_TASK(state, asyncTask) {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -39,7 +39,10 @@ export default {
     },
     UPDATE_ASYNC_TASK_FROM_INDEXEDDB(state, { task_id, ...mods }) {
       if (task_id && state.asyncTasksMap[task_id]) {
-        applyMods(state.asyncTasksMap[task_id], mods);
+        state.asyncTasksMap = {
+          ...state.asyncTasksMap,
+          [task_id]: applyMods(state.asyncTasksMap[task_id], mods),
+        };
       }
     },
     REMOVE_ASYNC_TASK(state, asyncTask) {

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/mutations.js
@@ -34,7 +34,10 @@ export function UPDATE_CHANNELSET(state, { id, ...payload }) {
 
 export function UPDATE_CHANNELSET_FROM_INDEXEDDB(state, { id, ...mods }) {
   if (id && state.channelSetsMap[id]) {
-    applyMods(state.channelSetsMap[id], mods);
+    state.channelSetsMap = {
+      ...state.channelSetsMap,
+      [id]: applyMods(state.channelSetsMap[id], mods),
+    };
   }
 }
 

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/mutations.js
@@ -34,10 +34,7 @@ export function UPDATE_CHANNELSET(state, { id, ...payload }) {
 
 export function UPDATE_CHANNELSET_FROM_INDEXEDDB(state, { id, ...mods }) {
   if (id && state.channelSetsMap[id]) {
-    state.channelSetsMap = {
-      ...state.channelSetsMap,
-      [id]: applyMods(state.channelSetsMap[id], mods),
-    };
+    Vue.set(state.channelSetsMap, id, { ...applyMods(state.channelSetsMap[id], mods) });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -22,18 +22,12 @@ import Dexie from 'dexie';
 import flatMap from 'lodash/flatMap';
 import { CHANGE_TYPES } from './constants';
 import { INDEXEDDB_RESOURCES } from './registry';
-
-function applyModifications(obj, modifications) {
-  Object.keys(modifications).forEach(function(keyPath) {
-    Dexie.setByKeyPath(obj, keyPath, modifications[keyPath]);
-  });
-  return obj;
-}
+import { applyMods } from './applyRemoteChanges';
 
 function combineCreateAndUpdate(oldChange, newChange) {
   // Apply modifications to existing object.
   // Passed in object should be modifiable, so no need to clone.
-  applyModifications(oldChange.obj, newChange.mods);
+  applyMods(oldChange.obj, newChange.mods);
   return oldChange;
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1791,6 +1791,10 @@ export const Task = new IndexedDBResource({
   tableName: TABLE_NAMES.TASK,
   idField: 'task_id',
   setTasks(tasks) {
+    for (let task of tasks) {
+      // Coerce channel_id to be a simple hex string
+      task.channel_id = task.channel_id.replace('-', '');
+    }
     return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
       return this.table
         .where(this.idField)

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
@@ -51,9 +51,13 @@ export function UPDATE_CHANNEL(state, { id, content_defaults = {}, ...payload } 
     });
   }
 }
+
 export function UPDATE_CHANNEL_FROM_INDEXEDDB(state, { id, ...mods }) {
   if (id && state.channelsMap[id]) {
-    applyMods(state.channelsMap[id], mods);
+    state.channelsMap = {
+      ...state.channelsMap,
+      [id]: applyMods(state.channelsMap[id], mods),
+    };
   }
 }
 

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/mutations.js
@@ -54,10 +54,7 @@ export function UPDATE_CHANNEL(state, { id, content_defaults = {}, ...payload } 
 
 export function UPDATE_CHANNEL_FROM_INDEXEDDB(state, { id, ...mods }) {
   if (id && state.channelsMap[id]) {
-    state.channelsMap = {
-      ...state.channelsMap,
-      [id]: applyMods(state.channelsMap[id], mods),
-    };
+    Vue.set(state.channelsMap, id, { ...applyMods(state.channelsMap[id], mods) });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -4,21 +4,9 @@ import { applyMods } from 'shared/data/applyRemoteChanges';
 
 function updateFileMaps(state, file) {
   if (file.assessment_item) {
-    state.assessmentItemFilesMap = {
-      ...state.assessmentItemFilesMap,
-      [file.assessment_item]: {
-        ...state.assessmentItemFilesMap[file.assessment_item],
-        [file.id]: file,
-      },
-    };
+    Vue.set(state.assessmentItemFilesMap[file.assessment_item], file.id, file);
   } else if (file.contentnode) {
-    state.contentNodeFilesMap = {
-      ...state.contentNodeFilesMap,
-      [file.contentnode]: {
-        ...state.contentNodeFilesMap[file.contentnode],
-        [file.id]: file,
-      },
-    };
+    Vue.set(state.contentNodeFilesMap[file.contentnode], file.id, file);
   }
 }
 
@@ -40,10 +28,7 @@ export function ADD_FILES(state, files = []) {
 
 export function UPDATE_FILE_FROM_INDEXEDDB(state, { id, ...mods }) {
   if (id && state.fileUploadsMap[id]) {
-    state.fileUploadsMap = {
-      ...state.fileUploadsMap,
-      [id]: applyMods(state.fileUploadsMap[id], mods),
-    };
+    Vue.set(state.fileUploadsMap, id, { ...applyMods(state.fileUploadsMap[id], mods) });
     updateFileMaps(state, state.fileUploadsMap[id]);
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -4,8 +4,14 @@ import { applyMods } from 'shared/data/applyRemoteChanges';
 
 function updateFileMaps(state, file) {
   if (file.assessment_item) {
+    if (!state.assessmentItemFilesMap[file.assessment_item]) {
+      Vue.set(state.assessmentItemFilesMap, file.assessment_item, {});
+    }
     Vue.set(state.assessmentItemFilesMap[file.assessment_item], file.id, file);
   } else if (file.contentnode) {
+    if (!state.contentNodeFilesMap[file.contentnode]) {
+      Vue.set(state.contentNodeFilesMap, file.contentnode, {});
+    }
     Vue.set(state.contentNodeFilesMap[file.contentnode], file.id, file);
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/mutations.js
@@ -4,17 +4,21 @@ import { applyMods } from 'shared/data/applyRemoteChanges';
 
 function updateFileMaps(state, file) {
   if (file.assessment_item) {
-    Vue.set(
-      state.assessmentItemFilesMap,
-      file.assessment_item,
-      mergeMapItem(state.assessmentItemFilesMap[file.assessment_item] || {}, file)
-    );
+    state.assessmentItemFilesMap = {
+      ...state.assessmentItemFilesMap,
+      [file.assessment_item]: {
+        ...state.assessmentItemFilesMap[file.assessment_item],
+        [file.id]: file,
+      },
+    };
   } else if (file.contentnode) {
-    Vue.set(
-      state.contentNodeFilesMap,
-      file.contentnode,
-      mergeMapItem(state.contentNodeFilesMap[file.contentnode] || {}, file)
-    );
+    state.contentNodeFilesMap = {
+      ...state.contentNodeFilesMap,
+      [file.contentnode]: {
+        ...state.contentNodeFilesMap[file.contentnode],
+        [file.id]: file,
+      },
+    };
   }
 }
 
@@ -36,7 +40,10 @@ export function ADD_FILES(state, files = []) {
 
 export function UPDATE_FILE_FROM_INDEXEDDB(state, { id, ...mods }) {
   if (id && state.fileUploadsMap[id]) {
-    applyMods(state.fileUploadsMap[id], mods);
+    state.fileUploadsMap = {
+      ...state.fileUploadsMap,
+      [id]: applyMods(state.fileUploadsMap[id], mods),
+    };
     updateFileMaps(state, state.fileUploadsMap[id]);
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
@@ -48,7 +48,7 @@ export default {
     },
     UPDATE_SESSION_FROM_INDEXEDDB(state, { id, ...mods }) {
       if (id === state.currentUser.id) {
-        state.currentUser = applyMods(state.currentUser, mods);
+        state.currentUser = { ...applyMods(state.currentUser, mods) };
       }
     },
     REMOVE_SESSION(state) {

--- a/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/session/index.js
@@ -48,7 +48,7 @@ export default {
     },
     UPDATE_SESSION_FROM_INDEXEDDB(state, { id, ...mods }) {
       if (id === state.currentUser.id) {
-        applyMods(state.currentUser, mods);
+        state.currentUser = applyMods(state.currentUser, mods);
       }
     },
     REMOVE_SESSION(state) {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

* Coerces channel_id returned from the API to be a hex string rather than `-` separated uuid for easier cross reference
* Removes a duplicated (and possibly unreported error producing during change squashes) version of `applyMods` and uses the version from `applyRemoteChanges`
* Updates all indexedDB update applying mutations to set the entire vuex map to ensure that new keys get set
* Updates the assessment item mutation to handle the compound `contentnode,assessment_id` id key
* Updates the file mutation to ensure that deletions applied in the indexedDB applyMods propagate to the other relevant maps
* In so doing makes the fileUploadsMap the single source of truth, that then just copy to the other maps


### Manual verification steps performed
Primarily tested this to ensure publishing was working as intended.

https://user-images.githubusercontent.com/1680573/192658190-a35a0339-acf7-44c8-a0ec-e5f1fdc20506.mp4

Automated test coverage for the file vuex module give me confidence about those changes.

### Are there any risky areas that deserve extra testing?
Once this is merged, we should probably do another quick pass to ensure that all collaborative edits are showing up as intended.


## References
Fixes #3683
