### PR TITLE
Strings n things

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -12,7 +12,7 @@
           :value="accessibilityItem.value"
           :label="accessibilityItem.label"
           color="primary"
-          :data-test="`checkbox-${accessibilityItem.label}`"
+          :data-test="`checkbox-${accessibilityItem.help}`"
         >
           <template #label>
             <span class="text-xs-left">{{ accessibilityItem.label }}</span>
@@ -22,7 +22,7 @@
               :text="$tr(accessibilityItem.help)"
               bottom
               class="px-2"
-              :data-test="`tooltip-${accessibilityItem.label}`"
+              :data-test="`tooltip-${accessibilityItem.help}`"
             />
           </template>
         </Checkbox>
@@ -89,11 +89,11 @@
       /**
        * Strings for the help tooltips
        */
-      altText: `Alternative text is provided for visual content (e.g., via the HTML alt attribute).`,
-      audioDescription: `Audio descriptions are available (e.g., via an HTML5 track element with kind="descriptions")`,
-      highContrast: `Content meets the visual contrast threshold set out in WCAG Success Criteria 1.4.6`,
-      signLanguage: `Synchronized sign language intepretation is available for audio and video content.`,
-      taggedPdf: `The structures in a PDF have been tagged to improve the navigation of the content.`,
+      altText: `Visual elements in the resource have descriptions that can be accessed by screen readers for the benefit of blind learners`,
+      audioDescription: `The resource contains a second narration audio track that provides additional information for the benefit of blind users and those with low vision`,
+      highContrast: `The resource text and visual elements are displayed with high contrast for the benefit of users with low vision`,
+      signLanguage: `Synchronized sign language intepretation is available for audio and video content`,
+      taggedPdf: `The document contains PDF tags that can be accessed by screen readers for the benefit of blind learners`,
       /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ActivityDuration.vue
@@ -183,9 +183,9 @@
     $trs: {
       minutesRequired: 'Minutes',
       optionalLabel:
-        '(Optional) Duration until resource is marked as complete. This value will not be shown to learners.',
+        '(Optional) Time required for the resource to be marked as completed. This value will not be displayed to learners.',
       notOptionalLabel:
-        'Duration until resource is marked as complete. This value will not be shown to learners.',
+        'Time required for the resource to be marked as completed. This value will not be displayed to learners.',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -870,14 +870,14 @@
     },
     $trs: {
       /* eslint-disable kolibri/vue-no-unused-translations */
-      allContent: 'All content viewed',
-      completeDuration: 'Complete duration',
-      determinedByResource: 'Determined by resource',
-      goal: 'Practice until goal is met',
+      allContent: 'Viewed in its entirety',
+      completeDuration: 'When time spent is equal to duration',
+      determinedByResource: 'Determined by the resource',
+      goal: 'When goal is met',
       practiceQuiz: 'Practice quiz',
       /* eslint-enable */
-      exactTime: 'Exact time to complete',
-      reference: 'Reference',
+      exactTime: 'Time to complete',
+      reference: 'Reference material',
       referenceHint:
         'Progress will not be tracked on reference material unless learners mark it as complete',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -199,6 +199,18 @@
             :required="isUnique(role)"
             @focus="trackClick('Role visibility')"
           />
+
+          <!-- For Beginners -->
+          <KCheckbox
+            id="beginners"
+            ref="beginners"
+            :checked="forBeginners"
+            @change="value => forBeginners = value"
+          >
+            <span class="text-xs-left v-label" style="padding-left: 8px;">
+              {{ translateMetadataString('forBeginners') }}
+            </span>
+          </KCheckbox>
         </VFlex>
       </VLayout>
 
@@ -387,7 +399,12 @@
   import VisibilityDropdown from 'shared/views/VisibilityDropdown';
   import Checkbox from 'shared/views/form/Checkbox';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
-  import { NEW_OBJECT, FeatureFlagKeys, AccessibilityCategories } from 'shared/constants';
+  import {
+    NEW_OBJECT,
+    FeatureFlagKeys,
+    AccessibilityCategories,
+    ResourcesNeededTypes,
+  } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
 
   // Define an object to act as the place holder for non unique values.
@@ -568,6 +585,20 @@
       accessibility: generateNestedNodesGetterSetter('accessibility_labels'),
       contentLevel: generateNestedNodesGetterSetter('grade_levels'),
       resourcesNeeded: generateNestedNodesGetterSetter('learner_needs'),
+      forBeginners: {
+        get() {
+          return this.resourcesNeeded.includes(ResourcesNeededTypes.FOR_BEGINNERS);
+        },
+        set(value) {
+          if (value) {
+            this.resourcesNeeded = [...this.resourcesNeeded, ResourcesNeededTypes.FOR_BEGINNERS];
+          } else {
+            this.resourcesNeeded = this.resourcesNeeded.filter(
+              r => r !== ResourcesNeededTypes.FOR_BEGINNERS
+            );
+          }
+        },
+      },
       contentLearningActivities: generateNestedNodesGetterSetter('learning_activities'),
       categories: generateNestedNodesGetterSetter('categories'),
       license() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -13,6 +13,8 @@
       clearable
       :menu-props="{ offsetY: true, lazy: true, zIndex: 4 }"
       :attach="$attrs.id ? `#${$attrs.id}` : '.resources-needed-container'"
+      :hint="hint"
+      persistent-hint
     />
   </div>
 
@@ -56,9 +58,16 @@
           value: ResourcesNeededTypes[key],
         }));
       },
+      hint() {
+        return this.value && this.value.includes(ResourcesNeededTypes.OTHER_SUPPLIES)
+          ? this.$tr('furtherExplanation')
+          : '';
+      },
     },
     $trs: {
       resourcesNeededLabel: 'Requirements',
+      furtherExplanation:
+        "Please add to the 'Description' field any additional supplies learners will need in order to use this resource",
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -23,27 +23,14 @@
   import { ResourcesNeededTypes } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
 
-  /**
-   * @param {array} listOfKeys
-   * @returns {Object}
-   *
-   * Determines resources to show in the dropdown, to remove resources
-   * that do not currently need to be displayed in Kolibri
-   */
-  export function updateResourcesDropdown(listOfKeys) {
-    if (listOfKeys) {
-      return Object.keys(ResourcesNeededTypes).reduce((acc, key) => {
-        if (listOfKeys.indexOf(key) === -1) {
-          acc[key] = ResourcesNeededTypes[key];
-        }
-        return acc;
-      }, {});
-    }
-  }
-
-  //the variable below can be changed or removed when metadata/Kolibri is updated
-  const keysToBeTemporarilyRemoved = ['PEERS', 'TEACHER', 'PRIOR_KNOWLEDGE', 'MATERIALS'];
-  const dropdown = updateResourcesDropdown(keysToBeTemporarilyRemoved) || ResourcesNeededTypes;
+  const dropdownItems = [
+    'PEERS',
+    'TEACHER',
+    'INTERNET',
+    'SPECIAL_SOFTWARE',
+    'PAPER_PENCIL',
+    'OTHER_SUPPLIES',
+  ];
 
   export default {
     name: 'ResourcesNeededOptions',
@@ -64,9 +51,9 @@
         },
       },
       resources() {
-        return Object.entries(dropdown).map(resource => ({
-          text: this.translateMetadataString(resource[0]),
-          value: resource[1],
+        return dropdownItems.map(key => ({
+          text: this.translateMetadataString(key),
+          value: ResourcesNeededTypes[key],
         }));
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -71,7 +71,7 @@
       },
     },
     $trs: {
-      resourcesNeededLabel: 'What you will need',
+      resourcesNeededLabel: 'Requirements',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
@@ -22,15 +22,11 @@ describe('AccessibilityOptions', () => {
       },
     });
 
-    expect(
-      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
-    ).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-altText"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-highContrast"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-taggedPdf"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-signLanguage"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-audioDescription"]').exists()).toBe(false);
   });
 
   it('should display the correct list of accessibility options if resource is a video', () => {
@@ -40,17 +36,13 @@ describe('AccessibilityOptions', () => {
       },
     });
 
-    expect(
-      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
-    ).toBe(false);
-    expect(
-      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
-    ).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Has captions or subtitles"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="tooltip-Has captions or subtitles"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-altText"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-highContrast"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-taggedPdf"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-signLanguage"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-audioDescription"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-captionsSubtitles"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-captionsSubtitles"]').exists()).toBe(false);
   });
 
   it('should display the correct list of accessibility options if resource is an exercise/practice', () => {
@@ -60,15 +52,11 @@ describe('AccessibilityOptions', () => {
       },
     });
 
-    expect(
-      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
-    ).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-altText"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-highContrast"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-taggedPdf"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-signLanguage"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-audioDescription"]').exists()).toBe(false);
   });
 
   it('should display the correct list of accessibility options if resource is html5/zip', () => {
@@ -78,15 +66,11 @@ describe('AccessibilityOptions', () => {
       },
     });
 
-    expect(
-      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
-    ).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-altText"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-highContrast"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-taggedPdf"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-signLanguage"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-audioDescription"]').exists()).toBe(false);
   });
 
   it('should render appropriate tooltips along with the checkbox', () => {
@@ -96,23 +80,15 @@ describe('AccessibilityOptions', () => {
       },
     });
 
-    expect(
-      wrapper.find('[data-test="checkbox-Has alternative text description for images"]').exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-test="tooltip-Has alternative text description for images"]').exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-test="checkbox-Has high contrast display for low vision"]').exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-test="tooltip-Has high contrast display for low vision"]').exists()
-    ).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Tagged PDF"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="tooltip-Tagged PDF"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="checkbox-Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="tooltip-Has sign language captions"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="checkbox-Has audio descriptions"]').exists()).toBe(false);
-    expect(wrapper.find('[data-test="tooltip-Has audio descriptions"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-altText"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-altText"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-highContrast"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-highContrast"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-taggedPdf"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-taggedPdf"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="checkbox-signLanguage"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="tooltip-signLanguage"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="checkbox-audioDescription"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="tooltip-audioDescription"]').exists()).toBe(false);
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/activityDuration.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/activityDuration.spec.js
@@ -87,9 +87,9 @@ describe('ActivityDuration', () => {
 
     describe(`hints`, () => {
       const optionalHint =
-        '(Optional) Duration until resource is marked as complete. This value will not be shown to learners.';
+        '(Optional) Time required for the resource to be marked as completed. This value will not be displayed to learners.';
       const requiredHint =
-        'Duration until resource is marked as complete. This value will not be shown to learners.';
+        'Time required for the resource to be marked as completed. This value will not be displayed to learners.';
       describe(`audio/video resource`, () => {
         it(`should display optional hint when 'Short activity' is chosen`, () => {
           const wrapper = shallowMount(ActivityDuration, {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/resourcesNeededOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/resourcesNeededOptions.spec.js
@@ -36,7 +36,7 @@ describe('ResourcesNeededOptions', () => {
 
     it('should emit new input values', () => {
       const resourcesNeeded = ['person', 'book', 'train'];
-      const wrapper = makeWrapper({});
+      const wrapper = makeWrapper([]);
       const dropdown = wrapper.find({ name: 'v-select' });
       dropdown.vm.$emit('input', resourcesNeeded);
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/resourcesNeededOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/resourcesNeededOptions.spec.js
@@ -1,8 +1,7 @@
 import Vue from 'vue';
 import Vuetify from 'vuetify';
 import { shallowMount, mount } from '@vue/test-utils';
-import ResourcesNeededOptions, { updateResourcesDropdown } from '../ResourcesNeededOptions.vue';
-import { ResourcesNeededTypes } from 'shared/constants';
+import ResourcesNeededOptions from '../ResourcesNeededOptions.vue';
 
 Vue.use(Vuetify);
 
@@ -19,22 +18,6 @@ describe('ResourcesNeededOptions', () => {
     const wrapper = shallowMount(ResourcesNeededOptions);
 
     expect(wrapper.isVueInstance()).toBe(true);
-  });
-
-  it('when there is a list of keys to remove from ResourcesNeededTypes, return updated map for ResourcesNeededTypes for dropdown', () => {
-    const list = ['FOR_BEGINNERS', 'INTERNET'];
-    const numberOfAvailableResources = Object.keys(ResourcesNeededTypes).length - list.length;
-    const dropdownItemsLength = Object.keys(updateResourcesDropdown(list)).length;
-
-    expect(dropdownItemsLength).toBe(numberOfAvailableResources);
-  });
-
-  it('when there are no keys to remove from ResourcesNeededTypes, dropdown should contain all resources', () => {
-    const list = [];
-    const numberOfAvailableResources = Object.keys(ResourcesNeededTypes).length - list.length;
-    const dropdownItemsLength = Object.keys(updateResourcesDropdown(list)).length;
-
-    expect(dropdownItemsLength).toBe(numberOfAvailableResources);
   });
 
   describe('updating state', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -520,9 +520,9 @@
       reviewMode: 'Review mode',
       emptyChannelText: 'No resources found',
       emptyChannelSubText:
-        'No changes to review! The channel contains all the latest folders and resources.',
+        'No changes to review! The channel contains all the most recent folders and resources.',
       collapseAllButton: 'Collapse all',
-      openCurrentLocationButton: 'Jump to current folder location',
+      openCurrentLocationButton: 'Expand to current folder location',
       totalResources: 'Total resources',
       totalSize: 'Total size',
       openSummaryDetailsDialogBtn: 'View summary',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
@@ -121,7 +121,7 @@
     $trs: {
       coachContent: 'Resources for coaches',
       assessments: 'Assessments',
-      topicsHidden: 'No folders',
+      topicsHidden: 'Folders excluded',
       createdAfter: "Added after '{date}'",
       clearAll: 'Clear all',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -105,12 +105,12 @@
       clearInterval(this.timer);
     },
     $trs: {
-      defaultErrorText: 'Last publish failed.',
+      defaultErrorText: 'Last attempt to publish failed',
       publishHeader: 'Publishing channel',
       lastPublished: 'Published {last_published}',
       unpublishedText: 'Unpublished',
       syncHeader: 'Syncing channel',
-      syncError: 'Last sync failed',
+      syncError: 'Last attempt to sync failed',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -98,7 +98,7 @@ describe('ProgressModal', () => {
       });
 
       it('should display an error message', () => {
-        expect(wrapper.text()).toContain('Last publish failed.');
+        expect(wrapper.text()).toContain('Last attempt to publish failed');
       });
 
       it('should not display progress', () => {
@@ -189,7 +189,7 @@ describe('ProgressModal', () => {
       });
 
       it('should display error', () => {
-        expect(wrapper.text()).toContain('Last sync failed');
+        expect(wrapper.text()).toContain('Last attempt to sync failed');
       });
     });
 

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -523,16 +523,30 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
       "'Peers' in this context refers to classmates or other learners who are interacting with Kolibri.",
   },
   ToUseWithPaperAndPencil: {
-    message: 'To use with paper and pencil',
+    message: 'Paper and pencil',
     context: 'Refers to a filter for resources.\n',
   },
   NeedsInternet: {
-    message: 'That need internet connection',
+    message: 'Internet connection',
     context: 'Refers to a filter for resources.',
   },
   NeedsMaterials: {
-    message: 'That need other materials',
+    message: 'Other supplies',
     context: 'Refers to a filter for resources.\n',
+  },
+  softwareTools: {
+    message: 'Other software tools',
+    context: 'Refers to a filter for resources that need additional software to be used.',
+  },
+  peers: {
+    message: 'Working with peers',
+    context:
+      'Refers to a filter for resources that require a learner to work with other learners to be used.',
+  },
+  teacher: {
+    message: 'Working with a teacher',
+    context:
+      'Refers to a filter for resources that require a learner to work with a teacher to be used.',
   },
 
   // Accessibility category name
@@ -543,12 +557,12 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
   },
   // Accessibility Categories
   signLanguage: {
-    message: 'Has sign language captions',
+    message: 'Includes sign language captions',
     context:
       'https://en.wikipedia.org/wiki/Sign_language\nhttps://en.wikipedia.org/wiki/List_of_sign_languages\nWherever communities of deaf people exist, sign languages have developed as useful means of communication, and they form the core of local Deaf cultures. Although signing is used primarily by the deaf and hard of hearing, it is also used by hearing individuals, such as those unable to physically speak, those who have trouble with spoken language due to a disability or condition (augmentative and alternative communication), or those with deaf family members, such as children of deaf adults. ',
   },
   audioDescription: {
-    message: 'Has audio descriptions',
+    message: 'Includes audio descriptions',
     context:
       'Content has narration used to provide information surrounding key visual elements for the benefit of blind and visually impaired users.\nhttps://en.wikipedia.org/wiki/Audio_description',
   },
@@ -558,17 +572,17 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
       'A tagged PDF includes hidden accessibility markups (tags) that make the document accessible to those who use screen readers and other assistive technology (AT).\n\nhttps://taggedpdf.com/what-is-a-tagged-pdf/',
   },
   altText: {
-    message: 'Has alternative text description for images',
+    message: 'Includes alternative text descriptions for images',
     context:
       'Alternative text, or alt text, is a written substitute for an image. It is used to describe information being provided by an image, graph, or any other visual element on a web page. It provides information about the context and function of an image for people with varying degrees of visual and cognitive impairments. When a screen reader encounters an image, it will read aloud the alternative text.\nhttps://www.med.unc.edu/webguide/accessibility/alt-text/',
   },
   highContrast: {
-    message: 'Has high contrast display for low vision',
+    message: 'Includes high contrast text for learners with low vision',
     context:
       "Accessibility filter used to search for resources that have high contrast color themes for users with low vision ('display' refers to digital content, not the hardware like screens or monitors).\nhttps://veroniiiica.com/2019/10/25/high-contrast-color-schemes-low-vision/",
   },
   captionsSubtitles: {
-    message: 'Has captions or subtitles',
+    message: 'Includes captions or subtitles',
     context:
       'Accessibility filter to search for video and audio resources that have text captions for users who are deaf or hard of hearing.\nhttps://www.w3.org/WAI/media/av/captions/',
   },
@@ -668,6 +682,8 @@ export const metadataTranslationMixin = {
 const nonconformingKeys = {
   PEOPLE: 'ToUseWithTeachersAndPeers',
   PAPER_PENCIL: 'ToUseWithPaperAndPencil',
+  PEERS: 'peers',
+  TEACHER: 'teacher',
   INTERNET: 'NeedsInternet',
   FOR_BEGINNERS: 'ForBeginners',
   digitalLiteracy: 'digitialLiteracy',
@@ -676,13 +692,8 @@ const nonconformingKeys = {
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
   toolsAndSoftwareTraining: 'softwareToolsAndTraining',
   foundations: 'basicSkills',
-
-  /*
-   * TODO: the following are in ResourcesNeededTypes map from le-utils, but not in Kolibri,
-   * and should be tracked in the issue - https://github.com/learningequality/kolibri/issues/9245
-   */
   OTHER_SUPPLIES: 'NeedsMaterials',
-  SPECIAL_SOFTWARE: 'softwareToolsAndTraining',
+  SPECIAL_SOFTWARE: 'softwareTools',
 };
 
 /**

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -430,7 +430,7 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
     message: 'Numeracy',
     context: 'Category type. See https://en.wikipedia.org/wiki/Numeracy',
   },
-  digitialLiteracy: {
+  digitalLiteracy: {
     message: 'Digital literacy',
     context: 'Category type. See https://en.wikipedia.org/wiki/Digital_literacy',
   },
@@ -513,24 +513,19 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
   },
 
   // Resources Needed Categories = {
-  ForBeginners: {
+  forBeginners: {
     message: 'For beginners',
     context: 'Filter option and a label for the resources in the Kolibri Library.',
   },
-  ToUseWithTeachersAndPeers: {
-    message: 'To use with teachers and peers',
-    context:
-      "'Peers' in this context refers to classmates or other learners who are interacting with Kolibri.",
-  },
-  ToUseWithPaperAndPencil: {
+  toUseWithPaperAndPencil: {
     message: 'Paper and pencil',
     context: 'Refers to a filter for resources.\n',
   },
-  NeedsInternet: {
+  needsInternet: {
     message: 'Internet connection',
     context: 'Refers to a filter for resources.',
   },
-  NeedsMaterials: {
+  needsMaterials: {
     message: 'Other supplies',
     context: 'Refers to a filter for resources.\n',
   },
@@ -680,19 +675,16 @@ export const metadataTranslationMixin = {
  * - Keys which, when _.camelCase()'ed will not result in a valid key, requiring manual mapping
  */
 const nonconformingKeys = {
-  PEOPLE: 'ToUseWithTeachersAndPeers',
-  PAPER_PENCIL: 'ToUseWithPaperAndPencil',
+  PAPER_PENCIL: 'toUseWithPaperAndPencil',
   PEERS: 'peers',
   TEACHER: 'teacher',
-  INTERNET: 'NeedsInternet',
-  FOR_BEGINNERS: 'ForBeginners',
-  digitalLiteracy: 'digitialLiteracy',
+  INTERNET: 'needsInternet',
   BASIC_SKILLS: 'allLevelsBasicSkills',
   FOUNDATIONS: 'basicSkills',
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
   toolsAndSoftwareTraining: 'softwareToolsAndTraining',
   foundations: 'basicSkills',
-  OTHER_SUPPLIES: 'NeedsMaterials',
+  OTHER_SUPPLIES: 'needsMaterials',
   SPECIAL_SOFTWARE: 'softwareTools',
 };
 

--- a/contentcuration/contentcuration/frontend/shared/translator.js
+++ b/contentcuration/contentcuration/frontend/shared/translator.js
@@ -1,6 +1,7 @@
 import { createTranslator } from 'shared/i18n';
 
 const MESSAGES = {
+  fieldRequired: 'This field is required',
   titleRequired: 'Title is required',
   licenseRequired: 'License is required',
   copyrightHolderRequired: 'Copyright holder is required',
@@ -17,13 +18,12 @@ const MESSAGES = {
   learningActivityRequired: 'Learning activity is required',
   durationRequired: 'Duration is required',
   activityDurationRequired: 'This field is required',
-  shortActivityGteOne: 'Short activity must be greater than or equal to 1',
-  shortActivityLteThirty: 'Short activity must be less than or equal to 30',
-  longActivityGtThirty: 'Long activity must be greater than 30',
-  longActivityLteOneTwenty: 'Long activity must be less than or equal to 120',
-  activityDurationTimeMinRequirement: 'Time must be greater than or equal to 1',
+  activityDurationGteOne: 'Value must be equal to or greater than 1',
+  shortActivityLteThirty: 'Value must be equal or less than 30',
+  longActivityGtThirty: 'Value must be greater than 30',
+  longActivityLteOneTwenty: 'Value must be equal or less than 120',
   activityDurationTooLongWarning:
-    'Please make sure this is the amount of time you want learners to spend on this resource to complete it',
+    'This value is very high. Please make sure this is how long learners should work on the resource for, in order to complete it.',
 };
 
 export default createTranslator('sharedVue', MESSAGES);

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -123,23 +123,23 @@ function _getLearningActivity(node) {
 
 function _getErrorMsg(error) {
   const messages = {
-    [ValidationErrors.TITLE_REQUIRED]: translator.$tr('titleRequired'),
-    [ValidationErrors.LICENSE_REQUIRED]: translator.$tr('licenseRequired'),
-    [ValidationErrors.COPYRIGHT_HOLDER_REQUIRED]: translator.$tr('copyrightHolderRequired'),
+    [ValidationErrors.TITLE_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.LICENSE_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.COPYRIGHT_HOLDER_REQUIRED]: translator.$tr('fieldRequired'),
     [ValidationErrors.LICENSE_DESCRIPTION_REQUIRED]: translator.$tr('licenseDescriptionRequired'),
-    [ValidationErrors.MASTERY_MODEL_REQUIRED]: translator.$tr('masteryModelRequired'),
-    [ValidationErrors.MASTERY_MODEL_M_REQUIRED]: translator.$tr('masteryModelMRequired'),
-    [ValidationErrors.MASTERY_MODEL_M_WHOLE_NUMBER]: translator.$tr('masteryModelMWholeNumber'),
+    [ValidationErrors.MASTERY_MODEL_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.MASTERY_MODEL_M_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.MASTERY_MODEL_M_WHOLE_NUMBER]: translator.$tr('fieldRequired'),
     [ValidationErrors.MASTERY_MODEL_M_GT_ZERO]: translator.$tr('masteryModelMGtZero'),
     [ValidationErrors.MASTERY_MODEL_M_LTE_N]: translator.$tr('masteryModelMLteN'),
-    [ValidationErrors.MASTERY_MODEL_N_REQUIRED]: translator.$tr('masteryModelNRequired'),
+    [ValidationErrors.MASTERY_MODEL_N_REQUIRED]: translator.$tr('fieldRequired'),
     [ValidationErrors.MASTERY_MODEL_N_WHOLE_NUMBER]: translator.$tr('masteryModelNWholeNumber'),
     [ValidationErrors.MASTERY_MODEL_N_GT_ZERO]: translator.$tr('masteryModelNGtZero'),
-    [ValidationErrors.LEARNING_ACTIVITY_REQUIRED]: translator.$tr('learningActivityRequired'),
-    [ValidationErrors.DURATION_REQUIRED]: translator.$tr('durationRequired'),
-    [ValidationErrors.ACTIVITY_DURATION_REQUIRED]: translator.$tr('activityDurationRequired'),
+    [ValidationErrors.LEARNING_ACTIVITY_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.DURATION_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.ACTIVITY_DURATION_REQUIRED]: translator.$tr('fieldRequired'),
     [ValidationErrors.ACTIVITY_DURATION_MIN_FOR_SHORT_ACTIVITY]: translator.$tr(
-      'shortActivityGteOne'
+      'activityDurationGteOne'
     ),
     [ValidationErrors.ACTIVITY_DURATION_MAX_FOR_SHORT_ACTIVITY]: translator.$tr(
       'shortActivityLteThirty'
@@ -150,9 +150,7 @@ function _getErrorMsg(error) {
     [ValidationErrors.ACTIVITY_DURATION_MAX_FOR_LONG_ACTIVITY]: translator.$tr(
       'longActivityLteOneTwenty'
     ),
-    [ValidationErrors.ACTIVITY_DURATION_MIN_REQUIREMENT]: translator.$tr(
-      'activityDurationTimeMinRequirement'
-    ),
+    [ValidationErrors.ACTIVITY_DURATION_MIN_REQUIREMENT]: translator.$tr('activityDurationGteOne'),
     [ValidationErrors.ACTIVITY_DURATION_TOO_LONG]: translator.$tr('activityDurationTooLongWarning'),
   };
 

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.spec.js
@@ -43,7 +43,7 @@ describe('channelEdit utils', () => {
 
     it('returns an error message if a validator function returns an error code for a value', () => {
       const title = '';
-      expect(translateValidator(getTitleValidators()[0])(title)).toBe('Title is required');
+      expect(translateValidator(getTitleValidators()[0])(title)).toBe('This field is required');
     });
   });
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Updates strings according to feedback from string review
* Updates _most_ 'field required' specific messages to a generic 'This field is required' - with the exception of the license description which has additional explanatory text as to why a description is needed.
* Removes string typos that were copy pasted from Kolibri strings
* Sorts the 'Requirements' dropdown
* Separates out peers and teachers to align with original spec
* Adds a contextual hint to add further description in case of catch all 'other supplies' selection
* Moves the For Beginners annotation out of the dropdown and into a separate checkbox under the Audience section


### Manual verification steps performed
1. Verified updated sorting and display of requirements dropdown
2. Confirmed functionality and backend persistence of new for beginners checkbox

### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1680573/192912373-4106199d-8d02-43e6-a4c2-e0d7c9a3315a.png)

![image](https://user-images.githubusercontent.com/1680573/192914402-a0ebb5a7-2334-453a-be17-905fe44f3fec.png)


![image](https://user-images.githubusercontent.com/1680573/192913180-88b69448-9c9f-43d7-857e-532169ec1b82.png)


### Does this introduce any tech-debt items?
I used `KCheckbox` to avoid relying on the soon to be deprecated `Checkbox` and `VCheckbox` but this might need to be tidied up as I had to tweak styling to match the existing checkboxes @thanksameeelian FYI!

## References
Fixes #3686
Fixes #3695 

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
