### PR TITLE
Do existence check on navigator.clipboard

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/components/ClipboardChip.vue
+++ b/contentcuration/contentcuration/frontend/administration/components/ClipboardChip.vue
@@ -6,7 +6,14 @@
         {{ value }}
       </div>
     </VChip>
-    <VBtn icon small right data-test="copy" @click="copyToClipboard">
+    <VBtn
+      v-if="clipboardAvailable"
+      icon
+      small
+      right
+      data-test="copy"
+      @click="copyToClipboard"
+    >
       <Icon small>
         content_copy
       </Icon>
@@ -30,11 +37,18 @@
         type: String,
       },
     },
+    computed: {
+      clipboardAvailable() {
+        return Boolean(navigator.clipboard);
+      },
+    },
     methods: {
       copyToClipboard() {
-        navigator.clipboard.writeText(this.value).then(() => {
-          this.$store.dispatch('showSnackbarSimple', this.successMessage);
-        });
+        if (this.clipboardAvailable) {
+          navigator.clipboard.writeText(this.value).then(() => {
+            this.$store.dispatch('showSnackbarSimple', this.successMessage);
+          });
+        }
       },
     },
   };

--- a/contentcuration/contentcuration/frontend/administration/components/__tests__/clipboardChip.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/components/__tests__/clipboardChip.spec.js
@@ -12,7 +12,13 @@ function makeWrapper() {
 describe('clipboardChip', () => {
   let wrapper;
   beforeEach(() => {
+    navigator.clipboard = {
+      writeText: jest.fn(),
+    };
     wrapper = makeWrapper();
+  });
+  afterEach(() => {
+    delete navigator.clipboard;
   });
   it('should fire a copy operation on button click', () => {
     const copyToClipboard = jest.fn();

--- a/contentcuration/contentcuration/frontend/shared/views/CopyToken.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/CopyToken.vue
@@ -3,8 +3,8 @@
   <VTextField
     v-if="token"
     v-model="displayToken"
-    :title="$tr('copyPrompt')"
-    appendIcon="content_copy"
+    :title="clipboardAvailable ? $tr('copyPrompt') : ''"
+    :appendIcon="clipboardAvailable ? 'content_copy' : null"
     readonly
     color="primary"
     :hideDetails="true"
@@ -46,20 +46,25 @@
       displayToken() {
         return this.hyphenate ? this.token.slice(0, 5) + '-' + this.token.slice(5) : this.token;
       },
+      clipboardAvailable() {
+        return Boolean(navigator.clipboard);
+      },
     },
     methods: {
       copyToken() {
-        navigator.clipboard
-          .writeText(this.displayToken)
-          .then(() => {
-            let text = this.successText || this.$tr('copiedTokenId');
-            this.$store.dispatch('showSnackbar', { text });
-            this.$analytics.trackEvent('copy_token');
-            this.$emit('copied');
-          })
-          .catch(() => {
-            this.$store.dispatch('showSnackbar', { text: this.$tr('copyFailed') });
-          });
+        if (this.clipboardAvailable) {
+          navigator.clipboard
+            .writeText(this.displayToken)
+            .then(() => {
+              let text = this.successText || this.$tr('copiedTokenId');
+              this.$store.dispatch('showSnackbar', { text });
+              this.$analytics.trackEvent('copy_token');
+              this.$emit('copied');
+            })
+            .catch(() => {
+              this.$store.dispatch('showSnackbar', { text: this.$tr('copyFailed') });
+            });
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/shared/views/errors/TechnicalTextBlock.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/TechnicalTextBlock.vue
@@ -18,6 +18,7 @@
     <pre ref="textBox" class="hidden-screen-only">{{ text }}</pre>
     <div>
       <KButton
+        v-if="clipboardAvailable"
         ref="copyButton"
         :style="{ marginTop: '8px', marginBottom: '8px' }"
         :primary="false"
@@ -60,19 +61,24 @@
           minHeight: `${this.minHeight}px`,
         };
       },
+      clipboardAvailable() {
+        return Boolean(navigator.clipboard);
+      },
     },
     methods: {
       copyError() {
-        navigator.clipboard
-          .writeText(this.formattedText)
-          .then(() => {
-            this.$store.dispatch('showSnackbar', {
-              text: this.$tr('copiedToClipboardConfirmation'),
+        if (this.clipboardAvailable) {
+          navigator.clipboard
+            .writeText(this.formattedText)
+            .then(() => {
+              this.$store.dispatch('showSnackbar', {
+                text: this.$tr('copiedToClipboardConfirmation'),
+              });
+            })
+            .catch(() => {
+              this.$store.dispatch('showSnackbar', { text: this.$tr('copiedToClipboardFailure') });
             });
-          })
-          .catch(() => {
-            this.$store.dispatch('showSnackbar', { text: this.$tr('copiedToClipboardFailure') });
-          });
+        }
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds existence checks everywhere that `navigator.clipboard` is referenced
* Hides copy buttons and prevents the clipboard being used

### Manual verification steps performed
1. Checked that token copying still works in admin and non-admin

## References
Fixes #3637