### PR TITLE
Minimal fix for duplicate tags for null channel errors

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -664,6 +664,7 @@ describe('ContentNode methods', () => {
         parent: parent.id,
         lft: 1,
         node_id: expect.not.stringMatching(new RegExp(`${node.node_id}|${parent.node_id}`)),
+        original_channel_id: node.original_channel_id || node.channel_id,
         original_source_node_id: node.original_source_node_id,
         source_channel_id: node.channel_id,
         source_node_id: node.node_id,

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -692,6 +692,7 @@ class Resource extends mix(APIResource, IndexedDBResource) {
         // Only fetch new updates if we've finished syncing the changes table
         db[CHANGES_TABLE].where('table')
           .equals(this.tableName)
+          .filter(c => !c.synced)
           .limit(1)
           .toArray()
           .then(pendingChanges => {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1392,6 +1392,7 @@ export const ContentNode = new TreeResource({
       // Placeholder node_id, we should receive the new value from backend result
       node_id: uuid4(),
       original_source_node_id: node.original_source_node_id || node.node_id,
+      original_channel_id: node.original_channel_id || node.channel_id,
       source_channel_id: node.channel_id,
       source_node_id: node.node_id,
       channel_id: parent.channel_id,

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1,4 +1,3 @@
-import functools
 import hashlib
 import json
 import logging
@@ -8,7 +7,6 @@ import uuid
 from datetime import datetime
 
 import pytz
-from celery import states
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.base_user import BaseUserManager
@@ -1104,20 +1102,6 @@ class ContentTag(models.Model):
 
     class Meta:
         unique_together = ['tag_name', 'channel']
-
-
-def delegate_manager(method):
-    """
-    Delegate method calls to base manager, if exists.
-    """
-
-    @functools.wraps(method)
-    def wrapped(self, *args, **kwargs):
-        if self._base_manager:
-            return getattr(self._base_manager, method.__name__)(*args, **kwargs)
-        return method(self, *args, **kwargs)
-
-    return wrapped
 
 
 class License(models.Model):

--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -97,9 +97,11 @@ def sync_node_tags(node, original):
     for tag in original.tags.exclude(
         tag_name__in=node.tags.values_list("tag_name", flat=True)
     ):
-        new_tag, _ = ContentTag.objects.get_or_create(
+        new_tag = ContentTag.objects.filter(
             tag_name=tag.tag_name, channel_id=None,
-        )
+        ).first()
+        if not new_tag:
+            new_tag = ContentTag.objects.create(tag_name=tag.tag_name, channel_id=None)
         node.tags.add(new_tag)
         node.changed = True
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Avoids using `get_or_create` as will error out when there are multiple ContentTag objects for the same `tag_name` and null channel combination
* Removes unused code in models.py that I discovered in the course of this
* Adds a test for syncing tags and a regression test for this fix
* Fixes a bug that would happen after copying a node due to not setting `original_channel_id` on a ContentNode during the copy operation on the frontend
* Fixes a bug that prevented any refresh of data from the backend if any changes were present in the changes table, even if they had been synced

### Manual verification steps performed
1. Import a resource from one channel into another channel
2. In the source channel apply a tag "testtag"
3. In Django shell (`./contentcuration/manage.py shell`) create a tag with the same `tag_name` property
```
from contentcuration.models import ContentTag
ContentTag.objects.create(tag_name="testtag", channel_id=None)
```
4. In the channel that imported this resource, now initiate a sync, and be sure to select `Tags` to sync
5. See the sync is successful

For the copy bug, this replicates by doing the following:
1. Import a resource from another channel
2. Wait for the copy to complete
3. Edit the resource - in the failure case the edit modal will only partially render - with this fix it now renders properly.


Fixes #3690
Fixes other undocumented bugs.