### PR TITLE
Tweaks to channel ordering for import from channels

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -112,6 +112,7 @@
           [this.channelFilter]: true,
           page: this.$route.query.page || 1,
           exclude: this.currentChannelId,
+          ordering: this.channelFilter === 'public' ? 'name' : '-modified',
         }).then(page => {
           this.pageCount = page.total_pages;
           this.channels = page.results;

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -48,7 +48,7 @@
 
   import { mapGetters, mapActions } from 'vuex';
   import orderBy from 'lodash/orderBy';
-  import { RouteNames, CHANNEL_PAGE_SIZE } from '../../constants';
+  import { RouteNames } from '../../constants';
   import ChannelItem from './ChannelItem';
   import LoadingText from 'shared/views/LoadingText';
   import { ChannelListTypes } from 'shared/constants';
@@ -98,9 +98,6 @@
       isEditable() {
         return this.listType === ChannelListTypes.EDITABLE;
       },
-      isStarred() {
-        return this.listType === ChannelListTypes.STARRED;
-      },
     },
     watch: {
       listType(newListType) {
@@ -129,17 +126,6 @@
       },
       loadData(listType) {
         this.loading = true;
-        let parameters = {
-          listType,
-          sortBy: '-modified',
-        };
-
-        // Don't paginate bookmarked channel list for more
-        // rapid updating when channels are starred/unstarred
-        if (!this.isStarred) {
-          parameters.page = Number(this.$route.query.page || 1);
-          parameters.page_size = CHANNEL_PAGE_SIZE;
-        }
 
         this.loadChannelList({ listType }).then(() => {
           this.loading = false;


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Sets a default ordering on the channel endpoint.
* Adds and uses custom ordering for import fetches.

### Manual verification steps performed
1. Check ordering on import from channels for content library - should be sorted by name
2. Check ordering on import from channels for 'my channels' - should be sorted by last modified
3. Check ordering on channel list pages that this has not changed


### Screenshots (if applicable)

My channels - last modified sort:
![Screenshot from 2022-09-29 16-56-28](https://user-images.githubusercontent.com/1680573/193162519-eb60f08c-d249-420a-83a4-857814c30789.png)

Content library - name sort:
![Screenshot from 2022-09-29 16-57-29](https://user-images.githubusercontent.com/1680573/193162526-9210ad00-9ec9-42c6-944c-53ff428151b4.png)

My channels page - last modified sort:
![image](https://user-images.githubusercontent.com/1680573/193162618-e000487f-3703-4b9d-b133-d2b71bc8bdf0.png)

Content Library - name sort:
![image](https://user-images.githubusercontent.com/1680573/193162645-62976498-01d7-4c6a-baf9-a9e35f2d10d0.png)


### Does this introduce any tech-debt items?
Might want to come back and cleanup how we are handling ordering slightly - Kolibri handles it a bit better, and leaning on that would allow us to sort by multiple fields from the frontend.


## References
Makes updates suggested here: https://github.com/learningequality/studio/pull/3592#issuecomment-1262182442
