### PR TITLE
Fix metadata 'level' labeling

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -331,8 +331,15 @@
         return null;
       },
       levels(level) {
-        const match = Object.keys(ContentLevel).find(key => ContentLevel[key] === level);
+        let match = Object.keys(ContentLevel).find(key => ContentLevel[key] === level);
         if (match) {
+          if (match === 'PROFESSIONAL') {
+            match = 'specializedProfessionalTraining';
+          } else if (match === 'WORK_SKILLS') {
+            match = 'allLevelsWorkSkills';
+          } else if (match === 'BASIC_SKILLS') {
+            match = 'allLevelsBasicSkills';
+          }
           return this.translateMetadataString(camelCase(match));
         }
         return null;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -593,7 +593,21 @@
           .sort()
           .filter(k => ids.includes(ContentLevel[k]));
         if (matches && matches.length > 0) {
-          return this.metadataListText(matches);
+          let mappedMatches = [];
+          let newMatch;
+          matches.map(match => {
+            if (match === 'PROFESSIONAL') {
+              newMatch = 'specializedProfessionalTraining';
+            } else if (match === 'WORK_SKILLS') {
+              newMatch = 'allLevelsWorkSkills';
+            } else if (match === 'BASIC_SKILLS') {
+              newMatch = 'allLevelsBasicSkills';
+            } else {
+              newMatch = match;
+            }
+            mappedMatches.push(newMatch);
+          });
+          return this.metadataListText(mappedMatches);
         } else {
           return '-';
         }


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Adds necessary conditions (due to a mis-match of strings/mapping) to ensure that all string references are able to be translated on the Resource Panel as well as on the display chips

Fixes #3664

### Manual verification steps performed
1. Add a resource
2. Add all levels to the resource - ensuring accurate display in the dropdown and in the chips within the form 
3. Save and exit. Check the display in the comfortable/default view on the main channel page to ensure chips are displaying strings accurately 
4. Open the side panel and ensure that the strings are displaying correctly for all levels there. 

### Screenshots (if applicable)
<img width="1009" alt="Screen Shot 2022-09-30 at 9 08 48 AM" src="https://user-images.githubusercontent.com/17235236/193278661-37a037dd-564d-4f3d-a157-48e6beb8fe41.png">
<img width="505" alt="Screen Shot 2022-09-30 at 9 09 03 AM" src="https://user-images.githubusercontent.com/17235236/193278675-65944876-4cf8-4e71-abf1-300c6339a07b.png">
<img width="1437" alt="Screen Shot 2022-09-30 at 9 09 11 AM" src="https://user-images.githubusercontent.com/17235236/193278690-860237f3-1da5-4efe-bb32-2d4dcaf8ef42.png">


### Does this introduce any tech-debt items?
This does not add any _new_ tech-debt, but it also doesn't resolve the strings problem, which should probably be revisited. The translation logic in general for all of the metadata work is replicated in a lot of places at this point, and could probably be refactored or otherwise cleaned up.

___
## Reviewer guidance
### How can a reviewer test these changes?
See manual verification steps above

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [x] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
