### PR TITLE
Updates to completion duration for references

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -336,6 +336,12 @@
                 model: CompletionCriteriaModels.PAGES,
                 threshold: '100%',
               };
+            } else if (value === CompletionDropdownMap.reference) {
+              update.suggested_duration_type = null;
+              update.completion_criteria = {
+                model: CompletionCriteriaModels.REFERENCE,
+                threshold: null,
+              };
             } else {
               update.suggested_duration_type = this.value.suggested_duration_type;
               update.suggested_duration = this.value.suggested_duration;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -873,6 +873,7 @@
       determinedByResource: 'Determined by the resource',
       goal: 'When goal is met',
       practiceQuiz: 'Practice quiz',
+      reference: 'Reference material',
       /* eslint-enable */
       exactTime: 'Exact time to complete',
       referenceHint:

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -4,7 +4,7 @@
     <!-- Layout when practice quizzes are enabled -->
     <VLayout v-if="hideCompletionDropdown" xs6 md6>
       <!-- "Completion" dropdown menu  -->
-      <VFlex v-if="!audioVideoResource" xs6 md6 class="completion-container pr-2">
+      <VFlex xs6 md6 class="completion-container pr-2">
         <VSelect
           ref="completion"
           v-model="completionDropdown"
@@ -163,7 +163,6 @@
     },
     data() {
       return {
-        disabledReference: ['reference'],
         // required state because we need to know the durationDropdown before it is set in backend
         currentDurationDropdown: null,
         // required state because we need to know the completion to determine durationDropdown model
@@ -201,11 +200,9 @@
             return true;
           }
           return (
-            (this.currentCompletionDropdown === CompletionDropdownMap.reference &&
-              !this.audioVideoResource) ||
+            this.currentCompletionDropdown === CompletionDropdownMap.reference ||
             (this.value.model === CompletionCriteriaModels.REFERENCE &&
-              !this.currentCompletionDropdown &&
-              !this.audioVideoResource) ||
+              !this.currentCompletionDropdown) ||
             //should be hidden if model is reference and we're getting this from the BE
             this.currentCompletionDropdown === CompletionDropdownMap.determinedByResource
           );
@@ -716,13 +713,22 @@
       },
       showCorrectCompletionOptions() {
         const CompletionOptionsDropdownMap = {
-          document: [CompletionDropdownMap.allContent, CompletionDropdownMap.completeDuration],
+          document: [
+            CompletionDropdownMap.allContent,
+            CompletionDropdownMap.completeDuration,
+            CompletionDropdownMap.reference,
+          ],
           exercise: [CompletionDropdownMap.goal, CompletionDropdownMap.practiceQuiz],
           html5: [
             CompletionDropdownMap.completeDuration,
             CompletionDropdownMap.determinedByResource,
+            CompletionDropdownMap.reference,
           ],
-          h5p: [CompletionDropdownMap.determinedByResource, CompletionDropdownMap.completeDuration],
+          h5p: [
+            CompletionDropdownMap.determinedByResource,
+            CompletionDropdownMap.completeDuration,
+            CompletionDropdownMap.reference,
+          ],
           audio: [CompletionDropdownMap.completeDuration, CompletionDropdownMap.reference],
           video: [CompletionDropdownMap.completeDuration, CompletionDropdownMap.reference],
         };
@@ -752,11 +758,6 @@
             value: CompletionCriteriaModels.APPROX_TIME,
             id: 'longActivity',
           },
-          {
-            text: this.translateMetadataString('readReference'),
-            value: CompletionCriteriaModels.REFERENCE,
-            id: 'reference',
-          },
         ];
       },
       /**
@@ -771,15 +772,12 @@
           return this.allPossibleDurationOptions.map(model => ({
             value: model.id,
             text: model.text,
-            disabled: this.disabledReference.includes(model.value),
           }));
         } else if (this.kind === ContentKindsNames.EXERCISE) {
-          return this.allPossibleDurationOptions
-            .filter(model => model.value !== CompletionCriteriaModels.REFERENCE)
-            .map(model => ({
-              value: model.id,
-              text: model.text,
-            }));
+          return this.allPossibleDurationOptions.map(model => ({
+            value: model.id,
+            text: model.text,
+          }));
         } else {
           return this.allPossibleDurationOptions.map(model => ({
             value: model.id,
@@ -876,8 +874,7 @@
       goal: 'When goal is met',
       practiceQuiz: 'Practice quiz',
       /* eslint-enable */
-      exactTime: 'Time to complete',
-      reference: 'Reference material',
+      exactTime: 'Exact time to complete',
       referenceHint:
         'Progress will not be tracked on reference material unless learners mark it as complete',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -881,7 +881,7 @@
       practiceQuiz: 'Practice quiz',
       reference: 'Reference material',
       /* eslint-enable */
-      exactTime: 'Exact time to complete',
+      exactTime: 'Time to complete',
       referenceHint:
         'Progress will not be tracked on reference material unless learners mark it as complete',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -643,7 +643,9 @@
           };
         },
         set({ completion_criteria, suggested_duration, suggested_duration_type, modality }) {
-          completion_criteria.learner_managed = this.learnerManaged;
+          if (completion_criteria) {
+            completion_criteria.learner_managed = this.learnerManaged;
+          }
           const options = { completion_criteria, modality };
           this.updateExtraFields({ options });
           this.updateExtraFields({ suggested_duration_type });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
@@ -202,7 +202,7 @@ describe('CompletionOptions', () => {
         });
       });
       describe(`audio/video`, () => {
-        it(`'Completion dropdown' is not visible and reference hint is visible when 'Reference' is selected`, () => {
+        it(`'Reference hint is visible when 'Reference' is selected`, () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
               kind: 'audio',
@@ -210,7 +210,6 @@ describe('CompletionOptions', () => {
             },
           });
           expect(wrapper.vm.showReferenceHint).toBe(true);
-          expect(wrapper.find({ ref: 'completion' }).exists()).toBe(false);
         });
       });
       describe(`exercise`, () => {
@@ -422,23 +421,6 @@ describe('CompletionOptions', () => {
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
           expect(wrapper.vm.showActivityDurationInput).toBe(true);
-        });
-        it(`'Reference' is disabled`, async () => {
-          const wrapper = mount(CompletionOptions, {
-            propsData: {
-              kind: 'document',
-              value: { model: 'time' },
-            },
-          });
-          wrapper.find({ ref: 'completion' }).vm.$emit('input', 'completeDuration');
-          await wrapper.vm.$nextTick();
-
-          const clickableDurationDropdown = wrapper.vm.selectableDurationOptions;
-          const reference = clickableDurationDropdown.filter(
-            option => option.value === 'reference'
-          );
-          expect(clickableDurationDropdown.length).toBe(4);
-          expect(reference[0].disabled).toBe(true);
         });
       });
       describe(`switching between 'All content viewed (ACV)' and 'Complete duration (CD)'`, () => {

--- a/integration_testing/features/wip-studio-edit-modal/edit-completion-field.feature
+++ b/integration_testing/features/wip-studio-edit-modal/edit-completion-field.feature
@@ -1,7 +1,7 @@
 Feature: Edit completion/duration field
 	Across all file types
 
-	Background: 
+	Background:
 		Given I am signed into Studio
 			And I am in an editable channel with all resource types
 		When I right click a <resource>
@@ -11,18 +11,20 @@ Feature: Edit completion/duration field
 
 	Scenario: View options for .MP4 or .MP3
 		Given I am viewing an .MP4 or an .MP3 file
+		When I click the *Completion* dropdown
+		Then I see the options: *Complete duration* and *Reference*
 		When I click the *Duration* dropdown
-		Then I see the options: *Exact time to complete*, *Short activity*, *Long activity* and *Reference*
+		Then I see the options: *Exact time to complete*, *Short activity*, and *Long activity*
 
 	Scenario: View options for .PDF, .EPUB or slides
 		Given I am viewing .PDF, .EPUB or slides
 		When I click the *Completion* dropdown
-		Then I see the options: *All content viewed* and *Complete duration*
+		Then I see the options: *All content viewed*, *Complete duration*, and *Reference*
 
 	Scenario: View options for .ZIP
 		Given I am viewing a .ZIP
 		When I click on the *Completion* dropdown
-		Then I see the options: *Complete duration* and *Determined by this resource*
+		Then I see the options: *Complete duration*, *Determined by this resource*, and *Reference*
 
 	Scenario: View options for Practice resources
 		Given I am viewing an exercise


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

As decided in Slack, "Reference" should be moved to the "Completion" dropdown, rather than the duration dropdown. Now, reference is an option for audio, video, and documentation resources. This moves that and makes some small edits to ensure everything works smoothly, and updates gherkin scenarios. 

Fixes #3673
Fixes #3659  (mostly because this UI no longer exists as a result of these changes)

### Manual verification steps performed
1. Open the edit modal for a document, audio, or video resource
2. Reference should be an option under completion on the form
3. If reference is selected, no duration form should be visible, and the "reference hint" should be displayed
4. If "When time spent is equal to duration" is selected, there are duration options to select below 
5. "Reference" is no longer present as a "duration" option


### Screenshots (if applicable)

<img width="629" alt="Screen Shot 2022-09-30 at 11 12 19 AM" src="https://user-images.githubusercontent.com/17235236/193302872-af5b0a27-8974-4168-9b1e-f3880657acd0.png">

<img width="534" alt="Screen Shot 2022-09-30 at 11 12 24 AM" src="https://user-images.githubusercontent.com/17235236/193302887-ec6c8851-c1ce-4d0f-8fdf-987548eef0d1.png">

<img width="698" alt="Screen Shot 2022-09-30 at 11 12 31 AM" src="https://user-images.githubusercontent.com/17235236/193302904-f2cbb90a-342d-4a46-8343-ba414c2f36eb.png">

___
## Reviewer guidance
### How can a reviewer test these changes?
See steps above


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## Comments
Is this right?? And, do the changes to the gherkins (and tests) accurate reflect the changes made?

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
