### PR TITLE
Resolve issues with editing and browsing newly added topics

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -38,7 +38,7 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import { RouteNames } from '../constants';
+  import { RouteNames, TabNames } from '../constants';
   import MoveModal from './move/MoveModal';
   import { ContentNode } from 'shared/data/resources';
   import { withChangeTracker } from 'shared/data/changes';
@@ -119,6 +119,7 @@
             params: {
               ...this.$route.params,
               detailNodeIds: newId,
+              tab: TabNames.DETAILS,
             },
           });
         });

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -7,6 +7,16 @@ export const CHANGE_TYPES = {
   PUBLISHED: 6,
   SYNCED: 7,
 };
+/**
+ * An array of change types that directly result in the creation of nodes
+ * @type {(number)[]}
+ */
+export const CREATION_CHANGE_TYPES = [CHANGE_TYPES.CREATED, CHANGE_TYPES.COPIED];
+/**
+ * An array of change types that directly result in changes to tree structure
+ * @type {(number)[]}
+ */
+export const TREE_CHANGE_TYPES = [CHANGE_TYPES.CREATED, CHANGE_TYPES.COPIED, CHANGE_TYPES.MOVED];
 
 // Tables
 export const CHANGES_TABLE = 'changesForSyncing';

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -26,6 +26,8 @@ import {
   CHANNEL_SYNC_KEEP_ALIVE_INTERVAL,
   MAX_REV_KEY,
   LAST_FETCHED,
+  CREATION_CHANGE_TYPES,
+  TREE_CHANGE_TYPES,
 } from './constants';
 import applyChanges, { applyMods, collectChanges } from './applyRemoteChanges';
 import mergeAllChanges from './mergeChanges';
@@ -685,21 +687,28 @@ class Resource extends mix(APIResource, IndexedDBResource) {
       if (objs === EMPTY_ARRAY) {
         return [];
       }
-      if (!objs.length && !objs.count) {
-        return this.fetchCollection(params);
-      }
-      if (doRefresh) {
-        // Only fetch new updates if we've finished syncing the changes table
-        db[CHANGES_TABLE].where('table')
-          .equals(this.tableName)
-          .filter(c => !c.synced)
-          .limit(1)
-          .toArray()
-          .then(pendingChanges => {
-            if (pendingChanges.length === 0) {
-              this.fetchCollection(params);
-            }
-          });
+      // if there are no objects, and it's also not an empty paginated response (objs.count),
+      // or we mean to refresh
+      if ((!objs.length && !objs.count) || doRefresh) {
+        let refresh = Promise.resolve(true);
+        // ContentNode tree operations are the troublemakers causing the logic below
+        if (this.tableName === TABLE_NAMES.CONTENTNODE) {
+          // Only fetch new updates if we don't have pending changes to ContentNode that
+          // affect tree structure
+          refresh = db[CHANGES_TABLE].where('table')
+            .equals(TABLE_NAMES.CONTENTNODE)
+            .filter(c => TREE_CHANGE_TYPES.includes(c.type))
+            .count()
+            .then(pendingCount => pendingCount === 0);
+        }
+
+        const fetch = refresh.then(shouldFetch => {
+          return shouldFetch ? this.fetchCollection(params) : [];
+        });
+        // Be sure to return the fetch promise to relay fetched objects in this condition
+        if (!objs.length && !objs.count) {
+          return fetch;
+        }
       }
       return objs;
     });
@@ -710,13 +719,12 @@ class Resource extends mix(APIResource, IndexedDBResource) {
     // the server has applied the change yet, we skip making the HEAD request for it
     return db[CHANGES_TABLE].where('[table+key]')
       .equals([this.tableName, id])
-      .filter(c => [CHANGE_TYPES.CREATED, CHANGE_TYPES.COPIED].includes(c.type))
+      .filter(c => CREATION_CHANGE_TYPES.includes(c.type))
       .count()
       .then(pendingCount => {
-        if (pendingCount > 0) {
-          return;
+        if (pendingCount === 0) {
+          return client.head(this.modelUrl(id));
         }
-        return client.head(this.modelUrl(id));
       });
   }
 


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- @ozer550 and cohacked on this
- Prevents making HEAD requests to the backend if the requested resource may not have been created on the backend yet, preventing 'Page not found' when opening newly created folders
- Fixes issue opening non-existent tabs in the edit modal, causing a blank screen when editing details

### Manual verification steps performed
For https://github.com/learningequality/studio/issues/3699
1. Stop celery
2. Open a channel for editing
3. Create a new folder
4. Open the folder
5. Verify you don't see 'Page not found'

For https://github.com/learningequality/studio/issues/3681
1. Click to edit the channel's details
2. Click the Sharing tab
3. Close the modal
4. Click on the kebab menu for a folder
5. Click to create a new folder
6. Verify the edit modal details fields aren't missing

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3699
Fixes https://github.com/learningequality/studio/issues/3681

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
