### PR TITLE
Adds regression test for and fixes metadata label syncing.

### DIFF
--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -75,13 +75,25 @@ def sync_node(
     return node
 
 
+synced_fields = [
+    "title",
+    "description",
+    "license_id",
+    "copyright_holder",
+    "author",
+    "extra_fields",
+    "categories",
+    "learner_needs",
+    "accessibility_labels",
+    "grade_levels",
+    "resource_types",
+    "learning_activities",
+]
+
+
 def sync_node_data(node, original):
-    node.title = original.title
-    node.description = original.description
-    node.license_id = original.license_id
-    node.copyright_holder = original.copyright_holder
-    node.author = original.author
-    node.extra_fields = original.extra_fields
+    for field in synced_fields:
+        setattr(node, field, getattr(original, field))
     # Set changed if anything has changed
     node.on_update()
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds support to the sync utility to sync the new metadata labels
* Adds a regression test to verify the fix

### Manual verification steps performed
1. Wrote regression test.
2. Fixed behaviour!

## References
Noticed in QA by @pcenov here: https://github.com/learningequality/studio/pull/3701#issuecomment-1265605036

### Contributor's Checklist

Testing:

- [X] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
