### PR TITLE
Remove feature flag for channel quizzes, thus fixing completion/duration dropdowns

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -2,7 +2,7 @@
 
   <div>
     <!-- Layout when practice quizzes are enabled -->
-    <VLayout v-if="hideCompletionDropdown" xs6 md6>
+    <VLayout xs6 md6>
       <!-- "Completion" dropdown menu  -->
       <VFlex xs6 md6 class="completion-container pr-2">
         <VSelect
@@ -21,20 +21,6 @@
       <VFlex>
         <MasteryCriteriaGoal
           v-if="showMasteryCriteriaGoalDropdown"
-          ref="mastery_model"
-          v-model="goal"
-          :placeholder="getPlaceholder('mastery_model')"
-          :required="isUnique(mastery_model)"
-          @focus="trackClick('Mastery model')"
-        />
-      </VFlex>
-    </VLayout>
-
-    <!-- Layout when practice quizzes are NOT enabled -->
-    <VLayout v-else xs6 md6>
-      <VFlex xs6 md6 class="pr-2">
-        <MasteryCriteriaGoal
-          v-if="kind === 'exercise'"
           ref="mastery_model"
           v-model="goal"
           :placeholder="getPlaceholder('mastery_model')"
@@ -151,10 +137,6 @@
         type: Boolean,
         default: true,
       },
-      practiceQuizzesAllowed: {
-        type: Boolean,
-        default: true,
-      },
       value: {
         type: Object,
         required: false,
@@ -182,13 +164,6 @@
           return true;
         }
         return false;
-      },
-      hideCompletionDropdown() {
-        /*
-          This condition can be removed once practice quizzes are fully implemented in 0.16
-          Named "hide" instead of "show" because "show" is the default behavior
-          */
-        return this.practiceQuizzesAllowed;
       },
       audioVideoResource() {
         return this.kind === ContentKindsNames.AUDIO || this.kind === ContentKindsNames.VIDEO;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -147,7 +147,6 @@
             :kind="firstNode.kind"
             :fileDuration="fileDuration"
             :required="!isDocument"
-            :practiceQuizzesAllowed="allowChannelQuizzes"
           />
         </VFlex>
       </VLayout>
@@ -399,12 +398,7 @@
   import VisibilityDropdown from 'shared/views/VisibilityDropdown';
   import Checkbox from 'shared/views/form/Checkbox';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
-  import {
-    NEW_OBJECT,
-    FeatureFlagKeys,
-    AccessibilityCategories,
-    ResourcesNeededTypes,
-  } from 'shared/constants';
+  import { NEW_OBJECT, AccessibilityCategories, ResourcesNeededTypes } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
 
   // Define an object to act as the place holder for non unique values.
@@ -720,9 +714,6 @@
       },
       newContent() {
         return !this.nodes.some(n => n[NEW_OBJECT]);
-      },
-      allowChannelQuizzes() {
-        return this.$store.getters.hasFeatureEnabled(FeatureFlagKeys.channel_quizzes);
       },
       isDocument() {
         return this.firstNode.kind === ContentKindsNames.DOCUMENT;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
@@ -153,17 +153,6 @@ describe('CompletionOptions', () => {
           });
           expect(wrapper.vm.completionDropdown).toBe('goal');
         });
-        it(`Completion dropdown should not be displayed if 'practice quiz' is not enabled while 'Practice until goal is met' is set in background`, () => {
-          const wrapper = mount(CompletionOptions, {
-            propsData: {
-              kind: 'exercise',
-              value: { model: null, threshold: { m: null, n: null }, modality: 'QUIZ' },
-              practiceQuizzesAllowed: false,
-            },
-          });
-          expect(wrapper.find({ ref: 'completion' }).exists()).toBe(false);
-          expect(wrapper.vm.completionDropdown).toBe('goal');
-        });
       });
       describe(`html5 or h5p`, () => {
         it(`'Complete duration' should be displayed by default for html5`, () => {

--- a/contentcuration/contentcuration/static/feature_flags.json
+++ b/contentcuration/contentcuration/static/feature_flags.json
@@ -8,11 +8,6 @@
       "title": "Test development feature",
       "description": "This no-op feature flag is excluded from non-dev environments",
       "$env": "development"
-    },
-    "channel_quizzes": {
-      "type": "boolean",
-      "title": "Channel quizzes",
-      "description": "Allows an exercise to be marked as a channel quiz"
     }
   },
   "examples": [


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR removes the channel quiz/practice quiz feature flag, based on a conversation with Richard. This feature was causing complications in the edit modal around completion and duration options. 


### Manual verification steps performed
1. Sign in as a **non-admin**
2. Add or edit a contentNode, opening the Edit Modal
3. The completion option should be available, for all content types

___
## Reviewer guidance

### How can a reviewer test these changes?

See above

### Comments

Are the of the right UI options available for all exercises now? 🤔 I'm not actually 100% sure

## References
https://github.com/learningequality/studio/pull/3705#issuecomment-1265613257



### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
