### PR TITLE
Added a healthcheck route for Daphne server.

### DIFF
--- a/contentcuration/contentcuration/asgi.py
+++ b/contentcuration/contentcuration/asgi.py
@@ -2,16 +2,34 @@ import django
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter
 from channels.routing import URLRouter
+from django.conf import settings
 
+from contentcuration.viewsets.websockets.routing import http_urlpatterns
 from contentcuration.viewsets.websockets.routing import websocket_urlpatterns
 
 django.setup(set_prefix=False)
 
-application = ProtocolTypeRouter({
-    "websocket":
+if settings.DEBUG:
+    # Settings for development environment
+    application = ProtocolTypeRouter({
+        "websocket":
         AuthMiddlewareStack(
             URLRouter(
                 websocket_urlpatterns
             )
         ),
-})
+    })
+else:
+    # Settings for production environment
+    # we dont want to expose other url routes to daphne server
+    application = ProtocolTypeRouter({
+        "http":
+        URLRouter(http_urlpatterns),
+
+        "websocket":
+        AuthMiddlewareStack(
+            URLRouter(
+                websocket_urlpatterns
+            )
+        ),
+    })

--- a/contentcuration/contentcuration/asgi.py
+++ b/contentcuration/contentcuration/asgi.py
@@ -9,27 +9,17 @@ from contentcuration.viewsets.websockets.routing import websocket_urlpatterns
 
 django.setup(set_prefix=False)
 
-if settings.DEBUG:
-    # Settings for development environment
-    application = ProtocolTypeRouter({
-        "websocket":
+protocol_config = {
+    "websocket":
         AuthMiddlewareStack(
             URLRouter(
                 websocket_urlpatterns
             )
         ),
-    })
-else:
-    # Settings for production environment
-    # we dont want to expose other url routes to daphne server
-    application = ProtocolTypeRouter({
-        "http":
-        URLRouter(http_urlpatterns),
+}
 
-        "websocket":
-        AuthMiddlewareStack(
-            URLRouter(
-                websocket_urlpatterns
-            )
-        ),
-    })
+# production settings to add healthcheck
+if not settings.DEBUG:
+    protocol_config.update(http=URLRouter(http_urlpatterns))
+
+application = ProtocolTypeRouter(protocol_config)

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -176,10 +176,10 @@ class SyncConsumer(WebsocketConsumer):
             'success': success
         }))
 
-# Consumer for handeling the only http request related with
-# Health check
-
 
 class HealthCheckHttpConsumer(AsyncHttpConsumer):
+    """
+    Consumer for handeling the only http request related with Health check
+    """
     async def handle(self, body):
         await self.send_response(200, b"OK")

--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -2,6 +2,7 @@ import json
 import logging as logger
 
 from asgiref.sync import async_to_sync
+from channels.generic.http import AsyncHttpConsumer
 from channels.generic.websocket import WebsocketConsumer
 
 from contentcuration.viewsets.sync.constants import CHANNEL
@@ -174,3 +175,11 @@ class SyncConsumer(WebsocketConsumer):
         self.send(text_data=json.dumps({
             'success': success
         }))
+
+# Consumer for handeling the only http request related with
+# Health check
+
+
+class HealthCheckHttpConsumer(AsyncHttpConsumer):
+    async def handle(self, body):
+        await self.send_response(200, b"OK")

--- a/contentcuration/contentcuration/viewsets/websockets/routing.py
+++ b/contentcuration/contentcuration/viewsets/websockets/routing.py
@@ -5,3 +5,7 @@ from . import consumers
 websocket_urlpatterns = [
     re_path(r'ws/sync_socket/(?P<channel_id>\w+)/$', consumers.SyncConsumer.as_asgi()),
 ]
+
+http_urlpatterns = [
+    re_path(r'healthz$', consumers.HealthCheckHttpConsumer.as_asgi()),
+]


### PR DESCRIPTION
## Summary
Added a route for checking the status of Daphne service. 


### Description of the change(s) you made
- Added an HTTP consumer which handles only the health check route.
- Daphne blocks any other HTTP route in production.


### Manual verification steps performed
1. Ran yarn run runserver (all routes working properly).
2. Ran Daphne server using ```make daphneserver```.
3. Go to /healthz route.
4. Responds with 200 ok.

### Contributor's Checklist
PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
