### PR TITLE
Update aggregate counts when adding, updating, copying, or moving nodes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -97,7 +97,7 @@
                     >
                       {{ category(node.categories) }}
                     </span>
-                    <span v-if="(isTopic && node.coach_count) || isCoach">
+                    <span v-if="isTopic && node.coach_count">
                       <!-- for each learning activity -->
                       <VTooltip bottom lazy>
                         <template #activator="{ on }">

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1452,6 +1452,24 @@ export const ContentNode = new TreeResource({
   },
 
   /**
+   * Calls `updateCallback` on each ancestor, and calls `.update` for that ancestor
+   * with the return value from `updateCallback`
+   *
+   * @param {String} id
+   * @param {String|null} source
+   * @param {Function} updateCallback
+   * @return {Promise<void>}
+   */
+  updateAncestors({ id, source = null }, updateCallback) {
+    return this.transaction({ mode: 'rw', source }, async () => {
+      const ancestors = await this.getAncestors(id);
+      for (let ancestor of ancestors) {
+        await this.update(ancestor.id, updateCallback(ancestor));
+      }
+    });
+  },
+
+  /**
    * Uses local IndexedDB index on node_id+channel_id, otherwise specifically requests the
    * collection using the same params since GET detail endpoint doesn't support that the params
    *

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1435,6 +1435,11 @@ export const ContentNode = new TreeResource({
     return payload;
   },
 
+  /**
+   * Returns all ancestors of a node, including itself
+   * @param {String} id
+   * @return {Promise<Object[]>}
+   */
   getAncestors(id) {
     return this.table.get(id).then(node => {
       if (node) {
@@ -1464,6 +1469,9 @@ export const ContentNode = new TreeResource({
     return this.transaction({ mode: 'rw', source }, async () => {
       const ancestors = await this.getAncestors(id);
       for (let ancestor of ancestors) {
+        if (ancestor.id === id) {
+          continue;
+        }
         await this.update(ancestor.id, updateCallback(ancestor));
       }
     });


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
Adds logic that increments and decrements the `total_count`, `resource_count`, and `coach_count` when adding, updating, copying or moving nodes. The code applies these changes to IndexedDB because the main reason the counts were incorrect is that it relied on data that was loaded into Vuex. This updates indexedDB to keep it reflecting the current state as much as possible, but keeps those updates from causing syncable changes.

### Manual verification steps performed
1. Create a new channel
2. Add a folder `Folder A`, then a `Folder B` inside of that, and `Folder C` inside of `B`
3. Upload a resource to `Folder C`
4. Go back to the `My Channels` page
5. Reopen the channel
6. Observe the resource count on `Folder A`
7. Duplicate the resource in `Folder C`
8. Repeat steps 4-6
9. Mark one of the resources in `Folder C` as coach content
10. Repeat steps 4-6, but verify the coach count shows correctly
11. Delete (move to trash) one of the resources in `Folder C`
12. Repeat steps 4-6

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
Deleting a node does not require any of this logic, since we move nodes to the trash tree before deleting them, but it does introduce some inconsistencies.
___

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3508
Fixes https://github.com/learningequality/studio/issues/2548

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
