### PR TITLE
checkbox conversion first pass: add v-model to kcheckbox, remove/alte…

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -142,7 +142,6 @@
           :label="$tr('ToSCheck')"
           required
           :rules="tosRules"
-          :hide-details="false"
           class="my-1 policy-checkbox"
         />
 
@@ -157,7 +156,6 @@
           :label="$tr('privacyPolicyCheck')"
           required
           :rules="policyRules"
-          :hide-details="false"
           class="mb-3 mt-1 policy-checkbox"
         />
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -47,7 +47,7 @@
                   v-if="isMultipleSelection"
                   :key="answerIdx"
                   :value="answerIdx"
-                  :input-value="correctAnswersIndices"
+                  :checked="correctAnswersIndices"
                   @change="onCorrectAnswersIndicesUpdate"
                 />
               </VFlex>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemPreview/AssessmentItemPreview.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemPreview/AssessmentItemPreview.vue
@@ -50,7 +50,7 @@
               :value="idx"
               readonly
             >
-              <template #label>
+              <template #default>
                 <div class="px-2">
                   <MarkdownViewer :markdown="answer.answer" />
                 </div>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -32,7 +32,7 @@
                       <Checkbox
                         ref="checkbox"
                         class="mt-0 pt-0"
-                        :inputValue="selected"
+                        :checked="selected"
                         :indeterminate="indeterminate"
                         @click.stop.prevent="goNextSelectionState"
                       />

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/AccessibilityOptions.vue
@@ -11,10 +11,9 @@
           v-model="accessibility"
           :value="accessibilityItem.value"
           :label="accessibilityItem.label"
-          color="primary"
           :data-test="`checkbox-${accessibilityItem.help}`"
         >
-          <template #label>
+          <template #default>
             <span class="text-xs-left">{{ accessibilityItem.label }}</span>
             &nbsp;
             <HelpTooltip

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -134,7 +134,6 @@
           <VFlex md6 class="pb-2">
             <Checkbox
               v-model="learnerManaged"
-              color="primary"
               :label="$tr('learnersCanMarkComplete')"
               style="margin-top: 0px; padding-top: 0px"
             />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -28,7 +28,7 @@
         <VFlex shrink>
           <Checkbox
             :key="`checkbox-${node.id}`"
-            :input-value="isSelected(node)"
+            :checked="isSelected(node)"
             :disabled="ancestorIsSelected"
             @change="toggleSelected(node)"
           />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilters.vue
@@ -51,7 +51,7 @@
 
     <!-- Show coach content toggle -->
     <Checkbox v-model="coach" class="mb-4 mt-2">
-      <template #label>
+      <template #default>
         <Icon small color="roleVisibilityCoach">
           local_library
         </Icon>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -62,7 +62,7 @@
               <VFlex class="px-1" shrink>
                 <Checkbox
                   :key="`checkbox-${node.id}`"
-                  :input-value="isSelected(node)"
+                  :checked="isSelected(node)"
                   class="mt-0 pt-0"
                   @change="toggleSelected(node)"
                 />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -16,7 +16,7 @@
 
         <VListTile @click.stop>
           <VListTileAction>
-            <Checkbox v-model="syncFiles" color="primary" />
+            <Checkbox v-model="syncFiles" />
           </VListTileAction>
           <VListTileContent @click="syncFiles = !syncFiles">
             <VListTileTitle>{{ $tr('syncFilesTitle') }}</VListTileTitle>
@@ -26,7 +26,7 @@
 
         <VListTile @click.stop>
           <VListTileAction>
-            <VCheckbox v-model="syncTags" color="primary" />
+            <Checkbox v-model="syncTags" />
           </VListTileAction>
           <VListTileContent @click="syncTags = !syncTags">
             <VListTileTitle>{{ $tr('syncTagsTitle') }}</VListTileTitle>
@@ -36,7 +36,7 @@
 
         <VListTile @click.stop>
           <VListTileAction>
-            <VCheckbox v-model="syncTitlesAndDescriptions" color="primary" />
+            <Checkbox v-model="syncTitlesAndDescriptions" />
           </VListTileAction>
           <VListTileContent @click="syncTitlesAndDescriptions = !syncTitlesAndDescriptions">
             <VListTileTitle>{{ $tr('syncTitlesAndDescriptionsTitle') }}</VListTileTitle>
@@ -46,7 +46,7 @@
 
         <VListTile @click.stop>
           <VListTileAction>
-            <VCheckbox v-model="syncExercises" color="primary" />
+            <Checkbox v-model="syncExercises" />
           </VListTileAction>
           <VListTileContent @click="syncExercises = !syncExercises">
             <VListTileTitle>{{ $tr('syncExercisesTitle') }}</VListTileTitle>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilters.vue
@@ -67,7 +67,6 @@
         <Checkbox
           v-if="loggedIn"
           v-model="bookmark"
-          color="primary"
           :label="$tr('starredLabel')"
         />
 
@@ -75,13 +74,13 @@
         <div class="subheading">
           {{ $tr('includesLabel') }}
         </div>
-        <Checkbox v-model="coach" color="primary">
-          <template #label>
+        <Checkbox v-model="coach">
+          <template #default>
             <span class="text-xs-left">{{ $tr('coachLabel') }}</span>
             <HelpTooltip :text="$tr('coachDescription')" bottom class="px-2" />
           </template>
         </Checkbox>
-        <Checkbox v-model="subtitles" color="primary" :label="$tr('subtitlesLabel')" />
+        <Checkbox v-model="subtitles" :label="$tr('subtitlesLabel')" />
         <ActionLink
           :to="faqLink"
           target="_blank"

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
@@ -29,8 +29,8 @@
       </VTooltip>
     </template>
     <template #item="{ item }">
-      <Checkbox :key="item.id" :input-value="value" :value="item.id" class="mt-0">
-        <template #label>
+      <Checkbox :key="item.id" :checked="value.includes(item.id)" :value="item.id" class="mt-0">
+        <template #default>
           <VTooltip bottom lazy>
             <template #activator="{ on }">
               <div class="text-truncate" style="width: 250px;" v-on="on">

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -22,12 +22,11 @@
         >
           <Checkbox
             v-model="selectedChannels"
-            color="primary"
             data-test="checkbox"
             :value="channel.id"
             class="channel ma-0"
           >
-            <template #label>
+            <template #default>
               <ChannelItem :channelId="channel.id" />
             </template>
           </Checkbox>

--- a/contentcuration/contentcuration/frontend/shared/styles/main.less
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.less
@@ -46,6 +46,10 @@ body {
     max-width: 200px;
     text-align: center;
   }
+
+  .k-checkbox-label {
+    font-size: 16px;
+  }
 }
 
 /* RTL-related rules */

--- a/contentcuration/contentcuration/frontend/shared/views/Alert.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Alert.vue
@@ -2,10 +2,9 @@
 
   <MessageDialog v-model="open" :header="header" :text="text">
     <slot></slot>
-    <VCheckbox
+    <Checkbox
       v-if="messageId"
       v-model="dontShowAgain"
-      color="primary"
       :label="$tr('dontShowAgain')"
     />
     <template #buttons="{ close }">
@@ -21,10 +20,12 @@
 <script>
 
   import MessageDialog from './MessageDialog';
+  import Checkbox from './form/Checkbox';
 
   export default {
     name: 'Alert',
     components: {
+      Checkbox,
       MessageDialog,
     },
     props: {

--- a/contentcuration/contentcuration/frontend/shared/views/form/Checkbox.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/Checkbox.vue
@@ -1,32 +1,37 @@
 <script>
 
-  import { VCheckbox } from 'vuetify/lib/components/VCheckbox';
+  import KCheckbox from 'kolibri-design-system/lib/KCheckbox';
+  import isBoolean from 'lodash/isBoolean';
+  import isArray from 'lodash/isArray';
+  import isObject from 'lodash/isObject';
 
   export default {
     name: 'Checkbox',
-    extends: VCheckbox,
+    extends: KCheckbox,
+    model: {
+      prop: 'checked',
+    },
     props: {
       /* eslint-disable kolibri/vue-no-unused-properties */
-      color: {
-        type: String,
-        default: 'primary',
-      },
-      hideDetails: {
-        type: Boolean,
+      value: {
+        type: [Boolean, String, Number, Object, Array],
         default: true,
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },
+    created() {
+      this.$on('change', checked => {
+        let falsyVal = null;
+        if (isArray(this.value)) {
+          falsyVal = [];
+        } else if (isObject(this.value)) {
+          falsyVal = {};
+        } else if (isBoolean(this.value)) {
+          falsyVal = false;
+        }
+        this.$emit('input', checked ? this.value : falsyVal);
+      });
+    },
   };
 
 </script>
-
-
-<style lang="less" scoped>
-
-  /deep/ label.theme--light {
-    padding: 0 8px;
-    color: var(--v-text);
-  }
-
-</style>

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -22,7 +22,7 @@
         </template>
         <template #item="{ item, tile }">
           <Checkbox v-bind="tile.props" class="ma-0">
-            <template #label>
+            <template #default>
               <span :class="{ notranslate }">{{ getText(item) }}</span>
             </template>
           </Checkbox>

--- a/contentcuration/contentcuration/frontend/shared/views/form/__tests__/contentDefaults.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/form/__tests__/contentDefaults.spec.js
@@ -65,7 +65,7 @@ function assertFormValues(wrapper, contentDefaults) {
     ],
     checkboxes,
     contentDefaults,
-    'inputValue'
+    'checked'
   );
 }
 


### PR DESCRIPTION
…r vcheckboxes, props, and funcs

<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->


### Manual verification steps performed
1. Step 1
2. Step 2
3. ...

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
