### PR TITLE
Fix i18n induced issues with learning activity icons.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContentNodeLearningActivityIcon.vue
@@ -86,12 +86,10 @@
     },
     methods: {
       icon(activity) {
-        return getLearningActivityIcon(this.text(activity));
+        return getLearningActivityIcon(activity);
       },
       text(activity) {
-        if (this.isTopic) {
-          return this.$tr('topic');
-        } else if (activity == 'multiple') {
+        if (activity === 'multiple') {
           return this.$tr('multipleLearningActivities');
         }
         return this.translateMetadataString(camelCase(activity));
@@ -99,7 +97,6 @@
     },
     $trs: {
       multipleLearningActivities: 'Multiple learning activities',
-      topic: 'Folder',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/vuetify/icons.js
+++ b/contentcuration/contentcuration/frontend/shared/vuetify/icons.js
@@ -28,9 +28,9 @@ export function getContentKindIcon(kind, isEmpty = false) {
 }
 
 export function getLearningActivityIcon(activity) {
-  if (activity == 'Explore') {
+  if (activity.toLowerCase() === 'explore') {
     return 'interactShaded';
-  } else if (activity == 'Multiple learning activities') {
+  } else if (activity === 'multiple') {
     return 'allActivities';
   } else {
     return `${camelCase(activity) + 'Solid'}`;


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* #3344 inadvertently used translated strings to select the appropriate learning activity icon
* This went undetected until we actually had translations in place, so for non-English languages this broke
* This fixes this by removing the translation step from the icon selection

### Manual verification steps performed
1. Switch to a non-English interface language
2. Look at the tree view for items with learning activities assigned
3. See them displayed properly

Updated behaviour to fix automated tests also.

### Screenshots (if applicable)
![Screenshot from 2022-10-18 16-21-48](https://user-images.githubusercontent.com/1680573/196564140-d816022b-2637-4387-817b-770272d020ce.png)

## References
Fixes #3748