### PR TITLE
Resolve RTL dropdown issues

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CategoryOptions.vue
@@ -167,7 +167,8 @@
     },
     methods: {
       treeItemStyle(item) {
-        return this.nested ? { paddingLeft: `${item.level * 24}px` } : {};
+        const rule = this.$isRTL ? 'paddingRight' : 'paddingLeft';
+        return this.nested ? { [rule]: `${item.level * 24}px` } : {};
       },
       add(value) {
         this.selected = [...this.selected, value];

--- a/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
@@ -48,7 +48,7 @@
           top: this.top,
           maxHeight: this.menuHeight,
           lazy: true,
-          contentClass: this.$isRTL ? 'forceRTLMenu' : null,
+          contentClass: this.$isRTL ? 'forceRTLMenu' : '',
         };
       },
     },

--- a/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/DropdownWrapper.vue
@@ -48,6 +48,7 @@
           top: this.top,
           maxHeight: this.menuHeight,
           lazy: true,
+          contentClass: this.$isRTL ? 'forceRTLMenu' : null,
         };
       },
     },
@@ -91,3 +92,16 @@
   };
 
 </script>
+<style>
+
+/* According to the documentation, Vuetify supposedly supports a `right` prop to position the menu
+   on the right side, but there isn't any code that actually does this. So when using an RTL
+   language, this class will be applied and these will get flipped, because our intention is
+   left:auto and right:0
+ */
+.forceRTLMenu {
+  left: 0 !important;
+  right: auto !important;
+}
+
+</style>


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Applies `.forceRTLMenu` within `<DropdownWrapper>` when the menu should be positioned to the right with RTL languages, specifically when there's a max width on the menu, like the case of the `<LanguageDropdown>`
- Swaps padding rule depending on RTL language for display of `<CategoryOptions>`

### Manual verification steps performed
1. Change language to RTL language
2. Open a channel and click edit a resource's details
3. Check the Category and Language dropdowns

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
![Screenshot from 2022-10-19 10-40-10](https://user-images.githubusercontent.com/819838/196765315-68e89e6d-b658-49af-a935-eb02e7364266.png)
![Screenshot from 2022-10-19 10-40-23](https://user-images.githubusercontent.com/819838/196765642-491562ad-564a-4398-9473-bf213e7e5da9.png)



## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3754
Fixes https://github.com/learningequality/studio/issues/3755

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
