### PR TITLE
Prevents reapplication of errored or disallowed changes and resolves issues handling M of N and `learner_managed` values

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import { getMasteryModelValidators, translateValidator } from '../../../shared/utils/validation';
+  import { getMasteryModelValidators, translateValidator } from 'shared/utils/validation';
   import MasteryModels, { MasteryModelsList } from 'shared/leUtils/MasteryModels';
   import { constantsTranslationMixin } from 'shared/mixins';
   import DropdownWrapper from 'shared/views/form/DropdownWrapper';

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaMofNFields.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaMofNFields.vue
@@ -52,8 +52,8 @@
     getMasteryModelMValidators,
     getMasteryModelNValidators,
     translateValidator,
-  } from '../../../shared/utils/validation';
-  import MasteryModels from 'shared/leUtils/MasteryModels'; // MasteryModelsNames, // MasteryModelsList,
+  } from 'shared/utils/validation';
+  import MasteryModels from 'shared/leUtils/MasteryModels';
   import { constantsTranslationMixin } from 'shared/mixins';
 
   export default {
@@ -108,9 +108,7 @@
           return this.value && this.value.m;
         },
         set(value) {
-          value = Number(value);
-          // Make sure n is always greater than or equal to m
-          this.handleInput(value > this.nValue ? { m: value, n: value } : { m: value });
+          this.handleInput({ m: Number(value) });
         },
       },
       nValue: {
@@ -118,9 +116,7 @@
           return this.value && this.value.n;
         },
         set(value) {
-          value = Number(value);
-          // Make sure m is always less than or equal to n
-          this.handleInput(value < this.mValue ? { m: value, n: value } : { n: value });
+          this.handleInput({ n: Number(value) });
         },
       },
       mRules() {
@@ -133,10 +129,15 @@
       },
     },
     methods: {
-      handleInput(newValue) {
+      handleInput(update) {
+        // Don't emit input events unless we're sure we should
+        if (!this.showMofN) {
+          return;
+        }
+
         let data = {
           ...this.value,
-          ...newValue,
+          ...update,
         };
         this.$emit('input', data);
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -279,15 +279,6 @@ function generateContentNodeData({
   }
   if (extra_fields !== NOVALUE) {
     contentNodeData.extra_fields = contentNodeData.extra_fields || {};
-    if (extra_fields.mastery_model) {
-      contentNodeData.extra_fields.mastery_model = extra_fields.mastery_model;
-    }
-    if (extra_fields.m) {
-      contentNodeData.extra_fields.m = extra_fields.m;
-    }
-    if (extra_fields.n) {
-      contentNodeData.extra_fields.n = extra_fields.n;
-    }
     if (extra_fields.randomize !== undefined) {
       contentNodeData.extra_fields.randomize = extra_fields.randomize;
     }

--- a/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/mergeChanges.js
@@ -132,10 +132,16 @@ export default function mergeAllChanges(changes, flatten = false, changesToSync 
     if (!('rev' in change) || typeof change.rev === 'undefined') {
       console.error('This change has no `rev`:', change);
       throw new Error('Cannot determine the correct order for a change with no `rev`.');
-    } else if (change.rev <= lastRev) {
+    } else if (lastRev && change.rev <= lastRev) {
       console.error("These changes aren't ordered by `rev`:", changes);
       throw new Error('Cannot merge changes unless they are ordered by `rev`.');
     }
+
+    // Skip the change if the change errored or was disallowed
+    if (change.disallowed || (change.errors && change.errors.length > 0)) {
+      continue;
+    }
+
     lastRev = change.rev;
 
     // Ignore changes initiated by non-Resource registered tables

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -154,7 +154,7 @@ function handleErrors(response) {
     // both with any errors and the results of any merging that happened prior
     // to the sync operation being called
     return db[CHANGES_TABLE].where('server_rev')
-      .anyOf(Object.keys(errorMap))
+      .anyOf(Object.keys(errorMap).map(Number))
       .modify(obj => {
         return Object.assign(obj, errorMap[obj.server_rev]);
       });

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -273,7 +273,7 @@ class ThresholdField(Field):
 class CompletionCriteriaSerializer(JSONFieldDictSerializer):
     threshold = ThresholdField(allow_null=True)
     model = CharField()
-    learner_managed = BooleanField(required=False)
+    learner_managed = BooleanField(required=False, allow_null=True)
 
     def update(self, instance, validated_data):
         instance = super(CompletionCriteriaSerializer, self).update(instance, validated_data)


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Corrects defensive behavior on handling M of N values, arising when adding a new exercise
- Prevents overwriting of M or N values when user changes one of them, requiring multiple edits from the user
- Allows `learner_managed` to be null so that the field is deleted in the serializer
- Fixes undocumented issue where errored or disallowed changes would be reapplied during fetch

### Manual verification steps performed
1. Manually remove the `allow_null=True` change to the `learner_managed` field
2. Start or restart the celery workers
3. Create a new exercise and set invalid M of N values
4. Observe you should receive errors for the change since it should also set `learner_managed` to null
5. Edit the exercise again and apply valid M of N values distinctly different than last time
6. Click <kbd>Finish</kbd>
7. Edit the exercise again, observe the M of N values shouldn't have changed
8. Reapply the `allow_null=True` change to the `learner_managed` field
9. Restart the celery workers
10. Edit the exercise and set invalid M of N values
11. Observe the change should no longer error (although the resource should be incomplete and show a validation error)
12. Edit the exercise again and apply valid M of N values distinctly different than last time
13. Click <kbd>Finish</kbd>
14. Edit the exercise again and observe the values are consistent
15. Switch the goal to '100% correct' and then back to 'M of N'
16. Observe your M of N values were preserved

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3758
Fixes https://github.com/learningequality/studio/issues/3757

## Comments
<!-- Additional comments may be added here -->
I originally split out https://github.com/learningequality/studio/issues/3757 into another issue https://github.com/learningequality/studio/issues/3758 but ended up fixing both here

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
