### PR TITLE
Learning Activity and Completion Criteria logic on when bulk editable

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -59,7 +59,7 @@
               <LearningActivityOptions
                 ref="learning_activities"
                 v-model="contentLearningActivities"
-                :disabled="isTopic"
+                :disabled="anyIsTopic"
                 @focus="trackClick('Learning activities')"
               />
               <!-- Level -->
@@ -125,7 +125,7 @@
       </VLayout>
 
       <!-- Completion section for all resources -->
-      <VLayout v-if="!isTopic" row wrap class="section">
+      <VLayout v-if="!anyIsTopic && allSameKind" row wrap class="section">
         <VFlex xs12>
           <h1 class="subheading">
             {{ $tr('completionLabel') }}
@@ -143,7 +143,7 @@
             v-model="completionAndDuration"
             :kind="firstNode.kind"
             :fileDuration="fileDuration"
-            :required="!isDocument"
+            :required="!anyIsDocument || !allSameKind"
           />
         </VFlex>
       </VLayout>
@@ -528,8 +528,21 @@
       allResources() {
         return !this.nodes.some(node => node.kind === ContentKindsNames.TOPIC);
       },
+      allSameKind() {
+        const kind = this.firstNode.kind;
+        return !this.nodes.some(node => node.kind !== kind);
+      },
+      anyIsDocument() {
+        return this.nodes.some(n => n.kind === ContentKindsNames.DOCUMENT);
+      },
+      anyIsTopic() {
+        return this.nodes.some(n => n.kind === ContentKindsNames.TOPIC);
+      },
       isImported() {
         return isImportedContent(this.firstNode);
+      },
+      newContent() {
+        return !this.nodes.some(n => n[NEW_OBJECT]);
       },
       importedChannelLink() {
         return importedChannelLink(this.firstNode, this.$router);
@@ -705,15 +718,6 @@
       },
       videoSelected() {
         return this.oneSelected && this.firstNode.kind === ContentKindsNames.VIDEO;
-      },
-      newContent() {
-        return !this.nodes.some(n => n[NEW_OBJECT]);
-      },
-      isDocument() {
-        return this.firstNode.kind === ContentKindsNames.DOCUMENT;
-      },
-      isTopic() {
-        return this.firstNode.kind === ContentKindsNames.TOPIC;
       },
     },
     watch: {


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updates the logic in the edit modal for when to allow display and editing of Learning Activity and Completion Criteria during bulk edits, according to the following rules:
  - When all selected nodes are the same kind and aren't topics, the completion criteria shows
  - When any of the selected nodes are topics, learning activity is disabled
  - When all selected are documents, completion criteria isn't required

### Manual verification steps performed
1. Open a channel with a variety of resources and folders
2. Select multiple resources and folders, and edit them
3. Verify the above rules according to what's selected in the edit modal

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3759

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
