### PR TITLE
Allow determined by resource to be stored as a value.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -277,7 +277,10 @@
           }
 
           if (this.kind === ContentKindsNames.H5P) {
-            if (!this.value['model']) {
+            if (
+              !this.value['model'] ||
+              this.value.model === CompletionCriteriaModels.DETERMINED_BY_RESOURCE
+            ) {
               return CompletionDropdownMap.determinedByResource;
             }
             return CompletionDropdownMap.completeDuration;
@@ -294,7 +297,7 @@
           return '';
         },
         set(value) {
-          let update = {};
+          const update = {};
           this.currentCompletionDropdown = value;
 
           // FOR AUDIO/VIDEO
@@ -351,8 +354,8 @@
           if (this.kind === ContentKindsNames.HTML5 || this.kind === ContentKindsNames.H5P) {
             if (value === CompletionDropdownMap.determinedByResource) {
               update.completion_criteria = {
-                model: this.value.model,
-                threshold: this.value.threshold,
+                model: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
+                threshold: null,
               };
             }
           }
@@ -384,7 +387,7 @@
           return { mastery_model: this.mastery_model };
         },
         set(threshold) {
-          let update = {};
+          const update = {};
           if (threshold.mastery_model === MasteryModelsNames.M_OF_N) {
             update.completion_criteria = {
               model: CompletionCriteriaModels.MASTERY,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Vuetify from 'vuetify';
 import { shallowMount, mount } from '@vue/test-utils';
 import CompletionOptions from '../CompletionOptions.vue';
+import { CompletionCriteriaModels } from 'shared/constants';
 
 Vue.use(Vuetify);
 
@@ -628,7 +629,10 @@ describe('CompletionOptions', () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
               kind: 'html5',
-              value: { suggested_duration: null, model: 'approx_time' },
+              value: {
+                suggested_duration: null,
+                model: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
+              },
             },
           });
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'shortActivity');
@@ -640,7 +644,10 @@ describe('CompletionOptions', () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
               kind: 'html5',
-              value: { suggested_duration: null, model: 'approx_time' },
+              value: {
+                suggested_duration: null,
+                model: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
+              },
             },
           });
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'longActivity');
@@ -652,7 +659,10 @@ describe('CompletionOptions', () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
               kind: 'html5',
-              value: { suggested_duration: null, model: 'time' },
+              value: {
+                suggested_duration: null,
+                model: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
+              },
             },
           });
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
@@ -670,6 +680,23 @@ describe('CompletionOptions', () => {
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(false);
           expect(wrapper.vm.showActivityDurationInput).toBe(false);
           expect(wrapper.vm.showReferenceHint).toBe(true);
+        });
+      });
+    });
+    describe(`html5`, () => {
+      describe(`when completion dropdown is the default value`, () => {
+        it(`should emit determined by resource when it is selected`, async () => {
+          const wrapper = mount(CompletionOptions, {
+            propsData: {
+              kind: 'html5',
+              value: { suggested_duration: null, model: null },
+            },
+          });
+          wrapper.find({ ref: 'completion' }).vm.$emit('input', 'determinedByResource');
+          await wrapper.vm.$nextTick();
+          expect(wrapper.emitted('input')[0][0].completion_criteria.model).toEqual(
+            CompletionCriteriaModels.DETERMINED_BY_RESOURCE
+          );
         });
       });
     });

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ djangorestframework==3.12.4
 psycopg2-binary==2.9.3
 django-js-reverse==0.9.1
 django-registration==3.3
-le-utils==0.1.41
+le-utils==0.1.42
 gunicorn==20.1.0
 django-postmark==0.1.6
 jsonfield==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -166,7 +166,7 @@ jsonschema==4.16.0
     # via -r requirements.in
 kombu==5.2.4
     # via celery
-le-utils==0.1.41
+le-utils==0.1.42
     # via -r requirements.in
 newrelic==6.2.0.156
     # via -r requirements.in

--- a/yarn.lock
+++ b/yarn.lock
@@ -8000,9 +8000,9 @@ known-css-properties@^0.24.0:
   integrity sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==
 
 kolibri-constants@^0.1.41:
-  version "0.1.41"
-  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
-  integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
+  version "0.1.42"
+  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.42.tgz#2f62a8d8b8894e5cfbd47ee6564b31018818c93f"
+  integrity sha512-2hUxYnzUEfhLFJO9egVSwYW8/PKob9wLeDYfB74mtIzgQ4zy6huRj3574WetK9gREi+W1Jcm7HGPsfZIFzFvrA==
 
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#e9a2ff34716bb6412fe99f835ded5b17345bab94":
   version "1.3.0"


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Updates le-utils and kolibri-constants to 0.1.42 to add `determined_by_resource` as a valid completion criterion.
* Uses it to both set and read data to and from the backend
* Updates tests to confirm that the modal properly sets this.

### Manual verification steps performed
1. Edit an HTML5 app
2. Set to determined by resource
3. Ensure that it gets properly set

### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1680573/197619219-e77329c7-329a-47f2-a98e-1514ba0a6bc2.png)


## References
Fixes #3750

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
