### PR TITLE
Stop using the google storage API url in production to prevent CORS issues

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
@@ -58,7 +58,7 @@ export function storageUrl(checksum, file_format) {
     return '';
   }
   /*eslint no-undef: "error"*/
-  return `${window.storageBaseUrl}${checksum[0]}/${checksum[1]}/${checksum}.${file_format}`;
+  return `/content/storage/${checksum[0]}/${checksum[1]}/${checksum}.${file_format}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Uses the /content/storage URL to access files in the frontend

### Manual verification steps performed
1. Ensure that file preview and thumbnail generation still work
2. Check that the source URL is from the local origin

### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1680573/197634447-593aa71f-498c-4fb8-bb19-fd9b525e6726.png)

## References
Fixes #3764

