### PR TITLE
Find unapplied changes and ensure we get updates from the backend about those.

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -258,7 +258,6 @@ async function syncChanges() {
   const unAppliedChanges = await db[CHANGES_TABLE].orderBy('server_rev')
     .filter(c => c.synced && !c.errors && !c.disallowed)
     .toArray();
-  unAppliedChanges.reverse();
   for (let channelId of channelIds) {
     channel_revs[channelId] = get(user, [MAX_REV_KEY, channelId], 0);
     const unAppliedChange = unAppliedChanges.find(c => c.channel_id === channelId);

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -141,7 +141,7 @@ class SyncView(APIView):
             "allowed": [],
             "changes": [],
             "errors": [],
-            "successess": [],
+            "successes": [],
             "tasks": [],
         }
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Ensures that tasks that are long running in their application and emit their own changes during their running (like copying, publishing, syncing etc.) get properly finalized and marked as succeeded
* Does this by looking for changes that are marked as `synced` but with no errors nor disallowed, which means they have been sent to the backend and are awaiting application
* If this value is less than the currently registered max rev for the channel, it sends that instead.

### Manual verification steps performed
1. Do a long running copy.
2. Ensure that the sync returns allowed, then that it returns the in progress tracking, and then that the change event is included in success (and that the channel rev sent to the backend is the server_rev for the copy change until it has succeeded

## References
Fixes #3753