### PR TITLE
Only use non-server generated events for max rev setting

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -937,6 +937,13 @@ export const Session = new IndexedDBResource({
       this.monitorKeepAlive();
       window.addEventListener('focus', () => this.monitorKeepAlive());
       window.addEventListener('blur', () => this.stopMonitorKeepAlive());
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+          this.stopMonitorKeepAlive();
+        } else {
+          this.monitorKeepAlive();
+        }
+      });
     }
   },
   async getSession() {

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -181,7 +181,9 @@ function handleMaxRevs(response, userId) {
       .concat(get(response, ['data', 'successes'], [])),
     'server_rev',
     'desc'
-  );
+    // Ignore server generated changes, as they are applied out of order.
+    // This leads to a false sense of which changes we have actually seen.
+  ).filter(c => c.created_by_id);
   const channelIds = uniq(allChanges.map(c => c.channel_id)).filter(Boolean);
   const maxRevs = {};
   const promises = [];
@@ -249,25 +251,8 @@ async function syncChanges() {
     .filter(([id, time]) => id && time > now - CHANNEL_SYNC_KEEP_ALIVE_INTERVAL)
     .map(([id]) => id);
   const channel_revs = {};
-  // Ensure we ask for information about our changes that are as yet unapplied
-  // We need to do this as server side changes are applied 'out of order' as they are generated
-  // already applied but can have a server_rev higher than as yet unapplied client generated
-  // changes. This should be cleaned up when we are able to directly communicate with the client
-  // via websockets and don't need to store these kind of events in the same mechanism as the change
-  // event log.
-  const unAppliedChanges = await db[CHANGES_TABLE].orderBy('server_rev')
-    .filter(c => c.synced && !c.errors && !c.disallowed)
-    .toArray();
   for (let channelId of channelIds) {
     channel_revs[channelId] = get(user, [MAX_REV_KEY, channelId], 0);
-    const unAppliedChange = unAppliedChanges.find(c => c.channel_id === channelId);
-    if (
-      unAppliedChange &&
-      unAppliedChange.server_rev &&
-      unAppliedChange.server_rev < channel_revs[channelId]
-    ) {
-      channel_revs[channelId] = unAppliedChange.server_rev;
-    }
   }
 
   const requestPayload = {

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -90,7 +90,9 @@ def current_user_for_context(user):
 
     user_data = {field: getattr(user, field) for field in user_fields}
 
-    user_data["user_rev"] = Change.objects.filter(applied=True, user=user).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
+    user_data["user_rev"] = Change.objects.filter(
+        applied=True, user=user, created_by__isnull=False
+    ).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
 
     return json_for_parse_from_data(user_data)
 
@@ -301,7 +303,9 @@ def channel(request, channel_id):
         if channel.deleted:
             channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED'
         else:
-            channel_rev = Change.objects.filter(applied=True, channel=channel).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
+            channel_rev = Change.objects.filter(
+                applied=True, channel=channel, created_by__isnull=False
+            ).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
 
     return render(
         request,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Reverts changes from #3771
Instead changes the max rev setting for events received from the backend to filter out server generated events
Also changes how we send max rev from the backend to do the same filtering
Adds use of the visibility API for the active channel tracking so that switching back to a browser tab is sufficient to mark a channel as active, rather than needing to click inside the window

### Manual verification steps performed
1. Do an import of a folder
2. Ensure that clicking into the folder properly lists it

1. Open a different browser session
2. Initiate an import into the same channel in that session
3. Click back to the window/tab of the original session and ensure the copied item appears once the copy completes

## References
Fixes issue reported here: https://github.com/learningequality/studio/pull/3771#issuecomment-1292107798
