### PR TITLE
Disable bulk editing of all new metadata

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -34,6 +34,7 @@
           />
           <VLayout row wrap>
             <VFlex
+              v-if="oneSelected"
               xs12
               md6
               class="basicInfoColumn"
@@ -41,7 +42,6 @@
             >
               <!-- Description -->
               <VTextarea
-                v-if="oneSelected"
                 ref="description"
                 v-model="description"
                 :label="$tr('descriptionLabel')"
@@ -54,7 +54,11 @@
                 @focus="trackClick('Description')"
               />
             </VFlex>
-            <VFlex xs12 :[mdValue]="true" :class="{ 'pl-2': $vuetify.breakpoint.mdAndUp }">
+            <VFlex
+              xs12
+              :[mdValue]="true"
+              :class="{ 'pl-2': $vuetify.breakpoint.mdAndUp && oneSelected }"
+            >
               <!-- Learning activity -->
               <LearningActivityOptions
                 v-if="oneSelected"
@@ -919,7 +923,7 @@
     }
 
     .section .flex {
-      margin: 24px 0 !important;
+      margin: 12px 0 !important;
     }
 
     .auth-section {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -54,9 +54,10 @@
                 @focus="trackClick('Description')"
               />
             </VFlex>
-            <VFlex xs12 md6 :class="{ 'pl-2': $vuetify.breakpoint.mdAndUp }">
+            <VFlex xs12 :[mdValue]="true" :class="{ 'pl-2': $vuetify.breakpoint.mdAndUp }">
               <!-- Learning activity -->
               <LearningActivityOptions
+                v-if="oneSelected"
                 ref="learning_activities"
                 v-model="contentLearningActivities"
                 :disabled="anyIsTopic"
@@ -64,12 +65,14 @@
               />
               <!-- Level -->
               <LevelsOptions
+                v-if="oneSelected"
                 ref="contentLevel"
                 v-model="contentLevel"
                 @focus="trackClick('Levels dropdown')"
               />
               <!-- What you will need -->
               <ResourcesNeededOptions
+                v-if="oneSelected"
                 ref="resourcesNeeded"
                 v-model="resourcesNeeded"
                 @focus="trackClick('What you will need')"
@@ -104,7 +107,7 @@
             </VFlex>
           </VLayout>
           <!-- Category -->
-          <CategoryOptions ref="categories" v-model="categories" />
+          <CategoryOptions v-if="oneSelected" ref="categories" v-model="categories" />
         </VFlex>
       </VLayout>
 
@@ -196,6 +199,7 @@
 
           <!-- For Beginners -->
           <KCheckbox
+            v-if="oneSelected"
             id="beginners"
             ref="beginners"
             :checked="forBeginners"
@@ -551,8 +555,11 @@
         return this.firstNode.original_channel_name;
       },
       requiresAccessibility() {
-        return this.nodes.every(
-          node => node.kind !== ContentKindsNames.AUDIO && node.kind !== ContentKindsNames.TOPIC
+        return (
+          this.oneSelected &&
+          this.nodes.every(
+            node => node.kind !== ContentKindsNames.AUDIO && node.kind !== ContentKindsNames.TOPIC
+          )
         );
       },
       audioAccessibility() {
@@ -718,6 +725,11 @@
       },
       videoSelected() {
         return this.oneSelected && this.firstNode.kind === ContentKindsNames.VIDEO;
+      },
+      // Dynamically compute the size of the VFlex used
+      /* eslint-disable-next-line kolibri/vue-no-unused-properties */
+      mdValue() {
+        return this.oneSelected ? 'md6' : 'md12';
       },
     },
     watch: {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Doing bulk editing of new metadata causes issues as we are not doing individualized updates to the metadata in the same way we do for tags
* The full spec (with indeterminate checkbox states) can't be implemented using the VSelect components currently being used for much of the UI
* The simplest fix this close to release seems to be just disabling all bulk editing for new metadata - this means that when we release, bulk editing will be unchanged from current production


### Manual verification steps performed
1. Select multiple resources
2. See that no new metadata is editable

### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1680573/198489897-9570f91e-f16f-499c-b03f-03195cc060df.png)

### Does this introduce any tech-debt items?
We will need to address this at least when we implement the new bulk editing workflows.
Updating the data processing to match how we handle the 'merge' behaviour for bulk editing in tags will be the first step
We will also need a way to indicate multiselect with indeterminate states in KSelect to implement this.


Fixes #3769