### PR TITLE
Do early return so we don't try to generate a thumbnail when we cannot.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/thumbnails/ThumbnailGenerator.vue
@@ -158,6 +158,7 @@
           return book.loaded.cover.then(() => {
             if (!book.cover) {
               this.handleError();
+              return;
             }
             return book.archive.createUrl(book.cover, { base64: true }).then(this.handleGenerated);
           });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* We do a check to see if we have the information we need to generate a thumbnail, but then try to generate the thumbnail anyway
* This fixes that by returning early

### Manual verification steps performed
1. Upload the epub in the archive here: https://github.com/learningequality/studio/files/9887092/TestGoogleEPUB.zip
2. Try to generate a thumbnail.
3. Confirm it tells the user there is an error, but no console errors are shown.

Fixes #3770