### PR TITLE
More completion duration updates

### DIFF
--- a/contentcuration/contentcuration/constants/completion_criteria.py
+++ b/contentcuration/contentcuration/constants/completion_criteria.py
@@ -20,6 +20,53 @@ def _build_validator():
 validator = _build_validator()
 
 
+ALLOWED_MODELS_PER_KIND = {
+    content_kinds.DOCUMENT: {
+        completion_criteria.PAGES,
+        completion_criteria.TIME,
+        completion_criteria.APPROX_TIME,
+        completion_criteria.REFERENCE,
+    },
+    content_kinds.EXERCISE: {completion_criteria.MASTERY},
+    content_kinds.HTML5: {
+        completion_criteria.DETERMINED_BY_RESOURCE,
+        completion_criteria.TIME,
+        completion_criteria.APPROX_TIME,
+        completion_criteria.REFERENCE,
+    },
+    content_kinds.H5P: {
+        completion_criteria.DETERMINED_BY_RESOURCE,
+        completion_criteria.TIME,
+        completion_criteria.APPROX_TIME,
+        completion_criteria.REFERENCE,
+    },
+    content_kinds.AUDIO: {
+        completion_criteria.TIME,
+        completion_criteria.APPROX_TIME,
+        completion_criteria.REFERENCE,
+    },
+    content_kinds.VIDEO: {
+        completion_criteria.TIME,
+        completion_criteria.APPROX_TIME,
+        completion_criteria.REFERENCE,
+    },
+}
+
+
+def check_model_for_kind(data, kind):
+    model = data.get("model")
+    if kind is None or model is None or kind not in ALLOWED_MODELS_PER_KIND:
+        return
+
+    # validate that content kind is allowed for the completion criteria model
+    if model not in ALLOWED_MODELS_PER_KIND[kind]:
+        raise ValidationError(
+            "Completion criteria model '{}' is invalid for content kind '{}'".format(
+                model, kind
+            )
+        )
+
+
 def validate(data, kind=None):
     """
     :param data: Dictionary of data to validate
@@ -49,16 +96,4 @@ def validate(data, kind=None):
         e.error_list.extend(error_descriptions)
         raise e
 
-    model = data.get("model")
-    if kind is None or model is None:
-        return
-
-    # validate that content kind is allowed for the completion criteria model
-    if (model == completion_criteria.PAGES and kind != content_kinds.DOCUMENT) or (
-        model == completion_criteria.MASTERY and kind != content_kinds.EXERCISE
-    ):
-        raise ValidationError(
-            "Completion criteria model '{}' is invalid for content kind '{}'".format(
-                model, kind
-            )
-        )
+    check_model_for_kind(data, kind)

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -266,6 +266,9 @@
             if (!this.audioVideoResource) {
               update.threshold = DEFAULT_SHORT_ACTIVITY;
               update.duration = update.threshold;
+            } else {
+              update.threshold = this.generateDefaultThreshold();
+              update.duration = update.threshold;
             }
             update.durationType = update.model;
           } else if (value === CompletionDropdownMap.allContent) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -281,7 +281,7 @@
             update.threshold = null;
           } else if (value === CompletionDropdownMap.practiceQuiz) {
             update.modality = ContentModalities.QUIZ;
-            update.threshold = this.threshold || { mastery_model: MasteryModelsNames.DO_ALL };
+            update.threshold = { mastery_model: MasteryModelsNames.DO_ALL };
           } else if (value === CompletionDropdownMap.goal) {
             update.modality = null;
             update.model = CompletionCriteriaModels.MASTERY;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -414,7 +414,7 @@
         if (this.kind && this.required) {
           return getCompletionValidators().map(translateValidator);
         }
-        return false;
+        return [];
       },
       durationRules() {
         if (this.completionDropdown === CompletionDropdownMap.completeDuration) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -1,6 +1,13 @@
 <template>
 
   <div>
+    <!-- Checkbox for "Allow learners to mark complete" -->
+    <Checkbox
+      v-model="learnerManaged"
+      color="primary"
+      :label="markCompleteLabel"
+      style="padding-bottom: 16px;"
+    />
     <!-- Layout when practice quizzes are enabled -->
     <VLayout xs6 md6>
       <!-- "Completion" dropdown menu  -->
@@ -24,9 +31,9 @@
         <MasteryCriteriaGoal
           v-if="showMasteryCriteriaGoalDropdown"
           ref="mastery_model"
-          v-model="goal"
+          v-model="masteryModel"
           :placeholder="getPlaceholder('mastery_model')"
-          :required="isUnique(mastery_model)"
+          :required="isUnique(masteryModel)"
           @focus="trackClick('Mastery model')"
         />
       </VFlex>
@@ -36,22 +43,21 @@
       <MasteryCriteriaMofNFields
         v-if="kind === 'exercise'"
         ref="mastery_model_m_of_n"
-        v-model="masteryModelItem"
+        v-model="mOfN"
         :showMofN="showMofN"
-        :mPlaceholder="getPlaceholder('m')"
-        :mRequired="isUnique(m)"
-        :nPlaceholder="getPlaceholder('n')"
-        :nRequired="isUnique(n)"
+        :mPlaceholder="getPlaceholder('mOfN.m')"
+        :mRequired="isUnique(mOfN.m)"
+        :nPlaceholder="getPlaceholder('mOfN.n')"
+        :nRequired="isUnique(mOfN.n)"
         @mFocus="trackClick('Mastery m value')"
         @nFocus="trackClick('Mastery n value')"
       />
     </VLayout>
 
     <VLayout row wrap>
-      <DropdownWrapper component="VFlex" xs6 md6 class="pr-2">
+      <DropdownWrapper v-if="showDuration" component="VFlex" xs6 md6 class="pr-2">
         <template #default="{ attach, menuProps }">
           <VSelect
-            v-if="!hideDurationDropdown"
             ref="duration"
             v-model="durationDropdown"
             box
@@ -67,14 +73,13 @@
       </DropdownWrapper>
 
       <!-- "Activity duration" minutes input -->
-      <VFlex xs6 md6>
+      <VFlex v-if="showDuration" xs6 md6>
         <ActivityDuration
-          v-if="showActivityDurationInput"
           ref="activity_duration"
-          v-model="minutes"
-          :selectedDuration="currentDurationDropdown || durationDropdown"
+          v-model="durationValue"
+          :selectedDuration="durationDropdown"
           :duration="fileDuration"
-          :selectedCompletion="currentCompletionDropdown || completionDropdown"
+          :selectedCompletion="completionDropdown"
           :audioVideoUpload="kind === 'video' || kind === 'audio'"
         />
       </VFlex>
@@ -99,7 +104,9 @@
     ContentModalities,
     CompletionDropdownMap,
     DurationDropdownMap,
+    nonUniqueValue,
   } from 'shared/constants';
+  import Checkbox from 'shared/views/form/Checkbox';
   import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import {
@@ -113,17 +120,64 @@
   const DEFAULT_SHORT_ACTIVITY = 600;
   const DEFAULT_LONG_ACTIVITY = 3000;
   const SHORT_LONG_ACTIVITY_MIDPOINT = 1860;
-  const nonUniqueValue = {};
-  nonUniqueValue.toString = () => '';
 
-  const SuggestedDurationTypesMap = {
-    APPROX_TIME: 'approx_time',
-    TIME: 'time',
+  const defaultCompletionCriteriaModels = {
+    [ContentKindsNames.VIDEO]: CompletionCriteriaModels.TIME,
+    [ContentKindsNames.AUDIO]: CompletionCriteriaModels.TIME,
+    [ContentKindsNames.DOCUMENT]: CompletionCriteriaModels.PAGES,
+    [ContentKindsNames.H5P]: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
+    [ContentKindsNames.HTML5]: CompletionCriteriaModels.APPROX_TIME,
+    [ContentKindsNames.EXERCISE]: CompletionCriteriaModels.MASTERY,
+  };
+
+  const defaultCompletionCriteriaThresholds = {
+    // Audio and Video threshold defaults are dynamic based
+    // on the duration of the file itself.
+    [ContentKindsNames.DOCUMENT]: '100%',
+    [ContentKindsNames.HTML5]: 300,
+    // We cannot set an automatic default threshold for exercises.
+  };
+
+  const completionCriteriaToDropdownMap = {
+    [CompletionCriteriaModels.TIME]: CompletionDropdownMap.completeDuration,
+    [CompletionCriteriaModels.APPROX_TIME]: CompletionDropdownMap.completeDuration,
+    [CompletionCriteriaModels.PAGES]: CompletionDropdownMap.allContent,
+    [CompletionCriteriaModels.DETERMINED_BY_RESOURCE]: CompletionDropdownMap.determinedByResource,
+    [CompletionCriteriaModels.MASTERY]: CompletionDropdownMap.goal,
+    [CompletionCriteriaModels.REFERENCE]: CompletionDropdownMap.reference,
+  };
+
+  const CompletionOptionsDropdownMap = {
+    [ContentKindsNames.DOCUMENT]: [
+      CompletionDropdownMap.allContent,
+      CompletionDropdownMap.completeDuration,
+      CompletionDropdownMap.reference,
+    ],
+    [ContentKindsNames.EXERCISE]: [CompletionDropdownMap.goal, CompletionDropdownMap.practiceQuiz],
+    [ContentKindsNames.HTML5]: [
+      CompletionDropdownMap.completeDuration,
+      CompletionDropdownMap.determinedByResource,
+      CompletionDropdownMap.reference,
+    ],
+    [ContentKindsNames.H5P]: [
+      CompletionDropdownMap.determinedByResource,
+      CompletionDropdownMap.completeDuration,
+      CompletionDropdownMap.reference,
+    ],
+    [ContentKindsNames.VIDEO]: [
+      CompletionDropdownMap.completeDuration,
+      CompletionDropdownMap.reference,
+    ],
+    [ContentKindsNames.AUDIO]: [
+      CompletionDropdownMap.completeDuration,
+      CompletionDropdownMap.reference,
+    ],
   };
 
   export default {
     name: 'CompletionOptions',
     components: {
+      Checkbox,
       DropdownWrapper,
       ActivityDuration,
       MasteryCriteriaMofNFields,
@@ -149,19 +203,22 @@
         required: false,
         default: () => ({}),
       },
-    },
-    data() {
-      return {
-        // required state because we need to know the durationDropdown before it is set in backend
-        currentDurationDropdown: null,
-        // required state because we need to know the completion to determine durationDropdown model
-        currentCompletionDropdown: null,
-        mastery_model: null,
-        m: null,
-        n: null,
-      };
+      // TODO: move string in here
+      markCompleteLabel: {
+        type: String,
+        required: true,
+      },
     },
     computed: {
+      model() {
+        return this.value.model || defaultCompletionCriteriaModels[this.kind];
+      },
+      threshold() {
+        if (!this.value.model) {
+          return this.generateDefaultThreshold();
+        }
+        return this.value.threshold;
+      },
       showMasteryCriteriaGoalDropdown() {
         if (this.kind === ContentKindsNames.EXERCISE) {
           //this ensures that anytime the completion dropdown is practice quiz
@@ -172,570 +229,154 @@
       audioVideoResource() {
         return this.kind === ContentKindsNames.AUDIO || this.kind === ContentKindsNames.VIDEO;
       },
-      hideDurationDropdown() {
-        // named "hide" instead of "show" because "show" is the default behavior
-        if (this.value) {
-          return (
-            this.value.model == CompletionCriteriaModels.REFERENCE ||
-            this.value.model == CompletionCriteriaModels.DETERMINED_BY_RESOURCE
-          );
-        }
-        return false;
+      showDuration() {
+        return (
+          this.model === CompletionCriteriaModels.TIME ||
+          this.model === CompletionCriteriaModels.APPROX_TIME
+        );
       },
       showReferenceHint() {
         /*
           The reference hint should be shown only when "Reference" is selected
         */
-        if (this.value) {
-          if (this.kind === ContentKindsNames.H5P || this.kind === ContentKindsNames.HTML5) {
-            if (this.currentCompletionDropdown === CompletionDropdownMap.determinedByResource) {
-              return false;
-            }
-            if (
-              this.value.model === CompletionCriteriaModels.REFERENCE &&
-              this.currentCompletionDropdown === CompletionDropdownMap.completeDuration
-            ) {
-              return true;
-            }
-          }
-          if (this.audioVideoResource) {
-            return this.value.model === CompletionCriteriaModels.REFERENCE;
-          }
-          return (
-            this.value.model === CompletionCriteriaModels.REFERENCE &&
-            this.currentCompletionDropdown !== CompletionDropdownMap.completeDuration
-          );
-        }
-        return false;
-      },
-      showActivityDurationInput() {
-        /* The `ActivityDuration` component should visible when:
-          - Long activity, short activity, or exact time are chosen if it is not an AV resource
-          - Long activity or short activity are chosen if it is an AV resource
-          - Long activity, short activity, or exact time are chosen in HTML5
-        */
-        if (this.value) {
-          if (
-            this.value.model == CompletionCriteriaModels.REFERENCE ||
-            this.value.model == CompletionCriteriaModels.DETERMINED_BY_RESOURCE
-          ) {
-            return false;
-          }
-
-          if (!this.audioVideoResource) {
-            return true;
-          }
-        }
-        return this.audioVideoResource && this.value.model !== CompletionCriteriaModels.REFERENCE;
+        return this.model === CompletionCriteriaModels.REFERENCE;
       },
       completionDropdown: {
         get() {
-          if (this.audioVideoResource) {
-            if (this.value.model === CompletionCriteriaModels.REFERENCE) {
-              return CompletionDropdownMap.reference;
-            }
-            return CompletionDropdownMap.completeDuration;
+          if (
+            this.value.modality === ContentModalities.QUIZ &&
+            this.model === CompletionCriteriaModels.MASTERY
+          ) {
+            return CompletionDropdownMap.practiceQuiz;
           }
-
-          if (this.value.model === CompletionCriteriaModels.REFERENCE) {
-            return CompletionDropdownMap.reference;
-          }
-
-          if (this.kind === ContentKindsNames.DOCUMENT) {
-            if (!this.value['model']) {
-              return CompletionDropdownMap.allContent;
-            } else {
-              if (
-                this.value.model === CompletionCriteriaModels.PAGES ||
-                this.value.model === CompletionCriteriaModels.REFERENCE
-              ) {
-                return CompletionDropdownMap.allContent;
-              }
-              return CompletionDropdownMap.completeDuration;
-            }
-          }
-
-          if (this.kind === ContentKindsNames.HTML5) {
-            if (
-              !this.value['model'] ||
-              this.value.model === CompletionCriteriaModels.APPROX_TIME ||
-              this.value.model === CompletionCriteriaModels.TIME
-            ) {
-              return CompletionDropdownMap.completeDuration;
-            } else if (this.value.model === CompletionCriteriaModels.REFERENCE) {
-              return CompletionDropdownMap.reference;
-            }
-
-            return CompletionDropdownMap.determinedByResource;
-          }
-
-          if (this.kind === ContentKindsNames.H5P) {
-            if (
-              !this.value['model'] ||
-              this.value.model === CompletionCriteriaModels.DETERMINED_BY_RESOURCE
-            ) {
-              return CompletionDropdownMap.determinedByResource;
-            }
-            return CompletionDropdownMap.completeDuration;
-          }
-
-          if (this.kind === ContentKindsNames.EXERCISE) {
-            if (this.value.modality === ContentModalities.QUIZ) {
-              return CompletionDropdownMap.practiceQuiz;
-            }
-            return CompletionDropdownMap.goal;
-          }
-
-          return '';
+          return completionCriteriaToDropdownMap[this.model];
         },
         set(value) {
           const update = {};
-          this.currentCompletionDropdown = value;
 
-          // FOR AUDIO/VIDEO
           if (value === CompletionDropdownMap.reference) {
-            update.suggested_duration_type = this.value.suggested_duration_type;
-            update.completion_criteria = {
-              model: CompletionCriteriaModels.REFERENCE,
-              threshold: null,
-            };
-          }
-          if (value === CompletionDropdownMap.completeDuration) {
-            update.completion_criteria = {
-              model: CompletionCriteriaModels.TIME,
-              threshold: this.fileDuration || this.value.suggested_duration,
-            };
-          }
-
-          // FOR DOCUMENTS
-          if (this.kind === ContentKindsNames.DOCUMENT) {
-            if (value === CompletionDropdownMap.allContent) {
-              update.suggested_duration_type = this.value.suggested_duration_type;
-              update.suggested_duration = this.value.suggested_duration;
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.PAGES,
-                threshold: '100%',
-              };
-            } else if (value === CompletionDropdownMap.reference) {
-              update.suggested_duration_type = null;
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.REFERENCE,
-                threshold: null,
-              };
-            } else if (value === CompletionDropdownMap.completeDuration) {
-              // set to '1' as the minimum here, due to validation rules requiring > 0
-              update.suggested_duration = this.value.suggested_duration || 60;
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.TIME,
-                threshold: this.value.suggested_duration || 60,
-              };
-            } else {
-              update.suggested_duration_type = this.value.suggested_duration_type;
-              update.suggested_duration = this.value.suggested_duration;
-              if (
-                this.durationDropdown === DurationDropdownMap.LONG_ACTIVITY ||
-                this.durationDropdown === DurationDropdownMap.SHORT_ACTIVITY
-              ) {
-                update.completion_criteria = {
-                  model: CompletionCriteriaModels.APPROX_TIME,
-                  threshold: this.value.suggested_duration || 0,
-                };
-              } else if (this.durationDropdown === DurationDropdownMap.EXACT_TIME) {
-                update.completion_criteria = {
-                  model: CompletionCriteriaModels.TIME,
-                  threshold: this.value.suggested_duration || 0,
-                };
-              } else {
-                // default state
-                update.completion_criteria = {
-                  model: this.value.model,
-                  threshold: this.value.threshold,
-                };
-              }
-            }
-          }
-
-          // FOR H5P/HTML5
-          if (this.kind === ContentKindsNames.HTML5 || this.kind === ContentKindsNames.H5P) {
-            if (value === CompletionDropdownMap.determinedByResource) {
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
-                threshold: null,
-              };
-            } else if (value === CompletionDropdownMap.completeDuration) {
-              update.suggested_duration = this.value.suggested_duration || 60;
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.TIME,
-                threshold: this.value.suggested_duration || 60,
-              };
-            }
-          }
-
-          // FOR EXERCISES
-          if (this.kind === ContentKindsNames.EXERCISE) {
-            if (value === CompletionDropdownMap.practiceQuiz) {
-              update.modality = ContentModalities.QUIZ;
-              update.completion_criteria = {
-                model: this.value.model || CompletionCriteriaModels.MASTERY,
-                threshold: this.value.threshold || { mastery_model: MasteryModelsNames.DO_ALL },
-              };
-            } else {
-              update.modality = null;
-              update.completion_criteria = {
-                model: this.value.model,
-                threshold: this.value.threshold,
-              };
-            }
+            update.model = CompletionCriteriaModels.REFERENCE;
+            update.durationType = null;
+            update.duration = null;
+            update.threshold = null;
+          } else if (value === CompletionDropdownMap.completeDuration) {
+            update.model = this.audioVideoResource
+              ? CompletionCriteriaModels.TIME
+              : CompletionCriteriaModels.APPROX_TIME;
+          } else if (value === CompletionDropdownMap.allContent) {
+            update.model = CompletionCriteriaModels.PAGES;
+            update.threshold = '100%';
+          } else if (value === CompletionDropdownMap.determinedByResource) {
+            update.model = CompletionCriteriaModels.DETERMINED_BY_RESOURCE;
+            update.durationType = null;
+            update.duration = null;
+            update.threshold = null;
+          } else if (value === CompletionDropdownMap.practiceQuiz) {
+            update.modality = ContentModalities.QUIZ;
+            update.threshold = this.threshold || { mastery_model: MasteryModelsNames.DO_ALL };
+          } else if (value === CompletionDropdownMap.goal) {
+            update.modality = null;
+            update.model = CompletionCriteriaModels.MASTERY;
           }
           this.handleInput(update);
         },
       },
-      goal: {
+      masteryModel: {
         get() {
-          if (this.value.threshold) {
-            return { mastery_model: this.value.threshold.mastery_model };
-          }
-          return { mastery_model: this.mastery_model };
+          return get(this, 'threshold.mastery_model');
         },
-        set(threshold) {
-          const update = {};
-          if (threshold.mastery_model === MasteryModelsNames.M_OF_N) {
-            update.completion_criteria = {
-              model: CompletionCriteriaModels.MASTERY,
-              threshold: {
-                mastery_model: threshold.mastery_model,
-                m: get(this.value, 'threshold.m') || this.m,
-                n: get(this.value, 'threshold.n') || this.n,
-              },
-            };
-          } else {
-            update.completion_criteria = {
-              model: CompletionCriteriaModels.MASTERY,
-              threshold: {
-                mastery_model: threshold.mastery_model,
-                m: null,
-                n: null,
-              },
-            };
+        set(mastery_model) {
+          const update = { threshold: { mastery_model } };
+          if (mastery_model === MasteryModelsNames.M_OF_N) {
+            update.threshold.m = get(this, 'threshold.m');
+            update.threshold.n = get(this, 'threshold.n');
           }
           this.handleInput(update);
         },
       },
       showMofN() {
-        if (this.kind === ContentKindsNames.EXERCISE) {
-          if (this.value.modality === ContentModalities.QUIZ) {
-            return false;
-          }
-          if (this.value.threshold) {
-            const defaultStateWhenSwitchingFromGoalToPracticeQuiz =
-              this.value.threshold.mastery_model === MasteryModelsNames.M_OF_N &&
-              this.currentCompletionDropdown === null;
-            if (
-              this.currentCompletionDropdown === CompletionDropdownMap.goal &&
-              this.value.threshold.mastery_model === MasteryModelsNames.M_OF_N
-            ) {
-              return true;
-            }
-            if (defaultStateWhenSwitchingFromGoalToPracticeQuiz) {
-              return true;
-            }
-          }
+        if (this.kind !== ContentKindsNames.EXERCISE) {
+          return false;
         }
-        return false;
+        if (this.value.modality === ContentModalities.QUIZ) {
+          return false;
+        }
+        return get(this, 'threshold.mastery_model') === MasteryModelsNames.M_OF_N;
       },
-      masteryModelItem: {
+      mOfN: {
         get() {
-          if (get(this.value, 'threshold.mastery_model') !== MasteryModelsNames.M_OF_N) {
-            return {
-              m: null,
-              n: null,
-            };
-          }
           return {
-            m: get(this.value, 'threshold.m') || this.m,
-            n: get(this.value, 'threshold.n') || this.n,
+            m: get(this.value, 'threshold.m'),
+            n: get(this.value, 'threshold.n'),
           };
         },
         set(threshold) {
-          this.m = get(threshold, 'm') || this.m;
-          this.n = get(threshold, 'n') || this.n;
-
-          const mastery_model = get(this.value, 'threshold.mastery_model');
-          const completion_criteria = {
-            model: CompletionCriteriaModels.MASTERY,
-            threshold: {
-              mastery_model,
-            },
-          };
+          const mastery_model = get(this, 'threshold.mastery_model');
           if (mastery_model === MasteryModelsNames.M_OF_N) {
-            completion_criteria.threshold.m = this.m;
-            completion_criteria.threshold.n = this.n;
+            threshold.mastery_model = mastery_model;
+            this.handleInput({ threshold });
           }
-          this.handleInput({ completion_criteria });
         },
       },
-      isLongActivity() {
+      timeBasedModel() {
         return (
-          this.value.suggested_duration > SHORT_LONG_ACTIVITY_MIDPOINT &&
-          this.value.suggested_duration_type === SuggestedDurationTypesMap.APPROX_TIME
+          this.model === CompletionCriteriaModels.TIME ||
+          this.model === CompletionCriteriaModels.APPROX_TIME
         );
       },
-      isShortActivity() {
-        return (
-          this.value.suggested_duration <= SHORT_LONG_ACTIVITY_MIDPOINT &&
-          this.value.suggested_duration_type === SuggestedDurationTypesMap.APPROX_TIME
-        );
-      },
-      isExactTime() {
-        return this.value.suggested_duration_type === SuggestedDurationTypesMap.TIME;
-      },
-      isSwitchingFromCompleteDurationToAllContent() {
-        return (
-          this.completionDropdown === CompletionDropdownMap.completeDuration &&
-          this.currentCompletionDropdown === CompletionDropdownMap.allContent
-        );
-      },
-      isSwitchingFromAllContentToCompleteDuration() {
-        return (
-          this.completionDropdown === CompletionDropdownMap.allContent &&
-          this.currentCompletionDropdown === CompletionDropdownMap.completeDuration
-        );
-      },
-      requiresAudioVideoDefault() {
-        return this.audioVideoResource && !this.value.model;
-      },
-      completionDropdownIsCompleteDuration() {
-        return (
-          (this.completionDropdown === null &&
-            this.currentCompletionDropdown === CompletionDropdownMap.completeDuration) ||
-          (this.completionDropdown === CompletionDropdownMap.completeDuration &&
-            this.currentCompletionDropdown === null) ||
-          (this.completionDropdown === CompletionDropdownMap.completeDuration &&
-            this.currentCompletionDropdown === CompletionDropdownMap.completeDuration) ||
-          this.currentCompletionDropdown === CompletionDropdownMap.completeDuration
-        );
-      },
-      completionDropdownIsAllContentViewed() {
-        return (
-          (this.completionDropdown === null &&
-            this.currentCompletionDropdown === CompletionDropdownMap.allContent) ||
-          (this.completionDropdown === CompletionDropdownMap.allContent &&
-            this.currentCompletionDropdown === null) ||
-          (this.completionDropdown === CompletionDropdownMap.allContent &&
-            this.currentCompletionDropdown === CompletionDropdownMap.allContent)
-        );
-      },
-      durationDropdown: {
+      durationValue: {
         get() {
-          if (this.value) {
-            const defaultStateForAudioVideo =
-              this.value.suggested_duration === null &&
-              !this.value.suggested_duration_type &&
-              this.audioVideoResource;
-            if (
-              this.value.model === CompletionCriteriaModels.REFERENCE ||
-              (this.currentCompletionDropdown === CompletionDropdownMap.completeDuration &&
-                this.currentDurationDropdown === DurationDropdownMap.REFERENCE)
-            ) {
-              return DurationDropdownMap.REFERENCE;
-            } else if (this.value.model === CompletionCriteriaModels.PAGES) {
-              if (this.isLongActivity) {
-                return DurationDropdownMap.LONG_ACTIVITY;
-              }
-              if (this.isShortActivity) {
-                return DurationDropdownMap.SHORT_ACTIVITY;
-              }
-              if (this.isExactTime) {
-                return DurationDropdownMap.EXACT_TIME;
-              }
-            } else if (
-              this.value.model === CompletionCriteriaModels.TIME ||
-              defaultStateForAudioVideo
-            ) {
-              return DurationDropdownMap.EXACT_TIME;
-            } else {
-              if (this.isLongActivity) {
-                return DurationDropdownMap.LONG_ACTIVITY;
-              }
-              if (this.isShortActivity) {
-                return DurationDropdownMap.SHORT_ACTIVITY;
-              }
-              if (this.isExactTime) {
-                return DurationDropdownMap.EXACT_TIME;
-              }
-            }
-          }
-          return '';
+          return this.timeBasedModel ? this.threshold : this.value.suggested_duration;
         },
         set(duration) {
-          const update = {};
-          this.currentDurationDropdown = duration;
-
-          if (duration === DurationDropdownMap.REFERENCE) {
-            update.suggested_duration_type = null;
-            update.completion_criteria = {
-              model: CompletionCriteriaModels.REFERENCE,
-              threshold: null,
-            };
-          } else if (
-            this.isSwitchingFromCompleteDurationToAllContent ||
-            this.completionDropdownIsAllContentViewed
-          ) {
-            if (duration === DurationDropdownMap.EXACT_TIME) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-            }
-            if (duration === DurationDropdownMap.SHORT_ACTIVITY) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.APPROX_TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-            }
-            if (duration === DurationDropdownMap.LONG_ACTIVITY) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.APPROX_TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-            }
-            update.completion_criteria = {
-              model: CompletionCriteriaModels.PAGES,
-              threshold: '100%',
-            };
-          } else if (
-            this.isSwitchingFromAllContentToCompleteDuration ||
-            this.requiresAudioVideoDefault ||
-            this.completionDropdownIsCompleteDuration ||
-            this.kind === ContentKindsNames.HTML5 ||
-            this.kind === ContentKindsNames.H5P
-          ) {
-            if (duration === DurationDropdownMap.SHORT_ACTIVITY) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.APPROX_TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.APPROX_TIME,
-                threshold: update.suggested_duration,
-              };
-            }
-            if (duration === DurationDropdownMap.LONG_ACTIVITY) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.APPROX_TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.APPROX_TIME,
-                threshold: update.suggested_duration,
-              };
-            }
-            if (duration === DurationDropdownMap.EXACT_TIME) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-              update.completion_criteria = {
-                model: CompletionCriteriaModels.TIME,
-                threshold: update.suggested_duration,
-              };
-            }
+          const update = {
+            duration,
+          };
+          if (this.timeBasedModel) {
+            update.threshold = duration;
           }
-
-          if (this.value.model === CompletionCriteriaModels.MASTERY) {
-            if (duration === DurationDropdownMap.SHORT_ACTIVITY) {
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-              update.completion_criteria = {
-                model: this.value.model,
-                threshold: this.value.threshold,
-              };
-            }
-            if (duration === DurationDropdownMap.LONG_ACTIVITY) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.APPROX_TIME;
-              const roundedValue = Math.round(this.value.suggested_duration / 600) * 600;
-              if (roundedValue < SHORT_LONG_ACTIVITY_MIDPOINT || roundedValue > 7200) {
-                update.suggested_duration = DEFAULT_LONG_ACTIVITY;
-              } else {
-                update.suggested_duration = roundedValue;
-              }
-              update.completion_criteria = {
-                model: this.value.model,
-                threshold: this.value.threshold,
-              };
-            }
-            if (duration === DurationDropdownMap.EXACT_TIME) {
-              update.suggested_duration_type = SuggestedDurationTypesMap.TIME;
-              update.suggested_duration = this.handleMinutesInputFromActivityDuration(
-                this.value.suggested_duration,
-                duration
-              );
-              update.completion_criteria = {
-                model: this.value.model,
-                threshold: this.value.threshold,
-              };
-            }
-          }
-
           this.handleInput(update);
         },
       },
-      minutes: {
+      durationType() {
+        return this.timeBasedModel ? this.model : this.value.suggested_duration_type;
+      },
+      durationDropdown: {
         get() {
-          return this.value.suggested_duration;
-        },
-        set(minutes) {
-          if (
-            this.value.model === CompletionCriteriaModels.PAGES ||
-            this.value.model === CompletionCriteriaModels.MASTERY
-          ) {
-            this.handleInput({
-              suggested_duration: minutes,
-              completion_criteria: {
-                model: this.value.model,
-                threshold: this.value.threshold,
-              },
-            });
-          } else {
-            this.handleInput({
-              suggested_duration: minutes,
-              completion_criteria: {
-                model: this.value.model,
-                threshold: minutes,
-              },
-            });
+          if (this.durationType === CompletionCriteriaModels.TIME) {
+            return DurationDropdownMap.EXACT_TIME;
           }
+          if (
+            this.durationValue > SHORT_LONG_ACTIVITY_MIDPOINT &&
+            this.durationType === CompletionCriteriaModels.APPROX_TIME
+          ) {
+            return DurationDropdownMap.LONG_ACTIVITY;
+          }
+          return DurationDropdownMap.SHORT_ACTIVITY;
+        },
+        set(dropdownValue) {
+          const update = {};
+          if (dropdownValue === DurationDropdownMap.EXACT_TIME) {
+            update.durationType = CompletionCriteriaModels.TIME;
+          } else if (
+            dropdownValue === DurationDropdownMap.LONG_ACTIVITY ||
+            dropdownValue === DurationDropdownMap.SHORT_ACTIVITY
+          ) {
+            update.durationType = CompletionCriteriaModels.APPROX_TIME;
+            update.duration = this.handleMinutesInputFromActivityDuration(
+              this.durationValue,
+              dropdownValue
+            );
+          } else {
+            update.durationType = null;
+          }
+          if (this.timeBasedModel) {
+            update.model = update.durationType;
+          }
+          this.handleInput(update);
         },
       },
       showCorrectCompletionOptions() {
-        const CompletionOptionsDropdownMap = {
-          document: [
-            CompletionDropdownMap.allContent,
-            CompletionDropdownMap.completeDuration,
-            CompletionDropdownMap.reference,
-          ],
-          exercise: [CompletionDropdownMap.goal, CompletionDropdownMap.practiceQuiz],
-          html5: [
-            CompletionDropdownMap.completeDuration,
-            CompletionDropdownMap.determinedByResource,
-            CompletionDropdownMap.reference,
-          ],
-          h5p: [
-            CompletionDropdownMap.determinedByResource,
-            CompletionDropdownMap.completeDuration,
-            CompletionDropdownMap.reference,
-          ],
-          audio: [CompletionDropdownMap.completeDuration, CompletionDropdownMap.reference],
-          video: [CompletionDropdownMap.completeDuration, CompletionDropdownMap.reference],
-        };
         if (this.kind) {
           return CompletionOptionsDropdownMap[this.kind].map(model => ({
             text: this.$tr(model),
@@ -744,128 +385,118 @@
         }
         return [];
       },
-      allPossibleDurationOptions() {
-        //this is used because of this Vuetify issue for dropdowns with multiple values: https://github.com/vuetifyjs/vuetify/issues/11529
+      selectableDurationOptions() {
         return [
           {
             text: this.$tr(DurationDropdownMap.EXACT_TIME),
-            value: CompletionCriteriaModels.TIME,
-            id: 'exactTime',
+            value: 'exactTime',
           },
           {
             text: this.translateMetadataString(DurationDropdownMap.SHORT_ACTIVITY),
-            value: CompletionCriteriaModels.APPROX_TIME,
-            id: 'shortActivity',
+            value: 'shortActivity',
           },
           {
             text: this.translateMetadataString(DurationDropdownMap.LONG_ACTIVITY),
-            value: CompletionCriteriaModels.APPROX_TIME,
-            id: 'longActivity',
+            value: 'longActivity',
           },
         ];
       },
-      /**
-       * When the duration dropdown is for audio, video, or documents, if "Complete duration"
-       * is chosen, then "Reference" cannot be selected
-       */
-      selectableDurationOptions() {
-        if (
-          this.kind === ContentKindsNames.DOCUMENT &&
-          this.currentCompletionDropdown === CompletionDropdownMap.completeDuration
-        ) {
-          return this.allPossibleDurationOptions.map(model => ({
-            value: model.id,
-            text: model.text,
-          }));
-        } else if (this.kind === ContentKindsNames.EXERCISE) {
-          return this.allPossibleDurationOptions.map(model => ({
-            value: model.id,
-            text: model.text,
-          }));
-        } else {
-          return this.allPossibleDurationOptions.map(model => ({
-            value: model.id,
-            text: model.text,
-          }));
-        }
-      },
       completionRules() {
-        if (this.kind) {
-          return this.required ? getCompletionValidators().map(translateValidator) : [];
+        if (this.kind && this.required) {
+          return getCompletionValidators().map(translateValidator);
         }
         return false;
       },
       durationRules() {
-        if (
-          this.currentCompletionDropdown === CompletionDropdownMap.completeDuration ||
-          this.completionDropdown === CompletionDropdownMap.completeDuration
-        ) {
+        if (this.completionDropdown === CompletionDropdownMap.completeDuration) {
           return getDurationValidators().map(translateValidator);
         }
         return [];
       },
+      learnerManaged: {
+        get() {
+          return get(this.value, ['completion_criteria', 'learner_managed'], false);
+        },
+        set(learner_managed) {
+          this.handleInput({ learner_managed });
+        },
+      },
     },
     methods: {
+      generateDefaultThreshold() {
+        if (this.audioVideoResource) {
+          return this.fileDuration || this.value.suggested_duration;
+        }
+        return defaultCompletionCriteriaThresholds[this.kind];
+      },
       trackClick(label) {
         this.$analytics.trackClick('channel_editor_modal_details', label);
       },
-      handleMinutesInputFromActivityDuration(minutes, duration) {
-        let suggested_duration;
-        let roundedValue;
-        if (duration === DurationDropdownMap.SHORT_ACTIVITY) {
-          roundedValue = Math.round(minutes / 300) * 300;
+      handleMinutesInputFromActivityDuration(minutes, durationDropdown) {
+        if (durationDropdown === DurationDropdownMap.SHORT_ACTIVITY) {
+          const roundedValue = Math.round(minutes / 300) * 300;
           if (roundedValue > SHORT_LONG_ACTIVITY_MIDPOINT || roundedValue <= 0) {
-            suggested_duration = DEFAULT_SHORT_ACTIVITY;
-          } else {
-            suggested_duration = roundedValue;
+            return DEFAULT_SHORT_ACTIVITY;
           }
+          return roundedValue;
         }
-        if (duration === DurationDropdownMap.LONG_ACTIVITY) {
-          roundedValue = Math.round(minutes / 600) * 600;
+        if (durationDropdown === DurationDropdownMap.LONG_ACTIVITY) {
+          const roundedValue = Math.round(minutes / 600) * 600;
           if (roundedValue < SHORT_LONG_ACTIVITY_MIDPOINT || roundedValue > 7200) {
-            suggested_duration = DEFAULT_LONG_ACTIVITY;
-          } else {
-            suggested_duration = roundedValue;
+            return DEFAULT_LONG_ACTIVITY;
           }
+          return roundedValue;
         }
-        if (duration === DurationDropdownMap.EXACT_TIME) {
-          suggested_duration = Math.round(minutes / 60) * 60;
-        }
-        return suggested_duration;
+        return Math.round(minutes / 60) * 60;
       },
-      handleInput({
-        completion_criteria,
-        suggested_duration,
-        suggested_duration_type,
-        modality,
-      } = {}) {
+      handleInput({ model, threshold, duration, durationType, modality, learner_managed } = {}) {
         const data = {
-          completion_criteria,
-          suggested_duration,
-          suggested_duration_type,
-          modality,
+          completion_criteria: {
+            model: this.model,
+            threshold: this.threshold,
+            learner_managed: this.learnerManaged,
+          },
+          suggested_duration: this.durationValue,
+          suggested_duration_type: this.durationType,
+          modality: this.value.modality,
         };
 
-        if (!completion_criteria) {
-          data['completion_criteria'] = this.value['completion_criteria'];
+        if (typeof model !== 'undefined') {
+          data.completion_criteria.model = model;
         }
-        if (modality === undefined) {
-          data['modality'] = this.value['modality'];
+        if (typeof modality !== 'undefined') {
+          data.modality = modality;
         }
-        if (suggested_duration === undefined) {
-          data['suggested_duration'] = this.value['suggested_duration'];
+        if (durationType) {
+          data.suggested_duration_type = durationType;
+        } else if (typeof durationType !== 'undefined') {
+          delete data.suggested_duration_type;
         }
-        if (suggested_duration_type === undefined) {
-          data['suggested_duration_type'] = this.value['suggested_duration_type'];
+        if (duration) {
+          data.suggested_duration = this.handleMinutesInputFromActivityDuration(
+            duration,
+            this.durationType
+          );
+        } else if (typeof duration !== 'undefined') {
+          delete data.suggested_duration;
         }
-
+        if (threshold) {
+          data.completion_criteria.threshold = threshold;
+        } else if (typeof threshold !== 'undefined') {
+          delete data.completion_criteria.threshold;
+        }
+        if (learner_managed) {
+          data.completion_criteria.learner_managed = true;
+        } else if (typeof learner_managed !== 'undefined') {
+          delete data.completion_criteria.learner_managed;
+        }
         this.$emit('input', data);
       },
       isUnique(value) {
         return value !== nonUniqueValue;
       },
       getPlaceholder(field) {
-        return this.isUnique(this[field]) ? '' : '---';
+        return this.isUnique(get(this, field)) ? '' : '---';
       },
     },
     $trs: {
@@ -884,6 +515,3 @@
   };
 
 </script>
-<style lang="less" scoped>
-
-</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -828,6 +828,9 @@
             suggested_duration = roundedValue;
           }
         }
+        if (duration === DurationDropdownMap.EXACT_TIME) {
+          suggested_duration = Math.round(minutes / 60) * 60;
+        }
         return suggested_duration;
       },
       handleInput({

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -5,7 +5,7 @@
     <Checkbox
       v-model="learnerManaged"
       color="primary"
-      :label="markCompleteLabel"
+      :label="$tr('learnersCanMarkComplete')"
       style="padding-bottom: 16px;"
     />
     <!-- Layout when practice quizzes are enabled -->
@@ -202,11 +202,6 @@
         type: Object,
         required: false,
         default: () => ({}),
-      },
-      // TODO: move string in here
-      markCompleteLabel: {
-        type: String,
-        required: true,
       },
     },
     computed: {
@@ -520,6 +515,7 @@
       exactTime: 'Time to complete',
       referenceHint:
         'Progress will not be tracked on reference material unless learners mark it as complete',
+      learnersCanMarkComplete: 'Allow learners to mark as complete',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -263,6 +263,11 @@
             update.model = this.audioVideoResource
               ? CompletionCriteriaModels.TIME
               : CompletionCriteriaModels.APPROX_TIME;
+            if (!this.audioVideoResource) {
+              update.threshold = DEFAULT_SHORT_ACTIVITY;
+              update.duration = update.threshold;
+            }
+            update.durationType = update.model;
           } else if (value === CompletionDropdownMap.allContent) {
             update.model = CompletionCriteriaModels.PAGES;
             update.threshold = '100%';
@@ -372,6 +377,7 @@
           }
           if (this.timeBasedModel) {
             update.model = update.durationType;
+            update.threshold = update.duration || this.durationValue;
           }
           this.handleInput(update);
         },
@@ -415,7 +421,7 @@
       },
       learnerManaged: {
         get() {
-          return get(this.value, ['completion_criteria', 'learner_managed'], false);
+          return get(this.value, 'learner_managed', false);
         },
         set(learner_managed) {
           this.handleInput({ learner_managed });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -135,7 +135,6 @@
             :kind="firstNode.kind"
             :fileDuration="fileDuration"
             :required="!anyIsDocument || !allSameKind"
-            :markCompleteLabel="$tr('learnersCanMarkComplete')"
           />
         </VFlex>
       </VLayout>
@@ -860,7 +859,6 @@
       assessmentOptionsLabel: 'Assessment options',
       randomizeQuestionLabel: 'Randomize question order for learners',
       completionLabel: 'Completion',
-      learnersCanMarkComplete: 'Allow learners to mark as complete',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -130,20 +130,12 @@
           <h1 class="subheading">
             {{ $tr('completionLabel') }}
           </h1>
-          <!-- Checkbox for "Allow learners to mark complete" -->
-          <VFlex md6 class="pb-2">
-            <Checkbox
-              v-model="learnerManaged"
-              color="primary"
-              :label="$tr('learnersCanMarkComplete')"
-              style="margin-top: 0px; padding-top: 0px"
-            />
-          </VFlex>
           <CompletionOptions
             v-model="completionAndDuration"
             :kind="firstNode.kind"
             :fileDuration="fileDuration"
             :required="!anyIsDocument || !allSameKind"
+            :markCompleteLabel="$tr('learnersCanMarkComplete')"
           />
         </VFlex>
       </VLayout>
@@ -392,12 +384,13 @@
   import VisibilityDropdown from 'shared/views/VisibilityDropdown';
   import Checkbox from 'shared/views/form/Checkbox';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
-  import { NEW_OBJECT, AccessibilityCategories, ResourcesNeededTypes } from 'shared/constants';
+  import {
+    NEW_OBJECT,
+    AccessibilityCategories,
+    ResourcesNeededTypes,
+    nonUniqueValue,
+  } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
-
-  // Define an object to act as the place holder for non unique values.
-  const nonUniqueValue = {};
-  nonUniqueValue.toString = () => '';
 
   function getValueFromResults(results) {
     if (results.length === 0) {
@@ -644,25 +637,10 @@
           };
         },
         set({ completion_criteria, suggested_duration, suggested_duration_type, modality }) {
-          if (completion_criteria) {
-            completion_criteria.learner_managed = this.learnerManaged;
-          }
           const options = { completion_criteria, modality };
           this.updateExtraFields({ options });
           this.updateExtraFields({ suggested_duration_type });
           this.update({ suggested_duration });
-        },
-      },
-      learnerManaged: {
-        get() {
-          const { completion_criteria = {} } = this.getExtraFieldsValueFromNodes('options') || {};
-          return completion_criteria.learner_managed;
-        },
-        set(value) {
-          const { completion_criteria = {}, ...options } =
-            this.getExtraFieldsValueFromNodes('options') || {};
-          completion_criteria.learner_managed = value;
-          this.updateExtraFields({ options: { ...options, completion_criteria } });
         },
       },
       /* COMPUTED PROPS */

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/MasteryCriteriaGoal.vue
@@ -41,17 +41,12 @@
     mixins: [constantsTranslationMixin],
     props: {
       value: {
-        type: Object,
+        type: String,
         required: false,
         validator: function(value) {
-          return (
-            !value ||
-            !value.mastery_model ||
-            !value.mastery_model.toString() ||
-            MasteryModels.has(value.mastery_model)
-          );
+          return !value || MasteryModels.has(value);
         },
-        default: () => ({}),
+        default: '',
       },
       placeholder: {
         type: String,
@@ -73,10 +68,10 @@
     computed: {
       masteryModel: {
         get() {
-          return this.value && this.value.mastery_model;
+          return this.value;
         },
         set(mastery_model) {
-          this.handleInput({ mastery_model });
+          this.$emit('input', mastery_model);
         },
       },
       masteryCriteria() {
@@ -87,15 +82,6 @@
       },
       masteryRules() {
         return this.required ? getMasteryModelValidators().map(translateValidator) : [];
-      },
-    },
-    methods: {
-      handleInput(newValue) {
-        let data = {
-          ...this.value,
-          ...newValue,
-        };
-        this.$emit('input', data);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/completionOptions.spec.js
@@ -210,7 +210,12 @@ describe('CompletionOptions', () => {
   });
   describe(`duration dropdown`, () => {
     it(`renders the duration dropdown`, () => {
-      const wrapper = mount(CompletionOptions);
+      const wrapper = mount(CompletionOptions, {
+        propsData: {
+          kind: 'audio',
+          value: { suggested_duration: null },
+        },
+      });
       const dropdown = wrapper.find({ ref: 'duration' });
       expect(dropdown.exists()).toBe(true);
     });
@@ -222,25 +227,29 @@ describe('CompletionOptions', () => {
             value: { suggested_duration: null },
           },
         });
+        const dropdown = wrapper.find({ ref: 'duration' });
+        expect(dropdown.exists()).toBe(true);
         expect(wrapper.vm.durationDropdown).toBe('exactTime');
       });
-      it(`duration dropdown is empty by default for documents`, () => {
+      it(`duration dropdown is hidden by default for documents`, () => {
         const wrapper = mount(CompletionOptions, {
           propsData: {
             kind: 'document',
             value: { suggested_duration: null },
           },
         });
-        expect(wrapper.vm.durationDropdown).toBe('');
+        const dropdown = wrapper.find({ ref: 'duration' });
+        expect(dropdown.exists()).toBe(false);
       });
-      it(`duration dropdown is empty by default for exercises`, () => {
+      it(`duration dropdown is hidden by default for exercises`, () => {
         const wrapper = mount(CompletionOptions, {
           propsData: {
             kind: 'exercise',
             value: { model: 'mastery', threshold: { m: 3, n: 5 }, suggested_duration: null },
           },
         });
-        expect(wrapper.vm.durationDropdown).toBe('');
+        const dropdown = wrapper.find({ ref: 'duration' });
+        expect(dropdown.exists()).toBe(false);
       });
       it(`'Reference' is disabled for exercises`, async () => {
         const wrapper = mount(CompletionOptions, {
@@ -254,15 +263,6 @@ describe('CompletionOptions', () => {
 
         const clickableDurationDropdown = wrapper.vm.selectableDurationOptions;
         expect(clickableDurationDropdown.length).toBe(3);
-      });
-      it(`duration dropdown is empty by default for html5`, () => {
-        const wrapper = mount(CompletionOptions, {
-          propsData: {
-            kind: 'html5',
-            value: { suggested_duration: null },
-          },
-        });
-        expect(wrapper.vm.durationDropdown).toBe('');
       });
       it(`duration dropdown is hidden by default for h5p`, () => {
         const wrapper = mount(CompletionOptions, {
@@ -282,7 +282,7 @@ describe('CompletionOptions', () => {
       it('input should be emitted when duration dropdown is updated', async () => {
         const wrapper = mount(CompletionOptions, {
           propsData: {
-            kind: 'document',
+            kind: 'audio',
             value: { model: null },
           },
         });
@@ -303,7 +303,6 @@ describe('CompletionOptions', () => {
         wrapper.find({ ref: 'duration' }).vm.$emit('input', 'shortActivity');
         await wrapper.vm.$nextTick();
         expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-        expect(wrapper.vm.showActivityDurationInput).toBe(true);
       });
       it(`minutes input is displayed when 'Long activity' is selected`, async () => {
         const wrapper = mount(CompletionOptions, {
@@ -315,11 +314,11 @@ describe('CompletionOptions', () => {
         wrapper.find({ ref: 'duration' }).vm.$emit('input', 'longActivity');
         await wrapper.vm.$nextTick();
         expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-        expect(wrapper.vm.showActivityDurationInput).toBe(true);
       });
     });
     describe(`document`, () => {
-      describe(`'All content viewed' is selected as completion`, () => {
+      // Skip these tests until we reenable descriptive duration setting.
+      describe.skip(`'All content viewed' is selected as completion`, () => {
         it(`minutes input is displayed when 'Short activity' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
@@ -330,7 +329,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'shortActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Long activity' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -342,7 +340,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'longActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Exact time' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -354,7 +351,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is hidden and reference hint is displayed when 'Reference' is selected`, () => {
           const wrapper = mount(CompletionOptions, {
@@ -364,7 +360,6 @@ describe('CompletionOptions', () => {
             },
           });
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(false);
-          expect(wrapper.vm.showActivityDurationInput).toBe(false);
           expect(wrapper.vm.showReferenceHint).toBe(true);
         });
       });
@@ -379,7 +374,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'shortActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Long activity' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -391,7 +385,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'longActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Exact time' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -403,16 +396,17 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
       });
-      describe(`switching between 'All content viewed (ACV)' and 'Complete duration (CD)'`, () => {
+      // Skip these tests until we reenable descriptive duration setting.
+      describe.skip(`switching between 'All content viewed (ACV)' and 'Complete duration (CD)'`, () => {
         it(`Duration dropdown and minutes input stay the same when switching betweeen 'Short activity' in ACV and CD`, async () => {
           const wrapper = mount(CompletionOptions, {
             propsData: {
               kind: 'document',
               value: {
                 model: 'approx_time',
+                threshold: 1200,
                 suggested_duration: 1200,
                 suggested_duration_type: 'approx_time',
               },
@@ -424,8 +418,7 @@ describe('CompletionOptions', () => {
 
           expect(wrapper.vm.durationDropdown).toBe('shortActivity');
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
-          expect(wrapper.vm.minutes).toBe(1200);
+          expect(wrapper.vm.durationValue).toBe(1200);
         });
         it(`Duration dropdown and minutes input stay the same when switching betweeen 'Long activity' in ACV and CD`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -444,8 +437,7 @@ describe('CompletionOptions', () => {
 
           expect(wrapper.vm.durationDropdown).toBe('longActivity');
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
-          expect(wrapper.vm.minutes).toBe(6000);
+          expect(wrapper.vm.durationValue).toBe(6000);
         });
         it(`Duration dropdown and minutes input stay the same when switching betweeen 'Exact time' in ACV and CD`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -465,12 +457,12 @@ describe('CompletionOptions', () => {
 
           expect(wrapper.vm.durationDropdown).toBe('exactTime');
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
-          expect(wrapper.vm.minutes).toBe(1234);
+          expect(wrapper.vm.durationValue).toBe(1234);
         });
       });
     });
-    describe(`exercise`, () => {
+    // Skip these tests until we reenable descriptive duration setting.
+    describe.skip(`exercise`, () => {
       describe(`when completion dropdown is 'Practice until goal is met'`, () => {
         it(`minutes input is displayed when 'Short activity' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -482,7 +474,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'shortActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Long activity' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -494,7 +485,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'longActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Exact time' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -506,7 +496,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
       });
       describe(`when completion dropdown is 'Practice quiz'`, () => {
@@ -520,7 +509,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'shortActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Long activity' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -532,7 +520,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'longActivity');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
         it(`minutes input is displayed when 'Exact time' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -544,7 +531,6 @@ describe('CompletionOptions', () => {
           wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
           await wrapper.vm.$nextTick();
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
         });
       });
       describe(`switching between 'Practice until goal is met (PUGIM)' and 'Practice quiz (PQ)'`, () => {
@@ -567,8 +553,7 @@ describe('CompletionOptions', () => {
 
           expect(wrapper.vm.durationDropdown).toBe('shortActivity');
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
-          expect(wrapper.vm.minutes).toBe(1200);
+          expect(wrapper.vm.durationValue).toBe(1200);
         });
         it(`Duration dropdown and minutes input stay the same when switching betweeen 'Long activity' in PUGIM and PQ`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -589,8 +574,7 @@ describe('CompletionOptions', () => {
 
           expect(wrapper.vm.durationDropdown).toBe('longActivity');
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
-          expect(wrapper.vm.minutes).toBe(6000);
+          expect(wrapper.vm.durationValue).toBe(6000);
         });
         it(`Duration dropdown and minutes input stay the same when switching betweeen 'Exact time' in PUGIM and PQ`, async () => {
           const wrapper = mount(CompletionOptions, {
@@ -611,8 +595,7 @@ describe('CompletionOptions', () => {
 
           expect(wrapper.vm.durationDropdown).toBe('exactTime');
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(true);
-          expect(wrapper.vm.showActivityDurationInput).toBe(true);
-          expect(wrapper.vm.minutes).toBe(1234);
+          expect(wrapper.vm.durationValue).toBe(1234);
         });
       });
     });
@@ -630,7 +613,6 @@ describe('CompletionOptions', () => {
           });
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(false);
           expect(wrapper.find({ ref: 'duration' }).exists()).toBe(false);
-          expect(wrapper.vm.showActivityDurationInput).toBe(false);
         });
         it(`minutes input is hidden and reference hint is displayed when 'Reference' is selected`, () => {
           const wrapper = mount(CompletionOptions, {
@@ -640,7 +622,6 @@ describe('CompletionOptions', () => {
             },
           });
           expect(wrapper.find({ ref: 'activity_duration' }).exists()).toBe(false);
-          expect(wrapper.vm.showActivityDurationInput).toBe(false);
           expect(wrapper.vm.showReferenceHint).toBe(true);
         });
       });
@@ -710,26 +691,24 @@ describe('CompletionOptions', () => {
           propsData: {
             kind: 'document',
             value: {
-              model: 'pages',
-              threshold: '100%',
-              suggested_duration: 4200,
+              model: 'approx_time',
+              threshold: 6000,
+              suggested_duration: 6000,
               suggested_duration_type: 'approx_time',
             },
           },
         });
         wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
         await wrapper.vm.$nextTick();
-
-        expect(wrapper.vm.currentDurationDropdown).toBe('exactTime');
-        expect(wrapper.vm.minutes).toBe(4200);
+        expect(wrapper.vm.durationValue).toBe(6000);
       });
       it(`displays 'Short activity' value`, async () => {
         const wrapper = mount(CompletionOptions, {
           propsData: {
             kind: 'document',
             value: {
-              model: 'pages',
-              threshold: '100%',
+              model: 'approx_time',
+              threshold: 200,
               suggested_duration: 200,
               suggested_duration_type: 'approx_time',
             },
@@ -738,8 +717,7 @@ describe('CompletionOptions', () => {
         wrapper.find({ ref: 'duration' }).vm.$emit('input', 'exactTime');
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.vm.currentDurationDropdown).toBe('exactTime');
-        expect(wrapper.vm.minutes).toBe(200);
+        expect(wrapper.vm.durationValue).toBe(200);
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/masteryCriteriaGoal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/masteryCriteriaGoal.spec.js
@@ -23,7 +23,7 @@ describe('masteryCriteriaGoal', () => {
   beforeEach(() => {
     formWrapper = makeWrapper();
     wrapper = formWrapper.find(MasteryCriteriaGoal);
-    wrapper.setProps({ value: { mastery_model: 'm_of_n' } });
+    wrapper.setProps({ value: 'm_of_n' });
     modelInput = wrapper.find({ ref: 'masteryModel' }).find('input');
   });
 
@@ -35,7 +35,7 @@ describe('masteryCriteriaGoal', () => {
     });
     it('should render according to masteryModel prop', () => {
       function test(model) {
-        wrapper.setProps({ value: { mastery_model: model } });
+        wrapper.setProps({ value: model });
         expect(wrapper.vm.$refs.masteryModel.value).toEqual(model);
       }
       MasteryModels.forEach(test);
@@ -71,12 +71,12 @@ describe('masteryCriteriaGoal', () => {
       expect(wrapper.emitted('input')).toBeFalsy();
       modelInput.setValue('do_all');
       expect(wrapper.emitted('input')).toBeTruthy();
-      expect(wrapper.emitted('input')[0][0].mastery_model).toEqual('do_all');
+      expect(wrapper.emitted('input')[0][0]).toEqual('do_all');
     });
   });
   describe('validation', () => {
     it('should flag empty required mastery models', () => {
-      wrapper.setProps({ value: { mastery_model: null } });
+      wrapper.setProps({ value: null });
       formWrapper.vm.validate();
       expect(
         wrapper

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -171,6 +171,7 @@ export const ValidationErrors = {
   INVALID_NUMBER_OF_CORRECT_ANSWERS: 'INVALID_NUMBER_OF_CORRECT_ANSWERS',
   NO_VALID_PRIMARY_FILES: 'NO_VALID_PRIMARY_FILES',
   INVALID_COMPLETION_CRITERIA_MODEL: 'INVALID_COMPLETION_CRITERIA_MODEL',
+  COMPLETION_REQUIRED: 'COMPLETION_REQUIRED',
   LEARNING_ACTIVITY_REQUIRED: 'LEARNING_ACTIVITY_REQUIRED',
   DURATION_REQUIRED: 'DURATION_REQUIRED',
   ACTIVITY_DURATION_REQUIRED: 'ACTIVITY_DURATION_REQUIRED',
@@ -218,5 +219,8 @@ export const DurationDropdownMap = {
   EXACT_TIME: 'exactTime',
   SHORT_ACTIVITY: 'shortActivity',
   LONG_ACTIVITY: 'longActivity',
-  REFERENCE: 'reference',
 };
+
+// Define an object to act as the place holder for non unique values.
+export const nonUniqueValue = {};
+nonUniqueValue.toString = () => '';

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import CompletionCriteriaModels from 'kolibri-constants/CompletionCriteria';
 import translator from '../translator';
-import { AssessmentItemTypes, ValidationErrors } from '../constants';
+import { AssessmentItemTypes, ValidationErrors, ContentModalities } from '../constants';
 import Licenses from 'shared/leUtils/Licenses';
 import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
@@ -106,11 +106,7 @@ export function isNodeComplete({ nodeDetails, assessmentItems, files }) {
 
 // Private helpers
 function _isPracticeQuiz(node) {
-  const modality = get(node, 'extra_fields.options.modality', {});
-  if (modality === 'QUIZ') {
-    return true;
-  }
-  return false;
+  return get(node, 'extra_fields.options.modality') === ContentModalities.QUIZ;
 }
 
 function _getLicense(node) {

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -380,7 +380,6 @@ export function getNodeDetailsErrors(node) {
   // Practice quiz requirements are set in the background, and separate validations
   // run to check this based on the completion_criteria in LE utils
   if (node.kind === ContentKindsNames.EXERCISE && !_isPracticeQuiz(node)) {
-    console.log('not practice quiz');
     const masteryModelErrors = getNodeMasteryModelErrors(node);
     const masteryModelMErrors = getNodeMasteryModelMErrors(node);
     const masteryModelNErrors = getNodeMasteryModelNErrors(node);

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -137,6 +137,7 @@ function _getErrorMsg(error) {
     [ValidationErrors.MASTERY_MODEL_N_GT_ZERO]: translator.$tr('masteryModelNGtZero'),
     [ValidationErrors.LEARNING_ACTIVITY_REQUIRED]: translator.$tr('fieldRequired'),
     [ValidationErrors.DURATION_REQUIRED]: translator.$tr('fieldRequired'),
+    [ValidationErrors.COMPLETION_REQUIRED]: translator.$tr('fieldRequired'),
     [ValidationErrors.ACTIVITY_DURATION_REQUIRED]: translator.$tr('fieldRequired'),
     [ValidationErrors.ACTIVITY_DURATION_MIN_FOR_SHORT_ACTIVITY]: translator.$tr(
       'activityDurationGteOne'

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -575,7 +575,9 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         )
 
     def test_update_contentnode_exercise_mastery_model(self):
-        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        metadata = self.contentnode_db_metadata
+        metadata["kind_id"] = content_kinds.EXERCISE
+        contentnode = models.ContentNode.objects.create(**metadata)
 
         # Update m and n fields
         m = 5
@@ -599,6 +601,7 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
 
     def test_update_contentnode_exercise_mastery_model_partial(self):
         data = self.contentnode_db_metadata
+        data["kind_id"] = content_kinds.EXERCISE
         data["extra_fields"] = {
             "options": {
                 "completion_criteria": {
@@ -628,6 +631,7 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
 
     def test_update_contentnode_exercise_mastery_model_old(self):
         data = self.contentnode_db_metadata
+        data["kind_id"] = content_kinds.EXERCISE
         data["extra_fields"] = {
             "m": 5,
             "n": 10,
@@ -778,6 +782,8 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
                     contentnode.id,
                     CONTENTNODE,
                     {
+                        # Only do full validation of this when the update is setting to True.
+                        "complete": True,
                         "extra_fields.options.completion_criteria.model": completion_criteria.TIME,
                     },
                     channel_id=self.channel.id

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -275,14 +275,6 @@ class CompletionCriteriaSerializer(JSONFieldDictSerializer):
     model = CharField()
     learner_managed = BooleanField(required=False, allow_null=True)
 
-    def update(self, instance, validated_data):
-        instance = super(CompletionCriteriaSerializer, self).update(instance, validated_data)
-        try:
-            completion_criteria_validator.validate(instance)
-        except DjangoValidationError as e:
-            raise ValidationError(e)
-        return instance
-
 
 class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
     modality = ChoiceField(choices=(("QUIZ", "Quiz"),), allow_null=True, required=False)
@@ -407,10 +399,19 @@ class ContentNodeSerializer(BulkModelSerializer):
                     raise ValidationError("tag is greater than 30 characters")
         return data
 
+    def _check_completion_criteria(self, kind, validated_data):
+        completion_criteria = validated_data.get("extra_fields", {}).get("options", {}).get("completion_criteria", {})
+        try:
+            completion_criteria_validator.check_model_for_kind(completion_criteria, kind)
+        except DjangoValidationError as e:
+            raise ValidationError(e)
+
     def create(self, validated_data):
         tags = None
         if "tags" in validated_data:
             tags = validated_data.pop("tags")
+
+        self._check_completion_criteria(validated_data.get("kind"), validated_data)
 
         instance = super(ContentNodeSerializer, self).create(validated_data)
 
@@ -429,6 +430,9 @@ class ContentNodeSerializer(BulkModelSerializer):
         if "tags" in validated_data:
             tags = validated_data.pop("tags")
             set_tags({instance.id: tags})
+
+        self._check_completion_criteria(validated_data.get("kind", instance.kind_id), validated_data)
+
         return super(ContentNodeSerializer, self).update(instance, validated_data)
 
 

--- a/contentcuration/locale/ar/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/ar/LC_MESSAGES/contentcuration-messages.json
@@ -820,7 +820,7 @@
   "DetailsTabView.importedFromButtonText": "استيراد من {channel}",
   "DetailsTabView.languageChannelHelpText": "اتركه فارغاً من أجل استخدام لغة القناة",
   "DetailsTabView.languageHelpText": "اتركه فارغًا من أجل استخدام لغة المجلد",
-  "DetailsTabView.learnersCanMarkComplete": "السماح للمتعلمين بتحديده على أنه مكتمل",
+  "CompletionOptions.learnersCanMarkComplete": "السماح للمتعلمين بتحديده على أنه مكتمل",
   "DetailsTabView.noTagsFoundText": "لم يتم العثور على نتائج بحث لـ\"{text}\". إضغط على 'إدخال' لإنشاء تصنيف جديد",
   "DetailsTabView.providerLabel": "موفر الخدمة",
   "DetailsTabView.providerToolTip": "المنظمة التي كلّفت بالمحتوى أو تقوم بنشر المحتوى",

--- a/contentcuration/locale/es_ES/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/es_ES/LC_MESSAGES/contentcuration-messages.json
@@ -820,7 +820,7 @@
   "DetailsTabView.importedFromButtonText": "Importado desde {channel}",
   "DetailsTabView.languageChannelHelpText": "Dejar en blanco para usar el idioma del canal",
   "DetailsTabView.languageHelpText": "Dejar en blanco para usar el idioma de la carpeta",
-  "DetailsTabView.learnersCanMarkComplete": "Permitir a los estudiantes marcar como completado",
+  "CompletionOptions.learnersCanMarkComplete": "Permitir a los estudiantes marcar como completado",
   "DetailsTabView.noTagsFoundText": "No se han encontrado resultados para \"{text}\". Pulse la tecla 'Entrar' para crear una nueva etiqueta",
   "DetailsTabView.providerLabel": "Proveedor",
   "DetailsTabView.providerToolTip": "Organización que ha encargado o está distribuyendo el contenido",

--- a/contentcuration/locale/fr_FR/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/fr_FR/LC_MESSAGES/contentcuration-messages.json
@@ -820,7 +820,7 @@
   "DetailsTabView.importedFromButtonText": "Importer à partir de {channel}",
   "DetailsTabView.languageChannelHelpText": "Laisser vide pour utiliser la langue de la chaîne",
   "DetailsTabView.languageHelpText": "Laisser vide pour utiliser la langue du dossier",
-  "DetailsTabView.learnersCanMarkComplete": "Autoriser les apprenants à marquer le contenu comme étant terminé",
+  "CompletionOptions.learnersCanMarkComplete": "Autoriser les apprenants à marquer le contenu comme étant terminé",
   "DetailsTabView.noTagsFoundText": "Aucun résultat trouvé pour \"{text}\". Appuyez sur la touche 'Entrée' pour créer une nouvelle étiquette",
   "DetailsTabView.providerLabel": "Fournisseur",
   "DetailsTabView.providerToolTip": "Organisation ayant commandé le contenu ou qui le distribue",

--- a/contentcuration/locale/hi_IN/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/hi_IN/LC_MESSAGES/contentcuration-messages.json
@@ -820,7 +820,7 @@
   "DetailsTabView.importedFromButtonText": "Imported from {channel}",
   "DetailsTabView.languageChannelHelpText": "Leave blank to use the channel language",
   "DetailsTabView.languageHelpText": "Leave blank to use the folder language",
-  "DetailsTabView.learnersCanMarkComplete": "Allow learners to mark as complete",
+  "CompletionOptions.learnersCanMarkComplete": "Allow learners to mark as complete",
   "DetailsTabView.noTagsFoundText": "No results found for \"{text}\". Press 'Enter' key to create a new tag",
   "DetailsTabView.providerLabel": "Provider",
   "DetailsTabView.providerToolTip": "Organization that commissioned or is distributing the content",

--- a/contentcuration/locale/pt_BR/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/pt_BR/LC_MESSAGES/contentcuration-messages.json
@@ -820,7 +820,7 @@
   "DetailsTabView.importedFromButtonText": "Importado do {channel}",
   "DetailsTabView.languageChannelHelpText": "Deixar em branco para usar o idioma do canal",
   "DetailsTabView.languageHelpText": "Deixar em branco para que o idioma da pasta seja utilizado",
-  "DetailsTabView.learnersCanMarkComplete": "Permitir que os alunos marquem como 'concluído'",
+  "CompletionOptions.learnersCanMarkComplete": "Permitir que os alunos marquem como 'concluído'",
   "DetailsTabView.noTagsFoundText": "Nenhum resultado encontrado para \"{text}\". Pressione 'Enter' para criar um novo marcador",
   "DetailsTabView.providerLabel": "Provedor",
   "DetailsTabView.providerToolTip": "Organização que encomendou ou distribui o conteúdo",

--- a/integration_testing/features/wip-studio-edit-modal/edit-completion-field.feature
+++ b/integration_testing/features/wip-studio-edit-modal/edit-completion-field.feature
@@ -9,93 +9,107 @@ Feature: Edit completion/duration field
 		Then I see the *Edit details* modal for the <resource>
 			And I see the *Completion* section underneath the *Basic information* section
 
+	Scenario: Default options for .MP4 or .MP3 on file upload
+		Given I am viewing an .MP4 or an .MP3 file that I have just added
+			And I see the *Completion* section
+		Then I see the *Completion* is set by default to *When time spent is equal to duration*
+			And *Duration* is set by default to *Time to complete*
+		Then I see the exact duration <XX:XX> appear next to the *Duration* field as plain text
+			And I see that I cannot edit it
+
 	Scenario: View options for .MP4 or .MP3
 		Given I am viewing an .MP4 or an .MP3 file
 		When I click the *Completion* dropdown
-		Then I see the options: *Complete duration* and *Reference*
+		Then I see the options: *When time spent is equal to duration* and *Reference material*
 		When I click the *Duration* dropdown
-		Then I see the options: *Exact time to complete*, *Short activity*, and *Long activity*
+		Then I see the options: *Time to complete*, *Short activity*, and *Long activity*
+
+
+	Scenario: Default options for .PDF, .EPUB or slides
+		Given I am viewing a .PDF, .EPUB or slidesfile that I have just added
+			And I see the *Completion* section
+		Then I see the *Completion* is set by default to *Viewed in its entirety*
+			And *Duration* is hidden by default
 
 	Scenario: View options for .PDF, .EPUB or slides
 		Given I am viewing .PDF, .EPUB or slides
 		When I click the *Completion* dropdown
-		Then I see the options: *All content viewed*, *Complete duration*, and *Reference*
+		Then I see the options: *Viewed in its entirety*, *When time spent is equal to duration*, and *Reference material*
+
+
+	Scenario: Default options for .ZIP on file upload
+		Given I am viewing a .ZIP file that I have just added
+			And I see the *Completion* section
+		Then I see the *Completion* is set by default to *When time spent is equal to duration*
+			And *Duration* is set by default to *Short Activity* with a value of *5 minutes*
 
 	Scenario: View options for .ZIP
 		Given I am viewing a .ZIP
 		When I click on the *Completion* dropdown
-		Then I see the options: *Complete duration*, *Determined by this resource*, and *Reference*
+		Then I see the options: *When time spent is equal to duration*,  *Determined by the resource*, and *Reference material*
+
+	Scenario: Default options for Exercise on content creation
+		Given I am viewing an exercise  that I have just added
+			And I see the *Completion* section
+		Then I see the *Completion* is set by default to *When goal is met*
+			And there is a *goal* dropdown with no default set
+			And *Duration* is not visible for exercises
 
 	Scenario: View options for Practice resources
 		Given I am viewing an exercise
 		When I click on the *Completion* dropdown
-		Then I see the options: *Practice until goal is met* and *Practice quiz*
+		Then I see the options: *When goal is met* and *Practice quiz*
 
 	Scenario: Set completion to *Short activity*
 		When I click on the *Completion* dropdown
 			And I select *Short activity*
 		Then I see *Short activity* appear in the text input
-			And I see a *Minutes* text input field appear next to *Completion*
-			And I see a slider appear next to *Minutes*
+			And I see a *Minutes* dropdown input field appear next to *Completion*
 			And I see *Minutes* is set to 10 by default
-			And I see the maximum value of the slider is 30 minutes
+			And I see the maximum option in the menu is 30 minutes
 			And I see the caption *(Optional) Duration until resource is marked as complete. This value will not be shown to learners*
 
 	Scenario: Adjust time for short activities
 		Given *Completion* is set to *Short activity*
-		When I adjust the slider
-		Then I see the value in the *Minutes* field change to match the slider
-		When I type in a new value into *Minutes*
-		When I lose focus on *Minutes*
-		Then I see the slider changes to match the value in *Minutes*
-		When I enter a value above 30 minutes into *Minutes*
-		Then I see the value in *Minutes* is set to 30 minutes
-			And I see the slider is set to 30 minutes
+		When I adjust the value by selecting a different option in the dropdown
+		Then I see the value in the *Minutes* field update
 
 	Scenario: Set completion to *Long activity*
 		When I click on the *Completion* dropdown
 			And I select *Long activity*
 		Then I see *Long activity* appear in the text input
-			And I see a *Minutes* text input field appear next to *Completion*
-			And I see a slider appear next to *Minutes*
-			And I see *Minutes* is set to 45 by default
-			And I see the maximum value of the slider is 120 minutes
-			And I see the caption *(Optional) Duration until resource is marked as complete. This value will not be shown to learners*
+		And I see a *Minutes* dropdown input field appear next to *Completion*
+		And I see *Minutes* is set to 50 by default
+		And I see the maximum option in the menu is 120 minutes
+		And I see the maximum option in the menu is 40 minutes
+		And I see the caption *(Optional) Duration until resource is marked as complete. This value will not be shown to learners*
 
 	Scenario: Adjust time for long activities
 		Given *Completion* is set to *Long activity*
-		When I adjust the slider
-		Then I see the value in the *Minutes* field change to match the slider
-		When I type in a new value into *Minutes*
-		When I lose focus on *Minutes*
-		Then I see the slider changes to match the value in *Minutes*
-		When I enter a value above 120 minutes into *Minutes*
-		Then I see the value in *Minutes* is set to 120 minutes
-			And I see the slider is set to 120 minutes
-		When I enter a value below 45 minutes into *Minutes*
-		Then I see the value in *Minutes* is set to 45 minutes
-			And I see the slider is set to 45 minutes
+		When I adjust the value by selecting a different option in the dropdown
+		Then I see the value in the *Minutes* field update
 
-	Scenario: Set completion to *Reference*
+	Scenario: Set completion to *Reference material*
 		When I click on the *Completion* dropdown
-			And I select *Reference*
-		Then I see *Reference* appear as an input for *Completion*
+			And I select *Reference material*
+		Then I see *Reference material* appear as an input for *Completion*
 			And I see the caption *Progress will not be tracked on reference material unless learners mark it as complete*
+			And the *Duration* input field is hidden
 
-	Scenario: Set completion to *Exact time to complete* on .MP4 or .MOV
+	Scenario: Set completion to *Time to complete* on .MP4 or .MOV
 		Given I am viewing an .MP4 or .MOV
 		When I click the *Completion* dropdown
-		When I select *Exact time to complete*
-		Then I see the exact duration <XX:XX> appear next to the *Completion* field as plain text
+		When I select *Time to complete*
+		Then I see the exact duration <XX:XX> appear next to the *Duration* field as plain text
 			And I see that I cannot edit it
 
-	Scenario: Set completion to *Exact time to complete* for non- .MP4 or .MOV
-		Given I am viewing a resource that is not an .MP4 or .MOV
-		When I click the *Completion* dropdown
-			And I select *Exact time to complete*
-		Then I see a *Exact time to complete* appear as an input for *Completion*
-			And I see a *Minutes* text input field appear next to *Completion*
-			And I see it is empty by default
+	Scenario: Set completion to *Time to complete* for .PDF, .EPUB, or slides
+		Given I am viewing a resource that is a .PDF, .EPUB, or slides
+			And *Completion* is set to *When time spent is equal to duration*
+		When I click the *Duration* dropdown
+			And I select *Time to complete*
+		Then I see a *Time to complete* appear as an input for *Duration*
+			And I see a *Minutes* text input field appear next to *Duration*
 		When I click the *Minutes* field
 			And I enter a whole number
 			And I lose focus on the field
@@ -106,11 +120,16 @@ Feature: Edit completion/duration field
 		When I try to enter a non-numeric input or non-whole number
 		Then I see that I am blocked from entering that input
 
+	Scenario: Check *Allow learners to mark as complete*
+		Given I can see the *Allow learners to mark as complete* field in *Completion*
+		When I click on the checkbox
+		Then I see that it changes from its current state to the opposite
+
 	Scenario: Set completion to *Practice until goal is met*
 		Given I am viewing an exercise
 		When I click the *Completion* dropdown
-			And I click *Practice until goal is met*
-		Then I see the *Completion* field is set to *Practice until goal is met*
+			And I click *When goal is met*
+		Then I see the *Completion* field is set to *When goal is met*
 			And I see an empty *Goal* text field dropdown appears next to it
 		When I click the *Goal* dropdown
 		Then I see the options: *100% correct*, *M of N*, *10 in a row*, *2 in a row*, *3 in a row*, *5 in a row*
@@ -118,16 +137,18 @@ Feature: Edit completion/duration field
 		Then I see an empty *Correct answers needed* text field, */*, and empty *Recent answers* text field appear
 
 	Scenario: See that *Completion* field is required
-		Given the *Completion* field of <resource> is empty
-		When I click the *Completion* text field
-			And I lose focus on the *Completion* text field
-		Then I see *Completion* is in an error state
-			And I see *Completion is required*
+		Given that a required *Completion* or *Duration* field of <resource> is empty
+		When I click the *Completion* or *Duration* text field
+			And I lose focus on the *Completion* or *Duration* text field
+		Then I see *Completion* or *Duration* is in an error state
+			And I see *This field is required*
 		When I click *FINISH*
+		Then I see a pop up that informs me that the resource is incomplete
+			And I can *Exit anyway* or *Keep editing*
+		When I click *EXIT* without adding the required fields
 		Then I see <resource> in the topic tree
 			And I see a red error icon on <resource>
 		When I left-click the <resource>
 		Then I see the previewer for the <resource>
-			And I see there is no learning activity label at the top left
-			And I see the *Completion* field has a red error icon
-			And I see the message *Missing completion criteria* in red text
+			And I see the missing *Completion* or *Duration* field has a red outline error
+		And I see *This field is required* below the field


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Cohack with @rtibbles that began as changes to address [feedback](https://github.com/learningequality/studio/pull/3777#issuecomment-1295067138), but resulted in some broader refactoring.

- Completion and duration should now work for _all_ content types 
- The descriptive aspect of duration has been hidden for now, so duration setting is only showed if a time based completion criterion is set. This was done due to the confusing interface language in the case that the it was being set descriptively.
- The learner managed state is moved into the completion options component, so that when it is set when no other completion criterion is set, the default completion criteria state to ensure validity.
- To simplify frontend state management, backend completion criteria validation is only run when the node is set as complete, allowing saving of partial completion criteria

Issue for Kolibri filed separately in Kolibri repo 

### Manual verification steps performed
1. many many many permutations of testing
2. test each content type
3. test all completion durations options of content type
4. switch from each completion option to each other option (i.e from reference to time-based, reference to all content viewed, time based to all content viewed, time based to reference, all content viewed to reference, all content viewed to time-based) 
5. ensure "learner can mark as complete" works without any other interactions with completion/duration (i.e. check the checkbox, but make no other changes to default state)


### Screenshots (if applicable)
toooo many to add 

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
