### PR TITLE
Updates our frontend sentry config to be harmonized with drawing from secrets in the backend

### DIFF
--- a/contentcuration/contentcuration/context_processors.py
+++ b/contentcuration/contentcuration/context_processors.py
@@ -22,6 +22,10 @@ def site_variables(request):
         "DEBUG": settings.DEBUG,
         "LANG_INFO": json_for_parse_from_data(language_globals()),
         "LOGGED_IN": not request.user.is_anonymous,
+        "SENTRY_DSN": settings.SENTRY_DSN,
+        "SENTRY_ENVIRONMENT": settings.SENTRY_ENVIRONMENT,
+        "SENTRY_RELEASE": settings.SENTRY_RELEASE,
+        "SENTRY_ACTIVE": settings.SENTRY_ACTIVE,
     }
 
 

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -123,10 +123,12 @@ import { Session, injectVuexStore } from 'shared/data/resources';
 // just say yes to devtools (in debug mode)
 if (process.env.NODE_ENV !== 'production') {
   Vue.config.devtools = true;
-} else {
+} else if (window.sentryActive) {
   Sentry.init({
     Vue,
-    dsn: 'https://e4b21baeb7a044b885464d2af687fb73@sentry.io/1252819',
+    dsn: window.sentryDSN,
+    environment: window.sentryEnvironment,
+    release: window.sentryRelease,
     initialScope: {
       user: window.user ? { id: window.user.id, email: window.user.email } : null,
     },

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -413,18 +413,23 @@ LIBRARY_MODE = False
 key = get_secret("SENTRY_DSN_KEY")
 if key:
     key = key.strip()  # strip any possible whitespace or trailing newline
-release_commit = get_secret("RELEASE_COMMIT_SHA")
-if key and len(key) > 0 and release_commit:
+
+SENTRY_DSN = 'https://{secret}@sentry.io/1252819'.format(secret=key) if key else None
+SENTRY_ENVIRONMENT = get_secret("BRANCH_ENVIRONMENT")
+SENTRY_RELEASE = get_secret("RELEASE_COMMIT_SHA")
+SENTRY_ACTIVE = False
+
+if SENTRY_DSN and SENTRY_RELEASE and SENTRY_ENVIRONMENT:
     import sentry_sdk
     # TODO: there are also Celery and Redis integrations, but since they are new
     # I left them as a separate task so we can spend more time on testing.
     from sentry_sdk.integrations.django import DjangoIntegration
 
     sentry_sdk.init(
-        dsn='https://{secret}@sentry.io/1252819'.format(secret=key),
+        dsn=SENTRY_DSN,
         integrations=[DjangoIntegration()],
-        release=release_commit,
-        environment=get_secret("BRANCH_ENVIRONMENT"),
+        release=SENTRY_RELEASE,
+        environment=SENTRY_ENVIRONMENT,
         send_default_pii=True,
     )
 

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -77,6 +77,12 @@
           var csrftoken = '{{ csrf_token }}';
           var betaMode = "{{ BETA_MODE }}" === "True";
           var storageBaseUrl = "{{ STORAGE_HOST }}/{{ STORAGE_BASE_URL }}";
+          {% if SENTRY_ACTIVE %}
+          var sentryActive = true;
+          var sentryDSN = "{{ SENTRY_DSN }}";
+          var sentryEnvironment = "{{ SENTRY_ENVIRONMENT }}";
+          var sentryRelease = "{{ SENTRY_RELEASE }}";
+          {% endif %}
           {%  if not debug %}
           if (user && user.id && window.Sentry) {
             Sentry.setUser({ id: user.id, email: user.email });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Seeing a bunch of errors in sentry from the frontend both from dev environments and from people randomly running forks of Studio, this seemed important to resolve
* Updates how we do our frontend Sentry integration to use the same DSN, Environment, and Release variables as the backend

I'm not really sure how to test this except to do it live!

## References
Fixes #2644