### PR TITLE
Implement Pinging mechanism to keep Websocket connection alive

### DIFF
--- a/contentcuration/contentcuration/viewsets/websockets/consumers.py
+++ b/contentcuration/contentcuration/viewsets/websockets/consumers.py
@@ -84,6 +84,14 @@ class SyncConsumer(WebsocketConsumer):
         from contentcuration.models import Channel
         from contentcuration.tasks import apply_channel_changes_task
         from contentcuration.tasks import apply_user_changes_task
+        
+        #If the message is PING message then just reply to keep connection alive
+        data = json.loads(text_data)
+        if "ping" in data:
+            self.send(json.dumps({
+            'response': "PONG!"
+        }))
+            return 
 
         response_payload = {
             "disallowed": [],


### PR DESCRIPTION
## Summary
Ping Websocket to keep the connection alive

### Description of the change(s) you made
- Frontend pings websocket connection in an interval of 25 seconds
- Ping messages are limited to only occur when any other messages hadn't been sent during the period timeframe.


### Manual verification steps performed
1. open a channel 
2. Try changing its name
3. Websocket PONG response is skipped and occurs after a bit delay then 25 seconds




### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
- I am thinking of a typical edge case where we ping and send some changes simultaneously!

## Comments
<!-- Additional comments may be added here -->
- Re-think about the 25 seconds interval as the worst case might be 50 seconds gap between pinging. This may occur in the edge case resulting in the closure of the connection despite our pinging mechanism.

### Contributor's Checklist

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
