### PR TITLE
Ensure changes get properly cleared as succeeded and make refresh blocking more targeted

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -705,7 +705,11 @@ class Resource extends mix(APIResource, IndexedDBResource) {
               if (c.type === CHANGE_TYPES.CREATED) {
                 parent = c.obj.parent;
               }
-              return params.parent === parent || (params.ids || []).includes(c.key);
+              return (
+                params.parent === parent ||
+                params.parent === c.key ||
+                (params.id__in || []).includes(c.key)
+              );
             })
             .count()
             .then(pendingCount => pendingCount === 0);

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -90,9 +90,7 @@ def current_user_for_context(user):
 
     user_data = {field: getattr(user, field) for field in user_fields}
 
-    user_data["user_rev"] = Change.objects.filter(
-        applied=True, user=user, created_by__isnull=False
-    ).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
+    user_data["user_rev"] = Change.objects.filter(applied=True, user=user).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
 
     return json_for_parse_from_data(user_data)
 
@@ -303,9 +301,7 @@ def channel(request, channel_id):
         if channel.deleted:
             channel_error = 'CHANNEL_EDIT_ERROR_CHANNEL_DELETED'
         else:
-            channel_rev = Change.objects.filter(
-                applied=True, channel=channel, created_by__isnull=False
-            ).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
+            channel_rev = Change.objects.filter(applied=True, channel=channel).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
 
     return render(
         request,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Reverts previous changes to max rev calculation logic, and instead explicitly polls the backend for server_revs that are marked as synced but not applied, errored, or disallowed in the frontend
* Makes the blocking of collection refreshes for ContentNodes more targeted, to prevent changes only to tree structure for local nodes (i.e. for fetches for parents or ids queries).


### Manual verification steps performed
1. Add a time.sleep to the `_clone_node` method of the `CustomContentNodeTreeManager` to make copies run slowly to replicate the error from production
2. Copy two folders in the same `import from channels` modal, to ensure two copy operations are started
3. When the first copy operation has finished, check that you can click into the folder and that the contents load
4. When the second copy operation has finished, check that you can click into that folder and that the contents load

### Screenshots (if applicable)

https://user-images.githubusercontent.com/1680573/199610844-a5d88f14-c46d-4708-ae88-e2ee8575e9e3.mp4


### Does this introduce any tech-debt items?
I think this can be done much more neatly and efficiently with the websockets work!
___
## Reviewer guidance
### How can a reviewer test these changes?
Do the manual steps suggested above.
Review the new logic for more targeted refresh blocking - does this miss any cases?

## References
Fixes #3753

