### PR TITLE
Bulk completion criteria fix

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -5,6 +5,8 @@
     <Checkbox
       v-model="learnerManaged"
       color="primary"
+      :indeterminate="notUnique"
+      :disabled="notUnique"
       :label="$tr('learnersCanMarkComplete')"
       style="padding-bottom: 16px;"
     />
@@ -17,6 +19,7 @@
             ref="completion"
             v-model="completionDropdown"
             box
+            :placeholder="getPlaceholder('value')"
             :items="showCorrectCompletionOptions"
             :label="translateMetadataString('completion')"
             :required="required"
@@ -61,6 +64,7 @@
             ref="duration"
             v-model="durationDropdown"
             box
+            :placeholder="getPlaceholder('value')"
             :items="selectableDurationOptions"
             :label="translateMetadataString('duration')"
             :required="required"
@@ -205,6 +209,9 @@
       },
     },
     computed: {
+      notUnique() {
+        return this.value === nonUniqueValue;
+      },
       model() {
         return this.value.model || defaultCompletionCriteriaModels[this.kind];
       },
@@ -238,6 +245,9 @@
       },
       completionDropdown: {
         get() {
+          if (this.notUnique) {
+            return;
+          }
           if (
             this.value.modality === ContentModalities.QUIZ &&
             this.model === CompletionCriteriaModels.MASTERY

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -636,10 +636,11 @@
       thumbnailEncoding: generateGetterSetter('thumbnail_encoding'),
       completionAndDuration: {
         get() {
-          const { completion_criteria, modality } = this.getExtraFieldsValueFromNodes(
-            'options',
-            {}
-          );
+          const options = this.getExtraFieldsValueFromNodes('options', {});
+          if (options === nonUniqueValue) {
+            return nonUniqueValue;
+          }
+          const { completion_criteria, modality } = options;
           const suggested_duration_type = this.getExtraFieldsValueFromNodes(
             'suggested_duration_type'
           );

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -367,7 +367,9 @@
   import difference from 'lodash/difference';
   import get from 'lodash/get';
   import intersection from 'lodash/intersection';
+  import isEqual from 'lodash/isEqual';
   import uniq from 'lodash/uniq';
+  import uniqWith from 'lodash/uniqWith';
   import { mapGetters, mapActions } from 'vuex';
   import ContentNodeThumbnail from '../../views/files/thumbnails/ContentNodeThumbnail';
   import FileUpload from '../../views/files/FileUpload';
@@ -634,8 +636,10 @@
       thumbnailEncoding: generateGetterSetter('thumbnail_encoding'),
       completionAndDuration: {
         get() {
-          const { completion_criteria, modality } =
-            this.getExtraFieldsValueFromNodes('options') || {};
+          const { completion_criteria, modality } = this.getExtraFieldsValueFromNodes(
+            'options',
+            {}
+          );
           const suggested_duration_type = this.getExtraFieldsValueFromNodes(
             'suggested_duration_type'
           );
@@ -808,7 +812,7 @@
         return getValueFromResults(results);
       },
       getExtraFieldsValueFromNodes(key, defaultValue = null) {
-        const results = uniq(
+        const results = uniqWith(
           this.nodes.map(node => {
             if (
               Object.prototype.hasOwnProperty.call(
@@ -820,7 +824,8 @@
               return this.diffTracker[node.id].extra_fields[key];
             }
             return get(node.extra_fields, key, defaultValue);
-          })
+          }),
+          isEqual
         );
         return getValueFromResults(results);
       },


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Uses uniqWith to do a deep comparison of options objects
* If all options are not unique then just return `nonUnique` for the entire value passed into `CompletionOptions`
* Disable editing of learner managed when non-unique
* Ensure that the completionDropdown shows an empty placeholder, forcing the user to make a selection there first in bulk edits


### Manual verification steps performed
1. Edit one item to have a specific set of completion criteria
2. Select two other items of the same kind that have a different criteria
3. Confirm that you can now (restrictedly) edit these in sync and have it persist

### Screenshots (if applicable)

https://user-images.githubusercontent.com/1680573/200079054-80bf74fc-52f7-4869-8908-8d0cc9bda18a.mp4


### Does this introduce any tech-debt items?
This is not an ideal user experience, but doing it better would involve more specific reading and patching of the nested representations inside the `options` objects

Fixes #3794