### PR TITLE
Do defaulting better to allow falsey values.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -365,6 +365,7 @@
 <script>
 
   import difference from 'lodash/difference';
+  import get from 'lodash/get';
   import intersection from 'lodash/intersection';
   import uniq from 'lodash/uniq';
   import { mapGetters, mapActions } from 'vuex';
@@ -818,7 +819,7 @@
             ) {
               return this.diffTracker[node.id].extra_fields[key];
             }
-            return node.extra_fields[key] || defaultValue;
+            return get(node.extra_fields, key, defaultValue);
           })
         );
         return getValueFromResults(results);


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Uses lodash get to get values from extra_fields rather than direct property access, to ensure that falsy values are not overridden by the default value.

### Manual verification steps performed
1. Unchecked 'randomize' on an exercise
2. Waited for save. Reopened edit modal.
3. Confirmed it remained unchecked.

### Screenshots (if applicable)

https://user-images.githubusercontent.com/1680573/200354598-9e1172d1-d3b5-46b2-be3a-92c45aa1e3b6.mp4


Fixes #3800