### PR TITLE
Prevent modification of contentnode extra_fields during publish

### DIFF
--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -397,7 +397,7 @@ def create_associated_thumbnail(ccnode, ccfilemodel):
             "points": [],
             "zoom": 0,
         })
-        ccnode.save()
+        ccnode.save(update_fields=("thumbnail_encoding",))
 
     return create_thumbnail_from_base64(
         encoding,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* When the thumbnail encoding is not set on a content node at publish time, it gets generated from its thumbnail file, and set on the node. This node is then saved.
* Adding the extra_field migration standardization has caused issues, because it modifies the extra_fields dict during the transformation, so when it got saved with a new thumbnail encoding these updates also got saved
* This fixes this issue by restricting the save to only the `thumbnail_encoding` field
* Adds regression tests for both legacy and new style exercises

Fixes #3799