### PR TITLE
Reduce Sentry errors by adding defensive checks

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -93,7 +93,7 @@
         </div>
       </VFadeTransition>
 
-      <VToolbarItems>
+      <VToolbarItems v-if="!loadingAncestors">
         <Menu class="pa-1">
           <template #activator="{ on }">
             <IconButton

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -63,7 +63,7 @@
         <span v-if="canManage && isRicecooker" class="font-weight-bold grey--text subheading">
           {{ $tr('apiGenerated') }}
         </span>
-        <VTooltip v-if="canManage" bottom attach="body" lazy>
+        <VTooltip v-if="!loading && canManage" bottom attach="body" lazy>
           <template #activator="{ on }">
             <!-- Need to wrap in div to enable tooltip when button is disabled -->
             <div style="height: 100%;" v-on="on">
@@ -82,7 +82,7 @@
           </template>
           <span>{{ publishButtonTooltip }}</span>
         </VTooltip>
-        <span v-else class="font-weight-bold grey--text subheading">
+        <span v-else-if="!loading" class="font-weight-bold grey--text subheading">
           {{ $tr('viewOnly') }}
         </span>
       </template>
@@ -279,6 +279,12 @@
       MessageDialog,
     },
     mixins: [titleMixin],
+    props: {
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+    },
     data() {
       return {
         drawer: false,
@@ -331,7 +337,9 @@
         }
       },
       showChannelMenu() {
-        return this.$vuetify.breakpoint.xsOnly || this.canManage || this.isPublished;
+        return (
+          !this.loading && (this.$vuetify.breakpoint.xsOnly || this.canManage || this.isPublished)
+        );
       },
       viewChannelDetailsLink() {
         return {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <TreeViewBase @dropToClipboard="handleDropToClipboard">
+  <TreeViewBase :loading="loading" @dropToClipboard="handleDropToClipboard">
     <template v-if="hasStagingTree && canManage" #extension>
       <Banner
         :value="true"

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/mutations.js
@@ -59,5 +59,7 @@ export function UPDATE_ASSESSMENTITEM_FROM_INDEXEDDB(state, { id, ...mods }) {
 }
 
 export function DELETE_ASSESSMENTITEM(state, assessmentItem) {
-  Vue.delete(state.assessmentItemsMap[assessmentItem.contentnode], assessmentItem.assessment_id);
+  if (state.assessmentItemsMap[assessmentItem.contentnode]) {
+    Vue.delete(state.assessmentItemsMap[assessmentItem.contentnode], assessmentItem.assessment_id);
+  }
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/task/index.js
@@ -28,7 +28,10 @@ export default {
     getPublishTaskForChannel(state) {
       return function(channelId) {
         return Object.values(state.asyncTasksMap).find(
-          t => t.channel_id.replace('-', '') === channelId && t.task_name === 'export-channel'
+          t =>
+            t.task_name === 'export-channel' &&
+            t.channel_id &&
+            t.channel_id.replace('-', '') === channelId
         );
       };
     },

--- a/contentcuration/contentcuration/frontend/shared/views/ExpandableList.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ExpandableList.vue
@@ -78,6 +78,7 @@
     props: {
       items: {
         type: Array,
+        required: true,
         default: () => [],
       },
       max: {

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1705,13 +1705,14 @@ class ContentNode(MPTTModel, models.Model):
             "accessible_languages": node.get("accessible_languages", ""),
             "licenses": node.get("licenses", ""),
             "tags": node.get("tags_list", []),
-            "copyright_holders": node["copyright_holders"],
-            "authors": node["authors"],
-            "aggregators": node["aggregators"],
-            "providers": node["providers"],
-            "sample_pathway": pathway,
             "original_channels": original_channels,
+            "sample_pathway": pathway,
             "sample_nodes": sample_nodes,
+            # source model fields for the below default to an empty string, but can also be null
+            "authors": list(filter(bool, node["authors"])),
+            "aggregators": list(filter(bool, node["aggregators"])),
+            "providers": list(filter(bool, node["providers"])),
+            "copyright_holders": list(filter(bool, node["copyright_holders"])),
         }
 
         # Set cache with latest data

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -184,6 +184,10 @@ class NodeGettersTestCase(StudioTestCase):
         assert details["resource_count"] > 0
         assert details["resource_size"] > 0
         assert len(details["kind_count"]) > 0
+        assert len(details["authors"]) == len([author for author in details["authors"] if author])
+        assert len(details["aggregators"]) == len([aggregator for aggregator in details["aggregators"] if aggregator])
+        assert len(details["providers"]) == len([provider for provider in details["providers"] if provider])
+        assert len(details["copyright_holders"]) == len([holder for holder in details["copyright_holders"] if holder])
 
 
 class NodeOperationsTestCase(StudioTestCase):


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Fixes regression in channel details API where it returns lists of falsy values ([sentry](https://sentry.io/organizations/learningequality/issues/3701107519/?project=1252819&referrer=slack))
- Enforces `items` prop is required for `ExpandableList` ([sentry](https://sentry.io/organizations/learningequality/issues/3730681661/?project=1252819&referrer=slack))
- Prevents access to string method on null value when checking a task's channel ID ([sentry](https://sentry.io/organizations/learningequality/issues/3730427082/?project=1252819&referrer=slack))
- Checks assessment vuex map exists before calling delete of a key ([sentry](https://sentry.io/organizations/learningequality/issues/3731836075/?project=1252819&referrer=slack))
- Delays rendering of UI elements until fully loaded ([sentry](https://sentry.io/organizations/learningequality/issues/3549479253/?project=1252819&referrer=slack))

### Manual verification steps performed
1. Add `sleep(20)` to `ContentNodeViewSet.get_queryset`
2. Clear your browsers cache or open incognito window
3. Sign into studio and open a channel
4. Observer not all interface components, like Publish, Add, or menus render until fully loaded


### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [X] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
