### PR TITLE
Fix task duplication when kwargs contain UUIDs

### DIFF
--- a/contentcuration/contentcuration/tests/test_asynctask.py
+++ b/contentcuration/contentcuration/tests/test_asynctask.py
@@ -212,6 +212,24 @@ class AsyncTaskTestCase(TransactionTestCase):
         async_result = test_task.fetch_or_enqueue(self.user, channel_id=channel_id)
         self.assertEqual(expected_task.task_id, async_result.task_id)
 
+    def test_fetch_or_enqueue_task__channel_id__hex(self):
+        channel_id = uuid.uuid4()
+        expected_task = test_task.enqueue(self.user, channel_id=channel_id.hex)
+        async_result = test_task.fetch_or_enqueue(self.user, channel_id=channel_id.hex)
+        self.assertEqual(expected_task.task_id, async_result.task_id)
+
+    def test_fetch_or_enqueue_task__channel_id__hex_then_uuid(self):
+        channel_id = uuid.uuid4()
+        expected_task = test_task.enqueue(self.user, channel_id=channel_id.hex)
+        async_result = test_task.fetch_or_enqueue(self.user, channel_id=channel_id)
+        self.assertEqual(expected_task.task_id, async_result.task_id)
+
+    def test_fetch_or_enqueue_task__channel_id__uuid_then_hex(self):
+        channel_id = uuid.uuid4()
+        expected_task = test_task.enqueue(self.user, channel_id=channel_id)
+        async_result = test_task.fetch_or_enqueue(self.user, channel_id=channel_id.hex)
+        self.assertEqual(expected_task.task_id, async_result.task_id)
+
     def test_requeue_task(self):
         existing_task_ids = requeue_test_task.find_ids()
         self.assertEqual(len(existing_task_ids), 0)

--- a/contentcuration/contentcuration/tests/test_asynctask.py
+++ b/contentcuration/contentcuration/tests/test_asynctask.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import threading
+import uuid
 
 from celery import states
 from celery.result import allow_join_result
@@ -203,6 +204,12 @@ class AsyncTaskTestCase(TransactionTestCase):
     def test_fetch_or_enqueue_task(self):
         expected_task = test_task.enqueue(self.user, is_test=True)
         async_result = test_task.fetch_or_enqueue(self.user, is_test=True)
+        self.assertEqual(expected_task.task_id, async_result.task_id)
+
+    def test_fetch_or_enqueue_task__channel_id(self):
+        channel_id = uuid.uuid4()
+        expected_task = test_task.enqueue(self.user, channel_id=channel_id)
+        async_result = test_task.fetch_or_enqueue(self.user, channel_id=channel_id)
         self.assertEqual(expected_task.task_id, async_result.task_id)
 
     def test_requeue_task(self):

--- a/contentcuration/contentcuration/utils/celery/tasks.py
+++ b/contentcuration/contentcuration/utils/celery/tasks.py
@@ -156,7 +156,8 @@ class CeleryTask(Task):
         """
         async_result = self.fetch(task_id)
         # the task kwargs are serialized in the DB so just ensure that args actually match
-        if async_result.kwargs == kwargs:
+        transcoded_kwargs = self.backend.decode(self.backend.encode(kwargs))
+        if async_result.kwargs == transcoded_kwargs:
             return async_result
         return None
 
@@ -192,7 +193,7 @@ class CeleryTask(Task):
         # after calling apply, we should have task result model, so get it and set our custom fields
         task_result = get_task_model(self, task_id)
         task_result.task_name = self.name
-        task_result.task_kwargs = self.backend.encode_content(kwargs)[2]
+        task_result.task_kwargs = self.backend.encode(kwargs)
         task_result.user = user
         task_result.channel_id = channel_id
         task_result.save()

--- a/contentcuration/contentcuration/utils/celery/tasks.py
+++ b/contentcuration/contentcuration/utils/celery/tasks.py
@@ -146,9 +146,10 @@ class CeleryTask(Task):
         """
         return self.AsyncResult(task_id)
 
-    def fetch_match(self, task_id, **kwargs):
+    def _fetch_match(self, task_id, **kwargs):
         """
-        Gets the result object for a task, assuming it was called async, and ensures it was called with kwargs
+        Gets the result object for a task, assuming it was called async, and ensures it was called with kwargs and
+        assumes that kwargs is has been decoded from an prepared form
         :param task_id: The hex task ID
         :param kwargs: The kwargs the task was called with, which must match when fetching
         :return: A CeleryAsyncResult
@@ -156,10 +157,15 @@ class CeleryTask(Task):
         """
         async_result = self.fetch(task_id)
         # the task kwargs are serialized in the DB so just ensure that args actually match
-        transcoded_kwargs = self.backend.decode(self.backend.encode(kwargs))
-        if async_result.kwargs == transcoded_kwargs:
+        if async_result.kwargs == kwargs:
             return async_result
         return None
+
+    def _prepare_kwargs(self, kwargs):
+        return self.backend.encode({
+            key: value.hex if isinstance(value, uuid.UUID) else value
+            for key, value in kwargs.items()
+        })
 
     def enqueue(self, user, **kwargs):
         """
@@ -177,14 +183,16 @@ class CeleryTask(Task):
             raise TypeError("All tasks must be assigned to a user.")
 
         task_id = uuid.uuid4().hex
-        channel_id = kwargs.get("channel_id")
+        prepared_kwargs = self._prepare_kwargs(kwargs)
+        transcoded_kwargs = self.backend.decode(prepared_kwargs)
+        channel_id = transcoded_kwargs.get("channel_id")
 
-        logging.info(f"Enqueuing task:id {self.name}:{task_id} for user:channel {user.pk}:{channel_id} | {kwargs}")
+        logging.info(f"Enqueuing task:id {self.name}:{task_id} for user:channel {user.pk}:{channel_id} | {prepared_kwargs}")
 
         # returns a CeleryAsyncResult
         async_result = self.apply_async(
             task_id=task_id,
-            kwargs=kwargs,
+            kwargs=transcoded_kwargs,
         )
 
         # ensure the result is saved to the backend (database)
@@ -193,7 +201,7 @@ class CeleryTask(Task):
         # after calling apply, we should have task result model, so get it and set our custom fields
         task_result = get_task_model(self, task_id)
         task_result.task_name = self.name
-        task_result.task_kwargs = self.backend.encode(kwargs)
+        task_result.task_kwargs = prepared_kwargs
         task_result.user = user
         task_result.channel_id = channel_id
         task_result.save()
@@ -212,9 +220,10 @@ class CeleryTask(Task):
         # if we're eagerly executing the task (synchronously), then we shouldn't check for an existing task because
         # implementations probably aren't prepared to rely on an existing asynchronous task
         if not self.app.conf.task_always_eager:
-            task_ids = self.find_incomplete_ids(**kwargs).order_by("date_created")[:1]
+            transcoded_kwargs = self.backend.decode(self._prepare_kwargs(kwargs))
+            task_ids = self.find_incomplete_ids(**transcoded_kwargs).order_by("date_created")[:1]
             if task_ids:
-                async_result = self.fetch_match(task_ids[0], **kwargs)
+                async_result = self._fetch_match(task_ids[0], **transcoded_kwargs)
                 if async_result:
                     logging.info(f"Fetched matching task {self.name} for user {user.pk} with id {async_result.id} | {kwargs}")
                     return async_result


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Compares encoded and decoded version of task kwargs which prevents mismatches when the kwargs possibly contain UUID values (or other serializable objects)

### Manual verification steps performed
Ran the tests... with the new regression test covering UUID values

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [X] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
