### PR TITLE
Allow exercises with raw_data set to be complete.

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1756,12 +1756,15 @@ class ContentNode(MPTTModel, models.Model):
             if self.kind_id == content_kinds.EXERCISE:
                 # Check to see if the exercise has at least one assessment item that has:
                 if not self.assessment_items.filter(
-                    # A non-blank question
-                    ~Q(question='')
-                    # Non-blank answers
-                    & ~Q(answers='[]')
-                    # With either an input question or one answer marked as correct
-                    & (Q(type=exercises.INPUT_QUESTION) | Q(answers__iregex=r'"correct":\s*true'))
+                    # Item with non-blank raw data
+                    ~Q(raw_data="") | (
+                        # A non-blank question
+                        ~Q(question='')
+                        # Non-blank answers
+                        & ~Q(answers='[]')
+                        # With either an input question or one answer marked as correct
+                        & (Q(type=exercises.INPUT_QUESTION) | Q(answers__iregex=r'"correct":\s*true'))
+                    )
                 ).exists():
                     errors.append("No questions with question text and complete answers")
                 # Check that it has a mastery model set

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -1061,6 +1061,15 @@ class NodeCompletionTestCase(StudioTestCase):
         new_obj.mark_complete()
         self.assertTrue(new_obj.complete)
 
+    def test_create_exercise_valid_assessment_items_raw_data(self):
+        licenses = list(License.objects.filter(copyright_holder_required=False, is_custom=False).values_list("pk", flat=True))
+        channel = testdata.channel()
+        new_obj = ContentNode(title="yes", kind_id=content_kinds.EXERCISE, parent=channel.main_tree, license_id=licenses[0], extra_fields=self.new_extra_fields)
+        new_obj.save()
+        AssessmentItem.objects.create(contentnode=new_obj, raw_data="{\"question\": {}}")
+        new_obj.mark_complete()
+        self.assertTrue(new_obj.complete)
+
     def test_create_exercise_no_extra_fields(self):
         licenses = list(License.objects.filter(copyright_holder_required=False, is_custom=False).values_list("pk", flat=True))
         channel = testdata.channel()


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes regression induced by more rigorous completion setting in the internal API endpoint
* Adds test for and allows exercise nodes to be complete if they have raw data AssessmentItems (like KA assessments)

### Manual verification steps performed
Wrote the test, ran the test!