### PR TITLE
Revert server side ordering to fix performance issues.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -124,7 +124,6 @@
           [this.channelFilter]: true,
           page: this.$route.query.page || 1,
           exclude: this.currentChannelId,
-          ordering: this.channelFilter === 'public' ? 'name' : '-modified',
         }).then(page => {
           this.pageCount = page.total_pages;
           this.channels = page.results;


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Reverts changes to ordering on the server side Channel endpoint made here: https://github.com/learningequality/studio/commit/91298354ce200d3ffb763a772a89ede263de856e

### Manual verification steps performed
1. Confirm that the channel list page still works
