### PR TITLE
disabled double submit while creating a channel

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -72,7 +72,7 @@
                 v-model="contentDefaults"
               />
 
-              <VBtn class="mt-5" color="primary" type="submit">
+              <VBtn class="mt-5" color="primary" type="submit" :disabled="isDisable">
                 {{ isNew ? $tr('createButton') : $tr('saveChangesButton' ) }}
               </VBtn>
             </VForm>
@@ -153,6 +153,7 @@
         showUnsavedDialog: false,
         diffTracker: {},
         dialog: true,
+        isDisable: false,
       };
     },
     computed: {
@@ -287,21 +288,25 @@
       ...mapActions('channel', ['updateChannel', 'loadChannel', 'commitChannel']),
       ...mapMutations('channel', ['REMOVE_CHANNEL']),
       saveChannel() {
+        this.isDisable = true;
         if (this.$refs.detailsform.validate()) {
           this.changed = false;
           if (this.isNew) {
             return this.commitChannel({ id: this.channelId, ...this.diffTracker }).then(() => {
               // TODO: Make sure channel gets created before navigating to channel
               window.location = window.Urls.channel(this.channelId);
+              this.isDisable = false;
             });
           } else {
             return this.updateChannel({ id: this.channelId, ...this.diffTracker }).then(() => {
               this.$store.dispatch('showSnackbarSimple', this.$tr('changesSaved'));
               this.header = this.channel.name;
+              this.isDisable = false;
             });
           }
         } else if (this.$refs.detailsform.$el.scrollIntoView) {
           this.$refs.detailsform.$el.scrollIntoView({ behavior: 'smooth' });
+          this.isDisable = false;
         }
       },
       updateTitleForPage() {


### PR DESCRIPTION
## Summary
This PR fixes the double submit error while creating a new channel.
Ref #3833
### Manual verification steps performed
Step 1: Try to create a new channel from studio, and observe what is happening on clicking create button.
Step 2: You may also try on a slow network connectivity




### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
