### PR TITLE
Remove misleading offline indicator

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -6,12 +6,12 @@
       justify-center
       class="main pt-5"
     >
-      <h3 class="corner">
-        <OfflineText indicator />
-      </h3>
       <div>
         <!-- Sign in -->
-        <VCard class="pa-4" style="width: 300px;margin: 0 auto;">
+        <VCard
+          class="pa-4"
+          style="width: 300px;margin: 0 auto;"
+        >
           <VImg
             height="200"
             maxHeight="100"
@@ -22,30 +22,67 @@
           <h2 class="primary--text py-2 text-xs-center">
             {{ $tr('kolibriStudio') }}
           </h2>
-          <Banner :value="loginFailed" :text="$tr('loginFailed')" error />
-          <Banner :value="offline" :text="$tr('loginFailedOffline')" error />
+          <Banner
+            :value="loginFailed"
+            :text="$tr('loginFailed')"
+            error
+          />
+          <Banner
+            :value="offline"
+            :text="$tr('loginFailedOffline')"
+            error
+          />
           <Banner
             :value="Boolean(nextParam)"
             :text="$tr('loginToProceed')"
             class="pb-0 px-0"
             data-test="loginToProceed"
           />
-          <VForm ref="form" lazy-validation class="py-3" @submit.prevent="submit">
-            <EmailField v-model="username" autofocus />
-            <PasswordField v-model="password" :label="$tr('passwordLabel')" />
+          <VForm
+            ref="form"
+            lazy-validation
+            class="py-3"
+            @submit.prevent="submit"
+          >
+            <EmailField
+              v-model="username"
+              autofocus
+            />
+            <PasswordField
+              v-model="password"
+              :label="$tr('passwordLabel')"
+            />
             <p>
-              <ActionLink :to="{ name: 'ForgotPassword' }" :text="$tr('forgotPasswordLink')" />
+              <ActionLink
+                :to="{ name: 'ForgotPassword' }"
+                :text="$tr('forgotPasswordLink')"
+              />
             </p>
-            <VBtn block color="primary" large type="submit" :disabled="offline || busy">
+            <VBtn
+              block
+              color="primary"
+              large
+              type="submit"
+              :disabled="offline || busy"
+            >
               {{ $tr('signInButton') }}
             </VBtn>
-            <VBtn block flat color="primary" class="mt-2" :to="{ name: 'Create' }">
+            <VBtn
+              block
+              flat
+              color="primary"
+              class="mt-2"
+              :to="{ name: 'Create' }"
+            >
               {{ $tr('createAccountButton') }}
             </VBtn>
           </VForm>
           <VDivider />
           <p class="mt-4 text-xs-center">
-            <ActionLink href="/channels" :text="$tr('guestModeLink')" />
+            <ActionLink
+              href="/channels"
+              :text="$tr('guestModeLink')"
+            />
           </p>
         </VCard>
 
@@ -90,7 +127,6 @@
   import PolicyModals from 'shared/views/policies/PolicyModals';
   import { policies } from 'shared/constants';
   import LanguageSwitcherList from 'shared/languageSwitcher/LanguageSwitcherList';
-  import OfflineText from 'shared/views/OfflineText';
 
   export default {
     name: 'Main',
@@ -100,7 +136,6 @@
       LanguageSwitcherList,
       PasswordField,
       PolicyModals,
-      OfflineText,
     },
     data() {
       return {
@@ -189,12 +224,6 @@
     color: var(--v-grey-base);
     vertical-align: middle;
     content: '•';
-  }
-
-  .corner {
-    position: absolute;
-    top: 1em;
-    left: 1em;
   }
 
 </style>

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "i18n-iso-countries": "^7.5.0",
     "intl": "1.2.5",
     "jquery": "^2.2.4",
-    "jspdf": "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
+    "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "kolibri-constants": "^0.1.41",
     "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#e9a2ff34716bb6412fe99f835ded5b17345bab94",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7906,9 +7906,9 @@ jsonpointer@^5.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
   integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
-"jspdf@https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e":
+"jspdf@https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e":
   version "2.1.1"
-  resolved "https://github.com/MrRio/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e"
+  resolved "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e"
   dependencies:
     atob "^2.1.2"
     btoa "^1.2.1"
@@ -11112,7 +11112,7 @@ stackblur-canvas@2.2.0:
 stackblur-canvas@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/stackblur-canvas/-/stackblur-canvas-1.4.1.tgz#849aa6f94b272ff26f6471fa4130ed1f7e47955b"
-  integrity sha1-hJqm+UsnL/JvZHH6QTDtH35HlVs=
+  integrity sha512-TfbTympL5C1K+F/RizDkMBqH18EkUKU8V+4PphIXR+fWhZwwRi3bekP04gy2TOwOT3R6rJQJXAXFrbcZde7wow==
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -11858,7 +11858,7 @@ tr46@^2.1.0:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 trim-newlines@^3.0.0:
   version "3.0.1"
@@ -12373,7 +12373,7 @@ web-streams-polyfill@^3.2.1:
 webidl-conversions@^3.0.0, webidl-conversions@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -12533,7 +12533,7 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
 whatwg-url@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-2.0.1.tgz#5396b2043f020ee6f704d9c45ea8519e724de659"
-  integrity sha1-U5ayBD8CDub3BNnEXqhRnnJN5lk=
+  integrity sha512-sX+FT4N6iR0ZiqGqyDEKklyfMGR99zvxZD+LQ8IGae5uVGswQ7DOeLPB5KgJY8FzkwSzwqOXLQeVQvtOTSQU9Q==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
@@ -12874,7 +12874,7 @@ xhr@^2.0.1:
 "xml-name-validator@>= 2.0.1 < 3.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-  integrity sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=
+  integrity sha512-jRKe/iQYMyVJpzPH+3HL97Lgu5HrCfii+qSo+TfjKHtOnvbnvdVfMYrn9Q34YV81M2e5sviJlI6Ko9y+nByzvA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr removes the misleading offline message on the sign-in page. it also updates the dependency url for `jsPDF` to its new location on Github.


### Manual verification steps performed
See #3226 for steps

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
#### Before
![Screenshot from 2021-07-07 15-48-39](https://user-images.githubusercontent.com/819838/124839819-662b1d00-df3e-11eb-84fe-04cd663bf200.png)

#### After
<img width="1109" alt="Screenshot 2022-11-29 at 22 05 35" src="https://user-images.githubusercontent.com/5203639/204629357-fa25d200-57fa-4b4d-bc54-7e60cb3f460d.png">

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Go to `/en/accounts/#/` unauthenticated
2. Open Chrome's Dev Tools and the Network tab or Click the Toggle device toolbar
3. Change network throttling to "Offline"
4. The misleading offline message should not be displayed on the sign-in.(See before and after screenshots)


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Closes #3226 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [x] Automated test coverage is satisfactory
- [x] PR is fully functional
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [x] External dependency files were updated if necessary (`yarn` and `pip`)
- [x] Documentation is updated
- [x] Contributor is in AUTHORS.md
