### PR TITLE
Add task helpers and stop enqueuing storage calculation tasks for admins

### DIFF
--- a/contentcuration/contentcuration/decorators.py
+++ b/contentcuration/contentcuration/decorators.py
@@ -76,6 +76,10 @@ class DelayUserStorageCalculation(ContextDecorator):
     def is_active(self):
         return self.depth > 0
 
+    def add(self, user_id):
+        if user_id not in self.queue:
+            self.queue.append(user_id)
+
     def __enter__(self):
         self.depth += 1
 

--- a/contentcuration/contentcuration/management/commands/reconcile_change_tasks.py
+++ b/contentcuration/contentcuration/management/commands/reconcile_change_tasks.py
@@ -1,0 +1,48 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from contentcuration.celery import app
+from contentcuration.models import Change
+from contentcuration.models import User
+
+logging.basicConfig()
+logger = logging.getLogger('command')
+
+
+class Command(BaseCommand):
+    """
+    Reconciles that unready tasks are marked as reserved or active according to celery control
+    """
+
+    def handle(self, *args, **options):
+        from contentcuration.tasks import apply_channel_changes_task
+        from contentcuration.tasks import apply_user_changes_task
+
+        active_task_ids = []
+        for worker_name, tasks in app.control.inspect().active().items():
+            active_task_ids.extend(task['id'] for task in tasks)
+        for worker_name, tasks in app.control.inspect().reserved().items():
+            active_task_ids.extend(task['id'] for task in tasks)
+
+        channel_changes = Change.objects.filter(channel_id__isnull=False, applied=False, errored=False) \
+            .order_by('channel_id', 'created_by_id') \
+            .values('channel_id', 'created_by_id') \
+            .distinct()
+        for channel_change in channel_changes:
+            apply_channel_changes_task.revoke(exclude_task_ids=active_task_ids, channel_id=channel_change['channel_id'])
+            apply_channel_changes_task.fetch_or_enqueue(
+                User.objects.get(pk=channel_change['created_by_id']),
+                channel_id=channel_change['channel_id']
+            )
+
+        user_changes = Change.objects.filter(channel_id__isnull=True, user_id__isnull=False, applied=False, errored=False) \
+            .order_by('user_id', 'created_by_id') \
+            .values('user_id', 'created_by_id') \
+            .distinct()
+        for user_change in user_changes:
+            apply_user_changes_task.revoke(exclude_task_ids=active_task_ids, user_id=user_change['user_id'])
+            apply_user_changes_task.fetch_or_enqueue(
+                User.objects.get(pk=user_change['created_by_id']),
+                user_id=user_change['user_id']
+            )

--- a/contentcuration/contentcuration/tests/helpers.py
+++ b/contentcuration/contentcuration/tests/helpers.py
@@ -2,6 +2,7 @@ from builtins import str
 from importlib import import_module
 
 import mock
+from celery import states
 
 from contentcuration.models import TaskResult
 
@@ -20,6 +21,7 @@ def clear_tasks(except_task_id=None):
         qs = qs.exclude(task_id=except_task_id)
     for task_id in qs.values_list("task_id", flat=True):
         app.control.revoke(task_id, terminate=True)
+    qs.update(status=states.REVOKED)
 
 
 def mock_class_instance(target):

--- a/contentcuration/contentcuration/tests/test_decorators.py
+++ b/contentcuration/contentcuration/tests/test_decorators.py
@@ -2,17 +2,22 @@ import mock
 
 from contentcuration.decorators import delay_user_storage_calculation
 from contentcuration.tests.base import StudioTestCase
+from contentcuration.tests.base import testdata
 from contentcuration.utils.user import calculate_user_storage
 
 
 class DecoratorsTestCase(StudioTestCase):
+    def setUp(self):
+        super(DecoratorsTestCase, self).setUp()
+        self.user = testdata.user()
+
     @mock.patch("contentcuration.utils.user.calculate_user_storage_task")
     def test_delay_storage_calculation(self, mock_task):
         @delay_user_storage_calculation
         def do_test():
-            calculate_user_storage(self.admin_user.id)
-            calculate_user_storage(self.admin_user.id)
+            calculate_user_storage(self.user.id)
+            calculate_user_storage(self.user.id)
             mock_task.fetch_or_enqueue.assert_not_called()
 
         do_test()
-        mock_task.fetch_or_enqueue.assert_called_once_with(self.admin_user, user_id=self.admin_user.id)
+        mock_task.fetch_or_enqueue.assert_called_once_with(self.user, user_id=self.user.id)

--- a/contentcuration/contentcuration/utils/celery/app.py
+++ b/contentcuration/contentcuration/utils/celery/app.py
@@ -54,37 +54,6 @@ class CeleryApp(Celery):
             count = conn.default_channel.client.llen(queue_name)
         return count
 
-    def _revoke_matching(self, tasks, task_name, matching_kwargs=None):
-        count = 0
-        for task in tasks:
-            if task['name'] == task_name and (matching_kwargs is None or task['kwargs'] == matching_kwargs):
-                print('Revoking task {}'.format(task))
-                count += 1
-                self.control.revoke(task['id'], terminate=True)
-        return count
-
-    def revoke_reserved_tasks_by_name(self, task_name, matching_kwargs=None):
-        """
-        :param task_name: The string name of the task
-        :param matching_kwargs: A dict of kwargs to match to the task
-        :return: The count of revoked tasks
-        """
-        count = 0
-        for worker_name, tasks in self.control.inspect().reserved().items():
-            count += self._revoke_matching(tasks, task_name, matching_kwargs)
-        return count
-
-    def terminate_active_tasks_by_name(self, task_name, matching_kwargs=None):
-        """
-        :param task_name: The string name of the task
-        :param matching_kwargs: A dict of kwargs to match to the task
-        :return: The count of terminated tasks
-        """
-        count = 0
-        for worker_name, tasks in self.control.inspect().active().items():
-            count += self._revoke_matching(tasks, task_name, matching_kwargs)
-        return count
-
     def decode_result(self, result, status=None):
         """
         Decodes the celery result, like the raw result from the database, using celery tools

--- a/contentcuration/contentcuration/utils/celery/app.py
+++ b/contentcuration/contentcuration/utils/celery/app.py
@@ -45,6 +45,46 @@ class CeleryApp(Celery):
 
         return decoded_tasks
 
+    def count_queued_tasks(self, queue_name="celery"):
+        """
+        :param queue_name: The queue name, defaults to the default "celery" queue
+        :return: int
+        """
+        with self.pool.acquire(block=True) as conn:
+            count = conn.default_channel.client.llen(queue_name)
+        return count
+
+    def _revoke_matching(self, tasks, task_name, matching_kwargs=None):
+        count = 0
+        for task in tasks:
+            if task['name'] == task_name and (matching_kwargs is None or task['kwargs'] == matching_kwargs):
+                print('Revoking task {}'.format(task))
+                count += 1
+                self.control.revoke(task['id'], terminate=True)
+        return count
+
+    def revoke_reserved_tasks_by_name(self, task_name, matching_kwargs=None):
+        """
+        :param task_name: The string name of the task
+        :param matching_kwargs: A dict of kwargs to match to the task
+        :return: The count of revoked tasks
+        """
+        count = 0
+        for worker_name, tasks in self.control.inspect().reserved().items():
+            count += self._revoke_matching(tasks, task_name, matching_kwargs)
+        return count
+
+    def terminate_active_tasks_by_name(self, task_name, matching_kwargs=None):
+        """
+        :param task_name: The string name of the task
+        :param matching_kwargs: A dict of kwargs to match to the task
+        :return: The count of terminated tasks
+        """
+        count = 0
+        for worker_name, tasks in self.control.inspect().active().items():
+            count += self._revoke_matching(tasks, task_name, matching_kwargs)
+        return count
+
     def decode_result(self, result, status=None):
         """
         Decodes the celery result, like the raw result from the database, using celery tools

--- a/contentcuration/contentcuration/utils/user.py
+++ b/contentcuration/contentcuration/utils/user.py
@@ -9,7 +9,7 @@ def calculate_user_storage(user_id):
     from contentcuration.decorators import delay_user_storage_calculation
 
     if delay_user_storage_calculation.is_active:
-        delay_user_storage_calculation.queue.append(user_id)
+        delay_user_storage_calculation.add(user_id)
         return
 
     try:

--- a/contentcuration/contentcuration/utils/user.py
+++ b/contentcuration/contentcuration/utils/user.py
@@ -16,6 +16,7 @@ def calculate_user_storage(user_id):
         if user_id is None:
             raise User.DoesNotExist
         user = User.objects.get(pk=user_id)
-        calculate_user_storage_task.fetch_or_enqueue(user, user_id=user_id)
+        if not user.is_admin:
+            calculate_user_storage_task.fetch_or_enqueue(user, user_id=user_id)
     except User.DoesNotExist:
         logging.error("Tried to calculate user storage for user with id {} but they do not exist".format(user_id))

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -37,6 +37,7 @@ from contentcuration import ricecooker_versions as rc
 from contentcuration.api import activate_channel
 from contentcuration.api import write_file_to_storage
 from contentcuration.constants import completion_criteria
+from contentcuration.decorators import delay_user_storage_calculation
 from contentcuration.models import AssessmentItem
 from contentcuration.models import Change
 from contentcuration.models import Channel
@@ -54,7 +55,6 @@ from contentcuration.utils.nodes import map_files_to_assessment_item
 from contentcuration.utils.nodes import map_files_to_node
 from contentcuration.utils.nodes import map_files_to_slideshow_slide_item
 from contentcuration.utils.sentry import report_exception
-from contentcuration.utils.tracing import trace
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.utils import generate_publish_event
 from contentcuration.viewsets.sync.utils import generate_update_event
@@ -565,7 +565,7 @@ class IncompleteNodeError(Exception):
         super(IncompleteNodeError, self).__init__(self.message)
 
 
-@trace
+@delay_user_storage_calculation
 def convert_data_to_nodes(user, content_data, parent_node):
     """ Parse dict and create nodes accordingly """
     try:


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Adds method to `CeleryTask` class that help manage tasks in production using the celery control interface, and ensure task result is marked accordingly
- Prevents storage calculation tasks from being enqueued for admins
- Adds delay of storage calculation to cheffing API endpoint which handles bulk node creation
- Adds management command that reconciles queued and active tasks with what's in the DB and any unapplied changes

### Manual verification steps performed
- Ran tests
- Ran management command
- Ran server and made a change to channel

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [X] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
