### PR TITLE
Added bullet points between languages on sign-in page

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
@@ -129,6 +129,7 @@
     text-align: left;
   }
 
+  // this selector applies to the elements defined in KButtonGroup
   .dots :not(:first-child, :last-child)::after {
     display: inline-block;
     margin: 0 6px;

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherList.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <KButtonGroup style="margin-top: 8px;">
+    <KButtonGroup style="margin-top: 8px;" class="dots">
       <KIconButton
         icon="language"
         aria-hidden="true"
@@ -10,7 +10,7 @@
         @click="showLanguageModal = true"
       />
       <span
-        class="dotsSpan selected"
+        class="selected"
         :style="{ 'margin': '0' }"
         :title="selectedLanguage.english_name"
       >
@@ -22,7 +22,6 @@
         :text="language.lang_name"
         :title="language.english_name"
         class="lang"
-        :class="determineLangDirection(language.lang_direction)"
         appearance="basic-link"
         :style="{ 'margin': '0 2px' }"
         @click="switchLanguage(language.id)"
@@ -101,11 +100,6 @@
           .slice(0, this.numVisibleLanguages);
       },
     },
-    methods: {
-      determineLangDirection(direction) {
-        return (!this.$isRTL && direction) || (this.$isRTL && !direction) ? 'dotsRtl' : 'dots';
-      },
-    },
     $trs: {
       showMoreLanguagesSelector: 'More languages',
     },
@@ -135,30 +129,9 @@
     text-align: left;
   }
 
-  .dots:not(:last-child)::after {
-    // because it is a pseudo-element, text-decoration none only works with 'display: inline-block`
-    display: inline-block;
-    margin: 0 8px;
-    font-size: 14pt;
-    color: var(--v-grey-base);
-    text-decoration: none;
-    vertical-align: middle;
-    content: '•';
-  }
-
-  .dotsSpan::after {
+  .dots :not(:first-child, :last-child)::after {
     display: inline-block;
     margin: 0 6px;
-    font-size: 14pt;
-    color: var(--v-grey-base);
-    text-decoration: none;
-    vertical-align: middle;
-    content: '•';
-  }
-
-  .dotsRtl:not(:last-child)::before {
-    display: inline-block;
-    margin: 0 8px;
     font-size: 14pt;
     color: var(--v-grey-base);
     text-decoration: none;


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the language bar on the sign-in page so that the bullet points are correctly displayed.

### Manual verification steps performed
See #3384 

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Before
<img width="562" alt="Before-en" src="https://user-images.githubusercontent.com/46411498/205091931-c68d5479-4556-48af-98b5-a86776e08ebe.png">
<img width="482" alt="Before-ar" src="https://user-images.githubusercontent.com/46411498/205091948-0d01e201-96b6-4c67-8841-10a1a43a4746.png">


After
<img width="510" alt="After-en" src="https://user-images.githubusercontent.com/46411498/205089389-7bd22165-1acb-43ad-bbf7-730a8ac8ef22.png">
<img width="504" alt="After-ar" src="https://user-images.githubusercontent.com/46411498/205089407-401532eb-b2b2-4c59-8183-e704fee4911e.png">
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Go to `/en/accounts/#/` and observe the language section. The bullet points should be displayed between the languages correctly.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Closes #3384 
## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
