### PR TITLE
Fixes `sync_channel` assessment item bug

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/base.py
+++ b/contentcuration/contentcuration/tests/viewsets/base.py
@@ -5,6 +5,9 @@ from django.urls import reverse
 from contentcuration.celery import app
 from contentcuration.models import Change
 from contentcuration.tests.helpers import clear_tasks
+from contentcuration.viewsets.sync.constants import CHANNEL
+from contentcuration.viewsets.sync.constants import SYNCED
+from contentcuration.viewsets.sync.utils import _generate_event as base_generate_event
 from contentcuration.viewsets.sync.utils import generate_copy_event as base_generate_copy_event
 from contentcuration.viewsets.sync.utils import generate_create_event as base_generate_create_event
 from contentcuration.viewsets.sync.utils import generate_delete_event as base_generate_delete_event
@@ -32,6 +35,16 @@ def generate_delete_event(*args, **kwargs):
 def generate_update_event(*args, **kwargs):
     event = base_generate_update_event(*args, **kwargs)
     event["rev"] = random.randint(1, 10000000)
+    return event
+
+
+def generate_sync_channel_event(channel_id, attributes, tags, files, assessment_items):
+    event = base_generate_event(key=channel_id, table=CHANNEL, event_type=SYNCED, channel_id=channel_id, user_id=None)
+    event["rev"] = random.randint(1, 10000000)
+    event["attributes"] = attributes
+    event["tags"] = tags
+    event["files"] = files
+    event["assessment_items"] = assessment_items
     return event
 
 

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -559,7 +559,7 @@ class ChannelViewSet(ValuesViewset):
                 attributes,
                 tags,
                 files,
-                tags,
+                assessment_items,
                 progress_tracker=progress_tracker,
             )
 


### PR DESCRIPTION
## Summary

This fixes a bug where `tags` argument was mistakenly passed instead of `assessment_items` in the sync channel endpoint controller.

### Manual verification steps performed
Ran unit test, reverting the changes fails the written unit test.

## References
References https://github.com/learningequality/studio/issues/3112. 

Quoting from https://github.com/learningequality/studio/issues/3112:

> Testing on hotfixes made me realize that https://github.com/learningequality/studio/pull/3803 fixes the backend part of it. But still in the frontend, the sync_channel updates are not getting reflected.
> 
> Only upon clearing index DB, I could see the results of sync_channel backend updates.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
