### PR TITLE
Fix markdown conversion for assessments

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/MarkdownEditor/MarkdownEditor.vue
@@ -233,8 +233,8 @@
         // https://github.com/nhn/tui.editor/blob/master/apps/editor/docs/custom-html-renderer.md
         customHTMLRenderer: {
           text(node) {
-            let content = formulaMdToHtml(node.literal);
-            content = imagesMdToHtml(content);
+            let content = formulaMdToHtml(node.literal, true);
+            content = imagesMdToHtml(content, true);
             return {
               type: 'html',
               content,

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/__tests__/utils.spec.js
@@ -1,4 +1,9 @@
-import { clearNodeFormat } from '../MarkdownEditor/utils';
+/**
+ * @jest-environment jest-environment-jsdom-sixteen
+ */
+// Jsdom@^16 is required to test toast UI, as it relies on the Range API.
+
+import { clearNodeFormat, generateCustomConverter } from '../MarkdownEditor/utils';
 
 const htmlStringToFragment = htmlString => {
   const template = document.createElement('template');
@@ -53,6 +58,20 @@ describe('clearNodeFormat', () => {
 
     expect(fragmentToHtmlString(clearedFragment)).toBe(
       'What co<i class="keep">lo</i>r is th<i class="keep">e sky</i>'
+    );
+  });
+});
+
+describe('markdown conversion', () => {
+  it('converts image tags to markdown without escaping them', () => {
+    const el = document.createElement('div');
+    const CustomConvertor = generateCustomConverter(el);
+    const converter = new CustomConvertor();
+    const html =
+      '<span is="markdown-image-field" vce-ready="" contenteditable="false" class="markdown-field-753aa86a-8159-403b-8b1c-d2b8f9504408 markdown-field-34843d46-79b8-40b4-866c-b83dc8916a47" editing="true" markdown="![](${☣ CONTENTSTORAGE}/bc1c5a86e1e46f20a6b4ee2c1bb6d6ff.png =485.453125x394)">![](${☣ CONTENTSTORAGE}/bc1c5a86e1e46f20a6b4ee2c1bb6d6ff.png =485.453125x394)</span>';
+
+    expect(converter.toMarkdown(html)).toBe(
+      '![](${☣ CONTENTSTORAGE}/bc1c5a86e1e46f20a6b4ee2c1bb6d6ff.png =485.453125x394)'
     );
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-md-to-html.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/formulas/formula-md-to-html.js
@@ -12,6 +12,10 @@
  *
  */
 
-export default markdown => {
-  return markdown.replace(/\$\$(.*?)\$\$/g, '<span is="markdown-formula-field">$1</span>');
+export default (markdown, editing) => {
+  const editAttr = editing ? ' editing="true"' : '';
+  return markdown.replace(
+    /\$\$(.*?)\$\$/g,
+    `<span is="markdown-formula-field"${editAttr}>$1</span>`
+  );
 };

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/image-md-to-html.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/image-md-to-html.js
@@ -14,6 +14,6 @@ import { IMAGE_REGEX, imageMdToImageFieldHTML } from './index';
 
 // convert markdown images to image editor field custom elements
 
-export default markdown => {
-  return markdown.replace(IMAGE_REGEX, imageMd => imageMdToImageFieldHTML(imageMd));
+export default (markdown, editing) => {
+  return markdown.replace(IMAGE_REGEX, imageMd => imageMdToImageFieldHTML(imageMd, editing));
 };

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/image-upload/index.js
@@ -30,8 +30,10 @@ export const paramsToImageMd = ({ src, alt, width, height }) => {
   }
 };
 
-export const imageMdToImageFieldHTML = imageMd =>
-  `<span is='markdown-image-field'>${imageMd}</span>`;
+export const imageMdToImageFieldHTML = (imageMd, editing) => {
+  const editAttr = editing ? ' editing="true"' : '';
+  return `<span is='markdown-image-field'${editAttr}>${imageMd}</span>`;
+};
 export const paramsToImageFieldHTML = params => imageMdToImageFieldHTML(paramsToImageMd(params));
 
 export default imageUploadExtension;

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/registerCustomMarkdownField.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/registerCustomMarkdownField.js
@@ -107,8 +107,6 @@ export default VueComponent => {
         }
       });
 
-      this.editing = true;
-
       if (!hasLeftwardSpace(this)) {
         this.insertAdjacentText('beforebegin', '\xa0');
       }

--- a/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/registerCustomMarkdownField.js
+++ b/contentcuration/contentcuration/frontend/shared/views/MarkdownEditor/plugins/registerCustomMarkdownField.js
@@ -102,7 +102,9 @@ export default VueComponent => {
             ''
           );
         }
-        this.parentNode.removeChild(this);
+        if (this.parentNode) {
+          this.parentNode.removeChild(this);
+        }
       });
 
       this.editing = true;


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Removes unnecessary reordering of HTML to MD conversion that was causing MD to be unnecessarily escaped
* Adds regression test
* Removes regression caused by applying 'editing' to all custom components
* Sets 'editing' attribute only in the MarkdownEditor component

### Manual verification steps performed
1. Add an image to a question
2. Publish the channel
3. Confirm the image is in the exercise (on a local machine can search your `.minio_data` folder for the `perseus` file and confirm that the archive contains the image


1. Confirm that the Image context menu only appears when the markdown is being displayed in edit mode.
2. Confirm that it does not appear when the markdown is displayed in view only.
