### PR TITLE
fix keyboard navigation order to be shown while pressing the tab keys

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -145,6 +145,7 @@
 
   .add-channel-button {
     margin: 0;
+    outline-offset: -2px !important;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -29,6 +29,7 @@
           v-for="listType in lists"
           :key="listType.id"
           :to="getChannelLink(listType)"
+          style="padding:5px;"
           @click="trackTabClick(listType)"
         >
           <VBadge :value="invitationsByListCounts[listType]" color="secondary">
@@ -38,10 +39,10 @@
             <span>{{ translateConstant(listType) }}</span>
           </VBadge>
         </VTab>
-        <VTab :to="catalogLink" @click="publicTabClick">
+        <VTab :to="catalogLink" style="padding:5px;" @click="publicTabClick">
           {{ $tr("catalog") }}
         </VTab>
-        <VTab :to="channelSetLink" @click="channelSetsTabClick">
+        <VTab :to="channelSetLink" style="padding:5px;" @click="channelSetsTabClick">
           {{ $tr("channelSets") }}
         </VTab>
       </template>


### PR DESCRIPTION


## Summary
This PR fixes the hidden focus of navigating when using the tab key.
closes #3786

### Screenshots (if applicable)


https://user-images.githubusercontent.com/103313919/206244289-d128295c-9441-4cee-8530-9c883512d5df.mp4


## Reviewer guidance
### How can a reviewer test these changes?
1. Step 1 - Navigate the menu using the tab key

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
