### PR TITLE
Optimized tsvectors insertion 🚀

### DIFF
--- a/contentcuration/search/management/commands/set_contentnode_tsvectors.py
+++ b/contentcuration/search/management/commands/set_contentnode_tsvectors.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                                               contentnode_tags=StringAgg("tags__tag_name", delimiter=" "),
                                               keywords_tsvector=CONTENTNODE_KEYWORDS_TSVECTOR,
                                               author_tsvector=CONTENTNODE_AUTHOR_TSVECTOR)
-                                    .filter(tsvector_not_already_inserted_query, tree_id=published_channel["main_tree__tree_id"])
+                                    .filter(tsvector_not_already_inserted_query, tree_id=published_channel["main_tree__tree_id"], published=True, complete=True)
                                     .values("id", "channel_id", "keywords_tsvector", "author_tsvector")
                                     .order_by())
 

--- a/contentcuration/search/management/commands/set_contentnode_tsvectors.py
+++ b/contentcuration/search/management/commands/set_contentnode_tsvectors.py
@@ -8,15 +8,17 @@ from django.contrib.postgres.aggregates import StringAgg
 from django.core.management.base import BaseCommand
 from django.db.models import Exists
 from django.db.models import OuterRef
+from django.db.models import Value
 from search.constants import CONTENTNODE_AUTHOR_TSVECTOR
 from search.constants import CONTENTNODE_KEYWORDS_TSVECTOR
 from search.models import ContentNodeFullTextSearch
 
+from contentcuration.models import Channel
 from contentcuration.models import ContentNode
 
 
 logmodule.basicConfig(level=logmodule.INFO)
-logging = logmodule.getLogger("command")
+logging = logmodule.getLogger(__name__)
 
 CHUNKSIZE = 10000
 
@@ -26,34 +28,40 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         start = time.time()
 
-        tsvector_not_already_inserted_query = ~Exists(ContentNodeFullTextSearch.objects.filter(contentnode_id=OuterRef("id")))
+        all_published_channels = list(Channel.objects.filter(main_tree__published=True, deleted=False).values("id", "main_tree__tree_id"))
 
-        tsvector_node_query = (ContentNode._annotate_channel_id(ContentNode.objects)
-                               .annotate(contentnode_tags=StringAgg("tags__tag_name", delimiter=" "),
-                                         keywords_tsvector=CONTENTNODE_KEYWORDS_TSVECTOR,
-                                         author_tsvector=CONTENTNODE_AUTHOR_TSVECTOR)
-                               .filter(tsvector_not_already_inserted_query, published=True, channel_id__isnull=False)
-                               .values("id", "channel_id", "keywords_tsvector", "author_tsvector").order_by())
-
-        insertable_nodes_tsvector = list(tsvector_node_query[:CHUNKSIZE])
         total_tsvectors_inserted = 0
 
-        while insertable_nodes_tsvector:
-            logging.info("Inserting contentnode tsvectors.")
+        for published_channel in all_published_channels:
+            tsvector_not_already_inserted_query = ~Exists(ContentNodeFullTextSearch.objects.filter(contentnode_id=OuterRef("id")))
+            tsvector_nodes_query = (ContentNode.objects
+                                    .annotate(channel_id=Value(published_channel["id"]),
+                                              contentnode_tags=StringAgg("tags__tag_name", delimiter=" "),
+                                              keywords_tsvector=CONTENTNODE_KEYWORDS_TSVECTOR,
+                                              author_tsvector=CONTENTNODE_AUTHOR_TSVECTOR)
+                                    .filter(tsvector_not_already_inserted_query, tree_id=published_channel["main_tree__tree_id"])
+                                    .values("id", "channel_id", "keywords_tsvector", "author_tsvector")
+                                    .order_by())
 
-            insert_objs = list()
-            for node in insertable_nodes_tsvector:
-                obj = ContentNodeFullTextSearch(contentnode_id=node["id"], channel_id=node["channel_id"],
-                                                keywords_tsvector=node["keywords_tsvector"], author_tsvector=node["author_tsvector"])
-                insert_objs.append(obj)
+            insertable_nodes_tsvector = list(tsvector_nodes_query[:CHUNKSIZE])
+            logging.info("Inserting contentnode tsvectors of channel {}.".format(published_channel["id"]))
 
-            inserted_objs_list = ContentNodeFullTextSearch.objects.bulk_create(insert_objs)
+            while insertable_nodes_tsvector:
+                insert_objs = list()
+                for node in insertable_nodes_tsvector:
+                    obj = ContentNodeFullTextSearch(contentnode_id=node["id"], channel_id=node["channel_id"],
+                                                    keywords_tsvector=node["keywords_tsvector"], author_tsvector=node["author_tsvector"])
+                    insert_objs.append(obj)
 
-            current_inserts_count = len(inserted_objs_list)
-            total_tsvectors_inserted = total_tsvectors_inserted + current_inserts_count
+                inserted_objs_list = ContentNodeFullTextSearch.objects.bulk_create(insert_objs)
 
-            logging.info("Inserted {} contentnode tsvectors.".format(current_inserts_count))
+                current_inserts_count = len(inserted_objs_list)
+                total_tsvectors_inserted = total_tsvectors_inserted + current_inserts_count
 
-            insertable_nodes_tsvector = list(tsvector_node_query[:CHUNKSIZE])
+                logging.info("Inserted {} contentnode tsvectors of channel {}.".format(current_inserts_count, published_channel["id"]))
+
+                insertable_nodes_tsvector = list(tsvector_nodes_query[:CHUNKSIZE])
+
+            logging.info("Insertion complete for channel {}.".format(published_channel["id"]))
 
         logging.info("Completed! Successfully inserted total of {} contentnode tsvectors in {} seconds.".format(total_tsvectors_inserted, time.time() - start))


### PR DESCRIPTION
## Summary

Me and @bjester recently co-hacked on slow performance of `make set-tsvectors` command on hotfixes. Blaine sir came up with a CTE that reduced the execution time exponentially! We analyzed the CTE and realized that the only concern we had was that the `published` boolean field being non-indexed can dramatically slow down our query. Even indexing `published` shouldn't make any difference because database will need to traverse the half of the leaf nodes any way.

So, this PR optimizes the performance of `make set-tsvectors` by first bringing in all the published `channel_id`s and `tree_id`s to python memory. Then our query utilizes these values to query for tsvectors. `tree_id` being indexed seems a good choice for querying.

Our optimization should bring the estimated completion time of `make set-tsvectors` from 8 months to 8 hours.

Query plan: https://explain.depesz.com/s/jl2m#html


### Manual verification steps performed
1. Create a channel with some nodes, publish the channel and run the command. Does tsvectors get created for all channel nodes? Run the command once again. Now, it should not create any tsvectors because all tsvectors are already created.
2. Add some more nodes to an existing published channel, re-publish it, run the command. Does tsvectors get created for those newly created nodes?
___
## Reviewer guidance
### How can a reviewer test these changes?
Performing manual verification steps and checking on query plan.


## References
Closes #3846.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [x] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md