### PR TITLE
Consolidate agreement opt-ins during account creation

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -133,13 +133,12 @@
 
         <!-- Terms of service -->
         <Checkbox
-          v-model="form.accepted_tos"
+          v-model="acceptedAgreement"
           :label="$tr('agreement')"
           required
           :rules="tosRules"
           :hide-details="false"
           class="my-1 policy-checkbox"
-          @input="updateAcceptedAgreement"
         />
         <div class="span-spacing">
           <span>
@@ -420,10 +419,6 @@
       showOtherField(id) {
         return id === uses.OTHER && this.form.uses.includes(id);
       },
-      updateAcceptedAgreement() {
-        this.acceptedAgreement = this.form.accepted_tos && this.form.accepted_policy;
-      },
-
       submit() {
         if (this.$refs.form.validate()) {
           let cleanedData = this.clean(this.form);

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -15,7 +15,7 @@
     <h2 ref="top" class="mb-4 primary--text text-xs-center">
       {{ $tr('createAnAccountTitle') }}
     </h2>
-    <VLayout justify-center class="px-4">
+    <VLayout justify-center class="px-3">
       <VForm ref="form" v-model="valid" lazy-validation @submit.prevent="submit">
         <Banner :value="!valid" error class="mb-4">
           {{ registrationFailed ? $tr('registrationFailed') : $tr('errorsMessage') }}
@@ -159,16 +159,15 @@
         </div>
 
         <div class="mt-2 span-spacing">
-          <span>
+          <div class="align-items">
             {{ $tr('contactMessage') }}
-          </span>
-          <span>
+
             <ActionLink
-              class="btn-space-mobile-2"
+              class="span-spacing-email"
               :text="$tr('mailtolink')"
               :href="`mailto:${email}`"
             />
-          </span>
+          </div>
         </div>
 
         <VBtn color="primary" large :disabled="offline" type="submit" class="mt-5">
@@ -545,9 +544,13 @@
     font-size: 16px;
   }
 
-  .btn-space-mobile-2 {
-    position: absolute;
+  .span-spacing-email {
+    margin-left: 3px;
     font-size: 16px;
+  }
+
+  .align-items {
+    display: block;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -131,12 +131,12 @@
           />
         </VSlideYTransition>
 
-        <!-- Terms of service -->
+        <!-- Agreements -->
         <Checkbox
           v-model="acceptedAgreement"
           :label="$tr('agreement')"
           required
-          :rules="tosRules"
+          :rules="tosAndPolicyRules"
           :hide-details="false"
           class="my-1 policy-checkbox"
         />
@@ -237,7 +237,7 @@
       passwordConfirmRules() {
         return [value => (this.form.password1 === value ? true : this.$tr('passwordMatchMessage'))];
       },
-      tosRules() {
+      tosAndPolicyRules() {
         return [value => (value ? true : this.$tr('ToSRequiredMessage'))];
       },
       acceptedAgreement: {
@@ -498,7 +498,7 @@
 
       // Privacy policy + terms of service
       viewToSLink: 'View Terms of Service',
-      ToSRequiredMessage: 'Please accept our terms of service',
+      ToSRequiredMessage: 'Please accept our terms of service and policy',
 
       viewPrivacyPolicyLink: 'View Privacy Policy',
       contactMessage: 'Questions or concerns? Please email us at content@learningequality.org',
@@ -522,6 +522,10 @@
     label {
       color: var(--v-grey-darken1) !important;
     }
+  }
+
+  .policy-checkbox /deep/ .v-messages {
+    margin-left: 40px;
   }
 
   iframe {

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -132,39 +132,45 @@
         </VSlideYTransition>
 
         <!-- Terms of service -->
-        <ActionLink
-          class="mt-4"
-          :text="$tr('viewToSLink')"
-          @click="showTermsOfService"
-        />
+
         <Checkbox
           v-model="form.accepted_tos"
-          :label="$tr('ToSCheck')"
+          :label="$tr('agreement')"
           required
           :rules="tosRules"
           :hide-details="false"
           class="my-1 policy-checkbox"
         />
+        <div class="span-spacing">
+          <span>
+            <ActionLink
+              :text="$tr('viewPrivacyPolicyLink')"
+              @click="showPrivacyPolicy"
+            />
 
-        <!-- Policy -->
-        <ActionLink
-          class="mt-2"
-          :text="$tr('viewPrivacyPolicyLink')"
-          @click="showPrivacyPolicy"
-        />
-        <Checkbox
-          v-model="form.accepted_policy"
-          :label="$tr('privacyPolicyCheck')"
-          required
-          :rules="policyRules"
-          :hide-details="false"
-          class="mb-3 mt-1 policy-checkbox"
-        />
+          </span>
+          <span> | </span>
+          <span>
+            <ActionLink
+              :text="$tr('viewToSLink')"
+              @click="showTermsOfService"
+            />
+          </span>
+        </div>
 
-        <p class="mb-4">
-          {{ $tr('contactMessage') }}
-        </p>
-        <VBtn color="primary" large :disabled="offline" type="submit">
+        <div class="mt-2 span-spacing">
+          <span>
+            {{ $tr('contactMessage') }}
+          </span>
+          <span>
+            <ActionLink
+              :text="$tr('contentlink')"
+              @click="showPrivacyPolicy"
+            />
+          </span>
+        </div>
+
+        <VBtn color="primary" large :disabled="offline" type="submit" class="mt-5">
           {{ $tr('finishButton') }}
         </VBtn>
       </VForm>
@@ -241,9 +247,7 @@
       tosRules() {
         return [value => (value ? true : this.$tr('ToSRequiredMessage'))];
       },
-      policyRules() {
-        return [value => (value ? true : this.$tr('privacyPolicyRequiredMessage'))];
-      },
+
       usageOptions() {
         return [
           {
@@ -492,15 +496,14 @@
       otherSourcePlaceholder: 'Please describe',
 
       // Privacy policy + terms of service
-      viewToSLink: 'View terms of service',
-      ToSCheck: 'I have read and agree to the terms of service',
+      viewToSLink: 'View Terms of Service',
       ToSRequiredMessage: 'Please accept our terms of service',
 
-      viewPrivacyPolicyLink: 'View privacy policy',
-      privacyPolicyCheck: 'I have read and agree to the privacy policy',
-      privacyPolicyRequiredMessage: 'Please accept our privacy policy',
-      contactMessage: 'Questions or concerns? Please email us at content@learningequality.org',
+      viewPrivacyPolicyLink: 'View Privacy Policy',
+      contactMessage: 'Questions or concerns? Please email us at ',
       finishButton: 'Finish',
+      contentlink: 'content@learningequality.org',
+      agreement: 'I have read and agree to terms of service and the privacy policy',
     },
   };
 
@@ -527,6 +530,15 @@
     padding: 8px;
     padding-right: 0;
     border: 0;
+  }
+
+  .span-spacing {
+    display: flex;
+    margin-left: 40px;
+  }
+
+  .span-spacing span {
+    margin-left: 5px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -525,6 +525,7 @@
   }
 
   .policy-checkbox /deep/ .v-messages {
+    min-height: 0;
     margin-left: 40px;
   }
 

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -132,7 +132,6 @@
         </VSlideYTransition>
 
         <!-- Terms of service -->
-
         <Checkbox
           v-model="form.accepted_tos"
           :label="$tr('agreement')"
@@ -140,6 +139,7 @@
           :rules="tosRules"
           :hide-details="false"
           class="my-1 policy-checkbox"
+          @input="updateAcceptedAgreement"
         />
         <div class="span-spacing">
           <span>
@@ -240,6 +240,15 @@
       },
       tosRules() {
         return [value => (value ? true : this.$tr('ToSRequiredMessage'))];
+      },
+      acceptedAgreement: {
+        get() {
+          return this.form.accepted_tos && this.form.accepted_policy;
+        },
+        set(accepted) {
+          this.form.accepted_tos = accepted;
+          this.form.accepted_policy = accepted;
+        },
       },
 
       usageOptions() {
@@ -411,6 +420,9 @@
       showOtherField(id) {
         return id === uses.OTHER && this.form.uses.includes(id);
       },
+      updateAcceptedAgreement() {
+        this.acceptedAgreement = this.form.accepted_tos && this.form.accepted_policy;
+      },
 
       submit() {
         if (this.$refs.form.validate()) {
@@ -446,7 +458,6 @@
       registrationFailed: 'There was an error registering your account. Please try again',
       registrationFailedOffline:
         'You seem to be offline. Please connect to the internet to create an account.',
-
       // Basic information strings
       basicInformationHeader: 'Basic information',
       firstNameLabel: 'First name',

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -161,12 +161,6 @@
         <div class="mt-2 span-spacing">
           <div class="align-items">
             {{ $tr('contactMessage') }}
-
-            <ActionLink
-              class="span-spacing-email"
-              :text="$tr('mailtolink')"
-              :href="`mailto:${email}`"
-            />
           </div>
         </div>
 
@@ -217,7 +211,6 @@
         valid: true,
         registrationFailed: false,
         emailErrors: [],
-        email: 'content@learningequality.org',
         form: {
           first_name: '',
           last_name: '',
@@ -502,9 +495,8 @@
       ToSRequiredMessage: 'Please accept our terms of service',
 
       viewPrivacyPolicyLink: 'View Privacy Policy',
-      contactMessage: 'Questions or concerns? Please email us at ',
+      contactMessage: 'Questions or concerns? Please email us at content@learningequality.org',
       finishButton: 'Finish',
-      mailtolink: 'content@learningequality.org',
       agreement: 'I have read and agree to terms of service and the privacy policy',
     },
   };

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -164,8 +164,9 @@
           </span>
           <span>
             <ActionLink
-              :text="$tr('contentlink')"
-              @click="showPrivacyPolicy"
+              class="btn-space-mobile-2"
+              :text="$tr('mailtolink')"
+              :href="`mailto:${email}`"
             />
           </span>
         </div>
@@ -217,6 +218,7 @@
         valid: true,
         registrationFailed: false,
         emailErrors: [],
+        email: 'content@learningequality.org',
         form: {
           first_name: '',
           last_name: '',
@@ -443,6 +445,7 @@
         return Promise.resolve();
       },
     },
+
     $trs: {
       backToLoginButton: 'Sign in',
       createAnAccountTitle: 'Create an account',
@@ -502,7 +505,7 @@
       viewPrivacyPolicyLink: 'View Privacy Policy',
       contactMessage: 'Questions or concerns? Please email us at ',
       finishButton: 'Finish',
-      contentlink: 'content@learningequality.org',
+      mailtolink: 'content@learningequality.org',
       agreement: 'I have read and agree to terms of service and the privacy policy',
     },
   };
@@ -538,7 +541,13 @@
   }
 
   .span-spacing span {
-    margin-left: 5px;
+    margin-left: 2px;
+    font-size: 16px;
+  }
+
+  .btn-space-mobile-2 {
+    position: absolute;
+    font-size: 16px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/create.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/create.spec.js
@@ -62,7 +62,6 @@ function makeWrapper(formData) {
   });
   return wrapper;
 }
-
 function makeFailedPromise(statusCode) {
   return () => {
     return new Promise((resolve, reject) => {

--- a/contentcuration/contentcuration/frontend/shared/layouts/ImmersiveModalLayout.vue
+++ b/contentcuration/contentcuration/frontend/shared/layouts/ImmersiveModalLayout.vue
@@ -70,7 +70,7 @@
   }
 
   .content-wrapper {
-    margin: 32px;
+    margin: 28px;
   }
 
   .content {


### PR DESCRIPTION

## Summary
This PR aims to consolidate the sign-up experience for users in Studio. Currently, a first-time user has to agree to two mandatory opt-ins at sign-up  Terms of Service and privacy policy these processes are separated and require users to complete multiple steps to fully sign up. Consolidating these processes into a single, cohesive flow will make it as simple and straightforward as possible for users to opt-in or sign up in Studio.
closes #3834

### Manual verification steps performed
1. Navigate to sign in page > create account


### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

Before
<img width="1424" alt="Screenshot 2022-12-30 at 17 10 42" src="https://user-images.githubusercontent.com/103313919/210080236-d85b0fba-05fc-43e2-84bf-568e801fc6b9.png">
After:
<img width="794" alt="Screenshot 2022-12-30 at 17 09 36" src="https://user-images.githubusercontent.com/103313919/210080307-5af2a9ba-bed3-4198-b6d0-a4dff9cca8b7.png">


### figma
https://www.figma.com/file/1tQQ0Sw1yDjzO66hyjLVPM?node-id=556:4666#323944643


### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
