### PR TITLE
Validates JSON fields for AssessmentItem

### DIFF
--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -44,16 +44,14 @@ def get_filenames_from_assessment(assessment_item):
     # Get unique checksums in the assessment item text fields markdown
     # Coerce to a string, for Python 2, as the stored data is in unicode, and otherwise
     # the unicode char in the placeholder will not match
-    print("DEBUGGING AI")
-    print(assessment_item.question)
-    print(assessment_item.answers)
-    print("hints" + assessment_item.hints)
+    answers = json.loads(assessment_item.answers)
+    hints = json.loads(assessment_item.hints)
     return set(
         exercise_image_filename_regex.findall(
             str(
                 assessment_item.question
-                + assessment_item.answers
-                + assessment_item.hints
+                + str([a["answer"] for a in answers])
+                + str([h["hint"] for h in hints])
             )
         )
     )
@@ -108,23 +106,21 @@ class AssessmentItemSerializer(BulkModelSerializer):
 
     def validate_answers(self, value):
         answers = json.loads(value)
-        if answers is not []:
-            for answer in answers:
-                if not type(answer) is dict:
-                    self.fail('JSON Data Invalid for answers')
-
-                if not all(k in answer for k in ('answer', 'correct', 'order')):
-                    self.fail('Incorrect field in answers')
+        for answer in answers:
+            if not type(answer) is dict:
+                raise ValidationError('JSON Data Invalid for answers')
+            if not all(k in answer for k in ('answer', 'correct', 'order')):
+                raise ValidationError('Incorrect field in answers')
+        return value
 
     def validate_hints(self, value):
         hints = json.loads(value)
-        print(hints)
         for hint in hints:
             if not type(hint) is dict:
-                self.fail('JSON Data Invalid for hints')
-
+                raise ValidationError('JSON Data Invalid for hints')
             if not all(k in hint for k in ('hint', 'order')):
-                self.fail('Incorrect field in hints')
+                raise ValidationError('Incorrect field in hints')
+        return value
 
     def set_files(self, all_objects, all_validated_data=None):  # noqa C901
         files_to_delete = []

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -132,8 +132,7 @@ class AssessmentItemSerializer(BulkModelSerializer):
             # If this is an update operation, check the validated data for which items
             # have had these fields modified.
             md_fields_modified = {
-                self.id_value_lookup(ai) for ai in all_validated_data
-                if "question" in ai or "hints" in ai or "answers" in ai
+                self.id_value_lookup(ai) for ai in all_validated_data if "question" in ai or "hints" in ai or "answers" in ai
             }
         else:
             # If this is a create operation, just check if these fields are not null.

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -133,7 +133,8 @@ class AssessmentItemSerializer(BulkModelSerializer):
             # have had these fields modified.
             md_fields_modified = {
                 self.id_value_lookup(ai) for ai in all_validated_data
-                if "question" in ai or "hints" in ai or "answers" in ai}
+                if "question" in ai or "hints" in ai or "answers" in ai
+            }
         else:
             # If this is a create operation, just check if these fields are not null.
             md_fields_modified = {


### PR DESCRIPTION
## Summary
Validates JSON fields for answers and hints in AssessmentItem

### Description of the change(s) you made
1. Added custom fields and validations for hints and answers.
2. Adapted get_filenames_from_assessment according to new validations.
3. Added tests for both fields.


### Manual verification steps performed
1. Ran Pytest
2. Open a channel 
3. Create an assessment with hints and multiple answers.
4. Save them.

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
