### PR TITLE
Remove new relic frontend monitor - disabled browser autorun

### DIFF
--- a/contentcuration/contentcuration/wsgi.py
+++ b/contentcuration/contentcuration/wsgi.py
@@ -13,7 +13,7 @@ from django.core.wsgi import get_wsgi_application
 # Attach newrelic APM
 try:
     import newrelic.agent
-
+    newrelic.agent.disable_browser_autorum()
     newrelic.agent.initialize()
 except ImportError:
     pass


### PR DESCRIPTION
## Summary
Disabled browser monitoring by new relic (addresses #3890)

### Description
Added 
```
    newrelic.agent.disable_browser_autorum()
```
to  contentcuration/contentcuration/wsgi.py

This call disables automatic browser monitoring 

This has been disabled as we're getting an error coming from New Relic , but since we haven't been using it, it'd be no harm to just disable it

### Manual verification steps performed
1. Step 1
2. Step 2
3. ...


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
not known

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
https://docs.newrelic.com/docs/apm/agents/python-agent/supported-features/browser-monitoring-python-agent/#disabling_instrumentation

## Comments
<!-- Additional comments may be added here -->
Targets unstable branch as there were no straightforward ways to test this implementation

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
