### PR TITLE
Add Translated String in MainNavigationDrawer for ChangeLanguage 

### DIFF
--- a/contentcuration/locale/ar/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/ar/LC_MESSAGES/contentcuration-messages.json
@@ -979,6 +979,7 @@
   "Main.privacyPolicyLink": "سياسة الخصوصية",
   "Main.signInButton": "تسجل الدخول",
   "MainNavigationDrawer.administrationLink": "ادارة",
+  "MainNavigationDrawer.changeLanguage": "تغيير اللغة",
   "MainNavigationDrawer.channelsLink": "القنوات التعليمية",
   "MainNavigationDrawer.copyright": "© {year} المساواة في التعلم",
   "MainNavigationDrawer.giveFeedback": "قدّم ملاحظاتك",

--- a/contentcuration/locale/es_ES/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/es_ES/LC_MESSAGES/contentcuration-messages.json
@@ -985,6 +985,7 @@
   "MainNavigationDrawer.helpLink": "Ayuda y soporte",
   "MainNavigationDrawer.logoutLink": "Cerrar sesión",
   "MainNavigationDrawer.settingsLink": "Configuración",
+  "MainNavigationDrawer.changeLanguage": "Cambiar idioma",
   "MarkdownEditor.bold": "Negrita (Ctrl+B)",
   "MarkdownEditor.formulas": "Insertar fórmula (Ctrl+F)",
   "MarkdownEditor.image": "Insertar imagen (Ctrl+P)",

--- a/contentcuration/locale/fr_FR/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/fr_FR/LC_MESSAGES/contentcuration-messages.json
@@ -979,6 +979,7 @@
   "Main.privacyPolicyLink": "Politique de confidentialité",
   "Main.signInButton": "Se connecter",
   "MainNavigationDrawer.administrationLink": "Administration",
+  "MainNavigationDrawer.changeLanguage": "Changer la langue",
   "MainNavigationDrawer.channelsLink": "Chaînes",
   "MainNavigationDrawer.copyright": "© {year} Learning Equality",
   "MainNavigationDrawer.giveFeedback": "Envoyer un commentaire",

--- a/contentcuration/locale/hi_IN/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/hi_IN/LC_MESSAGES/contentcuration-messages.json
@@ -979,6 +979,7 @@
   "Main.privacyPolicyLink": "Privacy policy",
   "Main.signInButton": "Sign in",
   "MainNavigationDrawer.administrationLink": "Administration",
+  "MainNavigationDrawer.changeLanguage": "Change language",
   "MainNavigationDrawer.channelsLink": "Channels",
   "MainNavigationDrawer.copyright": "© {year} Learning Equality",
   "MainNavigationDrawer.giveFeedback": "Give feedback",

--- a/contentcuration/locale/pt_BR/LC_MESSAGES/contentcuration-messages.json
+++ b/contentcuration/locale/pt_BR/LC_MESSAGES/contentcuration-messages.json
@@ -979,6 +979,7 @@
   "Main.privacyPolicyLink": "Política de privacidade",
   "Main.signInButton": "Iniciar sessão",
   "MainNavigationDrawer.administrationLink": "Administração",
+  "MainNavigationDrawer.changeLanguage": "Trocar de idioma",
   "MainNavigationDrawer.channelsLink": "Canais",
   "MainNavigationDrawer.copyright": "© {year} Learning Equality",
   "MainNavigationDrawer.giveFeedback": "Deixar um comentário",


### PR DESCRIPTION
## Summary
Copy Strings for translation of ChangeLanguage in MainNavigationDrawer 

### Description of the change(s) you made
Manually add the translated string for the ChangeLanguage nav option to respected language translation JSON files.


### Manual verification steps performed
1. Open the Studio web app
2. Change language 
3. Look for the change language option in Main Navigation Drawer

### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/51698593/215688512-eea6ee33-0bec-4f3f-8253-32f984297838.png)
![image](https://user-images.githubusercontent.com/51698593/215688572-5e575f22-13fb-4d19-a708-f3624e2a42e1.png)

### Contributor's Checklist
PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ x] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
