### PR TITLE
Revert Celery Late Acknowledgement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ set-tsvectors:
 	python contentcuration/manage.py set_contentnode_tsvectors --published
 
 reconcile:
-	python contentcuration/manage.py reconcile_change_tasks
 	python contentcuration/manage.py reconcile_publishing_status
+	python contentcuration/manage.py reconcile_change_tasks
 
 ###############################################################
 # END PRODUCTION COMMANDS #####################################

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ set-tsvectors:
 	python contentcuration/manage.py set_channel_tsvectors
 	python contentcuration/manage.py set_contentnode_tsvectors --published
 
+reconcile:
+	python contentcuration/manage.py reconcile_change_tasks
+	python contentcuration/manage.py reconcile_publishing_status
+
 ###############################################################
 # END PRODUCTION COMMANDS #####################################
 ###############################################################

--- a/contentcuration/contentcuration/management/commands/reconcile_publishing_status.py
+++ b/contentcuration/contentcuration/management/commands/reconcile_publishing_status.py
@@ -1,0 +1,42 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from contentcuration.celery import app
+from contentcuration.models import Change
+from contentcuration.models import Channel
+from contentcuration.viewsets.sync.constants import PUBLISHED
+
+logging.basicConfig()
+logger = logging.getLogger("command")
+
+
+class Command(BaseCommand):
+    """
+    Reconciles publishing status of channels.
+    """
+
+    def handle(self, *args, **options):
+        from contentcuration.tasks import apply_channel_changes_task
+
+        # Channels that are in `publishing` state according to our change event.
+        publishing_channels = list(Change.objects.filter(channel_id__isnull=False, applied=False,
+                                                         errored=False, change_type=PUBLISHED)
+                                   .values_list("channel_id", flat=True).distinct())
+
+        # channel_ids of tasks that are in Redis queue.
+        queued_channel_tasks = [task[1].get("channel_id") for task in app.get_queued_tasks()]
+
+        # channel_ids of tasks that are being run by the celery workers or are waiting to be run.
+        active_channel_tasks = [task["kwargs"].get("channel_id") for task in app.get_active_and_reserved_tasks()
+                                if task["name"] == apply_channel_changes_task.name]
+
+        # If channel is in publishing state and doesnot have any queued and running task,
+        # that means the worker has crashed. So, we reset the publishing state to False.
+        for channel_id in publishing_channels:
+            if (channel_id not in queued_channel_tasks) and (channel_id not in active_channel_tasks):
+                channel = Channel.objects.get(pk=channel_id)
+                if channel.main_tree.publishing:
+                    channel.main_tree.publishing = False
+                    channel.main_tree.save()
+                    logger.info(f"Resetted publishing status to False for channel {channel.id}.")

--- a/contentcuration/contentcuration/management/commands/reconcile_publishing_status.py
+++ b/contentcuration/contentcuration/management/commands/reconcile_publishing_status.py
@@ -22,8 +22,8 @@ class Command(BaseCommand):
         # Channels that are in `publishing` state.
         publishing_channels = list(Channel.objects.filter(deleted=False, main_tree__publishing=True).values_list("id", flat=True))
 
-        # channel_ids of tasks that are being run by the celery workers or are waiting to be run.
-        active_channel_tasks = [task["kwargs"].get("channel_id") for task in app.get_active_and_reserved_tasks()
+        # channel_ids of tasks that are currently being run by the celery workers.
+        active_channel_tasks = [task["kwargs"].get("channel_id") for task in app.get_active_tasks()
                                 if task["name"] == apply_channel_changes_task.name]
 
         # If channel is in publishing state and doesnot have any active task,

--- a/contentcuration/contentcuration/management/commands/reconcile_publishing_status.py
+++ b/contentcuration/contentcuration/management/commands/reconcile_publishing_status.py
@@ -3,9 +3,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from contentcuration.celery import app
-from contentcuration.models import Change
 from contentcuration.models import Channel
-from contentcuration.viewsets.sync.constants import PUBLISHED
 
 logging.basicConfig()
 logger = logging.getLogger("command")
@@ -14,29 +12,25 @@ logger = logging.getLogger("command")
 class Command(BaseCommand):
     """
     Reconciles publishing status of channels.
+    If there's no active task for a publishing channel then we reset its publishing status
+    to False.
     """
 
     def handle(self, *args, **options):
         from contentcuration.tasks import apply_channel_changes_task
 
-        # Channels that are in `publishing` state according to our change event.
-        publishing_channels = list(Change.objects.filter(channel_id__isnull=False, applied=False,
-                                                         errored=False, change_type=PUBLISHED)
-                                   .values_list("channel_id", flat=True).distinct())
-
-        # channel_ids of tasks that are in Redis queue.
-        queued_channel_tasks = [task[1].get("channel_id") for task in app.get_queued_tasks()]
+        # Channels that are in `publishing` state.
+        publishing_channels = list(Channel.objects.filter(deleted=False, main_tree__publishing=True).values_list("id", flat=True))
 
         # channel_ids of tasks that are being run by the celery workers or are waiting to be run.
         active_channel_tasks = [task["kwargs"].get("channel_id") for task in app.get_active_and_reserved_tasks()
                                 if task["name"] == apply_channel_changes_task.name]
 
-        # If channel is in publishing state and doesnot have any queued and running task,
+        # If channel is in publishing state and doesnot have any active task,
         # that means the worker has crashed. So, we reset the publishing state to False.
         for channel_id in publishing_channels:
-            if (channel_id not in queued_channel_tasks) and (channel_id not in active_channel_tasks):
+            if channel_id not in active_channel_tasks:
                 channel = Channel.objects.get(pk=channel_id)
-                if channel.main_tree.publishing:
-                    channel.main_tree.publishing = False
-                    channel.main_tree.save()
-                    logger.info(f"Resetted publishing status to False for channel {channel.id}.")
+                channel.main_tree.publishing = False
+                channel.main_tree.save()
+                logger.info(f"Resetted publishing status to False for channel {channel.id}.")

--- a/contentcuration/contentcuration/utils/celery/app.py
+++ b/contentcuration/contentcuration/utils/celery/app.py
@@ -76,6 +76,16 @@ class CeleryApp(Celery):
             for task in tasks:
                 yield task
 
+    def get_active_tasks(self):
+        """
+        Iterate over active tasks
+        :return: A list of dictionaries
+        """
+        active = self.control.inspect().active() or {}
+        for _, tasks in active.items():
+            for task in tasks:
+                yield task
+
     def decode_result(self, result, status=None):
         """
         Decodes the celery result, like the raw result from the database, using celery tools

--- a/contentcuration/contentcuration/utils/celery/tasks.py
+++ b/contentcuration/contentcuration/utils/celery/tasks.py
@@ -104,10 +104,8 @@ class CeleryTask(Task):
     track_started = True
     send_events = True
 
-    # ensure our tasks are restarted if they're interrupted
-    acks_late = True
-    acks_on_failure_or_timeout = True
-    reject_on_worker_lost = True
+    # Tasks are acknowledged just before they start executing
+    acks_late = False
 
     @property
     def TaskModel(self):
@@ -311,6 +309,7 @@ class CeleryAsyncResult(AsyncResult):
     The properties access additional properties in the same manner as super properties,
     and our custom properties are added to the meta via TaskResultCustom.as_dict()
     """
+
     def get_model(self):
         """
         :return: The TaskResult model object

--- a/contentcuration/contentcuration/utils/celery/tasks.py
+++ b/contentcuration/contentcuration/utils/celery/tasks.py
@@ -291,7 +291,7 @@ class CeleryTask(Task):
         task_ids = self.find_incomplete_ids(signature)
 
         if exclude_task_ids is not None:
-            task_ids = task_ids.exclude(task_id__in=task_ids)
+            task_ids = task_ids.exclude(task_id__in=exclude_task_ids)
         count = 0
         for task_id in task_ids:
             logging.info(f"Revoking task {task_id}")


### PR DESCRIPTION
## Summary
This PR reverts celery's late acknowledgement config that was enabled on https://github.com/learningequality/studio/pull/3304.


### Manual verification steps performed
1. Added `time.sleep(10000)` to publish function to make it wait for long time.
2. Start publishing a channel.
3. Quickly press `ctrl+c` twice on celery's terminal. The second `ctrl+c` tap should be quick otherwise python handles the interrupt.
4. Make sure the channel is marked still as `publishing` even though the worker has crashed.
5. Run the management command `python contentcuration/manage.py reconcile_publishing_status`.
6. You'll see the publishing status is resetted to `False` for that channel.
___

## Reviewer guidance
Performing manual verfication steps.


## References
Closes https://github.com/learningequality/studio/issues/3968.

----

### Contributor's Checklist

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
