### PR TITLE
Channel metadata and import metadata public endpoints

### DIFF
--- a/contentcuration/kolibri_content/constants/schema_versions.py
+++ b/contentcuration/kolibri_content/constants/schema_versions.py
@@ -1,6 +1,6 @@
 """
 This is a direct copy of the constants file of the same name in kolibri.core.content
-https://github.com/learningequality/kolibri/blob/b8ef7212f9ab44660e2c7cabeb0122311e5ae5ed/kolibri/core/content/constants/schema_versions.py
+https://github.com/learningequality/kolibri/blob/c7417e1d558a1e1e52ac8423927d61a0e44da576/kolibri/core/content/constants/schema_versions.py
 """
 
 V020BETA1 = "v0.2.0-beta1"

--- a/contentcuration/kolibri_content/constants/schema_versions.py
+++ b/contentcuration/kolibri_content/constants/schema_versions.py
@@ -1,0 +1,47 @@
+"""
+This is a direct copy of the constants file of the same name in kolibri.core.content
+https://github.com/learningequality/kolibri/blob/b8ef7212f9ab44660e2c7cabeb0122311e5ae5ed/kolibri/core/content/constants/schema_versions.py
+"""
+
+V020BETA1 = "v0.2.0-beta1"
+
+V040BETA3 = "v0.4.0-beta3"
+
+NO_VERSION = "unversioned"
+
+VERSION_1 = "1"
+
+VERSION_2 = "2"
+
+VERSION_3 = "3"
+
+VERSION_4 = "4"
+
+VERSION_5 = "5"
+
+# List of the content db schema versions, ordered from most recent to least recent.
+# When a new schema version is generated, it should be added here, at the top of the list.
+CONTENT_DB_SCHEMA_VERSIONS = [
+    VERSION_5,
+    VERSION_4,
+    VERSION_3,
+    VERSION_2,
+    VERSION_1,
+    NO_VERSION,
+    V040BETA3,
+    V020BETA1,
+]
+
+# The latest compatible exported schema version for this version of Kolibri
+CONTENT_SCHEMA_VERSION = VERSION_5
+
+# The version name for the current content schema,
+# which may have schema modifications not present in the export schema
+CURRENT_SCHEMA_VERSION = "current"
+
+# The minimum content schema version that we are able to provide import metadata for
+# from the Kolibri content app database tables.
+# This should be updated if we make a change to the content schema that it would be
+# exceptionally difficult for us to backfill, such as deleting a model field that
+# we cannot meaningfully infer the content of from other metadata.
+MIN_CONTENT_SCHEMA_VERSION = VERSION_5

--- a/contentcuration/kolibri_public/import_metadata_view.py
+++ b/contentcuration/kolibri_public/import_metadata_view.py
@@ -1,0 +1,159 @@
+"""
+This is a copy with modifications of the file:
+https://github.com/learningequality/kolibri/blob/b8ef7212f9ab44660e2c7cabeb0122311e5ae5ed/kolibri/core/content/public_api.py
+"""
+from uuid import UUID
+
+from django.db import connection
+from django.db.models import Q
+from django.http import HttpResponseBadRequest
+from kolibri_content import base_models
+from kolibri_content import models as kolibri_content_models
+from kolibri_content.constants.schema_versions import CONTENT_SCHEMA_VERSION  # Use kolibri_content
+from kolibri_content.constants.schema_versions import MIN_CONTENT_SCHEMA_VERSION  # Use kolibri_content
+from kolibri_public import models  # Use kolibri_public models
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+
+def _get_kc_and_base_models(model):
+    try:
+        kc_model = getattr(kolibri_content_models, model.__name__)
+        base_model = getattr(base_models, model.__name__)
+    except AttributeError:
+        # This will happen if it's a M2M through model, which only exist on ContentNode
+        through_model_name = model.__name__.replace("ContentNode_", "")
+        kc_model = getattr(kolibri_content_models.ContentNode, through_model_name).through
+        # Through models are not defined for the abstract base models, so we just cheat and
+        # use these instead.
+        base_model = kc_model
+    return kc_model, base_model
+
+
+class ImportMetadataViewset(GenericViewSet):
+    # Add an explicit allow any permission class to override the Studio default
+    permission_classes = (AllowAny,)
+    default_content_schema = CONTENT_SCHEMA_VERSION
+    min_content_schema = MIN_CONTENT_SCHEMA_VERSION
+
+    def _error_message(self, low):
+        error = "Schema version is too "
+        if low:
+            error += "low"
+        else:
+            error += "high"
+        if self.default_content_schema == self.min_content_schema:
+            error += ", exports only suported for version {}".format(
+                self.default_content_schema
+            )
+        else:
+            error += ", exports only suported for versions {} to {}".format(
+                self.min_content_schema, self.default_content_schema
+            )
+        return error
+
+    def retrieve(self, request, pk=None):
+        """
+        An endpoint to retrieve all content metadata required for importing a content node
+        all of its ancestors, and any relevant needed metadata.
+
+        :param request: request object
+        :param pk: id parent node
+        :return: an object with keys for each content metadata table and a schema_version key
+        """
+
+        content_schema = request.query_params.get(
+            "schema_version", self.default_content_schema
+        )
+
+        try:
+            if int(content_schema) > int(self.default_content_schema):
+                return HttpResponseBadRequest(self._error_message(False))
+            if int(content_schema) < int(self.min_content_schema):
+                return HttpResponseBadRequest(self._error_message(True))
+            # Remove reference to SQLAlchemy schema bases
+        except ValueError:
+            return HttpResponseBadRequest(
+                "Schema version is not parseable by this version of Kolibri"
+            )
+        except AttributeError:
+            return HttpResponseBadRequest(
+                "Schema version is not known by this version of Kolibri"
+            )
+
+        # Get the model for the target node here - we do this so that we trigger a 404 immediately if the node
+        # does not exist.
+        node = get_object_or_404(models.ContentNode.objects.all(), pk=pk)
+
+        nodes = node.get_ancestors(include_self=True)
+
+        data = {}
+
+        files = models.File.objects.filter(contentnode__in=nodes)
+        through_tags = models.ContentNode.tags.through.objects.filter(
+            contentnode__in=nodes
+        )
+        assessmentmetadata = models.AssessmentMetaData.objects.filter(
+            contentnode__in=nodes
+        )
+        localfiles = models.LocalFile.objects.filter(files__in=files).distinct()
+        tags = models.ContentTag.objects.filter(
+            id__in=through_tags.values_list("contenttag_id", flat=True)
+        ).distinct()
+        languages = models.Language.objects.filter(
+            Q(id__in=files.values_list("lang_id", flat=True))
+            | Q(id__in=nodes.values_list("lang_id", flat=True))
+        )
+        node_ids = nodes.values_list("id", flat=True)
+        prerequisites = models.ContentNode.has_prerequisite.through.objects.filter(
+            from_contentnode_id__in=node_ids, to_contentnode_id__in=node_ids
+        )
+        related = models.ContentNode.related.through.objects.filter(
+            from_contentnode_id__in=node_ids, to_contentnode_id__in=node_ids
+        )
+        channel_metadata = models.ChannelMetadata.objects.filter(id=node.channel_id)
+
+        cursor = connection.cursor()
+
+        for qs in [
+            nodes,
+            files,
+            through_tags,
+            assessmentmetadata,
+            localfiles,
+            tags,
+            languages,
+            prerequisites,
+            related,
+            channel_metadata,
+        ]:
+            # First get the kolibri_content model and base model to which this is equivalent
+            kc_model, base_model = _get_kc_and_base_models(qs.model)
+            # Map the table name from the kolibri_public table name to the equivalent Kolibri table name
+            table_name = kc_model._meta.db_table
+            # Tweak our introspection here to rely on Django model meta instead of SQLAlchemy
+            # Read from the base_models here, as those are the ones required for this schema version
+            raw_fields = [field.column for field in base_model._meta.fields]
+            if qs.model is models.Language:
+                raw_fields = [rf for rf in raw_fields if rf != "lang_name"] + ["native_name"]
+            qs = qs.values(*raw_fields)
+            # Avoid using the Django queryset directly, as it will coerce the database values
+            # via its field 'from_db_value' transformers, whereas import metadata is read
+            # directly from the database.
+            # One example is for JSON field data that is stored as a string in the database,
+            # we want to avoid that being coerced to Python objects.
+            cursor.execute(*qs.query.sql_with_params())
+            data[table_name] = [
+                # Coerce any UUIDs to their hex representation, as Postgres raw values will be UUIDs
+                dict(zip(raw_fields, (value.hex if isinstance(value, UUID) else value for value in row))) for row in cursor
+            ]
+            if qs.model is models.Language:
+                for lang in data[table_name]:
+                    lang["lang_name"] = lang["native_name"]
+                    del lang["native_name"]
+
+        data["schema_version"] = content_schema
+
+        return Response(data)

--- a/contentcuration/kolibri_public/import_metadata_view.py
+++ b/contentcuration/kolibri_public/import_metadata_view.py
@@ -1,17 +1,19 @@
 """
 This is a copy with modifications of the file:
-https://github.com/learningequality/kolibri/blob/b8ef7212f9ab44660e2c7cabeb0122311e5ae5ed/kolibri/core/content/public_api.py
+https://github.com/learningequality/kolibri/blob/c7417e1d558a1e1e52ac8423927d61a0e44da576/kolibri/core/content/public_api.py
 """
 from uuid import UUID
 
 from django.db import connection
 from django.db.models import Q
 from django.http import HttpResponseBadRequest
+from django.utils.decorators import method_decorator
 from kolibri_content import base_models
 from kolibri_content import models as kolibri_content_models
 from kolibri_content.constants.schema_versions import CONTENT_SCHEMA_VERSION  # Use kolibri_content
 from kolibri_content.constants.schema_versions import MIN_CONTENT_SCHEMA_VERSION  # Use kolibri_content
 from kolibri_public import models  # Use kolibri_public models
+from kolibri_public.views import metadata_cache
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -32,6 +34,9 @@ def _get_kc_and_base_models(model):
     return kc_model, base_model
 
 
+# Add the standard metadata_cache decorator to this endpoint to align
+# with other public endpoints
+@method_decorator(metadata_cache, name="dispatch")
 class ImportMetadataViewset(GenericViewSet):
     # Add an explicit allow any permission class to override the Studio default
     permission_classes = (AllowAny,)

--- a/contentcuration/kolibri_public/tests/test_content_app.py
+++ b/contentcuration/kolibri_public/tests/test_content_app.py
@@ -636,12 +636,28 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         response = self.client.get(reverse("publicchannel-list", kwargs={}))
         self.assertEqual(response.data[0]["name"], "testing")
 
+    def test_channelmetadata_list_headers(self):
+        channel = models.ChannelMetadata.objects.get()
+        channel.last_updated = datetime.datetime.now()
+        channel.save()
+        response = self.client.get(reverse("publicchannel-list", kwargs={}))
+        self._assert_headers(response, channel.last_updated)
+
     def test_channelmetadata_retrieve(self):
         data = models.ChannelMetadata.objects.values()[0]
         response = self.client.get(
             reverse("publicchannel-detail", kwargs={"pk": data["id"]})
         )
         self.assertEqual(response.data["name"], "testing")
+
+    def test_channelmetadata_retrieve_headers(self):
+        channel = models.ChannelMetadata.objects.get()
+        channel.last_updated = datetime.datetime.now()
+        channel.save()
+        response = self.client.get(
+            reverse("publicchannel-detail", kwargs={"pk": channel.id})
+        )
+        self._assert_headers(response, channel.last_updated)
 
     def test_channelmetadata_langfield(self):
         data = models.ChannelMetadata.objects.first()

--- a/contentcuration/kolibri_public/tests/test_content_app.py
+++ b/contentcuration/kolibri_public/tests/test_content_app.py
@@ -9,6 +9,7 @@ from calendar import timegm
 from itertools import chain
 
 from django.core.cache import cache
+from django.core.management import call_command
 from django.urls import reverse
 from django.utils.http import http_date
 from kolibri_public import models
@@ -301,6 +302,7 @@ def infer_learning_activity(kind):
 class ContentNodeAPIBase(object):
     @classmethod
     def setUpTestData(cls):
+        call_command("loadconstants")
         builder = ChannelBuilder()
         builder.insert_into_default_db()
         models.ContentNode.objects.all().update(available=True)
@@ -310,6 +312,7 @@ class ContentNodeAPIBase(object):
         ).first()
         cls.has_prereq = models.ContentNode.objects.exclude(kind=content_kinds.TOPIC)[1]
         cls.has_prereq.has_prerequisite.add(cls.is_prereq)
+        cls.channel_data = builder.channel
 
     def _get(self, *args, **kwargs):
         return self.client.get(*args, **kwargs)
@@ -629,87 +632,97 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         )
         self.assertEqual(set(response.data["tags"]), set(tags))
 
-    # def test_channelmetadata_list(self):
-    #     response = self.client.get(reverse("kolibri:core:channel-list", kwargs={}))
-    #     self.assertEqual(response.data[0]["name"], "testing")
+    def test_channelmetadata_list(self):
+        response = self.client.get(reverse("publicchannel-list", kwargs={}))
+        self.assertEqual(response.data[0]["name"], "testing")
 
-    # def test_channelmetadata_retrieve(self):
-    #     data = models.ChannelMetadata.objects.values()[0]
-    #     response = self.client.get(
-    #         reverse("kolibri:core:channel-detail", kwargs={"pk": data["id"]})
-    #     )
-    #     self.assertEqual(response.data["name"], "testing")
+    def test_channelmetadata_retrieve(self):
+        data = models.ChannelMetadata.objects.values()[0]
+        response = self.client.get(
+            reverse("publicchannel-detail", kwargs={"pk": data["id"]})
+        )
+        self.assertEqual(response.data["name"], "testing")
 
-    # def test_channelmetadata_langfield(self):
-    #     data = models.ChannelMetadata.objects.first()
-    #     root_lang = models.Language.objects.get(pk=1)
-    #     data.root.lang = root_lang
-    #     data.root.save()
+    def test_channelmetadata_langfield(self):
+        data = models.ChannelMetadata.objects.first()
+        root_lang = models.Language.objects.first()
+        data.root.lang = root_lang
+        data.root.save()
 
-    #     response = self.client.get(
-    #         reverse("kolibri:core:channel-detail", kwargs={"pk": data.id})
-    #     )
-    #     self.assertEqual(response.data["lang_code"], root_lang.lang_code)
-    #     self.assertEqual(response.data["lang_name"], root_lang.lang_name)
+        response = self.client.get(
+            reverse("publicchannel-detail", kwargs={"pk": data.id})
+        )
+        self.assertEqual(response.data["lang_code"], root_lang.lang_code)
+        self.assertEqual(response.data["lang_name"], root_lang.native_name)
 
-    # def test_channelmetadata_langfield_none(self):
-    #     data = models.ChannelMetadata.objects.first()
+    def test_channelmetadata_langfield_none(self):
+        data = models.ChannelMetadata.objects.first()
 
-    #     response = self.client.get(
-    #         reverse("kolibri:core:channel-detail", kwargs={"pk": data.id})
-    #     )
-    #     self.assertEqual(response.data["lang_code"], None)
-    #     self.assertEqual(response.data["lang_name"], None)
+        response = self.client.get(
+            reverse("publicchannel-detail", kwargs={"pk": data.id})
+        )
+        self.assertEqual(response.data["lang_code"], None)
+        self.assertEqual(response.data["lang_name"], None)
 
-    # def test_channelmetadata_content_available_param_filter_lowercase_true(self):
-    #     response = self.client.get(
-    #         reverse("kolibri:core:channel-list"), {"available": "true"}
-    #     )
-    #     self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
+    def test_channelmetadata_content_available_param_filter_lowercase_true(self):
+        response = self.client.get(
+            reverse("publicchannel-list"), {"available": "true"}
+        )
+        self.assertEqual(response.data[0]["id"], self.channel_data["id"])
 
-    # def test_channelmetadata_content_available_param_filter_uppercase_true(self):
-    #     response = self.client.get(
-    #         reverse("kolibri:core:channel-list"), {"available": True}
-    #     )
-    #     self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
+    def test_channelmetadata_content_available_param_filter_uppercase_true(self):
+        response = self.client.get(
+            reverse("publicchannel-list"), {"available": True}
+        )
+        self.assertEqual(response.data[0]["id"], self.channel_data["id"])
 
-    # def test_channelmetadata_content_unavailable_param_filter_false(self):
-    #     models.ContentNode.objects.filter(title="root").update(available=False)
-    #     response = self.client.get(
-    #         reverse("kolibri:core:channel-list"), {"available": False}
-    #     )
-    #     self.assertEqual(response.data[0]["id"], "6199dde695db4ee4ab392222d5af1e5c")
+    def test_channelmetadata_content_unavailable_param_filter_false(self):
+        models.ContentNode.objects.all().update(available=False)
+        response = self.client.get(
+            reverse("publicchannel-list"), {"available": False}
+        )
+        self.assertEqual(response.data[0]["id"], self.channel_data["id"])
 
-    # def test_channelmetadata_content_available_field_true(self):
-    #     response = self.client.get(reverse("kolibri:core:channel-list"))
-    #     self.assertEqual(response.data[0]["available"], True)
+    def test_channelmetadata_content_available_field_true(self):
+        response = self.client.get(reverse("publicchannel-list"))
+        self.assertEqual(response.data[0]["available"], True)
 
-    # def test_channelmetadata_content_available_field_false(self):
-    #     models.ContentNode.objects.filter(title="root").update(available=False)
-    #     response = self.client.get(reverse("kolibri:core:channel-list"))
-    #     self.assertEqual(response.data[0]["available"], False)
+    def test_channelmetadata_content_available_field_false(self):
+        models.ContentNode.objects.all().update(available=False)
+        response = self.client.get(reverse("publicchannel-list"))
+        self.assertEqual(response.data[0]["available"], False)
 
-    # def test_channelmetadata_has_exercises_filter(self):
-    #     # Has nothing else for that matter...
-    #     no_exercise_channel = models.ContentNode.objects.create(
-    #         pk="6a406ac66b224106aa2e93f73a94333d",
-    #         channel_id="f8ec4a5d14cd4716890999da596032d2",
-    #         content_id="ded4a083e75f4689b386fd2b706e792a",
-    #         kind="topic",
-    #         title="no exercise channel",
-    #     )
-    #     models.ChannelMetadata.objects.create(
-    #         id="63acff41781543828861ade41dbdd7ff",
-    #         name="no exercise channel metadata",
-    #         root=no_exercise_channel,
-    #     )
-    #     no_filter_response = self.client.get(reverse("kolibri:core:channel-list"))
-    #     self.assertEqual(len(no_filter_response.data), 2)
-    #     with_filter_response = self.client.get(
-    #         reverse("kolibri:core:channel-list"), {"has_exercise": True}
-    #     )
-    #     self.assertEqual(len(with_filter_response.data), 1)
-    #     self.assertEqual(with_filter_response.data[0]["name"], "testing")
+    def test_channelmetadata_has_exercises_filter(self):
+        # Has nothing else for that matter...
+        no_exercise_channel = models.ContentNode.objects.create(
+            pk="6a406ac66b224106aa2e93f73a94333d",
+            channel_id="f8ec4a5d14cd4716890999da596032d2",
+            content_id="ded4a083e75f4689b386fd2b706e792a",
+            kind="topic",
+            title="no exercise channel",
+        )
+        models.ChannelMetadata.objects.create(
+            id="63acff41781543828861ade41dbdd7ff",
+            name="no exercise channel metadata",
+            root=no_exercise_channel,
+            public=True,
+        )
+        models.ContentNode.objects.create(
+            pk=uuid.uuid4().hex,
+            channel_id=self.channel_data["id"],
+            content_id=uuid.uuid4().hex,
+            kind="exercise",
+            title="exercise",
+            parent=self.root,
+            available=True,
+        )
+        no_filter_response = self.client.get(reverse("publicchannel-list"))
+        self.assertEqual(len(no_filter_response.data), 2)
+        with_filter_response = self.client.get(
+            reverse("publicchannel-list"), {"has_exercise": True}
+        )
+        self.assertEqual(len(with_filter_response.data), 1)
+        self.assertEqual(with_filter_response.data[0]["name"], self.channel_data["name"])
 
     def test_filtering_coach_content_anon(self):
         response = self.client.get(

--- a/contentcuration/kolibri_public/tests/test_importmetadata_api.py
+++ b/contentcuration/kolibri_public/tests/test_importmetadata_api.py
@@ -1,0 +1,93 @@
+from django.db import connection
+from django.db.models import Q
+from django.urls import reverse
+from kolibri_content import models as content
+from kolibri_content.constants.schema_versions import CONTENT_SCHEMA_VERSION
+from kolibri_public import models as public
+from kolibri_public.tests.test_content_app import ChannelBuilder
+from le_utils.constants import content_kinds
+from rest_framework.test import APITestCase
+
+
+class ImportMetadataTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.builder = ChannelBuilder()
+        cls.builder.insert_into_default_db()
+        public.ContentNode.objects.all().update(available=True)
+        cls.root = public.ContentNode.objects.get(id=cls.builder.root_node["id"])
+        cls.node = cls.root.get_descendants().exclude(kind=content_kinds.TOPIC).first()
+        cls.all_nodes = cls.node.get_ancestors(include_self=True)
+        cls.files = public.File.objects.filter(contentnode__in=cls.all_nodes)
+        cls.assessmentmetadata = public.AssessmentMetaData.objects.filter(
+            contentnode__in=cls.all_nodes
+        )
+        cls.localfiles = public.LocalFile.objects.filter(
+            files__in=cls.files
+        ).distinct()
+        cls.languages = public.Language.objects.filter(
+            Q(id__in=cls.files.values_list("lang_id", flat=True))
+            | Q(id__in=cls.all_nodes.values_list("lang_id", flat=True))
+        )
+        cls.through_tags = public.ContentNode.tags.through.objects.filter(
+            contentnode__in=cls.all_nodes
+        )
+        cls.tags = public.ContentTag.objects.filter(
+            id__in=cls.through_tags.values_list("contenttag_id", flat=True)
+        ).distinct()
+
+    def _assert_data(self, Model, ContentModel, queryset):
+        response = self.client.get(
+            reverse("publicimportmetadata-detail", kwargs={"pk": self.node.id})
+        )
+        for response_data, obj in zip(response.data[ContentModel._meta.db_table], queryset):
+            # Ensure that we are not returning any empty objects
+            self.assertNotEqual(response_data, {})
+            for field in Model._meta.fields:
+                if field.column in response_data:
+                    value = response_data[field.column]
+                    if hasattr(field, "from_db_value"):
+                        value = field.from_db_value(value, None, connection)
+                    self.assertEqual(value, getattr(obj, field.column))
+
+    def test_import_metadata_nodes(self):
+        self._assert_data(public.ContentNode, content.ContentNode, self.all_nodes)
+
+    def test_import_metadata_files(self):
+        self._assert_data(public.File, content.File, self.files)
+
+    def test_import_metadata_assessmentmetadata(self):
+        self._assert_data(public.AssessmentMetaData, content.AssessmentMetaData, self.assessmentmetadata)
+
+    def test_import_metadata_localfiles(self):
+        self._assert_data(public.LocalFile, content.LocalFile, self.localfiles)
+
+    def test_import_metadata_languages(self):
+        self._assert_data(public.Language, content.Language, self.languages)
+
+    def test_import_metadata_through_tags(self):
+        self._assert_data(public.ContentNode.tags.through, content.ContentNode.tags.through, self.through_tags)
+
+    def test_import_metadata_tags(self):
+        self._assert_data(public.ContentTag, content.ContentTag, self.tags)
+
+    def test_schema_version_too_low(self):
+        response = self.client.get(
+            reverse("publicimportmetadata-detail", kwargs={"pk": self.node.id})
+            + "?schema_version=1"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_schema_version_too_high(self):
+        response = self.client.get(
+            reverse("publicimportmetadata-detail", kwargs={"pk": self.node.id})
+            + "?schema_version={}".format(int(CONTENT_SCHEMA_VERSION) + 1)
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_schema_version_just_right(self):
+        response = self.client.get(
+            reverse("publicimportmetadata-detail", kwargs={"pk": self.node.id})
+            + "?schema_version={}".format(CONTENT_SCHEMA_VERSION)
+        )
+        self.assertEqual(response.status_code, 200)

--- a/contentcuration/kolibri_public/urls.py
+++ b/contentcuration/kolibri_public/urls.py
@@ -2,15 +2,16 @@ from django.urls import include
 from django.urls import path
 from django.urls import re_path
 from kolibri_public import views_v1
+from kolibri_public.views import ChannelMetadataViewSet
 from kolibri_public.views import ContentNodeTreeViewset
 from kolibri_public.views import ContentNodeViewset
 from rest_framework import routers
 
 
 public_content_v2_router = routers.SimpleRouter()
-# public_content_v2_router.register(
-#     r"channel", ChannelMetadataViewSet, basename="publicchannel"
-# )
+public_content_v2_router.register(
+    r"channel", ChannelMetadataViewSet, basename="publicchannel"
+)
 public_content_v2_router.register(
     r"contentnode", ContentNodeViewset, basename="publiccontentnode"
 )

--- a/contentcuration/kolibri_public/urls.py
+++ b/contentcuration/kolibri_public/urls.py
@@ -2,6 +2,7 @@ from django.urls import include
 from django.urls import path
 from django.urls import re_path
 from kolibri_public import views_v1
+from kolibri_public.import_metadata_view import ImportMetadataViewset
 from kolibri_public.views import ChannelMetadataViewSet
 from kolibri_public.views import ContentNodeTreeViewset
 from kolibri_public.views import ContentNodeViewset
@@ -20,9 +21,9 @@ public_content_v2_router.register(
     ContentNodeTreeViewset,
     basename="publiccontentnode_tree",
 )
-# public_content_v2_router.register(
-#     r"importmetadata", ImportMetadataViewset, basename="importmetadata"
-# )
+public_content_v2_router.register(
+    r"importmetadata", ImportMetadataViewset, basename="publicimportmetadata"
+)
 
 urlpatterns = [
     re_path(r'^api/public/channel/(?P<channel_id>[^/]+)', views_v1.get_channel_name_by_id, name='get_channel_name_by_id'),


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds a v2 ChannelMetadata endpoint
* Adds a v2 ImportMetadata endpoint (matching tweaks made in https://github.com/learningequality/kolibri/pull/10250)
* Adds tests for both endpoints
* Adds appropriate public cache headers to both endpoints and tests them both
* Updates the device info endpoint to support newer version requests from newer Kolibri instances, including returning a min_content_schema_version to signal to Kolibri's whether they can import from this instance

### Manual verification steps performed
Automated testing, over and over again!
