### PR TITLE
Propagate logout to all open tabs

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -61,10 +61,18 @@ function runElection() {
   };
 }
 
+function applyResourceListener(change) {
+  const resource = INDEXEDDB_RESOURCES[change.table];
+  if (resource && resource.listeners && resource.listeners[change.type]) {
+    resource.listeners[change.type](change);
+  }
+}
+
 export async function initializeDB() {
   try {
     setupSchema();
     await db.open();
+    db.on('changes', changes => changes.map(applyResourceListener));
     await runElection();
   } catch (e) {
     Sentry.captureException(e);

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -69,13 +69,6 @@ function isSyncableChange(change) {
   );
 }
 
-function applyResourceListener(change) {
-  const resource = INDEXEDDB_RESOURCES[change.table];
-  if (resource && resource.listeners && resource.listeners[change.type]) {
-    resource.listeners[change.type](change);
-  }
-}
-
 /**
  * Reduces a change to only the fields that are needed for sending it to the backend
  *
@@ -338,7 +331,6 @@ if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
 }
 
 async function handleChanges(changes) {
-  changes.map(applyResourceListener);
   const syncableChanges = changes.filter(isSyncableChange);
   // Here we are handling changes triggered by Dexie Observable
   // this is listening to all of our IndexedDB tables, both for resources


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Move resource listener registration to run in all tabs, not just the leader tab.
* This was preventing the logout listener being triggered in all open tabs


### Manual verification steps performed
1. Run Studio.
2. Login.
3. Open another tab.
4. Logout in one tab - confirm that it redirects to the account page in every tab.

Fixes [#3915](https://github.com/learningequality/studio/issues/3915)