### PR TITLE
Levels and categories in channel details modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -194,7 +194,7 @@
   import ContentNodeValidator from '../ContentNodeValidator';
   import ContentNodeChangedIcon from '../ContentNodeChangedIcon';
   import TaskProgress from '../../views/progress/TaskProgress';
-  import { ContentLevel, Categories, NEW_OBJECT } from 'shared/constants';
+  import { ContentLevels, Categories, NEW_OBJECT } from 'shared/constants';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import { RolesNames } from 'shared/leUtils/Roles';
   import ImageOnlyThumbnail from 'shared/views/files/ImageOnlyThumbnail';
@@ -331,7 +331,7 @@
         return null;
       },
       levels(level) {
-        let match = Object.keys(ContentLevel).find(key => ContentLevel[key] === level);
+        let match = Object.keys(ContentLevels).find(key => ContentLevels[key] === level);
         if (match) {
           if (match === 'PROFESSIONAL') {
             match = 'specializedProfessionalTraining';

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -330,7 +330,7 @@
   import camelCase from 'lodash/camelCase';
   import { isImportedContent, importedChannelLink } from '../utils';
   import FilePreview from '../views/files/FilePreview';
-  import { ContentLevel, Categories, AccessibilityCategories } from '../../shared/constants';
+  import { ContentLevels, Categories, AccessibilityCategories } from '../../shared/constants';
   import AssessmentItemPreview from './AssessmentItemPreview/AssessmentItemPreview';
   import ContentNodeValidator from './ContentNodeValidator';
   import {
@@ -589,9 +589,9 @@
       },
       level(levels) {
         const ids = Object.keys(levels);
-        const matches = Object.keys(ContentLevel)
+        const matches = Object.keys(ContentLevels)
           .sort()
-          .filter(k => ids.includes(ContentLevel[k]));
+          .filter(k => ids.includes(ContentLevels[k]));
         if (matches && matches.length > 0) {
           let mappedMatches = [];
           let newMatch;

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -5,7 +5,6 @@ import featureFlagsSchema from 'static/feature_flags.json';
 
 export { default as LearningActivities } from 'kolibri-constants/labels/LearningActivities';
 export { default as CompletionCriteriaModels } from 'kolibri-constants/CompletionCriteria';
-export { default as ContentLevel } from 'kolibri-constants/labels/Levels';
 export { default as Categories } from 'kolibri-constants/labels/Subjects';
 export { default as AccessibilityCategories } from 'kolibri-constants/labels/AccessibilityCategories';
 export { default as ContentLevels } from 'kolibri-constants/labels/Levels';

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -1,6 +1,7 @@
 import invert from 'lodash/invert';
 import Subjects from 'kolibri-constants/labels/Subjects';
 import CompletionCriteria from 'kolibri-constants/CompletionCriteria';
+import ContentLevels from 'kolibri-constants/labels/Levels';
 import featureFlagsSchema from 'static/feature_flags.json';
 
 export { default as LearningActivities } from 'kolibri-constants/labels/LearningActivities';
@@ -12,6 +13,7 @@ export { default as ResourcesNeededTypes } from 'kolibri-constants/labels/Needs'
 
 export const CategoriesLookup = invert(Subjects);
 export const CompletionCriteriaLookup = invert(CompletionCriteria);
+export const LevelsLookup = invert(ContentLevels);
 
 export const ContentDefaults = {
   author: 'author',

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelDetailsModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelDetailsModal.vue
@@ -5,7 +5,7 @@
     color="black"
   >
     <template #header>
-      <span class="notranslate">{{ channel.name }}</span>
+      <span class="notranslate">{{ channel ? channel.name : '' }}</span>
     </template>
     <LoadingText v-if="loading" absolute />
     <VCardText v-else-if="channel">

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -83,6 +83,42 @@
           </VDataTable>
         </template>
       </DetailsRow>
+      <DetailsRow :label="$tr('levelsHeading')">
+        <template #default>
+          <div v-if="!levels.length">
+            {{ defaultText }}
+          </div>
+          <VChip
+            v-for="level in levels"
+            v-else-if="!printing"
+            :key="level"
+            class="tag"
+          >
+            {{ level }}
+          </VChip>
+          <span v-else>
+            {{ levelsPrintable }}
+          </span>
+        </template>
+      </DetailsRow>
+      <DetailsRow :label="$tr('categoriesHeading')">
+        <template #default>
+          <div v-if="!categories.length">
+            {{ defaultText }}
+          </div>
+          <VChip
+            v-for="category in categories"
+            v-else-if="!printing"
+            :key="category"
+            class="tag"
+          >
+            {{ category }}
+          </VChip>
+          <span v-else>
+            {{ categoriesPrintable }}
+          </span>
+        </template>
+      </DetailsRow>
       <DetailsRow :label="$tr('containsHeading')">
         <template v-if="!printing" #default>
           <VChip v-if="details.includes.coach_content" class="tag">
@@ -274,14 +310,17 @@
 
 <script>
 
+  import camelCase from 'lodash/camelCase';
   import orderBy from 'lodash/orderBy';
   import DetailsRow from './DetailsRow';
   import { SCALE_TEXT, SCALE, CHANNEL_SIZE_DIVISOR } from './constants';
+  import { CategoriesLookup, LevelsLookup } from 'shared/constants';
   import {
     fileSizeMixin,
     constantsTranslationMixin,
     printingMixin,
     titleMixin,
+    metadataTranslationMixin,
   } from 'shared/mixins';
   import LoadingText from 'shared/views/LoadingText';
   import ExpandableList from 'shared/views/ExpandableList';
@@ -299,7 +338,13 @@
       DetailsRow,
       Thumbnail,
     },
-    mixins: [fileSizeMixin, constantsTranslationMixin, printingMixin, titleMixin],
+    mixins: [
+      fileSizeMixin,
+      constantsTranslationMixin,
+      printingMixin,
+      titleMixin,
+      metadataTranslationMixin,
+    ],
     props: {
       // Object matching that returned by the channel details and
       // node details API endpoints, see backend for details of the
@@ -381,6 +426,34 @@
       tagPrintable() {
         return this.sortedTags.map(tag => tag.tag_name).join(', ');
       },
+      levels() {
+        return this.details.levels.map(level => {
+          level = LevelsLookup[level];
+          let translationKey;
+          if (level === 'PROFESSIONAL') {
+            translationKey = 'specializedProfessionalTraining';
+          } else if (level === 'WORK_SKILLS') {
+            translationKey = 'allLevelsWorkSkills';
+          } else if (level === 'BASIC_SKILLS') {
+            translationKey = 'allLevelsBasicSkills';
+          } else {
+            translationKey = camelCase(level);
+          }
+          return this.translateMetadataString(translationKey);
+        });
+      },
+      levelsPrintable() {
+        return this.levels.join(', ');
+      },
+      categories() {
+        return this.details.categories.map(category => {
+          category = CategoriesLookup[category];
+          return this.translateMetadataString(camelCase(category));
+        });
+      },
+      categoriesPrintable() {
+        return this.categories.join(', ');
+      },
     },
     methods: {
       channelUrl(channel) {
@@ -397,6 +470,8 @@
       tagsHeading: 'Common tags',
       creationHeading: 'Created on',
       containsHeading: 'Contains',
+      levelsHeading: 'Levels',
+      categoriesHeading: 'Categories',
       languagesHeading: 'Languages',
       subtitlesHeading: 'Captions and subtitles',
       authorsLabel: 'Authors',

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1531,8 +1531,6 @@ class ContentNode(MPTTModel, models.Model):
 
         descendants = (
             self.get_descendants()
-            .prefetch_related("children", "files", "tags")
-            .select_related("license", "language")
             .values("id")
         )
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1525,6 +1525,7 @@ class ContentNode(MPTTModel, models.Model):
         from contentcuration.viewsets.common import SQCount
         from contentcuration.viewsets.common import SQRelatedArrayAgg
         from contentcuration.viewsets.common import SQSum
+        from contentcuration.viewsets.common import SQJSONBKeyArrayAgg
 
         node = ContentNode.objects.filter(pk=self.id, tree_id=self.tree_id).order_by()
 
@@ -1561,6 +1562,8 @@ class ContentNode(MPTTModel, models.Model):
                 "sample_pathway": [],
                 "original_channels": [],
                 "sample_nodes": [],
+                "levels": [],
+                "categories": [],
             }
 
             # Set cache with latest data
@@ -1655,6 +1658,14 @@ class ContentNode(MPTTModel, models.Model):
             exercises=SQCount(
                 resources.filter(kind_id=content_kinds.EXERCISE), field="id"
             ),
+            levels=SQJSONBKeyArrayAgg(
+                descendants.exclude(grade_levels__isnull=True),
+                field="grade_levels",
+            ),
+            all_categories=SQJSONBKeyArrayAgg(
+                descendants.exclude(categories__isnull=True),
+                field="categories",
+            ),
         )
 
         # Get sample pathway by getting longest path
@@ -1744,6 +1755,8 @@ class ContentNode(MPTTModel, models.Model):
                 "tags_list",
                 "kind_count",
                 "exercises",
+                "levels",
+                "all_categories",
             )
             .first()
         )
@@ -1773,6 +1786,8 @@ class ContentNode(MPTTModel, models.Model):
             "aggregators": list(filter(bool, node["aggregators"])),
             "providers": list(filter(bool, node["providers"])),
             "copyright_holders": list(filter(bool, node["copyright_holders"])),
+            "levels": node.get("levels") or [],
+            "categories": node.get("all_categories") or [],
         }
 
         # Set cache with latest data

--- a/contentcuration/contentcuration/viewsets/common.py
+++ b/contentcuration/contentcuration/viewsets/common.py
@@ -95,6 +95,18 @@ class SQRelatedArrayAgg(SQArrayAgg):
     template = "(SELECT ARRAY_AGG(%(fieldname)s::text) FROM (%(subquery)s) AS %(field)s__sum)"
 
 
+class SQJSONBKeyArrayAgg(AggregateSubquery):
+    """
+    An aggregate subquery to get all the distinct keys of a JSON field that contains maps to store
+    e.g. metadata labels.
+    """
+    # Include ALIAS at the end to support Postgres
+    template = (
+        "(SELECT ARRAY_AGG(f) FROM (SELECT DISTINCT jsonb_object_keys(%(field)s) AS f FROM (%(subquery)s) AS x) AS %(field)s__sum)"
+    )
+    output_field = ArrayField(CharField())
+
+
 dot_path_regex = re.compile(r"^([^.]+)\.(.+)$")
 
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds an aggregation helper class for label maps
* Uses it to return categories and levels for channel details
* Displays those channel details in the channel details modal - makes a slight deviation from the spec after consultation with @jtamiace to use chips instead of comma separation for consistency with other elements
* Cleans up ContentLevels constants, as they were being defined twice
* Removes unnecessary prefetch_related and select_related in node details method - seems to have no impact on performance either way


### Manual verification steps performed
1. Add levels and categories to resources and topics in a channel
2. Verify that they appear, deduplicated in the channel details modal
3. Note that our  caching may cause stale data to the be returned to the frontend, so the cache needs to be cleared

### Screenshots (if applicable)
![Screenshot from 2023-03-15 10-22-25](https://user-images.githubusercontent.com/1680573/225397476-7be60d56-45bb-45ae-a133-d1d9caa062af.png)



## References
Fixes [#3877](https://github.com/learningequality/studio/issues/3877)

