### PR TITLE
Add Deploy Event Backend 

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/base.py
+++ b/contentcuration/contentcuration/tests/viewsets/base.py
@@ -11,6 +11,7 @@ from contentcuration.viewsets.sync.utils import _generate_event as base_generate
 from contentcuration.viewsets.sync.utils import generate_copy_event as base_generate_copy_event
 from contentcuration.viewsets.sync.utils import generate_create_event as base_generate_create_event
 from contentcuration.viewsets.sync.utils import generate_delete_event as base_generate_delete_event
+from contentcuration.viewsets.sync.utils import generate_deploy_event as base_generate_deploy_event
 from contentcuration.viewsets.sync.utils import generate_update_event as base_generate_update_event
 
 
@@ -45,6 +46,12 @@ def generate_sync_channel_event(channel_id, attributes, tags, files, assessment_
     event["tags"] = tags
     event["files"] = files
     event["assessment_items"] = assessment_items
+    return event
+
+
+def generate_deploy_channel_event(channel_id, user_id):
+    event = base_generate_deploy_event(channel_id, user_id=user_id)
+    event["rev"] = random.randint(1, 10000000)
     return event
 
 

--- a/contentcuration/contentcuration/viewsets/sync/base.py
+++ b/contentcuration/contentcuration/viewsets/sync/base.py
@@ -22,6 +22,7 @@ from contentcuration.viewsets.sync.constants import CONTENTNODE_PREREQUISITE
 from contentcuration.viewsets.sync.constants import COPIED
 from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
+from contentcuration.viewsets.sync.constants import DEPLOYED
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import FILE
 from contentcuration.viewsets.sync.constants import INVITATION
@@ -92,6 +93,7 @@ event_handlers = {
     COPIED: "copy_from_changes",
     PUBLISHED: "publish_from_changes",
     SYNCED: "sync_from_changes",
+    DEPLOYED: "deploy_from_changes",
 }
 
 

--- a/contentcuration/contentcuration/viewsets/sync/constants.py
+++ b/contentcuration/contentcuration/viewsets/sync/constants.py
@@ -6,6 +6,7 @@ MOVED = 4
 COPIED = 5
 PUBLISHED = 6
 SYNCED = 7
+DEPLOYED = 8
 
 
 ALL_CHANGES = set([
@@ -16,6 +17,7 @@ ALL_CHANGES = set([
     COPIED,
     PUBLISHED,
     SYNCED,
+    DEPLOYED,
 ])
 
 # Client-side table constants

--- a/contentcuration/contentcuration/viewsets/sync/utils.py
+++ b/contentcuration/contentcuration/viewsets/sync/utils.py
@@ -6,6 +6,7 @@ from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import COPIED
 from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
+from contentcuration.viewsets.sync.constants import DEPLOYED
 from contentcuration.viewsets.sync.constants import MOVED
 from contentcuration.viewsets.sync.constants import PUBLISHED
 from contentcuration.viewsets.sync.constants import UPDATED
@@ -71,6 +72,11 @@ def generate_publish_event(
     event = _generate_event(key, CHANNEL, PUBLISHED, key, None)
     event["version_notes"] = version_notes
     event["language"] = language
+    return event
+
+
+def generate_deploy_event(key, user_id):
+    event = _generate_event(key, CHANNEL, DEPLOYED, channel_id=key, user_id=user_id)
     return event
 
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This pr adds the required backend changes to create a new change event DEPLOY which gets triggered when we activate a channel that is being cheffed using [ricecooker](https://github.com/learningequality/ricecooker). 

### Manual verification steps performed
1. Created tests for the changes.
2. Ran all the tests locally.

## Comments
@vkWeb is working with the frontend part and required modifications can be done to adapt the information coming from the frontend.

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
