### PR TITLE
Updates mp3 resource previewer metadata to include has captions and s…

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -310,7 +310,11 @@
                   inline
                 />
               </DetailsRow>
-              <DetailsRow v-if="node.kind === 'video'" :label="$tr('subtitles')">
+              <DetailsRow
+                v-if="node.kind === 'video' ||
+                  node.kind === 'audio'"
+                :label="$tr('subtitles')"
+              >
                 <ExpandableList :noItemsText="defaultText" :items="subtitleFileLanguages" inline />
               </DetailsRow>
             </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -554,12 +554,7 @@
         return this.firstNode.original_channel_name;
       },
       requiresAccessibility() {
-        return (
-          this.oneSelected &&
-          this.nodes.every(
-            node => node.kind !== ContentKindsNames.AUDIO && node.kind !== ContentKindsNames.TOPIC
-          )
-        );
+        return this.oneSelected && this.nodes.every(node => node.kind !== ContentKindsNames.TOPIC);
       },
       audioAccessibility() {
         return this.oneSelected && this.firstNode.kind === 'audio';

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/__tests__/accessibilityOptions.spec.js
@@ -73,6 +73,17 @@ describe('AccessibilityOptions', () => {
     expect(wrapper.find('[data-test="checkbox-audioDescription"]').exists()).toBe(false);
   });
 
+  it('should display the correct list of accessibility options if resource is an audio', () => {
+    const wrapper = mount(AccessibilityOptions, {
+      propsData: {
+        kind: 'audio',
+      },
+    });
+
+    expect(wrapper.find('[data-test="checkbox-captionsSubtitles"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="tooltip-captionsSubtitles"]').exists()).toBe(false);
+  });
+
   it('should render appropriate tooltips along with the checkbox', () => {
     const wrapper = mount(AccessibilityOptions, {
       propsData: {

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -199,11 +199,11 @@ export const ContentModalities = {
 };
 
 export const AccessibilityCategoriesMap = {
-  // Note: audio is not included, as it is rendered in the UI differently.
   document: ['ALT_TEXT', 'HIGH_CONTRAST', 'TAGGED_PDF'],
   video: ['CAPTIONS_SUBTITLES', 'AUDIO_DESCRIPTION', 'SIGN_LANGUAGE'],
   exercise: ['ALT_TEXT'],
   html5: ['ALT_TEXT', 'HIGH_CONTRAST'],
+  audio: ['CAPTIONS_SUBTITLES'],
 };
 
 export const CompletionDropdownMap = {

--- a/contentcuration/contentcuration/management/commands/set_orm_based_has_captions.py
+++ b/contentcuration/contentcuration/management/commands/set_orm_based_has_captions.py
@@ -22,13 +22,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         start = time.time()
 
-        logging.info("Setting 'has captions' for video kinds")
+        logging.info("Setting 'has captions' for audio kinds")
 
         has_captions_subquery = Exists(File.objects.filter(contentnode=OuterRef("id"), language=OuterRef("language"), preset_id=format_presets.VIDEO_SUBTITLE))
-        # Only try to update video nodes which have not had any accessibility labels set on them
+        # Only try to update audio nodes which have not had any accessibility labels set on them
         # this will allow this management command to be rerun and resume from where it left off
         # and also prevent stomping previous edits to the accessibility_labels field.
-        updateable_nodes = ContentNode.objects.filter(has_captions_subquery, kind=content_kinds.VIDEO, accessibility_labels__isnull=True)
+        updateable_nodes = ContentNode.objects.filter(has_captions_subquery, kind=content_kinds.AUDIO, accessibility_labels__isnull=True)
 
         updateable_node_slice = updateable_nodes.values_list("id", flat=True)[0:CHUNKSIZE]
 


### PR DESCRIPTION
…ubtitles

<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This PR updates the previewer to correctly display 'Accessibility' and 'Captions and Subtitles' data for audio resources.
- The `AccessibilityCategoriesMap` has been updated to include the content kind `audio` and maps to `CAPTIONS_SUBTITLES`.
- The `ResourcePanel` has been updated to display 'Captions and Subtitles' for audio resources as as well as video resources.
- Resource edit form now includes the Accessibility section with the option 'includes captions or subtitles' for .mp3 resources.

### Manual verification steps performed
1.  Create or edit an .mp3 audio resource.
3. Verify the 'Accessibility' section with the option 'includes captions or subtitles' is underneath the 'Audience' section.
4. Select the 'has captions or subtitles' option.
5. Under 'Captions and subtitles', select the 'add captions' option, choose a language, and save the resource.
6. Click the resource to open the previewer.
7. Verify the previewer lists 'Accessibility' and 'Captions and Subtitles' data.

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
<img width="1259" alt="mp3resourceaccessibility" src="https://user-images.githubusercontent.com/46411498/226714942-11265a2b-2f8c-4d8d-ae9c-dc2782bd9e2d.png">

<img width="1259" alt="mp3resourcecaptionsandsubtitles" src="https://user-images.githubusercontent.com/46411498/226715112-26c63a88-61f4-409d-ad12-f3d44bb525c7.png">

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #3876 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [x] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time

Studio-specifc:

- [x] All user-facing strings are translated properly
- [x] All UI components are LTR and RTL compliant

Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
