### PR TITLE
Updates nested folder order in breadcrumb

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -5,11 +5,11 @@
     <VToolbar dense color="transparent" flat>
       <slot name="action"></slot>
       <Breadcrumbs :items="ancestors" class="mx-1 px-2 py-0">
-        <template #item="{ item, isFirst, isLast }">
+        <template #item="{ item, isLast }">
           <!-- Current item -->
           <VLayout v-if="isLast" align-center row>
             <VFlex class="font-weight-bold text-truncate" shrink :class="getTitleClass(item)">
-              {{ isFirst ? currentChannel.name : getTitle(item) }}
+              {{ getTitle(item) }}
             </VFlex>
             <Menu v-if="item.displayNodeOptions">
               <template #activator="{ on }">
@@ -23,7 +23,7 @@
             </Menu>
           </VLayout>
           <span v-else class="grey--text" :class="getTitleClass(item)">
-            {{ isFirst ? currentChannel.name : getTitle(item) }}
+            {{ getTitle(item) }}
           </span>
         </template>
       </Breadcrumbs>
@@ -341,7 +341,7 @@
           return {
             id: ancestor.id,
             to: this.treeLink({ nodeId: ancestor.id }),
-            title: ancestor.title,
+            title: ancestor.parent ? ancestor.title : this.currentChannel.name,
             displayNodeOptions: this.rootId !== ancestor.id,
           };
         });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Updates order of nested folders within breadcrumbs.

### Manual verification steps performed
1. Create or update channel with multiple nested folders.
2. Confirm that the breadcrumb reflects the correct sequence of the nested folders.


### Screenshots (if applicable)
Before

<img width="729" alt="BreadcrumbsBefore" src="https://user-images.githubusercontent.com/46411498/227568658-f9e84f31-d477-4bee-ac25-45ee67422d97.png">

After

<img width="722" alt="BreadcrumbsAfter" src="https://user-images.githubusercontent.com/46411498/227568720-13791f58-086b-49d7-b5fe-f48dd3014725.png">

<img width="721" alt="BreadcrumbsAfter2" src="https://user-images.githubusercontent.com/46411498/227568731-1aa13e9a-658a-4715-a62e-c0621973d170.png">



## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Closes #3842 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:
- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
