### PR TITLE
Disables "Move here" button in copy workflow once it has been clicked 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -112,13 +112,14 @@
     <!-- footer buttons -->
     <template #bottom>
       <VSpacer />
+      <KCircularLoader v-if="moveHereButtonDisabled" :size="20" />
       <VBtn flat exact data-test="cancel" @click="dialog = false">
         {{ $tr("cancel") }}
       </VBtn>
       <VBtn
         color="primary"
         data-test="move"
-        :disabled="!movingFromTrash && currentLocationId === targetNodeId"
+        :disabled="moveHereButtonDisabled"
         @click="moveNodes"
       >
         {{ $tr("moveHere") }}
@@ -179,6 +180,7 @@
       return {
         showNewTopicModal: false,
         loading: false,
+        moveNodesInProgress: false,
         targetNodeId: null,
         previewNodeId: null,
       };
@@ -201,6 +203,14 @@
       },
       moveHeader() {
         return this.$tr('moveItems', this.getTopicAndResourceCounts(this.moveNodeIds));
+      },
+      moveHereButtonDisabled() {
+        if (this.moveNodesInProgress) {
+          return true;
+        } else if (!this.movingFromTrash && this.currentLocationId === this.targetNodeId) {
+          return true;
+        }
+        return false;
       },
       currentLocationId() {
         // If opening modal from inside TrashModal, begin navigation at root node
@@ -271,6 +281,7 @@
         });
       },
       moveNodes() {
+        this.moveNodesInProgress = true;
         this.$emit('target', this.targetNodeId);
       },
       /*

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -112,7 +112,7 @@
     <!-- footer buttons -->
     <template #bottom>
       <VSpacer />
-      <KCircularLoader v-if="moveHereButtonDisabled" :size="20" />
+      <KCircularLoader v-if="moveHereButtonDisabled && moveNodesInProgress" :size="20" />
       <VBtn flat exact data-test="cancel" @click="dialog = false">
         {{ $tr("cancel") }}
       </VBtn>
@@ -295,6 +295,7 @@
           actionText: this.$tr('goToLocationButton'),
           actionCallback: this.goToLocation,
         });
+        this.moveNodesInProgress = false;
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Fixes #3940

This PR adds an additional condition that would make the button disabled - when the `move` has been initiated. It also adds a small loading spinner to indicate that the move is in progress


### Manual verification steps performed
1. Use devtools to set connection speed to slow 3G
2. Copy a number of resources to clipboard 
3. Move to another folder

### Screenshots (if applicable)

https://user-images.githubusercontent.com/17235236/228911762-6a17fff9-9e87-4adc-8410-ee3094eac2f7.mp4


___
## Reviewer guidance
### How can a reviewer test these changes?
Please see the steps outline under manual verification. Using the slow connection, and having a long-ish list of resources to be moved is important to actually see this happen.


----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
