### PR TITLE
Updates syncing metadata fields on syncing modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <VContainer fluid class="pa-0">
+  <VContainer
+    fluid
+    class="pa-0"
+  >
     <ToolBar
       v-if="currentChannel"
       color="white"
@@ -13,7 +16,10 @@
       <VToolbarTitle class="notranslate">
         {{ currentChannel.name }}
       </VToolbarTitle>
-      <VToolbarItems v-if="$vuetify.breakpoint.smAndUp" class="ml-4">
+      <VToolbarItems
+        v-if="$vuetify.breakpoint.smAndUp"
+        class="ml-4"
+      >
         <router-link
           :to="viewChannelDetailsLink"
           @click="trackClickEvent('Summary')"
@@ -30,7 +36,12 @@
         >
           <VBadge color="transparent">
             <template #badge>
-              <Icon v-if="!currentChannel.language" color="red" small class="edit-channel-error">
+              <Icon
+                v-if="!currentChannel.language"
+                color="red"
+                small
+                class="edit-channel-error"
+              >
                 error
               </Icon>
             </template>
@@ -46,10 +57,20 @@
       <VSpacer />
       <OfflineText indicator />
       <ProgressModal />
-      <div v-if="errorsInChannel && canEdit" class="mx-1">
-        <VTooltip bottom lazy>
+      <div
+        v-if="errorsInChannel && canEdit"
+        class="mx-1"
+      >
+        <VTooltip
+          bottom
+          lazy
+        >
           <template #activator="{ on }">
-            <div class="amber--text title" style="width: max-content;" v-on="on">
+            <div
+              class="amber--text title"
+              style="width: max-content;"
+              v-on="on"
+            >
               {{ $formatNumber(errorsInChannel) }}
               <Icon color="amber">
                 warning
@@ -60,13 +81,24 @@
         </VTooltip>
       </div>
       <template v-if="$vuetify.breakpoint.smAndUp">
-        <span v-if="canManage && isRicecooker" class="font-weight-bold grey--text subheading">
+        <span
+          v-if="canManage && isRicecooker"
+          class="font-weight-bold grey--text subheading"
+        >
           {{ $tr('apiGenerated') }}
         </span>
-        <VTooltip v-if="!loading && canManage" bottom attach="body" lazy>
+        <VTooltip
+          v-if="!loading && canManage"
+          bottom
+          attach="body"
+          lazy
+        >
           <template #activator="{ on }">
             <!-- Need to wrap in div to enable tooltip when button is disabled -->
-            <div style="height: 100%;" v-on="on">
+            <div
+              style="height: 100%;"
+              v-on="on"
+            >
               <VBtn
                 color="primary"
                 flat
@@ -82,14 +114,21 @@
           </template>
           <span>{{ publishButtonTooltip }}</span>
         </VTooltip>
-        <span v-else-if="!loading" class="font-weight-bold grey--text subheading">
+        <span
+          v-else-if="!loading"
+          class="font-weight-bold grey--text subheading"
+        >
           {{ $tr('viewOnly') }}
         </span>
       </template>
       <VToolbarItems>
         <Menu v-if="showChannelMenu">
           <template #activator="{ on }">
-            <VBtn flat icon v-on="on">
+            <VBtn
+              flat
+              icon
+              v-on="on"
+            >
               <Icon>more_horiz</Icon>
             </VBtn>
           </template>
@@ -105,7 +144,10 @@
               <VListTile :to="viewChannelDetailsLink">
                 <VListTileTitle>{{ $tr('channelDetails') }}</VListTileTitle>
               </VListTile>
-              <VListTile v-if="canEdit" :to="editChannelLink">
+              <VListTile
+                v-if="canEdit"
+                :to="editChannelLink"
+              >
                 <VListTileTitle>
                   {{ $tr('editChannel') }}
                   <Icon
@@ -164,9 +206,15 @@
     <MainNavigationDrawer v-model="drawer" />
     <slot></slot>
 
-    <PublishModal v-if="showPublishModal" v-model="showPublishModal" />
+    <PublishModal
+      v-if="showPublishModal"
+      v-model="showPublishModal"
+    />
     <template v-if="isPublished">
-      <ChannelTokenModal v-model="showTokenModal" :channel="currentChannel" />
+      <ChannelTokenModal
+        v-model="showTokenModal"
+        :channel="currentChannel"
+      />
     </template>
     <SyncResourcesModal
       v-if="currentChannel"
@@ -174,14 +222,25 @@
       :channel="currentChannel"
       @syncing="syncInProgress"
     />
-    <MessageDialog v-model="showDeleteModal" :header="$tr('deleteTitle')">
+    <MessageDialog
+      v-model="showDeleteModal"
+      :header="$tr('deleteTitle')"
+    >
       {{ $tr('deletePrompt') }}
       <template #buttons="{ close }">
         <VSpacer />
-        <VBtn color="primary" flat @click="close">
+        <VBtn
+          color="primary"
+          flat
+          @click="close"
+        >
           {{ $tr('cancel') }}
         </VBtn>
-        <VBtn color="primary" data-test="delete" @click="handleDelete">
+        <VBtn
+          color="primary"
+          data-test="delete"
+          @click="handleDelete"
+        >
           {{ $tr('deleteChannelButton') }}
         </VBtn>
       </template>
@@ -203,7 +262,11 @@
           @draggableDrop="$emit('dropToClipboard', $event)"
         >
           <template #default>
-            <VBtn v-model="showClipboard" fab class="clipboard-fab">
+            <VBtn
+              v-model="showClipboard"
+              fab
+              class="clipboard-fab"
+            >
               <Icon>content_paste</Icon>
             </VBtn>
           </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -1,14 +1,21 @@
 <template>
 
   <div class="px-1">
-    <div v-if="isSyncing && !syncError" class="grey--text" data-test="progress">
-      <span>{{ $tr('syncHeader') }}</span>&nbsp;<span>{{ progressPercent }}</span>
+    <div
+      v-if="isSyncing && !syncError"
+      class="grey--text"
+      data-test="progress"
+    >
+      <span>{{ $tr('syncHeader') }}</span>&nbsp;<span>{{ formattedProgressPercent }}</span>
     </div>
     <div
       v-else-if="syncError"
       class="red--text"
     >
-      <Icon small color="red">
+      <Icon
+        small
+        color="red"
+      >
         error
       </Icon>
       {{ $tr('syncError') }}
@@ -17,15 +24,25 @@
       v-else-if="currentPublishTaskError"
       class="red--text"
     >
-      <Icon small color="red">
+      <Icon
+        small
+        color="red"
+      >
         error
       </Icon>
       {{ $tr('defaultErrorText') }}
     </div>
-    <div v-else-if="isPublishing" class="grey--text" data-test="progress">
-      <span>{{ $tr('publishHeader') }}</span>&nbsp;<span>{{ progressPercent }}</span>
+    <div
+      v-else-if="isPublishing"
+      class="grey--text"
+      data-test="progress"
+    >
+      <span>{{ $tr('publishHeader') }}</span>&nbsp;<span>{{ formattedProgressPercent }}</span>
     </div>
-    <div v-else class="grey--text">
+    <div
+      v-else
+      class="grey--text"
+    >
       {{ lastPublished ?
         $tr('lastPublished', { last_published: $formatRelative(lastPublished, now) }) :
         $tr('unpublishedText')
@@ -64,8 +81,11 @@
         return this.getAsyncTask(this.currentChannel[TASK_ID]) || null;
       },
       progressPercent() {
-        const progressPercent = get(this.currentTask, ['progress'], 0);
-        return this.$formatNumber(Math.round(progressPercent || 0) / 100, {
+        return Math.round(get(this.currentTask, ['progress'], 0) || 0) / 100;
+      },
+
+      formattedProgressPercent() {
+        return this.$formatNumber(this.progressPercent, {
           style: 'percent',
           minimumFractionDigits: 0,
           maximumFractionDigits: 0,
@@ -109,7 +129,7 @@
       publishHeader: 'Publishing channel',
       lastPublished: 'Published {last_published}',
       unpublishedText: 'Unpublished',
-      syncHeader: 'Syncing channel',
+      syncHeader: 'Syncing resources',
       syncError: 'Last attempt to sync failed',
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ProgressModal.vue
@@ -56,7 +56,6 @@
 
   import { mapActions, mapGetters } from 'vuex';
   import get from 'lodash/get';
-  import { ContentNode } from 'shared/data/resources';
   import { TASK_ID } from 'shared/data/constants';
 
   export default {
@@ -65,11 +64,9 @@
       now: Date.now(),
     }),
     computed: {
-      ...mapGetters('contentNode', ['getContentNode']),
-      ...mapGetters('currentChannel', ['currentChannel', 'canManage', 'rootId']),
+      ...mapGetters('currentChannel', ['currentChannel', 'canManage']),
       ...mapGetters('task', ['getAsyncTask', 'getPublishTaskForChannel']),
       isSyncing() {
-        //console.log(this.currentTask);
         return this.currentTask && this.currentTask.task_name === 'sync-channel';
       },
       isPublishing() {
@@ -82,9 +79,6 @@
       },
       currentTask() {
         return this.getAsyncTask(this.currentChannel[TASK_ID]) || null;
-      },
-      nodeId() {
-        return get(this.getContentNode(this.rootId), ['id'], null);
       },
       progressPercent() {
         return this.$formatNumber(Math.round(get(this.currentTask, ['progress'], 0) || 0) / 100, {
@@ -123,8 +117,8 @@
     },
     watch: {
       showSyncingProgress: {
-        handler(newValue) {
-          this.showSnackbarOnCompleteSync(newValue);
+        handler(newValue, oldValue) {
+          this.showSnackbarOnCompleteSync(newValue, oldValue);
         },
         immediate: true,
         deep: true,
@@ -140,12 +134,10 @@
     },
     methods: {
       ...mapActions(['showSnackbar']),
-      showSnackbarOnCompleteSync(showProgress) {
-        if (showProgress && this.nodeId) {
-          ContentNode.waitForCopying([this.nodeId]).then(() => {
-            this.showSnackbar({
-              text: this.$tr('syncedSnackbar'),
-            });
+      showSnackbarOnCompleteSync(newShowProgress, oldShowProgress) {
+        if (!newShowProgress && oldShowProgress) {
+          this.showSnackbar({
+            text: this.$tr('syncedSnackbar'),
           });
         }
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/__tests__/progressModal.spec.js
@@ -165,7 +165,7 @@ describe('ProgressModal', () => {
       });
 
       it('should display syncing message', () => {
-        expect(wrapper.text()).toContain('Syncing channel');
+        expect(wrapper.text()).toContain('Syncing resources');
       });
 
       it('should display progress', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -8,15 +8,15 @@
       :submitDisabled="!continueAllowed"
       :submitText="$tr('continueButtonLabel')"
       :cancelText="$tr('cancelButtonLabel')"
-      :size="600"
+      :size="525"
       @cancel="syncModal = false"
       @submit="handleContinue"
     >
-      <VList
-        subheader
-        two-line
-      >
-        <VSubheader>{{ $tr('syncModalExplainer') }}</VSubheader>
+      <VList>
+        <p>{{ $tr('syncModalExplainer') }}</p>
+        <p class="mb-1">
+          {{ $tr('syncModalSelectAttributes') }}
+        </p>
 
         <VListTile @click.stop>
           <VListTileAction>
@@ -79,11 +79,13 @@
       :title="$tr('confirmSyncModalTitle')"
       :submitText="$tr('syncButtonLabel')"
       :cancelText="$tr('backButtonLabel')"
-      :size="600"
+      :size="525"
       @cancel="handleBack"
       @submit="handleSync"
     >
-      <VSubheader>{{ $tr('confirmSyncModalExplainer') }}</VSubheader>
+      <p class="mb-0">
+        {{ $tr('confirmSyncModalExplainer') }}
+      </p>
       <VCardText>
         <ul class="mb-1 mt-1 no-bullets">
           <li
@@ -112,7 +114,9 @@
           </li>
         </ul>
       </VCardText>
-      <VSubheader>{{ $tr('confirmSyncModalWarningExplainer') }}</VSubheader>
+      <p class="mb-0">
+        {{ $tr('confirmSyncModalWarningExplainer') }}
+      </p>
       <VSpacer />
     </KModal>
 
@@ -218,6 +222,7 @@
       syncModalTitle: 'Sync resources',
       syncModalExplainer:
         'Syncing resources in Kolibri Studio updates copied or imported resources in this channel with any changes made to the original resource files.',
+      syncModalSelectAttributes: 'Select the resource attributes that you would like to sync:',
       syncFilesTitle: 'Files',
       syncFilesExplainer: 'Update all files, including: thumbnails, subtitles, and captions',
       syncResourceDetailsTitle: 'Resource details',
@@ -255,9 +260,16 @@
     padding: 0;
   }
 
-  .v-list__tile {
+  /deep/ .v-list__tile {
+    align-items: flex-start;
     height: unset;
-    min-height: 72px;
+    padding: 8px 0;
+  }
+
+  .v-list__tile__action {
+    min-width: 42px;
+    height: unset;
+    padding: 2px 0 0;
   }
 
   .v-list__tile__sub-title {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/sync/SyncResourcesModal.vue
@@ -8,15 +8,22 @@
       :submitDisabled="!continueAllowed"
       :submitText="$tr('continueButtonLabel')"
       :cancelText="$tr('cancelButtonLabel')"
+      :size="600"
       @cancel="syncModal = false"
       @submit="handleContinue"
     >
-      <VList subheader two-line>
+      <VList
+        subheader
+        two-line
+      >
         <VSubheader>{{ $tr('syncModalExplainer') }}</VSubheader>
 
         <VListTile @click.stop>
           <VListTileAction>
-            <Checkbox v-model="syncFiles" color="primary" />
+            <Checkbox
+              v-model="syncFiles"
+              color="primary"
+            />
           </VListTileAction>
           <VListTileContent @click="syncFiles = !syncFiles">
             <VListTileTitle>{{ $tr('syncFilesTitle') }}</VListTileTitle>
@@ -26,17 +33,23 @@
 
         <VListTile @click.stop>
           <VListTileAction>
-            <VCheckbox v-model="syncTags" color="primary" />
+            <VCheckbox
+              v-model="syncResourceDetails"
+              color="primary"
+            />
           </VListTileAction>
-          <VListTileContent @click="syncTags = !syncTags">
-            <VListTileTitle>{{ $tr('syncTagsTitle') }}</VListTileTitle>
-            <VListTileSubTitle>{{ $tr('syncTagsExplainer') }}</VListTileSubTitle>
+          <VListTileContent @click="syncResourceDetails = !syncResourceDetails">
+            <VListTileTitle>{{ $tr('syncResourceDetailsTitle') }}</VListTileTitle>
+            <VListTileSubTitle>{{ $tr('syncResourceDetailsExplainer') }}</VListTileSubTitle>
           </VListTileContent>
         </VListTile>
 
         <VListTile @click.stop>
           <VListTileAction>
-            <VCheckbox v-model="syncTitlesAndDescriptions" color="primary" />
+            <VCheckbox
+              v-model="syncTitlesAndDescriptions"
+              color="primary"
+            />
           </VListTileAction>
           <VListTileContent @click="syncTitlesAndDescriptions = !syncTitlesAndDescriptions">
             <VListTileTitle>{{ $tr('syncTitlesAndDescriptionsTitle') }}</VListTileTitle>
@@ -46,7 +59,10 @@
 
         <VListTile @click.stop>
           <VListTileAction>
-            <VCheckbox v-model="syncExercises" color="primary" />
+            <VCheckbox
+              v-model="syncExercises"
+              color="primary"
+            />
           </VListTileAction>
           <VListTileContent @click="syncExercises = !syncExercises">
             <VListTileTitle>{{ $tr('syncExercisesTitle') }}</VListTileTitle>
@@ -63,26 +79,40 @@
       :title="$tr('confirmSyncModalTitle')"
       :submitText="$tr('syncButtonLabel')"
       :cancelText="$tr('backButtonLabel')"
+      :size="600"
       @cancel="handleBack"
       @submit="handleSync"
     >
       <VSubheader>{{ $tr('confirmSyncModalExplainer') }}</VSubheader>
       <VCardText>
-        <ul class="mb-4 ml-3 mt-2">
-          <li v-if="syncFiles" class="font-weight-bold">
+        <ul class="mb-1 mt-1 no-bullets">
+          <li
+            v-if="syncFiles"
+            class="font-weight-bold"
+          >
             {{ $tr('syncFilesTitle') }}
           </li>
-          <li v-if="syncTags" class="font-weight-bold">
-            {{ $tr('syncTagsTitle') }}
+          <li
+            v-if="syncResourceDetails"
+            class="font-weight-bold"
+          >
+            {{ $tr('syncResourceDetailsTitle') }}
           </li>
-          <li v-if="syncTitlesAndDescriptions" class="font-weight-bold">
+          <li
+            v-if="syncTitlesAndDescriptions"
+            class="font-weight-bold"
+          >
             {{ $tr('syncTitlesAndDescriptionsTitle') }}
           </li>
-          <li v-if="syncExercises" class="font-weight-bold">
+          <li
+            v-if="syncExercises"
+            class="font-weight-bold"
+          >
             {{ $tr('syncExercisesTitle') }}
           </li>
         </ul>
       </VCardText>
+      <VSubheader>{{ $tr('confirmSyncModalWarningExplainer') }}</VSubheader>
       <VSpacer />
     </KModal>
 
@@ -121,7 +151,7 @@
         confirmSyncModal: false, // the should show second step
         // user choices about which kind of resources to sync
         syncFiles: false,
-        syncTags: false,
+        syncResourceDetails: false,
         syncTitlesAndDescriptions: false,
         syncExercises: false,
       };
@@ -141,7 +171,10 @@
       continueAllowed() {
         // allow CONTINUE button to appear only if something will be synced
         return (
-          this.syncFiles || this.syncTags || this.syncTitlesAndDescriptions || this.syncExercises
+          this.syncFiles ||
+          this.syncResourceDetails ||
+          this.syncTitlesAndDescriptions ||
+          this.syncExercises
         );
       },
     },
@@ -161,8 +194,8 @@
       },
       handleSync() {
         Channel.sync(this.channelId, {
-          attributes: this.syncTitlesAndDescriptions,
-          tags: this.syncTags,
+          titles_and_descriptions: this.syncTitlesAndDescriptions,
+          resource_details: this.syncResourceDetails,
           files: this.syncFiles,
           assessment_items: this.syncExercises,
         })
@@ -171,7 +204,7 @@
             this.$emit('syncing');
           })
           .catch(() => {
-            // add a way for the progress modal to provide feedback
+            // add a way for the progress modal to provide feedback titles_and_descriptions
             // since the available error message doesn't make sense here,
             // for now we will just have the operation be reported complete
             // see ProgressModal nothingToSync for more info
@@ -183,21 +216,25 @@
     $trs: {
       // Sync modal (Step 1 of 3)
       syncModalTitle: 'Sync resources',
-      syncModalExplainer: 'Sync and update your resources with their original source.',
+      syncModalExplainer:
+        'Syncing resources in Kolibri Studio updates copied or imported resources in this channel with any changes made to the original resource files.',
       syncFilesTitle: 'Files',
-      syncFilesExplainer: 'Update all file information',
-      syncTagsTitle: 'Tags',
-      syncTagsExplainer: 'Update all tags',
+      syncFilesExplainer: 'Update all files, including: thumbnails, subtitles, and captions',
+      syncResourceDetailsTitle: 'Resource details',
+      syncResourceDetailsExplainer:
+        'Update information about resources: learning activity, level, requirements, category, tags, audience, and source',
       syncTitlesAndDescriptionsTitle: 'Titles and descriptions',
       syncTitlesAndDescriptionsExplainer: 'Update resource titles and descriptions',
       syncExercisesTitle: 'Assessment details',
-      syncExercisesExplainer: 'Update questions, answers, and hints',
+      syncExercisesExplainer: 'Update questions, answers, and hints in exercises and quizzes',
       cancelButtonLabel: 'Cancel',
       continueButtonLabel: 'Continue',
       //
       // Confirm sync (Step 2 of 3)
       confirmSyncModalTitle: 'Confirm sync',
       confirmSyncModalExplainer: 'You are about to sync and update the following:',
+      confirmSyncModalWarningExplainer:
+        'Warning: this will overwrite any changes you have made to copied or imported resources.',
       backButtonLabel: 'Back',
       syncButtonLabel: 'Sync',
       //
@@ -226,6 +263,12 @@
   .v-list__tile__sub-title {
     width: unset;
     white-space: unset;
+  }
+
+  .no-bullets {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1085,11 +1085,19 @@ export const Channel = new Resource({
     });
   },
 
-  sync(id, { attributes = false, tags = false, files = false, assessment_items = false } = {}) {
+  sync(
+    id,
+    {
+      titles_and_descriptions = false,
+      resource_details = false,
+      files = false,
+      assessment_items = false,
+    } = {}
+  ) {
     const change = {
       key: id,
-      attributes,
-      tags,
+      titles_and_descriptions,
+      resource_details,
       files,
       assessment_items,
       source: CLIENTID,

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -53,7 +53,12 @@ const ChangeTypeMapFields = {
     'excluded_descendants',
   ]),
   [CHANGE_TYPES.PUBLISHED]: commonFields.concat(['version_notes', 'language']),
-  [CHANGE_TYPES.SYNCED]: commonFields.concat(['attributes', 'tags', 'files', 'assessment_items']),
+  [CHANGE_TYPES.SYNCED]: commonFields.concat([
+    'titles_and_descriptions',
+    'resource_details',
+    'files',
+    'assessment_items',
+  ]),
 };
 
 function isSyncableChange(change) {

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -753,8 +753,8 @@ class SyncNodesOperationTestCase(StudioTestCase):
         orig_video, cloned_video = self._setup_original_and_deriative_nodes()
         sync_node(
             cloned_video,
-            sync_attributes=True,
-            sync_tags=True,
+            sync_titles_and_descriptions=True,
+            sync_resource_details=True,
             sync_files=True,
             sync_assessment_items=True,
         )
@@ -767,8 +767,8 @@ class SyncNodesOperationTestCase(StudioTestCase):
         self._add_subs_to_video_node(orig_video, "en")
         sync_node(
             cloned_video,
-            sync_attributes=True,
-            sync_tags=True,
+            sync_titles_and_descriptions=True,
+            sync_resource_details=True,
             sync_files=True,
             sync_assessment_items=True,
         )
@@ -781,8 +781,8 @@ class SyncNodesOperationTestCase(StudioTestCase):
         self._add_subs_to_video_node(orig_video, "en")
         sync_node(
             cloned_video,
-            sync_attributes=True,
-            sync_tags=True,
+            sync_titles_and_descriptions=True,
+            sync_resource_details=True,
             sync_files=True,
             sync_assessment_items=True,
         )
@@ -790,8 +790,8 @@ class SyncNodesOperationTestCase(StudioTestCase):
         self._add_subs_to_video_node(orig_video, "zul")
         sync_node(
             cloned_video,
-            sync_attributes=True,
-            sync_tags=True,
+            sync_titles_and_descriptions=True,
+            sync_resource_details=True,
             sync_files=True,
             sync_assessment_items=True,
         )

--- a/contentcuration/contentcuration/tests/viewsets/base.py
+++ b/contentcuration/contentcuration/tests/viewsets/base.py
@@ -38,11 +38,11 @@ def generate_update_event(*args, **kwargs):
     return event
 
 
-def generate_sync_channel_event(channel_id, attributes, tags, files, assessment_items):
+def generate_sync_channel_event(channel_id, titles_and_descriptions, resource_details, files, assessment_items):
     event = base_generate_event(key=channel_id, table=CHANNEL, event_type=SYNCED, channel_id=channel_id, user_id=None)
     event["rev"] = random.randint(1, 10000000)
-    event["attributes"] = attributes
-    event["tags"] = tags
+    event["titles_and_descriptions"] = titles_and_descriptions
+    event["resource_details"] = resource_details
     event["files"] = files
     event["assessment_items"] = assessment_items
     return event

--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -15,8 +15,8 @@ from contentcuration.models import File
 
 def sync_channel(
     channel,
-    sync_attributes=False,
-    sync_tags=False,
+    sync_titles_and_descriptions=False,
+    sync_resource_details=False,
     sync_files=False,
     sync_assessment_items=False,
     progress_tracker=None,
@@ -37,8 +37,8 @@ def sync_channel(
     for node in nodes_to_sync:
         node = sync_node(
             node,
-            sync_attributes=sync_attributes,
-            sync_tags=sync_tags,
+            sync_titles_and_descriptions=sync_titles_and_descriptions,
+            sync_resource_details=sync_resource_details,
             sync_files=sync_files,
             sync_assessment_items=sync_assessment_items,
         )
@@ -50,8 +50,8 @@ def sync_channel(
 
 def sync_node(
     node,
-    sync_attributes=False,
-    sync_tags=False,
+    sync_titles_and_descriptions=False,
+    sync_resource_details=False,
     sync_files=False,
     sync_assessment_items=False,
 ):
@@ -62,37 +62,38 @@ def sync_node(
                 node.title, original_node.get_channel().name
             )
         )
-        if sync_attributes:  # Sync node metadata
-            sync_node_data(node, original_node)
-        if sync_tags:  # Sync node tags
+        if sync_titles_and_descriptions:
+            fields = [
+                "title",
+                "description",
+            ]
+            sync_node_data(node, original_node, fields)
+        if sync_resource_details:
+            fields = [
+                "license_id",
+                "copyright_holder",
+                "author",
+                "extra_fields",
+                "categories",
+                "learner_needs",
+                "accessibility_labels",
+                "grade_levels",
+                "resource_types",
+                "learning_activities",
+            ]
+            sync_node_data(node, original_node, fields)
             sync_node_tags(node, original_node)
-        if sync_files:  # Sync node files
+        if sync_files:
             sync_node_files(node, original_node)
         if (
             sync_assessment_items and node.kind_id == content_kinds.EXERCISE
-        ):  # Sync node exercises
+        ):
             sync_node_assessment_items(node, original_node)
     return node
 
 
-synced_fields = [
-    "title",
-    "description",
-    "license_id",
-    "copyright_holder",
-    "author",
-    "extra_fields",
-    "categories",
-    "learner_needs",
-    "accessibility_labels",
-    "grade_levels",
-    "resource_types",
-    "learning_activities",
-]
-
-
-def sync_node_data(node, original):
-    for field in synced_fields:
+def sync_node_data(node, original, fields):
+    for field in fields:
         setattr(node, field, getattr(original, field))
     # Set changed if anything has changed
     node.on_update()

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -512,12 +512,12 @@ class ChannelViewSet(ValuesViewset):
     def sync_from_changes(self, changes):
         errors = []
         for sync in changes:
-            # Publish change will have key, attributes, tags, files, and assessment_items.
+            # Publish change will have key, titles_and_descriptions, resource_details, files, and assessment_items.
             try:
                 self.sync(
                     sync["key"],
-                    attributes=sync.get("attributes"),
-                    tags=sync.get("tags"),
+                    titles_and_descriptions=sync.get("titles_and_descriptions"),
+                    resource_details=sync.get("resource_details"),
                     files=sync.get("files"),
                     assessment_items=sync.get("assessment_items")
                 )
@@ -527,7 +527,7 @@ class ChannelViewSet(ValuesViewset):
                 errors.append(sync)
         return errors
 
-    def sync(self, pk, attributes=False, tags=False, files=False, assessment_items=False):
+    def sync(self, pk, titles_and_descriptions=False, resource_details=False, files=False, assessment_items=False):
         logging.debug("Entering the sync channel endpoint")
 
         channel = self.get_edit_queryset().get(pk=pk)
@@ -551,8 +551,8 @@ class ChannelViewSet(ValuesViewset):
         with create_change_tracker(pk, CHANNEL, channel.id, self.request.user, "sync-channel") as progress_tracker:
             sync_channel(
                 channel,
-                attributes,
-                tags,
+                titles_and_descriptions,
+                resource_details,
                 files,
                 assessment_items,
                 progress_tracker=progress_tracker,


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr updates the syncing modal to look as shown below;
<img width="488" alt="image" src="https://user-images.githubusercontent.com/5203639/231196183-8c5ef06b-caa9-47a6-b024-d17a31254aed.png">


### Manual verification steps performed
See https://github.com/learningequality/studio/issues/3986

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
No
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Login into Kolibri studio
2. Go to `/en/channels/#/my-channels`
3. Setup 2 channels, one to upload content to(A), and the other to import content from the first into(B)
4. Select select channel B and perform the syncing
5.  You should be presented with progress on start syncing and notification on completion of syncing


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3986

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
