### PR TITLE
Fix missing staging tree link in UI

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/ToolBar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ToolBar.vue
@@ -2,7 +2,9 @@
 
   <VToolbar v-bind="$attrs" :flat="flat" :color="color">
     <slot></slot>
-    <template #extension name="extension"></template>
+    <template #extension>
+      <slot name="extension"></slot>
+    </template>
   </VToolbar>
 
 </template>

--- a/contentcuration/contentcuration/viewsets/sync/utils.py
+++ b/contentcuration/contentcuration/viewsets/sync/utils.py
@@ -89,4 +89,4 @@ def log_sync_exception(e, user=None, change=None, changes=None):
     report_exception(e, user=user, contexts=contexts)
 
     # make sure we leave a record in the logs just in case.
-    logging.error(e)
+    logging.exception(e)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "devserver:hot": "npm-run-all --parallel build:dev:hot runserver",
     "devserver-hot": "yarn run devserver:hot",
     "devshell": "cd contentcuration && python manage.py shell --settings=contentcuration.dev_settings",
-    "celery": "(cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker --without-mingle --without-gossip -l info) || true",
+    "celery": "(cd contentcuration && DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker --without-mingle --without-gossip -c 1 -l info) || true",
     "storybook": "start-storybook",
     "storybook:debug": "start-storybook --debug-webpack",
     "storybook:build": "build-storybook",


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updates toolbar to pass along `#extension` slot content to Vuetify's component to fix missing link to the staging tree
- Updates logging of sync exceptions to report stack trace, helpful within celery workers
- Updates `yarn run celery` to run with `--concurrency=1` instead of the default matching the quantity of CPUs available

### Screenshots (if applicable)
![Screenshot from 2023-04-12 14-54-33](https://user-images.githubusercontent.com/819838/231596160-2c09a1ae-8d91-4555-a3df-f432161f61d8.png)

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1) Have Studio running locally at `http://localhost:8080`
1) Use `ricecooker` to create a cheffed channel:
```
CONTENTWORKSHOP_URL=http://localhost:8080 python tests/test_chef_integration.py
```
3) Open the channel in your local Studio
4) Verify you see the same as the screenshot

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Observed in reviewing https://github.com/learningequality/studio/pull/3997

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [X] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time

Studio-specifc:

- [x] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [x] All UI components are LTR and RTL compliant
- [x] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
