### PR TITLE
Remove additional files upon channel sync

### DIFF
--- a/contentcuration/contentcuration/tests/test_sync.py
+++ b/contentcuration/contentcuration/tests/test_sync.py
@@ -125,6 +125,31 @@ class SyncTestCase(StudioTestCase):
         )
         self.assertTrue(self.derivative_channel.has_changes())
 
+    def test_sync_files_remove(self):
+        """
+        Tests whether sync_files remove additional files from the copied node or not.
+        """
+        video_node = (self.channel.main_tree.get_descendants()
+                      .filter(kind_id=content_kinds.VIDEO)
+                      .first()
+                      )
+        video_node_copy = self.derivative_channel.main_tree.get_descendants().get(
+            source_node_id=video_node.node_id
+        )
+
+        self.assertEqual(video_node.files.count(), video_node_copy.files.count())
+
+        self._add_temp_file_to_content_node(video_node_copy)
+
+        self.assertNotEqual(video_node.files.count(), video_node_copy.files.count())
+
+        sync_channel(channel=self.derivative_channel, sync_files=True)
+
+        self.assertEqual(video_node.files.count(), video_node_copy.files.count())
+
+        for file in File.objects.filter(contentnode=video_node.id):
+            self.assertTrue(video_node_copy.files.filter(checksum=file.checksum).exists())
+
     def test_sync_assessment_item_add(self):
         """
         Test that calling sync_assessment_items successfully syncs a file added to the original node to

--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -122,22 +122,11 @@ def sync_node_files(node, original):  # noqa C901
     """
     Sync all files in ``node`` from the files in ``original`` node.
     """
-    node_files = {}
     is_node_uploaded_file = False
-
-    for file in node.files.all():
-        if file.preset_id == format_presets.VIDEO_SUBTITLE:
-            file_key = "{}:{}".format(file.preset_id, file.language_id)
-        else:
-            file_key = file.preset_id
-        node_files[file_key] = file
-        # If node has any non-thumbnail file then it means the node
-        # is an uploaded file.
-        if file.preset.thumbnail is False:
-            is_node_uploaded_file = True
 
     source_files = {}
 
+    # 1. Build a hashmap of all original node files.
     for file in original.files.all():
         if file.preset_id == format_presets.VIDEO_SUBTITLE:
             file_key = "{}:{}".format(file.preset_id, file.language_id)
@@ -149,25 +138,37 @@ def sync_node_files(node, original):  # noqa C901
         if file.preset.thumbnail is False:
             is_node_uploaded_file = True
 
+    # 2. Iterate through the copied node files. If the copied node file and
+    # source file are same then we remove it from source_files hashmap.
+    # Else we mark that file for deletion.
     files_to_delete = []
+    for file in node.files.all():
+        if file.preset_id == format_presets.VIDEO_SUBTITLE:
+            file_key = "{}:{}".format(file.preset_id, file.language_id)
+        else:
+            file_key = file.preset_id
+        source_file = source_files.get(file_key)
+        if source_file and source_file.checksum == file.checksum:
+            del source_files[file_key]
+        else:
+            files_to_delete.append(file.id)
+
+    # 3. Mark all files present in source_files hashmap for creation.
+    # Files that are not in copied node but in source node
+    # will be present in source_files hashmap.
     files_to_create = []
-    # B. Add all files that are in original
-    for file_key, source_file in source_files.items():
-        # 1. Look for old file with matching preset (and language if subs file)
-        node_file = node_files.get(file_key)
-        if not node_file or node_file.checksum != source_file.checksum:
-            if node_file:
-                files_to_delete.append(node_file.id)
-            source_file.id = None
-            source_file.contentnode_id = node.id
-            files_to_create.append(source_file)
-            node.changed = True
+    for source_file in source_files.values():
+        source_file.id = None
+        source_file.contentnode_id = node.id
+        files_to_create.append(source_file)
 
     if files_to_delete:
         File.objects.filter(id__in=files_to_delete).delete()
+        node.changed = True
 
     if files_to_create:
         File.objects.bulk_create(files_to_create)
+        node.changed = True
 
     if node.changed and is_node_uploaded_file:
         node.content_id = original.content_id


### PR DESCRIPTION
## Summary

This PR fixes `sync_node_files` algorithm to remove additional files from imported / copied nodes.


### Manual verification steps performed
1. Create a PDF file type contentnode and copy it.
2. Add an EPUB document to the copied node.
3. Sync channel by clicking on three-dot menu then 'Sync resources' and then make sure 'Files' option is ticked and click on 'Continue'.
4. Notice in the backend database the additional EPUB of the copied node no longer exists.

___
## Reviewer guidance
Does manual verification and unit test passes?


## References
Closes https://github.com/learningequality/studio/issues/3818.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
