### PR TITLE
Ensure the saving and validation runs on bulk edit, even if user has not selected all nodes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -29,7 +29,7 @@
               :clipped-right="$isRTL"
               app
             >
-              <VBtn data-test="close" icon dark @click="handleClose">
+              <VBtn data-test="close" icon dark @click="handleClose()">
                 <Icon>clear</Icon>
               </VBtn>
               <VToolbarTitle>{{ modalTitle }}</VToolbarTitle>
@@ -116,7 +116,7 @@
             </div>
           </VFlex>
           <VFlex shrink>
-            <VBtn color="primary" @click="handleClose">
+            <VBtn color="primary" @click="handleClose()">
               {{ $tr('finishButton') }}
             </VBtn>
           </VFlex>
@@ -421,27 +421,35 @@
       /* Button actions */
       handleClose() {
         // X button action
-        this.enableValidation(this.nodeIds);
-        let assessmentItems = this.getAssessmentItems(this.nodeIds);
-        assessmentItems.forEach(item => (item.question ? (item[DELAYED_VALIDATION] = false) : ''));
-        this.updateAssessmentItems(assessmentItems);
-        // reaches into Details Tab to run save of diffTracker
-        // before the validation pop up is executed
-        if (this.$refs.editView) {
-          this.$refs.editView.immediateSaveAll().then(() => {
-            // Catch uploads in progress and invalid nodes
-            if (this.invalidNodes.length) {
-              this.selected = [this.invalidNodes[0]];
-              this.promptInvalid = true;
-            } else if (this.contentNodesAreUploading(this.nodeIds)) {
-              this.promptUploading = true;
-            } else {
-              this.closeModal();
-            }
-          });
-        } else {
-          this.closeModal();
-        }
+        this.selected = this.nodeIds;
+        this.$nextTick(() => {
+          this.enableValidation(this.nodeIds);
+          let assessmentItems = this.getAssessmentItems(this.nodeIds);
+          assessmentItems.forEach(item =>
+            item.question ? (item[DELAYED_VALIDATION] = false) : ''
+          );
+          this.updateAssessmentItems(assessmentItems);
+
+          // reaches into Details Tab to run save of diffTracker
+          // before the validation pop up is executed
+          if (this.$refs.editView) {
+            this.$nextTick(() => {
+              this.$refs.editView.immediateSaveAll().then(() => {
+                // Catch uploads in progress and invalid nodes
+                if (this.invalidNodes.length) {
+                  this.selected = [this.invalidNodes[0]];
+                  this.promptInvalid = true;
+                } else if (this.contentNodesAreUploading(this.nodeIds)) {
+                  this.promptUploading = true;
+                } else {
+                  this.closeModal();
+                }
+              });
+            });
+          } else {
+            this.closeModal();
+          }
+        });
       },
 
       /* Creation actions */


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Fixes https://github.com/learningequality/studio/issues/3910

This PR adds a `nextTick` and sets `selected` to the nodes available in the edit modal before proceeding with the `handleClose` function, regardless of whether the user had selected all of them or not. Without having one or more nodes selected, `DetailsTab.vue` is not available, and therefore, accessing the saving functionality by reaching down through the child components to $refs.detailsTab is not possible. So, there is no `immediateSaveAll` and nothing happens.

[No Details Tab exists, since no items are checked]
<img width="1044" alt="Screenshot 2023-04-20 at 4 33 54 PM" src="https://user-images.githubusercontent.com/17235236/233481567-a8de91ff-27a9-451c-a09f-c944f795b196.png">

This is admittedly a bit of a hacky workaround, and there is undoubtedly a better solution. However, beginning a refactor of the EditModal, even if narrowly scoped to rearrange some of this saving logic, feels risky to do so close to release. 

I did consider some other solutions - such as moving the "Please select resources or folder to edit" into the details tab and rearranging some logic so the details tab would exist in this screen, but that seemed like a larger and potentially more complicated fix for not much more reward. I'd be happy to change my solution in that general direction or just try an entirely different approach, if there are some options I'm not considering.


### Manual verification steps performed
1. Unselect all items in the bulk edit view 
2. Click Finish - now, items should be saved and invalid items should be validated before proceeding
3. Repeat the same process using the close (X) button 


### Screenshots (if applicable)

https://user-images.githubusercontent.com/17235236/233482554-fa189384-315e-4b92-bfb2-394df57e269e.mp4



### Does this introduce any tech-debt items?
It doesn't add any new tech debt, but it certainly doesn't help alleviate any 


----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [x] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
