### PR TITLE
Disable checkbox based on policyAccepted

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/policies/PoliciesModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/PoliciesModal.vue
@@ -29,6 +29,7 @@
               :text="$tr('continueButton')"
               :primary="true"
               :style="{ 'display': 'block', 'margin-left': 'auto' }"
+              :disabled="!policyAccepted"
               data-test="continue-button"
               @click="onPolicyAccept"
             />

--- a/contentcuration/contentcuration/frontend/shared/views/policies/PoliciesModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/PoliciesModal.vue
@@ -20,9 +20,6 @@
               data-test="accept-checkbox"
               @change="togglePolicyAccepted"
             />
-            <div class="red--text" :style="{ height: '14pt' }">
-              <span v-if="showError">{{ $tr('checkboxValidationErrorMessage') }}</span>
-            </div>
           </KGridItem>
           <KGridItem :layout="{ span: 1 }">
             <KButton
@@ -88,7 +85,6 @@
     data() {
       return {
         policyAccepted: false,
-        showError: false,
       };
     },
     computed: {
@@ -105,7 +101,6 @@
         this.$emit('close');
       },
       validate() {
-        this.showError = !this.policyAccepted;
         return this.policyAccepted;
       },
       onPolicyAccept() {
@@ -118,7 +113,6 @@
       lastUpdated: 'Last updated {date}',
       closeButton: 'Close',
       continueButton: 'Continue',
-      checkboxValidationErrorMessage: 'Field is required',
       checkboxText: 'I have agreed to the above terms',
     },
   };

--- a/contentcuration/contentcuration/frontend/shared/views/policies/__tests__/policiesModal.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/__tests__/policiesModal.spec.js
@@ -90,7 +90,9 @@ describe('PoliciesModal', () => {
 
     describe('when accept policy checkbox is not checked', () => {
       it('disable continue button', () => {
-        expect(wrapper.find('[data-test="continue-button"]').attributes().disabled).toEqual('disabled')
+        expect(wrapper.find('[data-test="continue-button"]').attributes().disabled).toEqual(
+          'disabled'
+        );
       });
     });
 

--- a/contentcuration/contentcuration/frontend/shared/views/policies/__tests__/policiesModal.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/__tests__/policiesModal.spec.js
@@ -89,16 +89,8 @@ describe('PoliciesModal', () => {
     });
 
     describe('when accept policy checkbox is not checked', () => {
-      it('clicking continue button should display validation error', () => {
-        wrapper.find('[data-test="continue-button"]').trigger('click');
-
-        expect(wrapper.text()).toContain('Field is required');
-      });
-
-      it("clicking continue button shouldn't emit accept event", () => {
-        wrapper.find('[data-test="continue-button"]').trigger('click');
-
-        expect(wrapper.emitted().accept).toBeFalsy();
+      it('disable continue button', () => {
+        expect(wrapper.find('[data-test="continue-button"]').attributes().disabled).toEqual('disabled')
       });
     });
 


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
resolves #4014 


### Manual verification steps performed
1. Locally, if the agree checkbox is not checked the continue button is disabled.
2. Only when we check the checkbox the continue button is clickable.

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Unchecked: 
<img width="1440" alt="Screenshot 2023-04-25 at 2 12 30 AM" src="https://user-images.githubusercontent.com/83641534/234118543-4537b61b-ce71-4e2d-a6c8-a40193e048e6.png">
Checked:
<img width="1440" alt="Screenshot 2023-04-25 at 2 12 33 AM" src="https://user-images.githubusercontent.com/83641534/234118604-673434f0-53fc-454d-92ff-34af2455b467.png">
<!-- 
### Does this introduce any tech-debt items?
List anything that will need to be addressed later -->
___
<!--
## Reviewer guidance
### How can a reviewer test these changes?
 If not applicable, please delete this section -->

<!-- 
### Are there any risky areas that deserve extra testing?
If not applicable, please delete this section -->

<!--
## References

Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
<!-- 
## Comments
Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
