### PR TITLE
Fix #2797  incorrect order of options in the Exercise > Edit Details page > Assessment options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,18 @@ migrate:
 	python contentcuration/manage.py migrate || true
 	python contentcuration/manage.py loadconstants
 
+# This is a special command that is we'll reuse to run data migrations outside of the normal
+# django migration process. This is useful for long running migrations which we don't want to block
+# the CD build. Do not delete!
+# Procedure:
+# 1) Add a new management command for the migration
+# 2) Call it here
+# 3) Perform the release
+# 4) Remove the management command from this `deploy-migrate` recipe
+# 5) Repeat!
+deploy-migrate:
+	echo "Nothing to do here"
+
 contentnodegc:
 	python contentcuration/manage.py garbage_collect
 

--- a/contentcuration/contentcuration/frontend/shared/leUtils/MasteryModels.js
+++ b/contentcuration/contentcuration/frontend/shared/leUtils/MasteryModels.js
@@ -2,10 +2,10 @@
 const MasteryModels = new Set([
   'do_all',
   'm_of_n',
-  'num_correct_in_a_row_10',
   'num_correct_in_a_row_2',
   'num_correct_in_a_row_3',
   'num_correct_in_a_row_5',
+  'num_correct_in_a_row_10',
 ]);
 
 export default MasteryModels;
@@ -15,8 +15,8 @@ export const MasteryModelsList = Array.from(MasteryModels);
 export const MasteryModelsNames = {
   DO_ALL: 'do_all',
   M_OF_N: 'm_of_n',
-  NUM_CORRECT_IN_A_ROW_10: 'num_correct_in_a_row_10',
   NUM_CORRECT_IN_A_ROW_2: 'num_correct_in_a_row_2',
   NUM_CORRECT_IN_A_ROW_3: 'num_correct_in_a_row_3',
   NUM_CORRECT_IN_A_ROW_5: 'num_correct_in_a_row_5',
+  NUM_CORRECT_IN_A_ROW_10: 'num_correct_in_a_row_10',
 };

--- a/deploy/generatejsconstantfiles.py
+++ b/deploy/generatejsconstantfiles.py
@@ -127,7 +127,7 @@ def generate_constants_set_file(
     # Don't generate this unless ids are strings
     generate_names_constants = True
     for constant in sorted(
-        constant_list, key=lambda x: x if mapper is None else getattr(x, sort_by)
+        constant_list, key=lambda x: 0 if mapper is None else getattr(x, sort_by)
     ):
         output += "  "
         value = mapper(constant) if mapper is not None else constant
@@ -177,7 +177,9 @@ def main():
     )
 
     generate_constants_set_file(
-        [m[0] for m in exercises.MASTERY_MODELS if m[0] != exercises.SKILL_CHECK],
+        [m[0] for m in sorted(
+            exercises.MASTERY_MODELS, key=lambda x: int(x[0][21:]) if 'num_correct_in_a_row_' in x[0] else 0
+        ) if m[0] != exercises.SKILL_CHECK and m[0] != exercises.QUIZ],
         "MasteryModels",
     )
     generate_constants_set_file([r[0] for r in roles.choices], "Roles")


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary

From issue #2797 
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

Made Changes in the ordering of dropdown elements in `contentcuration/contentcuration/frontend/shared/leUtils/MasteryModels.js`
 
### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

#### Before applying changes 
![Screenshot from 2023-04-26 14-49-41](https://user-images.githubusercontent.com/81693090/234563547-8f024924-a4ef-4682-b7ce-4d947abe7788.png)



#### After applying changes 

![Screenshot from 2023-04-26 16-02-47](https://user-images.githubusercontent.com/81693090/234563834-4aaa06d0-65c7-480d-9f90-40e70cebe39c.png)

### Does this introduce any tech-debt items?
No 
___
## Reviewer guidance
### How can a reviewer test these changes?
[Screencast from 26-04-23 04:51:13 PM IST.webm](https://user-images.githubusercontent.com/81693090/234566389-9059cada-d575-45ea-9039-18a01b4dc818.webm)


<!-- If not applicable, please delete this section -->


 


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in IceCube or the Perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->
I have made minor changes kindly let me know if it needs futhur changes

 
----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [X] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
