### PR TITLE
Add Github actions to dependabot managed upgrades and fix time for upgrades to midnight UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "00:00"
 
   # Maintain dependencies for Javascript
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "00:00"
+
+  # Maintain dependencies for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds Github Actions to the dependabot managed upgrades
* Sets the time to make upgrade PRs at midnight UTC to avoid them popping up in the middle of the workday PST

### Manual verification steps performed
I have made the same change on multiple repos, and it seems to be working!