### PR TITLE
Factor in language when counting distinct content items

### DIFF
--- a/contentcuration/contentcuration/management/commands/count_public_resources.py
+++ b/contentcuration/contentcuration/management/commands/count_public_resources.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         public_tree_ids = Channel.objects.filter(public=True, deleted=False).values_list('main_tree__tree_id', flat=True)
         count = ContentNode.objects.filter(tree_id__in=public_tree_ids) \
                                    .exclude(kind_id='topic') \
-                                   .values_list('content_id', flat=True) \
+                                   .values('content_id', 'language_id') \
                                    .distinct() \
                                    .count()
         logger.info("{} unique resources".format(count))


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Ideally, we want the "same" piece of content across multiple languages to have distinct content_ids, so that progress isn't shared etc. We already knew this wasn't the case for Khan Academy channels, for legacy reasons, but it turns out there are other channels in the same boat. This PR calculates uniqueness when counting items in the library as a combination of content_id and language_id.

This bumps the count up from 147K to almost 190K distinct content items in the public library.

### Manual verification steps performed
1. Tested out management command and ensured the numbers all made sense

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

Testing:

- [x] Contributor has fully tested the PR manually
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
