### PR TITLE
Add completion criteria to the side panel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -138,15 +138,21 @@
               showEachActivityIcon
             />
           </DetailsRow>
-          <DetailsRow v-if="isExercise" :label="$tr('completion')">
-            <span v-if="noMasteryModel" class="red--text">
+
+          <DetailsRow :label="$tr('completion')">
+            <span v-if="isExercise && noMasteryModel" class="red--text">
               <Icon color="red" small>error</Icon>
               <span class="mx-1">{{ $tr('noMasteryModelError') }}</span>
             </span>
             <span v-else>
-              {{ masteryCriteria }}
+              {{ completion }}
             </span>
           </DetailsRow>
+
+          <DetailsRow :label="translateMetadataString('duration')">
+            {{ duration }}
+          </DetailsRow>
+
           <DetailsRow
             v-if="!isTopic"
             :label="translateMetadataString('category')"
@@ -332,11 +338,12 @@
   import sortBy from 'lodash/sortBy';
   import { mapActions, mapGetters } from 'vuex';
   import camelCase from 'lodash/camelCase';
-  import { isImportedContent, importedChannelLink } from '../utils';
+  import { isImportedContent, importedChannelLink, getCompletionCriteriaLabels } from '../utils';
   import FilePreview from '../views/files/FilePreview';
   import { ContentLevel, Categories, AccessibilityCategories } from '../../shared/constants';
   import AssessmentItemPreview from './AssessmentItemPreview/AssessmentItemPreview';
   import ContentNodeValidator from './ContentNodeValidator';
+
   import {
     getAssessmentItemErrors,
     getNodeLicenseErrors,
@@ -360,7 +367,6 @@
     titleMixin,
     metadataTranslationMixin,
   } from 'shared/mixins';
-  import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
   export default {
@@ -404,6 +410,12 @@
       ...mapGetters('assessmentItem', ['getAssessmentItems']),
       node() {
         return this.getContentNode(this.nodeId);
+      },
+      completion() {
+        return getCompletionCriteriaLabels(this.node).completion;
+      },
+      duration() {
+        return getCompletionCriteriaLabels(this.node).duration;
       },
       files() {
         return sortBy(this.getContentNodeFiles(this.nodeId), f => f.preset.order);
@@ -458,19 +470,6 @@
       },
       importedChannelName() {
         return this.node.original_channel_name;
-      },
-      masteryCriteria() {
-        if (!this.isExercise) {
-          return '';
-        }
-
-        const masteryModel = this.node.extra_fields.mastery_model;
-        if (!masteryModel) {
-          return this.defaultText;
-        } else if (masteryModel === MasteryModelsNames.M_OF_N) {
-          return this.$tr('masteryMofN', this.node.extra_fields);
-        }
-        return this.translateConstant(masteryModel);
       },
       sortedTags() {
         return orderBy(this.node.tags, ['count'], ['desc']);
@@ -663,7 +662,6 @@
     },
     $trs: {
       questions: 'Questions',
-      masteryMofN: 'Goal: {m} out of {n}',
       details: 'Details',
       completion: 'Completion',
       showAnswers: 'Show answers',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -689,6 +689,11 @@
       fileSize: 'Size',
 
       // Validation strings
+      /* eslint-disable kolibri/vue-no-unused-translations */
+      noLearningActivityError: 'Missing learning activity',
+      noCompletionCriteriaError: 'Missing completion criteria',
+      noDurationError: 'Missing duration',
+      /* eslint-enable kolibri/vue-no-unused-translations */
       noLicenseError: 'Missing license',
       noCopyrightHolderError: 'Missing copyright holder',
       noLicenseDescriptionError: 'Missing license description',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -139,7 +139,7 @@
             />
           </DetailsRow>
 
-          <DetailsRow :label="$tr('completion')">
+          <DetailsRow :label="translateMetadataString('completion')">
             <span v-if="isExercise && noMasteryModel" class="red--text">
               <Icon color="red" small>error</Icon>
               <span class="mx-1">{{ $tr('noMasteryModelError') }}</span>
@@ -663,7 +663,6 @@
     $trs: {
       questions: 'Questions',
       details: 'Details',
-      completion: 'Completion',
       showAnswers: 'Show answers',
       questionCount: '{value, number, integer} {value, plural, one {question} other {questions}}',
       description: 'Description',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -393,7 +393,7 @@
       showCorrectCompletionOptions() {
         if (this.kind) {
           return CompletionOptionsDropdownMap[this.kind].map(model => ({
-            text: this.$tr(model),
+            text: this.translateMetadataString(model),
             value: CompletionDropdownMap[model],
           }));
         }
@@ -402,7 +402,7 @@
       selectableDurationOptions() {
         return [
           {
-            text: this.$tr(DurationDropdownMap.EXACT_TIME),
+            text: this.translateMetadataString(DurationDropdownMap.EXACT_TIME),
             value: 'exactTime',
           },
           {
@@ -514,15 +514,6 @@
       },
     },
     $trs: {
-      /* eslint-disable kolibri/vue-no-unused-translations */
-      allContent: 'Viewed in its entirety',
-      completeDuration: 'When time spent is equal to duration',
-      determinedByResource: 'Determined by the resource',
-      goal: 'When goal is met',
-      practiceQuiz: 'Practice quiz',
-      reference: 'Reference material',
-      /* eslint-enable */
-      exactTime: 'Time to complete',
       referenceHint:
         'Progress will not be tracked on reference material unless learners mark it as complete',
       learnersCanMarkComplete: 'Allow learners to mark as complete',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -109,6 +109,7 @@
     CompletionDropdownMap,
     DurationDropdownMap,
     nonUniqueValue,
+    SHORT_LONG_ACTIVITY_MIDPOINT,
   } from 'shared/constants';
   import Checkbox from 'shared/views/form/Checkbox';
   import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
@@ -123,7 +124,6 @@
 
   const DEFAULT_SHORT_ACTIVITY = 600;
   const DEFAULT_LONG_ACTIVITY = 3000;
-  const SHORT_LONG_ACTIVITY_MIDPOINT = 1860;
 
   const defaultCompletionCriteriaModels = {
     [ContentKindsNames.VIDEO]: CompletionCriteriaModels.TIME,

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -1,6 +1,5 @@
 import translator from './translator';
 import { RouteNames } from './constants';
-import { createTranslator } from 'shared/i18n';
 import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
 import { metadataStrings, constantStrings } from 'shared/mixins';
 import {
@@ -158,15 +157,6 @@ export function assessmentItemKey(assessmentItem) {
   };
 }
 
-// TODO: Rename and move to metadata strings translator
-const completionStrings = createTranslator('CompletionStrings', {
-  reference: 'Reference material',
-  completeDuration: 'When time spent is equal to duration',
-  allContent: 'Viewed in its entirety',
-  determinedByResource: 'Determined by the resource',
-  masteryMofN: 'Goal: {m} out of {n}',
-});
-
 /**
  * Converts a value in seconds to a human-readable format.
  * If the value is greater than or equal to one hour, the format will be hh:mm:ss.
@@ -255,18 +245,18 @@ export function getCompletionCriteriaLabels(node) {
 
   switch (completionModel) {
     case CompletionCriteriaModels.REFERENCE:
-      labels.completion = completionStrings.$tr('reference');
+      labels.completion = metadataStrings.$tr('reference');
       break;
 
     case CompletionCriteriaModels.TIME:
-      labels.completion = completionStrings.$tr('completeDuration');
+      labels.completion = metadataStrings.$tr('completeDuration');
       if (suggestedDuration) {
         labels.duration = secondsToHms(suggestedDuration);
       }
       break;
 
     case CompletionCriteriaModels.APPROX_TIME:
-      labels.completion = completionStrings.$tr('completeDuration');
+      labels.completion = metadataStrings.$tr('completeDuration');
       if (isLongActivity(node)) {
         labels.duration = metadataStrings.$tr('longActivity');
       } else {
@@ -276,7 +266,7 @@ export function getCompletionCriteriaLabels(node) {
 
     case CompletionCriteriaModels.PAGES:
       if (completionThreshold === '100%') {
-        labels.completion = completionStrings.$tr('allContent');
+        labels.completion = metadataStrings.$tr('allContent');
       }
       break;
 
@@ -285,7 +275,7 @@ export function getCompletionCriteriaLabels(node) {
         break;
       }
       if (masteryModel === MasteryModelsNames.M_OF_N) {
-        labels.completion = completionStrings.$tr('masteryMofN', {
+        labels.completion = metadataStrings.$tr('masteryMofN', {
           m: completionThreshold.m,
           n: completionThreshold.n,
         });
@@ -295,7 +285,7 @@ export function getCompletionCriteriaLabels(node) {
       break;
 
     case CompletionCriteriaModels.DETERMINED_BY_RESOURCE:
-      labels.completion = completionStrings.$tr('determinedByResource');
+      labels.completion = metadataStrings.$tr('determinedByResource');
       break;
 
     default:

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -1,6 +1,13 @@
 import translator from './translator';
 import { RouteNames } from './constants';
-import { AssessmentItemTypes } from 'shared/constants';
+import { createTranslator } from 'shared/i18n';
+import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
+import { metadataStrings, constantStrings } from 'shared/mixins';
+import {
+  AssessmentItemTypes,
+  CompletionCriteriaModels,
+  SHORT_LONG_ACTIVITY_MIDPOINT,
+} from 'shared/constants';
 
 /**
  * Get correct answer index/indices out of an array of answer objects.
@@ -149,4 +156,151 @@ export function assessmentItemKey(assessmentItem) {
     contentnode: assessmentItem.contentnode,
     assessment_id: assessmentItem.assessment_id,
   };
+}
+
+// TODO: Rename and move to metadata strings translator
+const completionStrings = createTranslator('CompletionStrings', {
+  reference: 'Reference material',
+  completeDuration: 'When time spent is equal to duration',
+  allContent: 'Viewed in its entirety',
+  determinedByResource: 'Determined by the resource',
+  masteryMofN: 'Goal: {m} out of {n}',
+});
+
+/**
+ * Converts a value in seconds to a human-readable format.
+ * If the value is greater than or equal to one hour, the format will be hh:mm:ss.
+ * If the value is less than one hour, the format will be mm:ss.
+ *
+ * @param {Number} seconds - The value in seconds to be converted.
+ * @returns {String} The value in human-readable format.
+ */
+export function secondsToHms(seconds) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds - hours * 3600) / 60);
+  const remainingSeconds = seconds - hours * 3600 - minutes * 60;
+
+  let hms = '';
+  if (hours > 0) {
+    hms += hours.toString().padStart(2, '0') + ':';
+  }
+  hms += minutes.toString().padStart(2, '0') + ':' + remainingSeconds.toString().padStart(2, '0');
+  return hms;
+}
+
+/**
+ * Gathers data from a content node related to its completion.
+ *
+ * @param {Object} node
+ * @returns {Object} { completionModel, completionThreshold, masteryModel,
+ *                     suggestedDurationType, suggestedDuration}
+ */
+export function getCompletionDataFromNode(node) {
+  if (!node) {
+    return;
+  }
+
+  const { model, threshold } = node.extra_fields?.options?.completion_criteria || {};
+  const masteryModel = threshold?.mastery_model;
+  const suggestedDurationType = node.extra_fields?.suggested_duration_type;
+  const suggestedDuration = node.suggested_duration;
+
+  return {
+    completionModel: model,
+    completionThreshold: threshold,
+    masteryModel,
+    suggestedDurationType,
+    suggestedDuration,
+  };
+}
+
+/**
+ * @param {Object} node
+ * @returns {Boolean, undefined}
+ */
+export function isLongActivity(node) {
+  if (!node) {
+    return;
+  }
+  const { completionModel, suggestedDuration } = getCompletionDataFromNode(node);
+  return (
+    completionModel === CompletionCriteriaModels.APPROX_TIME &&
+    suggestedDuration > SHORT_LONG_ACTIVITY_MIDPOINT
+  );
+}
+
+/**
+ * Determines completion and duration labels from completion
+ * criteria and related of a content node.
+ *
+ * @param {Object} node
+ * @returns {Object} { completion, duration }
+ */
+export function getCompletionCriteriaLabels(node) {
+  if (!node) {
+    return;
+  }
+
+  const {
+    completionModel,
+    completionThreshold,
+    masteryModel,
+    suggestedDuration,
+  } = getCompletionDataFromNode(node);
+
+  const labels = {
+    completion: '-',
+    duration: '-',
+  };
+
+  switch (completionModel) {
+    case CompletionCriteriaModels.REFERENCE:
+      labels.completion = completionStrings.$tr('reference');
+      break;
+
+    case CompletionCriteriaModels.TIME:
+      labels.completion = completionStrings.$tr('completeDuration');
+      if (suggestedDuration) {
+        labels.duration = secondsToHms(suggestedDuration);
+      }
+      break;
+
+    case CompletionCriteriaModels.APPROX_TIME:
+      labels.completion = completionStrings.$tr('completeDuration');
+      if (isLongActivity(node)) {
+        labels.duration = metadataStrings.$tr('longActivity');
+      } else {
+        labels.duration = metadataStrings.$tr('shortActivity');
+      }
+      break;
+
+    case CompletionCriteriaModels.PAGES:
+      if (completionThreshold === '100%') {
+        labels.completion = completionStrings.$tr('allContent');
+      }
+      break;
+
+    case CompletionCriteriaModels.MASTERY:
+      if (!masteryModel) {
+        break;
+      }
+      if (masteryModel === MasteryModelsNames.M_OF_N) {
+        labels.completion = completionStrings.$tr('masteryMofN', {
+          m: completionThreshold.m,
+          n: completionThreshold.n,
+        });
+      } else {
+        labels.completion = constantStrings.$tr(masteryModel);
+      }
+      break;
+
+    case CompletionCriteriaModels.DETERMINED_BY_RESOURCE:
+      labels.completion = completionStrings.$tr('determinedByResource');
+      break;
+
+    default:
+      break;
+  }
+
+  return labels;
 }

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -206,6 +206,9 @@ export const AccessibilityCategoriesMap = {
   audio: ['CAPTIONS_SUBTITLES'],
 };
 
+// an activity with duration longer than this value is considered long, otherwise short
+export const SHORT_LONG_ACTIVITY_MIDPOINT = 1860;
+
 export const CompletionDropdownMap = {
   allContent: 'allContent',
   completeDuration: 'completeDuration',

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -52,6 +52,12 @@ const statusStrings = createTranslator('StatusStrings', {
   noStorageError: 'Not enough space',
 });
 
+export const validationStrings = createTranslator('ValidationStrings', {
+  message: 'Missing required information',
+  context:
+    'An error message displayed when some information required before publishing a channel is missing, for example when a resource has no license set.',
+});
+
 export const fileStatusMixin = {
   mixins: [fileSizeMixin],
   computed: {

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -212,6 +212,48 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
     message: 'Category',
     context: 'A title for the metadata that explains the subject matter of an activity',
   },
+  // Completion criteria types
+  reference: {
+    message: 'Reference material',
+    context:
+      'One of the completion criteria types. Progress made on a resource with this criteria is not tracked.',
+  },
+  completeDuration: {
+    message: 'When time spent is equal to duration',
+    context:
+      'One of the completion criteria types. A resource with this criteria is considered complete when learners spent given time studying it.',
+  },
+  exactTime: {
+    message: 'Time to complete',
+    context:
+      'One of the completion criteria types. A subset of "When time spent is equal to duration". For example, for an audio resource with this criteria, learnes need to hear the whole length of audio for the resource to be considered complete.',
+  },
+  allContent: {
+    message: 'Viewed in its entirety',
+    context:
+      'One of the completion criteria types. A resource with this criteria is considered complete when learners studied it all, for example they saw all pages of a document.',
+  },
+  determinedByResource: {
+    message: 'Determined by the resource',
+    context:
+      'One of the completion criteria types. Typically used for embedded html5/h5p resources that contain their own completion criteria, for example reaching a score in an educational game.',
+  },
+  masteryMofN: {
+    message: 'Goal: {m} out of {n}',
+    context:
+      'One of the completion criteria types specific to exercises. An exercise with this criteria is considered complete when learners answered m questions out of n correctly.',
+  },
+  goal: {
+    message: 'When goal is met',
+    context:
+      'One of the completion criteria types specific to exercises. An exercise with this criteria is considered complete when learners reached a given goal, for example 100% correct.',
+  },
+  practiceQuiz: {
+    message: 'Practice quiz',
+    context:
+      'One of the completion criteria types specific to exercises. An exercise with this criteria represents a quiz.',
+  },
+
   // Learning Activities
   all: {
     message: 'All',


### PR DESCRIPTION
## Summary

- Displays "Completion" and "Duration" metadata in the resource side panel

![channel edit](https://user-images.githubusercontent.com/13509191/236462184-412b1915-a3b3-44a8-aef9-d26a9fc0e864.png)

- Adds new strings for related error messages to be likely used in the upcoming work

### Resource

| _Edit modal settings_  |  Reference material | Viewed in its entirety | When time spent is equal to duration - Short activity  | When time spent is equal to duration - Long activity  | When time spent is equal to duration - Time to complete  | Determined by the resource |
|---|---|---|---|---|---|---|
| *Side panel*  | ![Screenshot from 2023-05-05 14-45-17](https://user-images.githubusercontent.com/13509191/236461572-95961229-e06c-4f49-8feb-e97afb32fd5a.png) | ![Viewed in its entirety ](https://user-images.githubusercontent.com/13509191/236464485-4617f06a-d1c8-425b-8875-e20b5792922a.png) | ![Screenshot from 2023-05-05 14-44-43](https://user-images.githubusercontent.com/13509191/236461651-0d301c0f-281d-45d5-9c74-4025dffa8edc.png) | ![Screenshot from 2023-05-05 14-44-57](https://user-images.githubusercontent.com/13509191/236461713-b7bce62c-3842-4c7d-b0a6-dfcf06b74d33.png) | ![Screenshot from 2023-05-05 14-44-22](https://user-images.githubusercontent.com/13509191/236461765-ef3ab1de-b94f-4ad3-b52c-ea4bf48eb261.png) | ![determined](https://user-images.githubusercontent.com/13509191/236465564-10d878cc-b466-480c-baa1-f4230d06a06f.png) |

### Exercise

| _Edit modal settings_  | Practice quiz | Goal 100%   | Goal m of n  | Goal 2 in a row | Goal 3 in a row | Goal 5 in a row | Goal 10 in a row |
|---|---|---|---|---|---|---|---|
| *Side panel*  | ![quiz](https://user-images.githubusercontent.com/13509191/236470431-33ba804a-a975-40e1-994c-25921b55d40f.png) | ![goal-100](https://user-images.githubusercontent.com/13509191/236469674-8853364e-f3f5-4c95-a3be-875d990cdb02.png) | ![m-of-n](https://user-images.githubusercontent.com/13509191/236469716-4908359b-0107-40a4-b6df-7ec7962a5722.png) | ![row-2](https://user-images.githubusercontent.com/13509191/236469760-572010ea-1310-4833-84d7-d4cee83a49ff.png) | ![goal-3](https://user-images.githubusercontent.com/13509191/236469790-d704f192-626d-40fa-b3a9-1eec8a259ba5.png) | ![goal-5](https://user-images.githubusercontent.com/13509191/236469820-16172e85-41e3-4ab5-ba4e-5347b75ff16f.png) | ![goal-10](https://user-images.githubusercontent.com/13509191/236469858-39edd5ad-8a65-4744-9f27-740b355c24e5.png) |

### Manual verification steps performed

Set completion and duration in the edit modal for various resource types and exercises.

### Does this introduce any tech-debt items?

- We have some strings that we are currently not using. This was agreed on beforehand due to the string freeze
- Error messages are not implemented yet, some further clarification is needed (will follow up)

## Reviewer guidance

### How can a reviewer test these changes?

- see "Manual verification steps performed"
- @radinamatic you're welcome to check context messages for strings

## References

- [Figma designs](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=1411-0&t=NDrsSuf3EdtOvkTf-0)
- closes https://github.com/learningequality/studio/issues/3873

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~
- [ ] ~The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?~
- [ ] ~If any Python requirements have changed, the updated `requirements.txt` files also included in this PR~
- [ ] ~Opportunities for using Google Analytics here are noted~
- [ ] ~Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)~

Studio-specifc:

- [x] All user-facing strings are translated properly
- [x] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [x] All UI components are LTR and RTL compliant
- [x] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] ~Users' storage used is recalculated properly on any changes to main tree files~
- [ ] ~If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.~

Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
