### PR TITLE
Localize change sync operations

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/actions.js
@@ -41,16 +41,20 @@ export function addAssessmentItem(context, assessmentItem) {
     hints: JSON.stringify(assessmentItem.hints || []),
   };
 
-  return db.transaction('rw', [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM], () => {
-    return AssessmentItem.add(stringifiedAssessmentItem).then(([contentnode, assessment_id]) => {
-      context.commit('UPDATE_ASSESSMENTITEM', {
-        ...assessmentItem,
-        contentnode,
-        assessment_id,
+  return db.transaction(
+    'rw',
+    [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM, TABLE_NAMES.CHANGES_TABLE],
+    () => {
+      return AssessmentItem.add(stringifiedAssessmentItem).then(([contentnode, assessment_id]) => {
+        context.commit('UPDATE_ASSESSMENTITEM', {
+          ...assessmentItem,
+          contentnode,
+          assessment_id,
+        });
+        return updateNodeComplete(contentnode, context);
       });
-      return updateNodeComplete(contentnode, context);
-    });
-  });
+    }
+  );
 }
 export function updateAssessmentItem(context, assessmentItem) {
   return updateAssessmentItems(context, [assessmentItem]);
@@ -65,38 +69,46 @@ export function updateAssessmentItems(context, assessmentItems) {
     context.commit('UPDATE_ASSESSMENTITEM', assessmentItem);
   });
 
-  return db.transaction('rw', [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM], () => {
-    return Promise.all(
-      assessmentItems.map(assessmentItem => {
-        // API accepts answers and hints as strings
-        const stringifiedAssessmentItem = {
-          ...assessmentItem,
-        };
-        if (assessmentItem.answers) {
-          stringifiedAssessmentItem.answers = JSON.stringify(assessmentItem.answers);
-        }
-        if (assessmentItem.hints) {
-          stringifiedAssessmentItem.hints = JSON.stringify(assessmentItem.hints);
-        }
-        return AssessmentItem.update(
-          [assessmentItem.contentnode, assessmentItem.assessment_id],
-          stringifiedAssessmentItem
-        ).then(() => {
-          updateNodeComplete(assessmentItem.contentnode, context);
-        });
-      })
-    );
-  });
+  return db.transaction(
+    'rw',
+    [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM, TABLE_NAMES.CHANGES_TABLE],
+    () => {
+      return Promise.all(
+        assessmentItems.map(assessmentItem => {
+          // API accepts answers and hints as strings
+          const stringifiedAssessmentItem = {
+            ...assessmentItem,
+          };
+          if (assessmentItem.answers) {
+            stringifiedAssessmentItem.answers = JSON.stringify(assessmentItem.answers);
+          }
+          if (assessmentItem.hints) {
+            stringifiedAssessmentItem.hints = JSON.stringify(assessmentItem.hints);
+          }
+          return AssessmentItem.update(
+            [assessmentItem.contentnode, assessmentItem.assessment_id],
+            stringifiedAssessmentItem
+          ).then(() => {
+            updateNodeComplete(assessmentItem.contentnode, context);
+          });
+        })
+      );
+    }
+  );
 }
 
 export function deleteAssessmentItem(context, assessmentItem) {
-  return db.transaction('rw', [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM], () => {
-    return AssessmentItem.delete([assessmentItem.contentnode, assessmentItem.assessment_id]).then(
-      () => {
-        context.commit('DELETE_ASSESSMENTITEM', assessmentItem);
-        const contentnode = assessmentItem.contentnode;
-        return updateNodeComplete(contentnode, context);
-      }
-    );
-  });
+  return db.transaction(
+    'rw',
+    [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM, TABLE_NAMES.CHANGES_TABLE],
+    () => {
+      return AssessmentItem.delete([assessmentItem.contentnode, assessmentItem.assessment_id]).then(
+        () => {
+          context.commit('DELETE_ASSESSMENTITEM', assessmentItem);
+          const contentnode = assessmentItem.contentnode;
+          return updateNodeComplete(contentnode, context);
+        }
+      );
+    }
+  );
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/assessmentItem/actions.js
@@ -42,7 +42,7 @@ export function addAssessmentItem(context, assessmentItem) {
   };
 
   return db.transaction('rw', [TABLE_NAMES.CONTENTNODE, TABLE_NAMES.ASSESSMENTITEM], () => {
-    return AssessmentItem.put(stringifiedAssessmentItem).then(([contentnode, assessment_id]) => {
+    return AssessmentItem.add(stringifiedAssessmentItem).then(([contentnode, assessment_id]) => {
       context.commit('UPDATE_ASSESSMENTITEM', {
         ...assessmentItem,
         contentnode,

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
@@ -4,6 +4,7 @@ import assessmentItem from '../../assessmentItem/index';
 import file from 'shared/vuex/file';
 import { ContentNode } from 'shared/data/resources';
 import storeFactory from 'shared/vuex/baseStore';
+import { mockChannelScope, resetMockChannelScope } from 'shared/utils/testing';
 
 jest.mock('../../currentChannel/index');
 
@@ -15,7 +16,8 @@ describe('contentNode actions', () => {
   let store;
   let id;
   const contentNodeDatum = { title: 'test', parent: parentId, lft: 1, tags: {} };
-  beforeEach(() => {
+  beforeEach(async () => {
+    await mockChannelScope('test-123');
     return ContentNode._add(contentNodeDatum).then(newId => {
       id = newId;
       contentNodeDatum.id = newId;
@@ -38,7 +40,8 @@ describe('contentNode actions', () => {
       });
     });
   });
-  afterEach(() => {
+  afterEach(async () => {
+    await resetMockChannelScope();
     jest.restoreAllMocks();
     return ContentNode.table.toCollection().delete();
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
@@ -16,7 +16,7 @@ describe('contentNode actions', () => {
   let id;
   const contentNodeDatum = { title: 'test', parent: parentId, lft: 1, tags: {} };
   beforeEach(() => {
-    return ContentNode._put(contentNodeDatum).then(newId => {
+    return ContentNode._add(contentNodeDatum).then(newId => {
       id = newId;
       contentNodeDatum.id = newId;
       jest
@@ -25,7 +25,7 @@ describe('contentNode actions', () => {
       jest
         .spyOn(ContentNode, 'fetchModel')
         .mockImplementation(() => Promise.resolve(contentNodeDatum));
-      return ContentNode._put({ title: 'notatest', parent: newId, lft: 2 }).then(() => {
+      return ContentNode._add({ title: 'notatest', parent: newId, lft: 2 }).then(() => {
         store = storeFactory({
           modules: {
             assessmentItem,

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -191,7 +191,7 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     assessmentItems: [],
     files: [],
   });
-  return ContentNode.put(contentNodeData).then(id => {
+  return ContentNode.add(contentNodeData).then(id => {
     context.commit('ADD_CONTENTNODE', {
       id,
       ...contentNodeData,

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
@@ -38,7 +38,7 @@ export function createSearch({ commit, rootState }, params) {
     saved_by: rootState.session.currentUser.id,
     created: new Date(),
   };
-  return SavedSearch.put(data).then(id => {
+  return SavedSearch.add(data).then(id => {
     commit('UPDATE_SAVEDSEARCH', {
       id,
       ...data,

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -18,7 +18,7 @@ describe('invitation actions', () => {
   let store;
   let id;
   beforeEach(() => {
-    return Invitation.put(invitation).then(newId => {
+    return Invitation.add(invitation).then(newId => {
       id = newId;
       store = storeFactory({
         modules: {
@@ -59,7 +59,7 @@ describe('invitation actions', () => {
   //   const channel = { id: channel_id, name: 'test', deleted: false, edit: true };
   //   beforeEach(() => {
   //     store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);
-  //     return Channel.put(channel);
+  //     return Channel.add(channel);
   //   });
   //   afterEach(() => {
   //     return Channel.table.toCollection().delete();

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -3,7 +3,6 @@ import channelList from '../index';
 import { Channel, Invitation } from 'shared/data/resources';
 import storeFactory from 'shared/vuex/baseStore';
 
-jest.mock('shared/client');
 jest.mock('shared/vuex/connectionPlugin');
 
 const channel_id = '11111111111111111111111111111111';

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
@@ -1,5 +1,5 @@
 import channelSet from '../index';
-import { ChannelSet } from 'shared/data/resources';
+import { ChannelSet, injectVuexStore } from 'shared/data/resources';
 import storeFactory from 'shared/vuex/baseStore';
 
 jest.mock('shared/vuex/connectionPlugin');
@@ -14,17 +14,19 @@ describe('channelSet actions', () => {
     edit: true,
   };
   beforeEach(() => {
+    store = storeFactory({
+      modules: {
+        channelSet,
+      },
+    });
+    store.state.session.currentUser.id = userId;
+    injectVuexStore(store);
     return ChannelSet.add(channelSetDatum).then(newId => {
       id = newId;
-      store = storeFactory({
-        modules: {
-          channelSet,
-        },
-      });
-      store.state.session.currentUser.id = userId;
     });
   });
   afterEach(() => {
+    injectVuexStore();
     return ChannelSet.table.toCollection().delete();
   });
   describe('loadChannelSetList action', () => {

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelSet/__tests__/module.spec.js
@@ -14,7 +14,7 @@ describe('channelSet actions', () => {
     edit: true,
   };
   beforeEach(() => {
-    return ChannelSet.put(channelSetDatum).then(newId => {
+    return ChannelSet.add(channelSetDatum).then(newId => {
       id = newId;
       store = storeFactory({
         modules: {

--- a/contentcuration/contentcuration/frontend/shared/__tests__/app.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/__tests__/app.spec.js
@@ -45,7 +45,7 @@ describe('startApp', () => {
 
     describe('if there is a current user saved in a session', () => {
       beforeEach(async () => {
-        await Session.put({ ...USER_1, CURRENT_USER });
+        await Session.table.put({ ...USER_1, CURRENT_USER });
 
         const sessionTable = await Session.table.toArray();
         expect(sessionTable).toEqual([{ ...USER_1, CURRENT_USER }]);
@@ -77,7 +77,7 @@ describe('startApp', () => {
 
     describe('if there is the same current user saved in a session', () => {
       beforeEach(async () => {
-        await Session.put({ ...USER_1, CURRENT_USER });
+        await Session.table.put({ ...USER_1, CURRENT_USER });
 
         const sessionTable = await Session.table.toArray();
         expect(sessionTable).toEqual([{ ...USER_1, CURRENT_USER }]);
@@ -91,7 +91,7 @@ describe('startApp', () => {
 
     describe('if there is a different current user saved in a session', () => {
       beforeEach(async () => {
-        await Session.put({ ...USER_2, CURRENT_USER });
+        await Session.table.put({ ...USER_2, CURRENT_USER });
 
         const sessionTable = await Session.table.toArray();
         expect(sessionTable).toEqual([{ ...USER_2, CURRENT_USER }]);

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -256,7 +256,7 @@ Vue.component('Menu', Menu);
 function initiateServiceWorker() {
   // Second conditional must be removed if you are doing dev work on the service
   // worker.
-  if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
+  if ('serviceWorker' in navigator) {
     const wb = new Workbox(window.Urls.service_worker());
     let registration;
 

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -1,6 +1,7 @@
 import sortBy from 'lodash/sortBy';
 import shuffle from 'lodash/shuffle';
 import find from 'lodash/find';
+import { Store } from 'vuex';
 import {
   RELATIVE_TREE_POSITIONS,
   COPYING_FLAG,
@@ -15,6 +16,7 @@ import {
   ContentNodePrerequisite,
   TreeResource,
   uuid4,
+  injectVuexStore,
 } from 'shared/data/resources';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
@@ -323,16 +325,13 @@ describe('ContentNode methods', () => {
             lft: 1,
             changed: true,
           },
-          change: {
+          changeData: {
             key: 'abc123',
             from_key: null,
             target: parent.id,
             position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
             oldObj: node,
-            source: CLIENTID,
             table: 'contentnode',
-            type: CHANGE_TYPES.MOVED,
-            channel_id: parent.channel_id,
           },
         });
       });
@@ -359,16 +358,13 @@ describe('ContentNode methods', () => {
             lft: 1,
             changed: true,
           },
-          change: {
+          changeData: {
             key: 'abc123',
             from_key: null,
             target: parent.id,
             position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
             oldObj: node,
-            source: CLIENTID,
             table: 'contentnode',
-            type: CHANGE_TYPES.MOVED,
-            channel_id: node.channel_id,
           },
         });
       });
@@ -399,15 +395,13 @@ describe('ContentNode methods', () => {
             lft,
             changed: true,
           },
-          change: {
+          changeData: {
             key: 'abc123',
             from_key: null,
             target: 'target',
             position: 'position',
             oldObj: node,
-            source: CLIENTID,
             table: 'contentnode',
-            type: CHANGE_TYPES.MOVED,
           },
         });
       });
@@ -426,22 +420,6 @@ describe('ContentNode methods', () => {
         expect(get).toHaveBeenCalledWith('abc123', false);
         expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
         expect(getNewSortOrder).toHaveBeenCalledWith('abc123', 'target', 'position', siblings);
-        expect(cb).not.toBeCalled();
-      });
-
-      it('should reject if null channel_id', async () => {
-        const cb = jest.fn(() => Promise.resolve('results'));
-        parent.channel_id = null;
-        node.channel_id = null;
-
-        await expect(
-          ContentNode.resolveTreeInsert('abc123', 'target', 'position', false, cb)
-        ).rejects.toThrow('Missing channel_id for tree insertion change event');
-        expect(resolveParent).toHaveBeenCalledWith('target', 'position');
-        expect(treeLock).toHaveBeenCalledWith(parent.root_id, expect.any(Function));
-        expect(get).toHaveBeenCalledWith('abc123', false);
-        expect(where).toHaveBeenCalledWith({ parent: parent.id }, false);
-        expect(getNewSortOrder).not.toBeCalled();
         expect(cb).not.toBeCalled();
       });
     });
@@ -468,18 +446,16 @@ describe('ContentNode methods', () => {
             lft: 1,
             changed: true,
           },
-          change: {
+          changeData: {
             key: expect.not.stringMatching('abc123'),
             from_key: 'abc123',
             target: parent.id,
             position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
             oldObj: null,
-            source: CLIENTID,
             table: 'contentnode',
-            type: CHANGE_TYPES.COPIED,
           },
         });
-        expect(result.payload.id).toEqual(result.change.key);
+        expect(result.payload.id).toEqual(result.changeData.key);
       });
 
       it('should determine lft from siblings', async () => {
@@ -507,18 +483,16 @@ describe('ContentNode methods', () => {
             lft,
             changed: true,
           },
-          change: {
+          changeData: {
             key: expect.not.stringMatching('abc123'),
             from_key: 'abc123',
             target: 'target',
             position: 'position',
             oldObj: null,
-            source: CLIENTID,
             table: 'contentnode',
-            type: CHANGE_TYPES.COPIED,
           },
         });
-        expect(result.payload.id).toEqual(result.change.key);
+        expect(result.payload.id).toEqual(result.changeData.key);
       });
 
       it('should reject if null lft', async () => {
@@ -615,7 +589,7 @@ describe('ContentNode methods', () => {
     let node,
       parent,
       payload,
-      change,
+      // change,
       table = {};
 
     beforeEach(() => {
@@ -641,16 +615,14 @@ describe('ContentNode methods', () => {
         node_id: uuid4(),
       };
       payload = { id: uuid4(), parent: parent.id, changed: true, lft: 1 };
-      change = {
-        key: payload.id,
-        from_key: node.id,
-        target: parent.id,
-        position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
-        oldObj: null,
-        source: CLIENTID,
-        table: 'contentnode',
-        type: CHANGE_TYPES.COPIED,
-      };
+      // change = {
+      //   key: payload.id,
+      //   from_key: node.id,
+      //   target: parent.id,
+      //   position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+      //   oldObj: null,
+      //   table: 'contentnode',
+      // };
 
       mockProperty('table', table);
     });
@@ -673,11 +645,12 @@ describe('ContentNode methods', () => {
         [COPYING_FLAG]: true,
         [TASK_ID]: null,
       };
-      await expect(ContentNode.tableCopy({ node, parent, payload, change })).resolves.toMatchObject(
+      await expect(ContentNode.tableCopy({ node, parent, payload })).resolves.toMatchObject(
         expectedPayload
       );
       expect(table.put).toHaveBeenCalledWith(expectedPayload);
       // TODO: Fails
+      // I think because the change is only saved in the `copy` method not the tableCopy method?
       // await expect(db[CHANGES_TABLE].get({ '[table+key]': [ContentNode.tableName, node.id] }))
       //   .resolves.toMatchObject(change);
     });
@@ -756,11 +729,12 @@ describe('Clipboard methods', () => {
   });
 
   describe('copy method', () => {
-    let node_id, channel_id, clipboardRootId, node, siblings, where, getByNodeIdChannelId;
+    let node_id, channel_id, clipboardRootId, node, siblings, where, getByNodeIdChannelId, user_id;
     beforeEach(() => {
       node_id = uuid4();
       channel_id = uuid4();
       clipboardRootId = uuid4();
+      user_id = uuid4();
       node = {
         id: node_id,
         kind: ContentKindsNames.DOCUMENT,
@@ -771,6 +745,18 @@ describe('Clipboard methods', () => {
         .spyOn(ContentNode, 'getByNodeIdChannelId')
         .mockImplementation(() => Promise.resolve(node));
       mocks.push(getByNodeIdChannelId);
+      const store = new Store({
+        getters: {
+          currentUserId() {
+            return user_id;
+          },
+        },
+      });
+      injectVuexStore(store);
+    });
+
+    afterEach(() => {
+      injectVuexStore();
     });
 
     it('should create a bare copy of the node', async () => {
@@ -854,7 +840,7 @@ describe('ContentNodePrerequisite methods', () => {
     });
     it('should return all associated requisites, even when there is a cyclic dependency', () => {
       const cyclic = { target_node: 'id-chemistry', prerequisite: 'id-lab' };
-      return ContentNodePrerequisite.add(cyclic).then(() => {
+      return ContentNodePrerequisite.table.add(cyclic).then(() => {
         return ContentNode.getRequisites('id-integrals').then(entries => {
           expect(sortBy(entries, 'target_node')).toEqual(
             sortBy(mappings.concat([cyclic]), 'target_node')

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -854,7 +854,7 @@ describe('ContentNodePrerequisite methods', () => {
     });
     it('should return all associated requisites, even when there is a cyclic dependency', () => {
       const cyclic = { target_node: 'id-chemistry', prerequisite: 'id-lab' };
-      return ContentNodePrerequisite.put(cyclic).then(() => {
+      return ContentNodePrerequisite.add(cyclic).then(() => {
         return ContentNode.getRequisites('id-integrals').then(entries => {
           expect(sortBy(entries, 'target_node')).toEqual(
             sortBy(mappings.concat([cyclic]), 'target_node')

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
@@ -1,5 +1,6 @@
 import pick from 'lodash/pick';
 import {
+  Change,
   CreatedChange,
   UpdatedChange,
   DeletedChange,
@@ -11,6 +12,7 @@ import {
 } from '../changes';
 import {
   CHANGES_TABLE,
+  CHANGE_TYPES,
   TABLE_NAMES,
   RELATIVE_TREE_POSITIONS,
   LAST_FETCHED,
@@ -19,6 +21,8 @@ import {
 } from 'shared/data/constants';
 import db from 'shared/data/db';
 import { mockChannelScope, resetMockChannelScope } from 'shared/utils/testing';
+
+const CLIENTID = 'test-client-id';
 
 describe('Change Types', () => {
   const channel_id = 'test-123';
@@ -36,20 +40,27 @@ describe('Change Types', () => {
       key: '1',
       table: TABLE_NAMES.CONTENTNODE,
       obj: { a: 1, b: 2 },
+      source: CLIENTID,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
       channel_id,
       rev,
-      ...pick(change, ['type', 'key', 'table', 'obj']),
+      ...pick(change, ['type', 'key', 'table', 'obj', 'source']),
     });
   });
 
   it('should persist only the specified fields in the UpdatedChange', async () => {
     const oldObj = { a: 1, b: 2 };
     const changes = { a: 1, b: 3 };
-    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const change = new UpdatedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      oldObj,
+      changes,
+      source: CLIENTID,
+    });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
@@ -58,14 +69,20 @@ describe('Change Types', () => {
       mods: { b: 3 },
       rev,
       channel_id,
-      ...pick(change, ['type', 'key', 'table']),
+      ...pick(change, ['type', 'key', 'table', 'source']),
     });
   });
 
   it('should save the mods as key paths in the UpdatedChange', async () => {
     const oldObj = { a: 1, b: { c: 1 } };
     const changes = { a: 1, b: { c: 2 } };
-    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const change = new UpdatedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      oldObj,
+      changes,
+      source: CLIENTID,
+    });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
@@ -74,14 +91,20 @@ describe('Change Types', () => {
       mods: { 'b.c': 2 },
       rev,
       channel_id,
-      ...pick(change, ['type', 'key', 'table']),
+      ...pick(change, ['type', 'key', 'table', 'source']),
     });
   });
 
   it('should save deleted mods as key paths to null in the UpdatedChange', async () => {
     const oldObj = { a: 1, b: { c: 1 } };
     const changes = { a: 1, b: {} };
-    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const change = new UpdatedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      oldObj,
+      changes,
+      source: CLIENTID,
+    });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
@@ -90,7 +113,7 @@ describe('Change Types', () => {
       mods: { 'b.c': null },
       rev,
       channel_id,
-      ...pick(change, ['type', 'key', 'table']),
+      ...pick(change, ['type', 'key', 'table', 'source']),
     });
   });
 
@@ -103,7 +126,13 @@ describe('Change Types', () => {
       [TASK_ID]: '18292183921',
       [COPYING_FLAG]: true,
     };
-    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const change = new UpdatedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      oldObj,
+      changes,
+      source: CLIENTID,
+    });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
@@ -112,7 +141,7 @@ describe('Change Types', () => {
       mods: { b: 3 },
       rev,
       channel_id,
-      ...pick(change, ['type', 'key', 'table']),
+      ...pick(change, ['type', 'key', 'table', 'source']),
     });
   });
 
@@ -125,7 +154,13 @@ describe('Change Types', () => {
       [TASK_ID]: '18292183921',
       [COPYING_FLAG]: true,
     };
-    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const change = new UpdatedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      oldObj,
+      changes,
+      source: CLIENTID,
+    });
     const rev = await change.saveChange();
     expect(rev).toBeNull();
   });
@@ -135,13 +170,14 @@ describe('Change Types', () => {
       key: '1',
       table: TABLE_NAMES.CONTENTNODE,
       oldObj: { a: 1, b: 2 },
+      source: CLIENTID,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
       channel_id,
       rev,
-      ...pick(change, ['type', 'key', 'table', 'oldObj']),
+      ...pick(change, ['type', 'key', 'table', 'oldObj', 'source']),
     });
   });
 
@@ -152,13 +188,14 @@ describe('Change Types', () => {
       target: '2',
       position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
       parent: '3',
+      source: CLIENTID,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
       rev,
       channel_id,
-      ...pick(change, ['type', 'key', 'table', 'target', 'position', 'parent']),
+      ...pick(change, ['type', 'key', 'table', 'target', 'position', 'parent', 'source']),
     });
   });
 
@@ -172,6 +209,7 @@ describe('Change Types', () => {
       position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
       excluded_descendants: null,
       parent: '3',
+      source: CLIENTID,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
@@ -188,6 +226,7 @@ describe('Change Types', () => {
         'position',
         'excluded_descendants',
         'parent',
+        'source',
       ]),
     });
   });
@@ -198,13 +237,14 @@ describe('Change Types', () => {
       table: TABLE_NAMES.CHANNEL,
       version_notes: 'Some version notes',
       language: 'en',
+      source: CLIENTID,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
       rev,
       channel_id: change.key,
-      ...pick(change, ['type', 'key', 'table', 'version_notes', 'language']),
+      ...pick(change, ['type', 'key', 'table', 'version_notes', 'language', 'source']),
     });
   });
 
@@ -216,6 +256,7 @@ describe('Change Types', () => {
       resource_details: false,
       files: true,
       assessment_items: false,
+      source: CLIENTID,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
@@ -230,68 +271,127 @@ describe('Change Types', () => {
         'resource_details',
         'files',
         'assessment_items',
+        'source',
       ]),
     });
   });
 
   it('should persist only the specified fields in the DeployedChange', async () => {
-    const change = new DeployedChange({ key: '1', table: TABLE_NAMES.CHANNEL });
+    const change = new DeployedChange({ key: '1', table: TABLE_NAMES.CHANNEL, source: CLIENTID });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
       rev,
       channel_id: change.key,
-      ...pick(change, ['type', 'key', 'table']),
+      ...pick(change, ['type', 'key', 'table', 'source']),
     });
   });
 });
 
 describe('Change Types Unhappy Paths', () => {
+  // Base Change
+  it('should throw error when Change is instantiated without key', () => {
+    expect(
+      () =>
+        new Change({ table: TABLE_NAMES.CONTENTNODE, source: CLIENTID, type: CHANGE_TYPES.CREATED })
+    ).toThrow(new TypeError('key is required for a Change but it was undefined'));
+  });
+  it('should throw error when Change is instantiated with a null key', () => {
+    expect(
+      () =>
+        new Change({
+          key: null,
+          table: TABLE_NAMES.CONTENTNODE,
+          source: CLIENTID,
+          type: CHANGE_TYPES.CREATED,
+        })
+    ).toThrow(new TypeError('key is required for a Change but it was null'));
+  });
+
+  it('should throw error when Change is instantiated without a source', () => {
+    expect(
+      () => new Change({ key: '1', table: TABLE_NAMES.CONTENTNODE, type: CHANGE_TYPES.CREATED })
+    ).toThrow(new ReferenceError('source should be a string, but undefined was passed instead'));
+  });
+
+  it('should throw error when Change is instantiated with a non-string source', () => {
+    expect(
+      () =>
+        new Change({
+          key: '1',
+          source: 123,
+          table: TABLE_NAMES.CONTENTNODE,
+          type: CHANGE_TYPES.CREATED,
+        })
+    ).toThrow(new ReferenceError('source should be a string, but 123 was passed instead'));
+  });
+
+  it('should throw error when Change is instantiated with invalid table', () => {
+    expect(
+      () => new Change({ key: '1', table: 'test', source: CLIENTID, type: CHANGE_TYPES.CREATED })
+    ).toThrow(new ReferenceError('test is not a valid table value'));
+  });
+
+  it('should throw error when Change is instantiated with a non-syncable table', () => {
+    expect(
+      () =>
+        new Change({
+          key: '1',
+          table: TABLE_NAMES.SESSION,
+          source: CLIENTID,
+          type: CHANGE_TYPES.CREATED,
+        })
+    ).toThrow(new TypeError('session is not a syncable table'));
+  });
+
   // CreatedChange
-  it('should throw error when CreatedChange is instantiated without key', () => {
-    expect(() => new CreatedChange({ table: TABLE_NAMES.CONTENTNODE, obj: {} })).toThrow(
-      new TypeError('key is required for a CreatedChange but it was undefined')
-    );
-  });
-  it('should throw error when CreatedChange is instantiated with a null key', () => {
-    expect(() => new CreatedChange({ key: null, table: TABLE_NAMES.CONTENTNODE, obj: {} })).toThrow(
-      new TypeError('key is required for a CreatedChange but it was null')
-    );
-  });
+
   it('should throw error when CreatedChange is instantiated without obj', () => {
-    expect(() => new CreatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
-      new TypeError('obj should be an object, but undefined was passed instead')
-    );
+    expect(
+      () => new CreatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, source: CLIENTID })
+    ).toThrow(new TypeError('obj should be an object, but undefined was passed instead'));
   });
 
   it('should throw error when CreatedChange is instantiated with incorrect obj type', () => {
     expect(
-      () => new CreatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, obj: 'invalid' })
+      () =>
+        new CreatedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          obj: 'invalid',
+          source: CLIENTID,
+        })
     ).toThrow(new TypeError('obj should be an object, but invalid was passed instead'));
-  });
-
-  it('should throw error when CreatedChange is instantiated with a non-syncable table', () => {
-    expect(() => new CreatedChange({ key: '1', table: TABLE_NAMES.SESSION, obj: {} })).toThrow(
-      new TypeError('session is not a syncable table')
-    );
   });
 
   // UpdatedChange
   it('should throw error when UpdatedChange is instantiated without changes', () => {
-    expect(() => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
-      new TypeError('changes should be an object, but undefined was passed instead')
-    );
+    expect(
+      () => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, source: CLIENTID })
+    ).toThrow(new TypeError('changes should be an object, but undefined was passed instead'));
   });
 
   it('should throw error when UpdatedChange is instantiated with incorrect changes type', () => {
     expect(
-      () => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, changes: 'invalid' })
+      () =>
+        new UpdatedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          changes: 'invalid',
+          source: CLIENTID,
+        })
     ).toThrow(new TypeError('changes should be an object, but invalid was passed instead'));
   });
 
   it('should throw error when UpdatedChange is instantiated without oldObj', () => {
     expect(
-      () => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, changes: {} })
+      () =>
+        new UpdatedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          changes: {},
+          source: CLIENTID,
+        })
     ).toThrow(new TypeError('oldObj should be an object, but undefined was passed instead'));
   });
 
@@ -303,19 +403,14 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CONTENTNODE,
           changes: {},
           oldObj: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('oldObj should be an object, but invalid was passed instead'));
   });
 
   // DeletedChange
-  it('should throw error when DeletedChange is instantiated without key', () => {
-    expect(() => new DeletedChange({ table: TABLE_NAMES.CONTENTNODE })).toThrow(
-      new TypeError('key is required for a DeletedChange but it was undefined')
-    );
-  });
-
   it('should throw error when DeletedChange is instantiated with invalid table', () => {
-    expect(() => new DeletedChange({ key: '1', table: 'test' })).toThrow(
+    expect(() => new DeletedChange({ key: '1', table: 'test', source: CLIENTID })).toThrow(
       new ReferenceError('test is not a valid table value')
     );
   });
@@ -328,6 +423,7 @@ describe('Change Types Unhappy Paths', () => {
           key: '1',
           table: TABLE_NAMES.CONTENTNODE,
           position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('target is required for a MovedChange but it was undefined'));
   });
@@ -340,6 +436,7 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CONTENTNODE,
           target: '2',
           position: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(new ReferenceError('invalid is not a valid position value'));
   });
@@ -352,15 +449,16 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CONTENTNODE,
           target: '2',
           position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+          source: CLIENTID,
         })
     ).toThrow(new ReferenceError('parent is required for a MovedChange but it was undefined'));
   });
 
   // CopiedChange
   it('should throw error when CopiedChange is instantiated without from_key', () => {
-    expect(() => new CopiedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
-      new TypeError('from_key is required for a CopiedChange but it was undefined')
-    );
+    expect(
+      () => new CopiedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, source: CLIENTID })
+    ).toThrow(new TypeError('from_key is required for a CopiedChange but it was undefined'));
   });
 
   it('should throw error when CopiedChange is instantiated with incorrect mods type', () => {
@@ -371,6 +469,7 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CONTENTNODE,
           from_key: '2',
           mods: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('mods should be an object, but invalid was passed instead'));
   });
@@ -383,6 +482,7 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CONTENTNODE,
           from_key: '2',
           mods: { a: 1 },
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('target is required for a CopiedChange but it was undefined'));
   });
@@ -397,6 +497,7 @@ describe('Change Types Unhappy Paths', () => {
           mods: { a: 1 },
           target: '3',
           position: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(new ReferenceError('invalid is not a valid position value'));
   });
@@ -412,6 +513,7 @@ describe('Change Types Unhappy Paths', () => {
           target: '3',
           position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
           excluded_descendants: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(
       new TypeError(
@@ -431,13 +533,16 @@ describe('Change Types Unhappy Paths', () => {
           target: '3',
           position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
           excluded_descendants: null,
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('parent is required for a CopiedChange but it was undefined'));
   });
 
   // PublishedChange
   it('should throw error when PublishedChange is instantiated without version_notes', () => {
-    expect(() => new PublishedChange({ key: '1', table: TABLE_NAMES.CHANNEL })).toThrow(
+    expect(
+      () => new PublishedChange({ key: '1', table: TABLE_NAMES.CHANNEL, source: CLIENTID })
+    ).toThrow(
       new TypeError('version_notes is required for a PublishedChange but it was undefined')
     );
   });
@@ -449,13 +554,16 @@ describe('Change Types Unhappy Paths', () => {
           key: '1',
           table: TABLE_NAMES.CHANNEL,
           version_notes: 'Some notes',
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('language is required for a PublishedChange but it was undefined'));
   });
 
   // SyncedChange
   it('should throw error when SyncedChange is instantiated without titles_and_descriptions', () => {
-    expect(() => new SyncedChange({ key: '1', table: TABLE_NAMES.CHANNEL })).toThrow(
+    expect(
+      () => new SyncedChange({ key: '1', table: TABLE_NAMES.CHANNEL, source: CLIENTID })
+    ).toThrow(
       new TypeError('titles_and_descriptions should be a boolean, but undefined was passed instead')
     );
   });
@@ -467,6 +575,7 @@ describe('Change Types Unhappy Paths', () => {
           key: '1',
           table: TABLE_NAMES.CHANNEL,
           titles_and_descriptions: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(
       new TypeError('titles_and_descriptions should be a boolean, but invalid was passed instead')
@@ -481,6 +590,7 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CHANNEL,
           titles_and_descriptions: true,
           resource_details: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(
       new TypeError('resource_details should be a boolean, but invalid was passed instead')
@@ -496,6 +606,7 @@ describe('Change Types Unhappy Paths', () => {
           titles_and_descriptions: true,
           resource_details: false,
           files: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(new TypeError('files should be a boolean, but invalid was passed instead'));
   });
@@ -510,6 +621,7 @@ describe('Change Types Unhappy Paths', () => {
           resource_details: false,
           files: true,
           assessment_items: 'invalid',
+          source: CLIENTID,
         })
     ).toThrow(
       new TypeError('assessment_items should be a boolean, but invalid was passed instead')
@@ -518,13 +630,13 @@ describe('Change Types Unhappy Paths', () => {
 
   // DeployedChange
   it('should throw error when DeployedChange is instantiated without key', () => {
-    expect(() => new DeployedChange({ table: TABLE_NAMES.CHANNEL })).toThrow(
+    expect(() => new DeployedChange({ table: TABLE_NAMES.CHANNEL, source: CLIENTID })).toThrow(
       new TypeError('key is required for a DeployedChange but it was undefined')
     );
   });
 
   it('should throw error when DeployedChange is instantiated with invalid table', () => {
-    expect(() => new DeployedChange({ key: '1', table: 'test' })).toThrow(
+    expect(() => new DeployedChange({ key: '1', table: 'test', source: CLIENTID })).toThrow(
       new ReferenceError('test is not a valid table value')
     );
   });

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
@@ -1,0 +1,494 @@
+import pick from 'lodash/pick';
+import {
+  CreatedChange,
+  UpdatedChange,
+  DeletedChange,
+  MovedChange,
+  CopiedChange,
+  PublishedChange,
+  SyncedChange,
+  DeployedChange,
+} from '../changes';
+import {
+  CHANGES_TABLE,
+  TABLE_NAMES,
+  RELATIVE_TREE_POSITIONS,
+  LAST_FETCHED,
+  COPYING_FLAG,
+  TASK_ID,
+} from 'shared/data/constants';
+import db from 'shared/data/db';
+
+describe('Change Types', () => {
+  beforeEach(() => {
+    db[CHANGES_TABLE].clear();
+  });
+
+  it('should persist only the specified fields in the CreatedChange', async () => {
+    const change = new CreatedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      obj: { a: 1, b: 2 },
+    });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({ rev, ...pick(change, ['type', 'key', 'table', 'obj']) });
+  });
+
+  it('should persist only the specified fields in the UpdatedChange', async () => {
+    const oldObj = { a: 1, b: 2 };
+    const changes = { a: 1, b: 3 };
+    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      oldObj,
+      obj: changes,
+      mods: { b: 3 },
+      rev,
+      ...pick(change, ['type', 'key', 'table']),
+    });
+  });
+
+  it('should save the mods as key paths in the UpdatedChange', async () => {
+    const oldObj = { a: 1, b: { c: 1 } };
+    const changes = { a: 1, b: { c: 2 } };
+    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      oldObj,
+      obj: changes,
+      mods: { 'b.c': 2 },
+      rev,
+      ...pick(change, ['type', 'key', 'table']),
+    });
+  });
+
+  it('should save deleted mods as key paths to null in the UpdatedChange', async () => {
+    const oldObj = { a: 1, b: { c: 1 } };
+    const changes = { a: 1, b: {} };
+    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      oldObj,
+      obj: changes,
+      mods: { 'b.c': null },
+      rev,
+      ...pick(change, ['type', 'key', 'table']),
+    });
+  });
+
+  it('should ignore updates to specific subfields in the UpdatedChange', async () => {
+    const oldObj = { a: 1, b: 2 };
+    const changes = {
+      a: 1,
+      b: 3,
+      [LAST_FETCHED]: new Date(),
+      [TASK_ID]: '18292183921',
+      [COPYING_FLAG]: true,
+    };
+    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      oldObj,
+      obj: { a: 1, b: 3 },
+      mods: { b: 3 },
+      rev,
+      ...pick(change, ['type', 'key', 'table']),
+    });
+  });
+
+  it('should not save a change when no updates are made in the UpdatedChange', async () => {
+    const oldObj = { a: 1, b: 2 };
+    const changes = {
+      a: 1,
+      b: 2,
+      [LAST_FETCHED]: new Date(),
+      [TASK_ID]: '18292183921',
+      [COPYING_FLAG]: true,
+    };
+    const change = new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, oldObj, changes });
+    const rev = await change.saveChange();
+    expect(rev).toBeNull();
+  });
+
+  it('should persist only the specified fields in the DeletedChange', async () => {
+    const change = new DeletedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      oldObj: { a: 1, b: 2 },
+    });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({ rev, ...pick(change, ['type', 'key', 'table', 'oldObj']) });
+  });
+
+  it('should persist only the specified fields in the MovedChange', async () => {
+    const change = new MovedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      target: '2',
+      position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+      parent: '3',
+    });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      rev,
+      ...pick(change, ['type', 'key', 'table', 'target', 'position', 'parent']),
+    });
+  });
+
+  it('should persist only the specified fields in the CopiedChange', async () => {
+    const change = new CopiedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      from_key: '2',
+      mods: { a: 1, b: 2 },
+      target: '3',
+      position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+      excluded_descendants: null,
+      parent: '3',
+    });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      rev,
+      ...pick(change, [
+        'type',
+        'key',
+        'table',
+        'from_key',
+        'mods',
+        'target',
+        'position',
+        'excluded_descendants',
+        'parent',
+      ]),
+    });
+  });
+
+  it('should persist only the specified fields in the PublishedChange', async () => {
+    const change = new PublishedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      version_notes: 'Some version notes',
+      language: 'en',
+    });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      rev,
+      ...pick(change, ['type', 'key', 'table', 'version_notes', 'language']),
+    });
+  });
+
+  it('should persist only the specified fields in the SyncedChange', async () => {
+    const change = new SyncedChange({
+      key: '1',
+      table: TABLE_NAMES.CONTENTNODE,
+      titles_and_descriptions: true,
+      resource_details: false,
+      files: true,
+      assessment_items: false,
+    });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({
+      rev,
+      ...pick(change, [
+        'type',
+        'key',
+        'table',
+        'titles_and_descriptions',
+        'resource_details',
+        'files',
+        'assessment_items',
+      ]),
+    });
+  });
+
+  it('should persist only the specified fields in the DeployedChange', async () => {
+    const change = new DeployedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE });
+    const rev = await change.saveChange();
+    const persistedChange = await db[CHANGES_TABLE].get(rev);
+    expect(persistedChange).toEqual({ rev, ...pick(change, ['type', 'key', 'table']) });
+  });
+});
+
+describe('Change Types Unhappy Paths', () => {
+  // CreatedChange
+  it('should throw error when CreatedChange is instantiated without obj', () => {
+    expect(() => new CreatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('obj should be an object, but undefined was passed instead')
+    );
+  });
+
+  it('should throw error when CreatedChange is instantiated with incorrect obj type', () => {
+    expect(
+      () => new CreatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, obj: 'invalid' })
+    ).toThrow(new TypeError('obj should be an object, but invalid was passed instead'));
+  });
+
+  it('should throw error when CreatedChange is instantiated with a non-syncable table', () => {
+    expect(() => new CreatedChange({ key: '1', table: TABLE_NAMES.SESSION, obj: {} })).toThrow(
+      new TypeError('session is not a syncable table')
+    );
+  });
+
+  // UpdatedChange
+  it('should throw error when UpdatedChange is instantiated without changes', () => {
+    expect(() => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('changes should be an object, but undefined was passed instead')
+    );
+  });
+
+  it('should throw error when UpdatedChange is instantiated with incorrect changes type', () => {
+    expect(
+      () => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, changes: 'invalid' })
+    ).toThrow(new TypeError('changes should be an object, but invalid was passed instead'));
+  });
+
+  it('should throw error when UpdatedChange is instantiated without oldObj', () => {
+    expect(
+      () => new UpdatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE, changes: {} })
+    ).toThrow(new TypeError('oldObj should be an object, but undefined was passed instead'));
+  });
+
+  it('should throw error when UpdatedChange is instantiated with incorrect oldObj type', () => {
+    expect(
+      () =>
+        new UpdatedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          changes: {},
+          oldObj: 'invalid',
+        })
+    ).toThrow(new TypeError('oldObj should be an object, but invalid was passed instead'));
+  });
+
+  // DeletedChange
+  it('should throw error when DeletedChange is instantiated without key', () => {
+    expect(() => new DeletedChange({ table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('key is required for a DeletedChange but it was undefined')
+    );
+  });
+
+  it('should throw error when DeletedChange is instantiated with invalid table', () => {
+    expect(() => new DeletedChange({ key: '1', table: 'test' })).toThrow(
+      new ReferenceError('test is not a valid table value')
+    );
+  });
+
+  // MovedChange
+  it('should throw error when MovedChange is instantiated without target', () => {
+    expect(
+      () =>
+        new MovedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+        })
+    ).toThrow(new TypeError('target is required for a MovedChange but it was undefined'));
+  });
+
+  it('should throw error when MovedChange is instantiated with incorrect position type', () => {
+    expect(
+      () =>
+        new MovedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          target: '2',
+          position: 'invalid',
+        })
+    ).toThrow(new ReferenceError('invalid is not a valid position value'));
+  });
+
+  it('should throw error when MovedChange is instantiated without parent', () => {
+    expect(
+      () =>
+        new MovedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          target: '2',
+          position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+        })
+    ).toThrow(new ReferenceError('parent is required for a MovedChange but it was undefined'));
+  });
+
+  // CopiedChange
+  it('should throw error when CopiedChange is instantiated without from_key', () => {
+    expect(() => new CopiedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('from_key is required for a CopiedChange but it was undefined')
+    );
+  });
+
+  it('should throw error when CopiedChange is instantiated with incorrect mods type', () => {
+    expect(
+      () =>
+        new CopiedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          from_key: '2',
+          mods: 'invalid',
+        })
+    ).toThrow(new TypeError('mods should be an object, but invalid was passed instead'));
+  });
+
+  it('should throw error when CopiedChange is instantiated without target', () => {
+    expect(
+      () =>
+        new CopiedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          from_key: '2',
+          mods: { a: 1 },
+        })
+    ).toThrow(new TypeError('target is required for a CopiedChange but it was undefined'));
+  });
+
+  it('should throw error when CopiedChange is instantiated with incorrect position type', () => {
+    expect(
+      () =>
+        new CopiedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          from_key: '2',
+          mods: { a: 1 },
+          target: '3',
+          position: 'invalid',
+        })
+    ).toThrow(new ReferenceError('invalid is not a valid position value'));
+  });
+
+  it('should throw error when CopiedChange is instantiated with incorrect excluded_descendants type', () => {
+    expect(
+      () =>
+        new CopiedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          from_key: '2',
+          mods: { a: 1 },
+          target: '3',
+          position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+          excluded_descendants: 'invalid',
+        })
+    ).toThrow(
+      new TypeError(
+        'excluded_descendants should be an object or null, but invalid was passed instead'
+      )
+    );
+  });
+
+  it('should throw error when CopiedChange is instantiated without a parent', () => {
+    expect(
+      () =>
+        new CopiedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          from_key: '2',
+          mods: { a: 1 },
+          target: '3',
+          position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
+          excluded_descendants: null,
+        })
+    ).toThrow(new TypeError('parent is required for a CopiedChange but it was undefined'));
+  });
+
+  // PublishedChange
+  it('should throw error when PublishedChange is instantiated without version_notes', () => {
+    expect(() => new PublishedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('version_notes is required for a PublishedChange but it was undefined')
+    );
+  });
+
+  it('should throw error when PublishedChange is instantiated without language', () => {
+    expect(
+      () =>
+        new PublishedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          version_notes: 'Some notes',
+        })
+    ).toThrow(new TypeError('language is required for a PublishedChange but it was undefined'));
+  });
+
+  // SyncedChange
+  it('should throw error when SyncedChange is instantiated without titles_and_descriptions', () => {
+    expect(() => new SyncedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('titles_and_descriptions should be a boolean, but undefined was passed instead')
+    );
+  });
+
+  it('should throw error when SyncedChange is instantiated with incorrect titles_and_descriptions type', () => {
+    expect(
+      () =>
+        new SyncedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          titles_and_descriptions: 'invalid',
+        })
+    ).toThrow(
+      new TypeError('titles_and_descriptions should be a boolean, but invalid was passed instead')
+    );
+  });
+
+  it('should throw error when SyncedChange is instantiated with incorrect resource_details type', () => {
+    expect(
+      () =>
+        new SyncedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          titles_and_descriptions: true,
+          resource_details: 'invalid',
+        })
+    ).toThrow(
+      new TypeError('resource_details should be a boolean, but invalid was passed instead')
+    );
+  });
+
+  it('should throw error when SyncedChange is instantiated with incorrect files type', () => {
+    expect(
+      () =>
+        new SyncedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          titles_and_descriptions: true,
+          resource_details: false,
+          files: 'invalid',
+        })
+    ).toThrow(new TypeError('files should be a boolean, but invalid was passed instead'));
+  });
+
+  it('should throw error when SyncedChange is instantiated with incorrect assessment_items type', () => {
+    expect(
+      () =>
+        new SyncedChange({
+          key: '1',
+          table: TABLE_NAMES.CONTENTNODE,
+          titles_and_descriptions: true,
+          resource_details: false,
+          files: true,
+          assessment_items: 'invalid',
+        })
+    ).toThrow(
+      new TypeError('assessment_items should be a boolean, but invalid was passed instead')
+    );
+  });
+
+  // DeployedChange
+  it('should throw error when DeployedChange is instantiated without key', () => {
+    expect(() => new DeployedChange({ table: TABLE_NAMES.CONTENTNODE })).toThrow(
+      new TypeError('key is required for a DeployedChange but it was undefined')
+    );
+  });
+
+  it('should throw error when DeployedChange is instantiated with invalid table', () => {
+    expect(() => new DeployedChange({ key: '1', table: 'test' })).toThrow(
+      new ReferenceError('test is not a valid table value')
+    );
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
@@ -248,6 +248,16 @@ describe('Change Types', () => {
 
 describe('Change Types Unhappy Paths', () => {
   // CreatedChange
+  it('should throw error when CreatedChange is instantiated without key', () => {
+    expect(() => new CreatedChange({ table: TABLE_NAMES.CONTENTNODE, obj: {} })).toThrow(
+      new TypeError('key is required for a CreatedChange but it was undefined')
+    );
+  });
+  it('should throw error when CreatedChange is instantiated with a null key', () => {
+    expect(() => new CreatedChange({ key: null, table: TABLE_NAMES.CONTENTNODE, obj: {} })).toThrow(
+      new TypeError('key is required for a CreatedChange but it was null')
+    );
+  });
   it('should throw error when CreatedChange is instantiated without obj', () => {
     expect(() => new CreatedChange({ key: '1', table: TABLE_NAMES.CONTENTNODE })).toThrow(
       new TypeError('obj should be an object, but undefined was passed instead')

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
@@ -1,0 +1,219 @@
+import { queueChange, debouncedSyncChanges } from '../serverSync';
+import { CreatedChange } from '../changes';
+import db from '../db';
+import { Session, Task } from 'shared/data/resources';
+import client from 'shared/client';
+import { CHANGES_TABLE, CURRENT_USER, TABLE_NAMES } from 'shared/data/constants';
+
+async function makeChange(key, server_rev) {
+  const rev = await new CreatedChange({
+    key: String(key),
+    table: TABLE_NAMES.CONTENTNODE,
+    obj: { a: 1, b: 2 },
+  }).saveChange();
+  if (server_rev) {
+    await db[CHANGES_TABLE].update(rev, { server_rev });
+  }
+  return rev;
+}
+
+describe('Debounce behaviour', () => {
+  beforeEach(async () => {
+    await Session.table.put({ id: 0, CURRENT_USER });
+    client.post.mockReset();
+  });
+
+  it('should debounce sync changes', async () => {
+    // Call queueChange multiple times quickly
+    const change1 = await makeChange(1);
+    const change2 = await makeChange(2);
+    const change3 = await makeChange(3);
+
+    queueChange(change1);
+    queueChange(change2);
+    queueChange(change3);
+
+    // Wait for a short duration
+    await debouncedSyncChanges();
+    // Check that client.post was called only once
+    expect(client.post).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ServerSync tests', () => {
+  beforeEach(async () => {
+    await Session.table.put({ id: 0, CURRENT_USER });
+    client.post.mockReset();
+  });
+
+  afterEach(async () => {
+    await db[CHANGES_TABLE].clear();
+  });
+
+  it('should handle allowed responses', async () => {
+    const change1 = await makeChange(1);
+    const change2 = await makeChange(2);
+    const change3 = await makeChange(3);
+
+    const allowed = [
+      { rev: change1, server_rev: 100 },
+      { rev: change2, server_rev: 200 },
+      { rev: change3, server_rev: 300 },
+    ];
+    // Mock the client.post response for this specific test
+    client.post.mockResolvedValue({
+      data: {
+        disallowed: [],
+        allowed,
+        returned: [],
+        errors: [],
+        successes: [],
+        maxRevs: [],
+        tasks: [],
+      },
+    });
+
+    await debouncedSyncChanges();
+
+    // Check that client.post was called only once
+    expect(client.post).toHaveBeenCalledTimes(1);
+    for (const allow of allowed) {
+      const change = await db[CHANGES_TABLE].get(allow.rev);
+      expect(change.server_rev).toEqual(allow.server_rev);
+    }
+  });
+  it('should handle disallowed responses', async () => {
+    const change1 = await makeChange(1);
+    const change2 = await makeChange(2);
+    const change3 = await makeChange(3);
+
+    const disallowed = [{ rev: change1 }, { rev: change2 }, { rev: change3 }];
+
+    client.post.mockResolvedValue({
+      data: {
+        disallowed,
+        allowed: [],
+        returned: [],
+        errors: [],
+        successes: [],
+        maxRevs: [],
+        tasks: [],
+      },
+    });
+
+    await debouncedSyncChanges();
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    for (const disallow of disallowed) {
+      const change = await db[CHANGES_TABLE].get(disallow.rev);
+      expect(change.disallowed).toBe(true);
+    }
+  });
+
+  it('should handle errors responses', async () => {
+    const change1 = await makeChange(1, 100);
+    const change2 = await makeChange(2, 200);
+    const change3 = await makeChange(3, 300);
+
+    const errors = [
+      { rev: change1, server_rev: 100, errored: true },
+      { rev: change2, server_rev: 200, errored: true },
+      { rev: change3, server_rev: 300, errored: true },
+    ];
+
+    client.post.mockResolvedValue({
+      data: {
+        disallowed: [],
+        allowed: [],
+        returned: [],
+        errors,
+        successes: [],
+        maxRevs: [],
+        tasks: [],
+      },
+    });
+
+    await debouncedSyncChanges();
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    for (const error of errors) {
+      const change = await db[CHANGES_TABLE].get(error.rev);
+      expect(change.errored).toBe(true);
+    }
+  });
+
+  it('should handle successes responses', async () => {
+    const change1 = await makeChange(1, 100);
+    const change2 = await makeChange(2, 200);
+    const change3 = await makeChange(3, 300);
+
+    const successes = [
+      { rev: change1, server_rev: 100 },
+      { rev: change2, server_rev: 200 },
+      { rev: change3, server_rev: 300 },
+    ];
+
+    client.post.mockResolvedValue({
+      data: {
+        disallowed: [],
+        allowed: [],
+        returned: [],
+        errors: [],
+        successes,
+        maxRevs: [],
+        tasks: [],
+      },
+    });
+
+    await debouncedSyncChanges();
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    for (const s of successes) {
+      const change = await db[CHANGES_TABLE].get(s.rev);
+      expect(change).not.toBeDefined();
+    }
+  });
+
+  it('should handle tasks responses', async () => {
+    const tasks = [
+      {
+        task_id: 'task1',
+        progress: 0,
+        status: 'PENDING',
+        channel_id: 'aaaaaaaaaaaaaaaaa-bbbbbbbbbbbbb-ccccccccccccc',
+      },
+      {
+        task_id: 'task2',
+        progress: 0,
+        status: 'PENDING',
+        channel_id: 'aaaaaaaaaaaaaaaaa-bbbbbbbbbbbbb-ccccccccccccc',
+      },
+      {
+        task_id: 'task3',
+        progress: 0,
+        status: 'PENDING',
+        channel_id: 'aaaaaaaaaaaaaaaaa-bbbbbbbbbbbbb-ccccccccccccc',
+      },
+    ];
+
+    client.post.mockResolvedValue({
+      data: {
+        disallowed: [],
+        allowed: [],
+        returned: [],
+        errors: [],
+        successes: [],
+        maxRevs: [],
+        tasks,
+      },
+    });
+
+    await debouncedSyncChanges();
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    for (const task of tasks) {
+      const dbTask = await Task.get(task.task_id);
+      expect(dbTask.status).toEqual(task.status);
+    }
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
@@ -4,6 +4,7 @@ import db from '../db';
 import { Session, Task } from 'shared/data/resources';
 import client from 'shared/client';
 import { CHANGES_TABLE, CURRENT_USER, TABLE_NAMES } from 'shared/data/constants';
+import { mockChannelScope, resetMockChannelScope } from 'shared/utils/testing';
 
 async function makeChange(key, server_rev) {
   const rev = await new CreatedChange({
@@ -21,6 +22,11 @@ describe('Debounce behaviour', () => {
   beforeEach(async () => {
     await Session.table.put({ id: 0, CURRENT_USER });
     client.post.mockReset();
+    await mockChannelScope('test-123');
+  });
+
+  afterEach(async () => {
+    await resetMockChannelScope();
   });
 
   it('should debounce sync changes', async () => {
@@ -44,9 +50,11 @@ describe('ServerSync tests', () => {
   beforeEach(async () => {
     await Session.table.put({ id: 0, CURRENT_USER });
     client.post.mockReset();
+    await mockChannelScope('test-123');
   });
 
   afterEach(async () => {
+    await resetMockChannelScope();
     await db[CHANGES_TABLE].clear();
   });
 

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
@@ -11,6 +11,7 @@ async function makeChange(key, server_rev) {
     key: String(key),
     table: TABLE_NAMES.CONTENTNODE,
     obj: { a: 1, b: 2 },
+    source: 'test-source-id',
   }).saveChange();
   if (server_rev) {
     await db[CHANGES_TABLE].update(rev, { server_rev });

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -1,7 +1,7 @@
 import Dexie from 'dexie';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
-import { CHANGE_TYPES, IGNORED_SOURCE, TABLE_NAMES } from './constants';
+import { CHANGE_TYPES, TABLE_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
 
@@ -46,7 +46,6 @@ function transaction(change, ...args) {
   const callback = args.pop();
   const tableNames = [change.table, ...args];
   return db.transaction('rw', tableNames, () => {
-    Dexie.currentTransaction.source = IGNORED_SOURCE;
     return callback();
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -1,5 +1,6 @@
 import Dexie from 'dexie';
 import sortBy from 'lodash/sortBy';
+import logging from '../logging';
 import { CHANGE_TYPES, IGNORED_SOURCE, TABLE_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
@@ -129,18 +130,27 @@ export default async function applyChanges(changes) {
   const results = [];
   for (const change of sortBy(changes, ['server_rev', 'rev'])) {
     let result;
-    if (change.type === CHANGE_TYPES.CREATED) {
-      result = await applyCreate(change);
-    } else if (change.type === CHANGE_TYPES.UPDATED) {
-      result = await applyUpdate(change);
-    } else if (change.type === CHANGE_TYPES.DELETED) {
-      result = await applyDelete(change);
-    } else if (change.type === CHANGE_TYPES.MOVED) {
-      result = await applyMove(change);
-    } else if (change.type === CHANGE_TYPES.COPIED) {
-      result = await applyCopy(change);
-    } else if (change.type === CHANGE_TYPES.PUBLISHED) {
-      result = await applyPublish(change);
+    try {
+      if (change.type === CHANGE_TYPES.CREATED) {
+        result = await applyCreate(change);
+      } else if (change.type === CHANGE_TYPES.UPDATED) {
+        result = await applyUpdate(change);
+      } else if (change.type === CHANGE_TYPES.DELETED) {
+        result = await applyDelete(change);
+      } else if (change.type === CHANGE_TYPES.MOVED) {
+        result = await applyMove(change);
+      } else if (change.type === CHANGE_TYPES.COPIED) {
+        result = await applyCopy(change);
+      } else if (change.type === CHANGE_TYPES.PUBLISHED) {
+        result = await applyPublish(change);
+      }
+    } catch (e) {
+      logging.error(e, {
+        filename: 'change.json',
+        // strip csrf token from headers
+        data: JSON.stringify(change),
+        contentType: 'application/json',
+      });
     }
 
     if (result) {

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -6,7 +6,6 @@ import isUndefined from 'lodash/isUndefined';
 import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
-import { applyMods } from './applyRemoteChanges';
 import db from 'shared/data/db';
 import { promiseChunk } from 'shared/utils/helpers';
 import {
@@ -291,8 +290,9 @@ export class UpdatedChange extends Change {
     // For now, the aim here is to preserve the same change structure as found in
     // the Dexie Observable updating hook:
     // https://github.com/dexie/Dexie.js/blob/master/addons/Dexie.Observable/src/hooks/updating.js#L15
-    const mods = Dexie.getObjectDiff(oldObj, changes);
     const newObj = Dexie.deepClone(oldObj);
+    Object.assign(newObj, changes);
+    const mods = Dexie.getObjectDiff(oldObj, newObj);
     for (const propPath in mods) {
       const mod = mods[propPath];
       const currentValue = Dexie.getByKeyPath(oldObj, propPath);
@@ -309,7 +309,6 @@ export class UpdatedChange extends Change {
     if (!this.changed) {
       return;
     }
-    applyMods(newObj, mods);
     this.oldObj = oldObj;
     this.obj = newObj;
   }

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -205,8 +205,8 @@ function omitIgnoredSubFields(obj) {
   return omit(obj, ignoredSubFields);
 }
 
-class Change {
-  constructor({ type, key, table } = {}) {
+export class Change {
+  constructor({ type, key, table, source } = {}) {
     this.setAndValidateLookup(type, 'type', CHANGE_TYPES_LOOKUP);
     this.setAndValidateNotNull(key, 'key');
     this.setAndValidateLookup(table, 'table', TABLE_NAMES_LOOKUP);
@@ -215,6 +215,7 @@ class Change {
       logging.error(error);
       throw error;
     }
+    this.setAndValidateString(source, 'source');
   }
   get changeType() {
     return this.constructor.name;
@@ -293,6 +294,14 @@ class Change {
       throw error;
     }
     this[name] = mapper(value);
+  }
+  setAndValidateString(value, name) {
+    if (typeof value !== 'string') {
+      const error = new TypeError(`${name} should be a string, but ${value} was passed instead`);
+      logging.error(error, value);
+      throw error;
+    }
+    this[name] = value;
   }
   saveChange() {
     if (!this.channelOrUserIdSet) {

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -208,7 +208,7 @@ function omitIgnoredSubFields(obj) {
 class Change {
   constructor({ type, key, table } = {}) {
     this.setAndValidateLookup(type, 'type', CHANGE_TYPES_LOOKUP);
-    this.setAndValidateNotUndefined(key, 'key');
+    this.setAndValidateNotNull(key, 'key');
     this.setAndValidateLookup(table, 'table', TABLE_NAMES_LOOKUP);
     if (!INDEXEDDB_RESOURCES[this.table].syncable) {
       const error = new ReferenceError(`${this.table} is not a syncable table`);
@@ -243,11 +243,23 @@ class Change {
     }
     this[name] = value;
   }
-  setAndValidateNotUndefined(value, name) {
+  validateNotUndefined(value, name) {
     if (isUndefined(value)) {
       const error = new TypeError(
         `${name} is required for a ${this.changeType} but it was undefined`
       );
+      logging.error(error, value);
+      throw error;
+    }
+  }
+  setAndValidateNotUndefined(value, name) {
+    this.validateNotUndefined(value, name);
+    this[name] = value;
+  }
+  setAndValidateNotNull(value, name) {
+    this.validateNotUndefined(value, name);
+    if (isNull(value)) {
+      const error = new TypeError(`${name} is required for a ${this.changeType} but it was null`);
       logging.error(error, value);
       throw error;
     }

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -7,6 +7,7 @@ import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
 import { applyMods } from './applyRemoteChanges';
+import { queueChange } from './serverSync';
 import db from 'shared/data/db';
 import { promiseChunk } from 'shared/utils/helpers';
 import {
@@ -269,6 +270,11 @@ class Change {
   }
   saveChange() {
     return db[CHANGES_TABLE].add(this);
+  }
+  saveAndQueueChange() {
+    return this.saveChange().then(() => {
+      return queueChange(this);
+    });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -6,7 +6,7 @@ import isUndefined from 'lodash/isUndefined';
 import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
-import db from 'shared/data/db';
+import db, { CLIENTID } from 'shared/data/db';
 import { promiseChunk } from 'shared/utils/helpers';
 import {
   CHANGES_TABLE,
@@ -14,7 +14,6 @@ import {
   CHANGE_TYPES_LOOKUP,
   TABLE_NAMES,
   TABLE_NAMES_LOOKUP,
-  IGNORED_SOURCE,
   RELATIVE_TREE_POSITIONS,
   RELATIVE_TREE_POSITIONS_LOOKUP,
   LAST_FETCHED,
@@ -98,7 +97,8 @@ export class ChangeTracker {
     }
 
     this._changes = await changes
-      .filter(change => !change.source.match(IGNORED_SOURCE))
+      // Filter out changes that were not made by this client/browser tab
+      .filter(change => change.source === CLIENTID)
       .sortBy('rev');
   }
 

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -7,7 +7,6 @@ import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
 import { applyMods } from './applyRemoteChanges';
-import { queueChange } from './serverSync';
 import db from 'shared/data/db';
 import { promiseChunk } from 'shared/utils/helpers';
 import {
@@ -270,11 +269,6 @@ class Change {
   }
   saveChange() {
     return db[CHANGES_TABLE].add(this);
-  }
-  saveAndQueueChange() {
-    return this.saveChange().then(() => {
-      return queueChange(this);
-    });
   }
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -55,15 +55,6 @@ export const TABLE_NAMES_LOOKUP = invert(TABLE_NAMES);
 
 export const APP_ID = 'KolibriStudio';
 
-// Transaction sources
-/**
- * This transaction source will be ignored when tracking the
- * client's changes
- *
- * @type {string}
- */
-export const IGNORED_SOURCE = 'IGNORED_SOURCE';
-
 export const RELATIVE_TREE_POSITIONS = {
   FIRST_CHILD: 'first-child',
   LAST_CHILD: 'last-child',

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -82,9 +82,4 @@ export const LAST_FETCHED = '__last_fetch';
 // user object from the session table
 export const CURRENT_USER = 'CURRENT_USER';
 
-// A key in the session table that stores the currently active channels to listen for updates
-export const ACTIVE_CHANNELS = 'ACTIVE_CHANNELS';
-
-export const CHANNEL_SYNC_KEEP_ALIVE_INTERVAL = 300 * 1000;
-
 export const MAX_REV_KEY = 'max_rev';

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -1,3 +1,5 @@
+import invert from 'lodash/invert';
+
 export const CHANGE_TYPES = {
   CREATED: 1,
   UPDATED: 2,
@@ -18,6 +20,11 @@ export const CREATION_CHANGE_TYPES = [CHANGE_TYPES.CREATED, CHANGE_TYPES.COPIED]
  * @type {(number)[]}
  */
 export const TREE_CHANGE_TYPES = [CHANGE_TYPES.CREATED, CHANGE_TYPES.COPIED, CHANGE_TYPES.MOVED];
+
+/**
+ * An inverse lookup of CHANGE_TYPES to allow validation of CHANGE_TYPE values
+ */
+export const CHANGE_TYPES_LOOKUP = invert(CHANGE_TYPES);
 
 // Tables
 export const CHANGES_TABLE = 'changesForSyncing';
@@ -41,6 +48,11 @@ export const TABLE_NAMES = {
   BOOKMARK: 'bookmark',
 };
 
+/**
+ * An inverse lookup of TABLE_NAMES to allow validation of TABLE_NAME values
+ */
+export const TABLE_NAMES_LOOKUP = invert(TABLE_NAMES);
+
 export const APP_ID = 'KolibriStudio';
 
 // Transaction sources
@@ -58,6 +70,8 @@ export const RELATIVE_TREE_POSITIONS = {
   LEFT: 'left',
   RIGHT: 'right',
 };
+
+export const RELATIVE_TREE_POSITIONS_LOOKUP = invert(RELATIVE_TREE_POSITIONS);
 
 // Special fields used for frontend specific handling
 export const COPYING_FLAG = '__COPYING';

--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -4,7 +4,7 @@ import mapValues from 'lodash/mapValues';
 import { CHANGES_TABLE, IGNORED_SOURCE, TABLE_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
-import { startSyncing, stopSyncing } from './serverSync';
+import { startSyncing, stopSyncing, syncOnChanges } from './serverSync';
 import * as resources from './resources';
 
 // Re-export for ease of reference.
@@ -61,6 +61,7 @@ export async function initializeDB() {
     if (!document.hidden) {
       startSyncing();
     }
+    syncOnChanges();
   } catch (e) {
     Sentry.captureException(e);
   }

--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -1,7 +1,6 @@
-import Dexie from 'dexie';
 import * as Sentry from '@sentry/vue';
 import mapValues from 'lodash/mapValues';
-import { CHANGES_TABLE, IGNORED_SOURCE, TABLE_NAMES } from './constants';
+import { CHANGES_TABLE, TABLE_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
 import { startSyncing, stopSyncing, syncOnChanges } from './serverSync';
@@ -30,7 +29,6 @@ export function setupSchema() {
 export function resetDB() {
   const tableNames = Object.values(TABLE_NAMES);
   return db.transaction('rw', ...tableNames, () => {
-    Dexie.currentTransaction.source = IGNORED_SOURCE;
     return Promise.all(tableNames.map(table => db[table].clear()));
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/data/registry.js
+++ b/contentcuration/contentcuration/frontend/shared/data/registry.js
@@ -1,4 +1,8 @@
+import Vue from 'vue';
+
 // Put resource registry objects in here to avoid circular import issues
 export const API_RESOURCES = {};
 
 export const INDEXEDDB_RESOURCES = {};
+
+export const changeRevs = Vue.observable([]);

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1492,7 +1492,8 @@ export const ContentNode = new TreeResource({
     }
 
     return this.resolveTreeInsert(id, target, position, true, data => {
-      data.change.excluded_descendants = excluded_descendants;
+      data.changeData.excluded_descendants = excluded_descendants;
+      data.changeData.mods = {};
 
       return this.transaction({ mode: 'rw' }, CHANGES_TABLE, async () => {
         const payload = await this.tableCopy(data);

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1425,7 +1425,7 @@ export const ContentNode = new TreeResource({
       RELATIVE_TREE_POSITIONS.LAST_CHILD,
       true,
       data => {
-        return this.transaction({ mode: 'rw' }, () => {
+        return this.transaction({ mode: 'rw' }, CHANGES_TABLE, () => {
           const obj = { ...prepared, ...data.payload };
           return this.table.add(obj).then(id => {
             return this._createChange(id, obj).then(() => id);

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -560,6 +560,7 @@ class IndexedDBResource {
       table: this.tableName,
       oldObj,
       changes,
+      source: CLIENTID,
     });
     return this._saveAndQueueChange(change);
   }
@@ -620,6 +621,7 @@ class IndexedDBResource {
       key: id,
       table: this.tableName,
       obj,
+      source: CLIENTID,
     });
     return this._saveAndQueueChange(change);
   }
@@ -663,6 +665,7 @@ class IndexedDBResource {
         key: id,
         table: this.tableName,
         oldObj,
+        source: CLIENTID,
       });
       return this._saveAndQueueChange(change);
     });
@@ -1170,6 +1173,7 @@ export const Channel = new Resource({
       files,
       assessment_items,
       table: this.tableName,
+      source: CLIENTID,
     });
     return this.transaction({ mode: 'rw', source: IGNORED_SOURCE }, CHANGES_TABLE, () => {
       return this._saveAndQueueChange(change);
@@ -1412,6 +1416,7 @@ export const ContentNode = new TreeResource({
               parent: parent.id,
               oldObj: isCreate ? null : node,
               table: this.tableName,
+              source: CLIENTID,
             };
 
             return callback({

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1802,18 +1802,20 @@ export const AssessmentItem = new Resource({
       });
     });
   },
+  // Retain super's delete method
+  _delete: Resource.prototype.delete,
   delete(id) {
     const nodeId = id[0];
-    return this.transaction({ mode: 'rw' }, () => {
-      return this.table.delete(id);
-    }).then(data => {
+    return this._delete(id).then(data => {
       return this.modifyAssessmentItemCount(nodeId, -1).then(() => {
         return data;
       });
     });
   },
+  // Retain super's add method
+  _add: Resource.prototype.add,
   add(obj) {
-    return super.add(obj).then(id => {
+    return this._add(obj).then(id => {
       return this.modifyAssessmentItemCount(obj.contentnode, 1).then(() => {
         return id;
       });

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import findLastIndex from 'lodash/findLastIndex';
 import get from 'lodash/get';
 import pick from 'lodash/pick';
@@ -5,6 +6,7 @@ import orderBy from 'lodash/orderBy';
 import uniq from 'lodash/uniq';
 import logging from '../logging';
 import applyChanges from './applyRemoteChanges';
+import { changeRevs } from './registry';
 import { CHANGE_TYPES, CHANGES_TABLE, IGNORED_SOURCE, MAX_REV_KEY } from './constants';
 import db, { channelScope } from './db';
 import { Channel, Session, Task } from './resources';
@@ -200,8 +202,6 @@ function handleTasks(response) {
 
 const noUserError = 'No user logged in';
 
-const changeRevs = [];
-
 async function syncChanges(syncAllChanges) {
   // Note: we could in theory use Dexie syncable for what
   // we are doing here, but I can't find a good way to make
@@ -354,6 +354,10 @@ if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
 }
 
 let intervalTimer;
+
+export function syncOnChanges() {
+  Vue.$watch(() => changeRevs.length, debouncedSyncChanges);
+}
 
 export function startSyncing() {
   // Start the sync interval

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -7,7 +7,7 @@ import uniq from 'lodash/uniq';
 import logging from '../logging';
 import applyChanges from './applyRemoteChanges';
 import { changeRevs } from './registry';
-import { CHANGE_TYPES, CHANGES_TABLE, IGNORED_SOURCE, MAX_REV_KEY } from './constants';
+import { CHANGE_TYPES, CHANGES_TABLE, MAX_REV_KEY } from './constants';
 import db, { channelScope } from './db';
 import { Channel, Session, Task } from './resources';
 import client from 'shared/client';
@@ -179,7 +179,7 @@ function handleMaxRevs(response, userId) {
     );
     if (lastChannelEditIndex > lastPublishIndex) {
       promises.push(
-        Channel.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
+        Channel.transaction({ mode: 'rw' }, () => {
           return Channel.table.update(channelId, { unpublished_changes: true });
         })
       );

--- a/contentcuration/contentcuration/frontend/shared/logging.js
+++ b/contentcuration/contentcuration/frontend/shared/logging.js
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/vue';
+
+export default {
+  error(error, ...attachments) {
+    if (process.env.NODE_ENV !== 'production') {
+      // In dev build log warnings to console for developer use
+      console.trace(error, ...attachments); // eslint-disable-line no-console
+    } else {
+      Sentry.withScope(function(scope) {
+        for (let attachment of attachments) {
+          scope.addAttachment(attachment);
+        }
+        Sentry.captureException(error);
+      });
+    }
+  },
+};

--- a/contentcuration/contentcuration/frontend/shared/logging.js
+++ b/contentcuration/contentcuration/frontend/shared/logging.js
@@ -2,12 +2,12 @@ import * as Sentry from '@sentry/vue';
 
 export default {
   error(error, ...attachments) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV === 'development') {
       // In dev build log warnings to console for developer use
       console.trace(error, ...attachments); // eslint-disable-line no-console
-    } else {
+    } else if (process.env.NODE_ENV === 'production') {
       Sentry.withScope(function(scope) {
-        for (let attachment of attachments) {
+        for (const attachment of attachments) {
           scope.addAttachment(attachment);
         }
         Sentry.captureException(error);

--- a/contentcuration/contentcuration/frontend/shared/utils/testing.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/testing.js
@@ -1,3 +1,5 @@
+import { Session } from 'shared/data/resources';
+
 export function resetJestGlobal() {
   // This global object is bootstraped into channel_edit.html and is
   // assumed by the frontend code for it
@@ -5,4 +7,21 @@ export function resetJestGlobal() {
     channel_id: '',
     channel_error: '',
   };
+}
+
+export async function mockChannelScope(channel_id) {
+  // Function to allow setting the channel scope for use in testing
+  // When we have upgraded to Jest 29, we can change this logic to
+  // make a mock property instead of doing this swap in and out.
+  Session._oldCurrentChannelId = Session.currentChannelId;
+  Session.currentChannelId = channel_id;
+  await Session.setChannelScope();
+}
+
+export async function resetMockChannelScope() {
+  // Function to undo the above
+  // when we have done the above suggested change, we can just reset the mock here.
+  await Session.clearChannelScope();
+  Session.currentChannelId = Session._oldCurrentChannelId;
+  delete Session._oldCurrentChannelId;
 }

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -53,7 +53,7 @@ export function isNodeComplete({ nodeDetails, assessmentItems, files }) {
   }
 
   if (getNodeDetailsErrors(nodeDetails).length) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
       console.info('Node is incomplete', getNodeDetailsErrors(nodeDetails));
     }
     return false;
@@ -63,7 +63,7 @@ export function isNodeComplete({ nodeDetails, assessmentItems, files }) {
     nodeDetails.kind !== ContentKindsNames.EXERCISE
   ) {
     if (getNodeFilesErrors(files).length) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
         console.info("Node's files are incomplete", getNodeFilesErrors(files));
       }
       return false;
@@ -72,7 +72,7 @@ export function isNodeComplete({ nodeDetails, assessmentItems, files }) {
   if (nodeDetails.kind !== ContentKindsNames.TOPIC) {
     const completionCriteria = get(nodeDetails, 'extra_fields.options.completion_criteria');
     if (completionCriteria && !validateCompletionCriteria(completionCriteria, nodeDetails.kind)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
         console.info("Node's completion criteria is invalid", validateCompletionCriteria.errors);
       }
       return false;
@@ -80,7 +80,7 @@ export function isNodeComplete({ nodeDetails, assessmentItems, files }) {
   }
   if (nodeDetails.kind === ContentKindsNames.EXERCISE) {
     if (!assessmentItems.length) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
         console.info('Exercise node is missing assessment items');
       }
       return false;
@@ -91,7 +91,7 @@ export function isNodeComplete({ nodeDetails, assessmentItems, files }) {
       return getAssessmentItemErrors(sanitizedAssessmentItem).length;
     };
     if (assessmentItems.some(isInvalid)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
         console.info(
           "Exercise node's assessment items are invalid",
           assessmentItems.some(isInvalid)

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/__tests__/module.spec.js
@@ -22,7 +22,7 @@ describe('channel actions', () => {
   let id;
   const channelDatum = { name: 'test', deleted: false, edit: true };
   beforeEach(() => {
-    return Channel.put(channelDatum).then(newId => {
+    return Channel.add(channelDatum).then(newId => {
       id = newId;
       channelDatum.id = id;
       store = storeFactory({
@@ -178,14 +178,14 @@ describe('channel actions', () => {
     });
   });
   describe('bookmarkChannel action', () => {
-    it('should call Bookmark.put when creating a bookmark', () => {
-      const putSpy = jest.spyOn(Bookmark, 'put');
+    it('should call Bookmark.add when creating a bookmark', () => {
+      const addSpy = jest.spyOn(Bookmark, 'add');
       store.commit('channel/ADD_CHANNEL', {
         id,
         name: 'test',
       });
       return store.dispatch('channel/bookmarkChannel', { id, bookmark: true }).then(() => {
-        expect(putSpy).toHaveBeenCalledWith({ channel: id });
+        expect(addSpy).toHaveBeenCalledWith({ channel: id });
       });
     });
     it('should call Bookmark.delete when removing a bookmark', () => {
@@ -268,7 +268,7 @@ describe('Channel sharing vuex', () => {
     jest
       .spyOn(ChannelUser, 'fetchCollection')
       .mockImplementation(() => Promise.resolve([testUser]));
-    return Channel.put(channelDatum).then(newId => {
+    return Channel.add(channelDatum).then(newId => {
       channelId = newId;
       const user = {
         ...testUser,
@@ -276,8 +276,8 @@ describe('Channel sharing vuex', () => {
       const invitations = makeInvitations(channelId);
       testInvitations = invitations;
 
-      return User.put(user).then(() => {
-        return ViewerM2M.put({ user: user.id, channel: channelDatum.id }).then(() => {
+      return User.add(user).then(() => {
+        return ViewerM2M.add({ user: user.id, channel: channelDatum.id }).then(() => {
           return Invitation.table.bulkPut(invitations).then(() => {
             store = storeFactory({
               modules: {
@@ -382,7 +382,7 @@ describe('Channel sharing vuex', () => {
         declined: true,
       };
 
-      Invitation.put(declinedInvitation).then(() => {
+      Invitation.add(declinedInvitation).then(() => {
         store.dispatch('channel/loadChannelUsers', channelId).then(() => {
           expect(Object.keys(store.state.channel.invitationsMap)).not.toContain(
             'choosy-invitation'

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -199,7 +199,7 @@ export function updateChannel(
 
 export function bookmarkChannel(context, { id, bookmark }) {
   if (bookmark) {
-    return Bookmark.put({ channel: id }).then(() => {
+    return Bookmark.add({ channel: id }).then(() => {
       context.commit('SET_BOOKMARK', { channel: id });
     });
   } else {

--- a/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/channel/actions.js
@@ -1,6 +1,5 @@
 import pickBy from 'lodash/pickBy';
 import { NOVALUE } from 'shared/constants';
-import { IGNORED_SOURCE } from 'shared/data/constants';
 import { Bookmark, Channel, Invitation, ChannelUser } from 'shared/data/resources';
 import client from 'shared/client';
 
@@ -264,7 +263,7 @@ export async function sendInvitation(context, { channelId, email, shareMode }) {
     share_mode: shareMode,
     channel_id: channelId,
   });
-  await Invitation.transaction({ mode: 'rw', source: IGNORED_SOURCE }, () => {
+  await Invitation.transaction({ mode: 'rw' }, () => {
     return Invitation.table.put(postedInvitation.data);
   });
   context.commit('ADD_INVITATION', postedInvitation.data);

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
@@ -1,6 +1,7 @@
 import storeFactory from 'shared/vuex/baseStore';
-import { File } from 'shared/data/resources';
+import { File, injectVuexStore } from 'shared/data/resources';
 import client from 'shared/client';
+import { mockChannelScope, resetMockChannelScope } from 'shared/utils/testing';
 
 jest.mock('shared/vuex/connectionPlugin');
 
@@ -21,18 +22,22 @@ const userId = 'some user';
 describe('file store', () => {
   let store;
   let id;
-  beforeEach(() => {
+  beforeEach(async () => {
+    await mockChannelScope('test-123');
     jest.spyOn(File, 'fetchCollection').mockImplementation(() => Promise.resolve([testFile]));
     jest.spyOn(File, 'fetchModel').mockImplementation(() => Promise.resolve(testFile));
+    store = storeFactory();
+    injectVuexStore(store);
+    store.state.session.currentUser.id = userId;
     return File.add(testFile).then(newId => {
       id = newId;
-      store = storeFactory();
       store.commit('file/ADD_FILE', { id, ...testFile });
-      store.state.session.currentUser.id = userId;
     });
   });
-  afterEach(() => {
+  afterEach(async () => {
+    await resetMockChannelScope();
     jest.restoreAllMocks();
+    injectVuexStore();
     return File.table.toCollection().delete();
   });
   describe('file getters', () => {

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
@@ -24,7 +24,7 @@ describe('file store', () => {
   beforeEach(() => {
     jest.spyOn(File, 'fetchCollection').mockImplementation(() => Promise.resolve([testFile]));
     jest.spyOn(File, 'fetchModel').mockImplementation(() => Promise.resolve(testFile));
-    return File.put(testFile).then(newId => {
+    return File.add(testFile).then(newId => {
       id = newId;
       store = storeFactory();
       store.commit('file/ADD_FILE', { id, ...testFile });

--- a/contentcuration/contentcuration/views/pwa.py
+++ b/contentcuration/contentcuration/views/pwa.py
@@ -3,6 +3,7 @@ import os
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.http import Http404
 from django.views.generic.base import TemplateView
 
 
@@ -13,17 +14,27 @@ class ServiceWorkerView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Code to access the compiled serivce worker in developer mode
+        content = None
         if getattr(settings, "DEBUG", False):
             import requests
+            try:
+                request = requests.get("http://127.0.0.1:4000/dist/serviceWorker.js")
+                content = request.content.decode("utf-8")
+            except requests.exceptions.RequestException:
+                pass
 
-            request = requests.get("http://127.0.0.1:4000/dist/serviceWorker.js")
-            content = request.content.decode("utf-8")
-        else:
+        if content is None:
             path = staticfiles_storage.path("studio/serviceWorker.js")
             if not os.path.exists(path):
                 path = finders.find("studio/serviceWorker.js")
-            with open(path) as f:
-                content = f.read()
+            try:
+                with open(path) as f:
+                    content = f.read()
+            except (FileNotFoundError, IOError):
+                pass
+
+        if content is None:
+            raise Http404("Service worker not found")
         context["webpack_service_worker"] = content
         return context
 

--- a/contentcuration/contentcuration/views/pwa.py
+++ b/contentcuration/contentcuration/views/pwa.py
@@ -1,5 +1,6 @@
 import os
 
+from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.views.generic.base import TemplateView
@@ -12,17 +13,17 @@ class ServiceWorkerView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Code to access the compiled serivce worker in developer mode
-        # if getattr(settings, "DEBUG", False):
-        #     import requests
+        if getattr(settings, "DEBUG", False):
+            import requests
 
-        #     request = requests.get("http://127.0.0.1:4000/dist/serviceWorker.js")
-        #     content = request.content
-        # else:
-        path = staticfiles_storage.path("studio/serviceWorker.js")
-        if not os.path.exists(path):
-            path = finders.find("studio/serviceWorker.js")
-        with open(path) as f:
-            content = f.read()
+            request = requests.get("http://127.0.0.1:4000/dist/serviceWorker.js")
+            content = request.content.decode("utf-8")
+        else:
+            path = staticfiles_storage.path("studio/serviceWorker.js")
+            if not os.path.exists(path):
+                path = finders.find("studio/serviceWorker.js")
+            with open(path) as f:
+                content = f.read()
         context["webpack_service_worker"] = content
         return context
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Attempts to prevent issues with background tabs sleeping timers and saving memory by making each tab responsible for the creation and persistence to the backend of edits made in the tab context
* Creates Change classes mapping to each Change type to handle proper instantiation of the change and persistence to the indexedDB changes table
* Updates all `put` operations to be `add` operations (new in Dexie v3) to make explicit create vs update changes
* Adds change creation logic into `add`, `update`, and `delete` methods
* Updates existing move, copy, publish, sync, and deploy changes to use the new Change classes
* Removes unused methods on the resource class that modify tables, to prevent future developers from using them without the appropriate change updates
* Updates the server sync logic to run in every open tab (but only to poll when the window is visible)
* Updates the debounce behaviour to remove need for the `syncActive` flag, and instead chain from previous invocations
* Updates the debounce behaviour to always return a promise that will resolve with the next sync
* Updates the forceServerSync function to try to persist all currently unsynced changes, as a last resort before someone logs out.
* Activates the service worker to be active during development (this was not ultimately needed for the implementation, and can be dropped if not wanted)

### Manual verification steps performed
1. Make edits to nodes
2. Upload new nodes
3. Open multiple tabs, make changes in each, ensure that changes from each tab sync from within the tab

___
## Reviewer guidance
### Are there any risky areas that deserve extra testing?
I think the main area for concern here is that it feels like there is more of a chance of a change not getting synced, because a page could be refreshed etc. Not sure how to make sure changes do get synced, while also maintaining the separation of tabs syncing their own changes.


## References
Hopefully fixes #3992

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
