### PR TITLE
Fixes loading spinner issue

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -1,12 +1,27 @@
 <template>
 
-  <VLayout row wrap @scroll="$emit('scroll', $event)">
+  <VLayout
+    row
+    wrap
+    @scroll="$emit('scroll', $event)"
+  >
     <VFlex xs12>
-      <VLayout v-if="!hideNavigation" row>
-        <div v-if="!loading && node" class="mb-1">
+      <VLayout
+        v-if="!hideNavigation"
+        row
+      >
+        <div
+          v-if="!loading && node"
+          class="mb-1"
+        >
           <!-- Slot for elements like "Back" link -->
           <slot name="navigation"></slot>
-          <ContentNodeLearningActivityIcon v-if="isTopic" :isTopic="true" includeText chip />
+          <ContentNodeLearningActivityIcon
+            v-if="isTopic"
+            :isTopic="true"
+            includeText
+            chip
+          />
           <ContentNodeLearningActivityIcon
             v-else-if="hasLearningActivities"
             :learningActivities="node.learning_activities"
@@ -28,9 +43,20 @@
         </VBtn>
       </VLayout>
     </VFlex>
-    <LoadingText v-if="loading || !node" class="mt-4" />
-    <VFlex v-else xs12 class="pb-5">
-      <VLayout row align-center class="my-2">
+    <LoadingText
+      v-if="loading || !node"
+      class="mt-4"
+    />
+    <VFlex
+      v-else
+      xs12
+      class="pb-5"
+    >
+      <VLayout
+        row
+        align-center
+        class="my-2"
+      >
         <h1 class="font-weight-bold notranslate text-truncate title">
           {{ node.title }}
         </h1>
@@ -43,21 +69,45 @@
           <slot name="actions"></slot>
         </VFlex>
       </VLayout>
-      <Tabs v-if="isExercise" slider-color="primary">
-        <VTab class="px-2" :to="{ query: { tab: 'questions' } }" exact>
+      <Tabs
+        v-if="isExercise"
+        slider-color="primary"
+      >
+        <VTab
+          class="px-2"
+          :to="{ query: { tab: 'questions' } }"
+          exact
+        >
           {{ $tr('questions') }}
-          <Icon v-if="invalidQuestions" color="red" small class="mx-2">
+          <Icon
+            v-if="invalidQuestions"
+            color="red"
+            small
+            class="mx-2"
+          >
             error
           </Icon>
         </VTab>
-        <VTab class="px-2" :to="{ query: { tab: 'details' } }" exact>
+        <VTab
+          class="px-2"
+          :to="{ query: { tab: 'details' } }"
+          exact
+        >
           {{ $tr('details') }}
-          <Icon v-if="invalidDetails" color="red" small class="mx-2">
+          <Icon
+            v-if="invalidDetails"
+            color="red"
+            small
+            class="mx-2"
+          >
             error
           </Icon>
         </VTab>
       </Tabs>
-      <VTabsItems :value="tab" @change="tab = $event">
+      <VTabsItems
+        :value="tab"
+        @change="tab = $event"
+      >
         <VTabItem value="questions">
           <Banner
             :value="!assessmentItems.length"
@@ -71,24 +121,46 @@
             error
             :text="$tr('incompleteQuestionError', { count: invalidQuestionCount })"
           />
-          <VLayout v-if="assessmentItems.length" justify-space-between align-center class="my-3">
+          <VLayout
+            v-if="assessmentItems.length"
+            justify-space-between
+            align-center
+            class="my-3"
+          >
             <VFlex>
-              <Checkbox v-model="showAnswers" :label="$tr('showAnswers')" class="ma-0" />
+              <Checkbox
+                v-model="showAnswers"
+                :label="$tr('showAnswers')"
+                class="ma-0"
+              />
             </VFlex>
-            <VFlex shrink class="px-2 subheading">
+            <VFlex
+              shrink
+              class="px-2 subheading"
+            >
               {{ $tr('questionCount', { value: assessmentItems.length }) }}
             </VFlex>
           </VLayout>
-          <VCard v-for="(item, index) in assessmentItems" :key="item.id" flat>
+          <VCard
+            v-for="(item, index) in assessmentItems"
+            :key="item.id"
+            flat
+          >
             <VCardText>
               <VLayout>
-                <VFlex shrink class="py-2">
+                <VFlex
+                  shrink
+                  class="py-2"
+                >
                   <div style="width: 64px;">
                     {{ index + 1 }}
                   </div>
                 </VFlex>
                 <VFlex>
-                  <AssessmentItemPreview :item="item" :detailed="showAnswers" />
+                  <AssessmentItemPreview
+                    :item="item"
+                    :detailed="showAnswers"
+                  />
                 </VFlex>
               </VLayout>
             </VCardText>
@@ -102,11 +174,25 @@
             :nodeId="nodeId"
             :fileId="primaryFiles[0].id"
           />
-          <VCard v-else-if="isResource && !isExercise" class="preview-error" flat>
-            <VLayout align-center justify-center fill-height>
-              <VTooltip bottom lazy>
+          <VCard
+            v-else-if="isResource && !isExercise"
+            class="preview-error"
+            flat
+          >
+            <VLayout
+              align-center
+              justify-center
+              fill-height
+            >
+              <VTooltip
+                bottom
+                lazy
+              >
                 <template #activator="{ on }">
-                  <Icon color="red" v-on="on">
+                  <Icon
+                    color="red"
+                    v-on="on"
+                  >
                     error
                   </Icon>
                 </template>
@@ -116,22 +202,37 @@
           </VCard>
 
           <!-- Content details -->
-          <DetailsRow v-if="isExercise" :label="$tr('questions')">
-            <span v-if="!assessmentItems.length" class="red--text">
-              <Icon color="red" small>error</Icon>
+          <DetailsRow
+            v-if="isExercise"
+            :label="$tr('questions')"
+          >
+            <span
+              v-if="!assessmentItems.length"
+              class="red--text"
+            >
+              <Icon
+                color="red"
+                small
+              >error</Icon>
               <span class="mx-1">{{ $tr('noQuestionsError') }}</span>
             </span>
             <span v-else>
               {{ $formatNumber(assessmentItems.length) }}
             </span>
           </DetailsRow>
-          <DetailsRow :label="$tr('description')" :text="getText('description')" />
+          <DetailsRow
+            :label="$tr('description')"
+            :text="getText('description')"
+          />
           <DetailsRow
             v-if="!isTopic"
             :label="translateMetadataString('level')"
             :text="level(node.grade_levels)"
           />
-          <DetailsRow v-if="!isTopic" :label="translateMetadataString('learningActivity')">
+          <DetailsRow
+            v-if="!isTopic"
+            :label="translateMetadataString('learningActivity')"
+          >
             <ContentNodeLearningActivityIcon
               :learningActivities="node.learning_activities"
               includeText
@@ -140,8 +241,14 @@
           </DetailsRow>
 
           <DetailsRow :label="translateMetadataString('completion')">
-            <span v-if="isExercise && noMasteryModel" class="red--text">
-              <Icon color="red" small>error</Icon>
+            <span
+              v-if="isExercise && noMasteryModel"
+              class="red--text"
+            >
+              <Icon
+                color="red"
+                small
+              >error</Icon>
               <span class="mx-1">{{ $tr('noMasteryModelError') }}</span>
             </span>
             <span v-else>
@@ -172,14 +279,25 @@
               {{ tag }}
             </VChip>
           </DetailsRow>
-          <DetailsRow v-if="isResource" :label="$tr('fileSize')" :text="formatFileSize(fileSize)" />
+          <DetailsRow
+            v-if="isResource"
+            :label="$tr('fileSize')"
+            :text="formatFileSize(fileSize)"
+          />
 
           <!-- Audience section -->
           <div class="section-header">
             {{ $tr('audience') }}
           </div>
-          <DetailsRow :label="$tr('language')" :text="languageName" />
-          <DetailsRow v-if="!isTopic" :label="$tr('visibleTo')" :text="roleName" />
+          <DetailsRow
+            :label="$tr('language')"
+            :text="languageName"
+          />
+          <DetailsRow
+            v-if="!isTopic"
+            :label="$tr('visibleTo')"
+            :text="roleName"
+          />
           <DetailsRow
             v-if="!isTopic"
             :label="translateMetadataString('accessibility')"
@@ -195,8 +313,15 @@
               <div v-if="!previousSteps.length">
                 {{ defaultText }}
               </div>
-              <div v-else dense class="mb-2 pa-1">
-                <div v-for="prerequisite in previousSteps" :key="prerequisite.id">
+              <div
+                v-else
+                dense
+                class="mb-2 pa-1"
+              >
+                <div
+                  v-for="prerequisite in previousSteps"
+                  :key="prerequisite.id"
+                >
                   <ContentNodeLearningActivityIcon
                     v-if="prerequisite.learning_activities"
                     :learningActivities="prerequisite.learning_activities"
@@ -210,8 +335,15 @@
               <div v-if="!nextSteps.length">
                 {{ defaultText }}
               </div>
-              <div v-else dense class="mb-2 pa-1">
-                <div v-for="postrequisite in nextSteps" :key="postrequisite.id">
+              <div
+                v-else
+                dense
+                class="mb-2 pa-1"
+              >
+                <div
+                  v-for="postrequisite in nextSteps"
+                  :key="postrequisite.id"
+                >
                   <ContentNodeLearningActivityIcon
                     v-if="postrequisite.learning_activities"
                     :learningActivities="postrequisite.learning_activities"
@@ -244,22 +376,35 @@
               <p>
                 {{ $formatNumber(node.resource_count) }}
               </p>
-              <VList v-if="node.resource_count" dense class="mb-2 pa-0">
-                <VListTile v-for="kind in kindCount" :key="kind.kind">
+              <VList
+                v-if="node.resource_count"
+                dense
+                class="mb-2 pa-0"
+              >
+                <VListTile
+                  v-for="kind in kindCount"
+                  :key="kind.kind"
+                >
                   <VListTileContent>
                     <VListTileTitle />
                   </VListTileContent>
                 </VListTile>
               </VList>
             </DetailsRow>
-            <DetailsRow :label="$tr('coachResources')" :text="$formatNumber(node.coach_count)" />
+            <DetailsRow
+              :label="$tr('coachResources')"
+              :text="$formatNumber(node.coach_count)"
+            />
           </template>
           <template v-else>
             <!-- Source section -->
             <div class="section-header">
               {{ $tr('source') }}
             </div>
-            <DetailsRow v-if="isImported && importedChannelLink" :label="$tr('originalChannel')">
+            <DetailsRow
+              v-if="isImported && importedChannelLink"
+              :label="$tr('originalChannel')"
+            >
               <ActionLink
                 :text="importedChannelName"
                 :href="importedChannelLink"
@@ -268,45 +413,90 @@
                 target="_blank"
               />
             </DetailsRow>
-            <DetailsRow :label="$tr('author')" :text="getText('author')" notranslate />
-            <DetailsRow :label="$tr('provider')" :text="getText('provider')" notranslate />
-            <DetailsRow :label="$tr('aggregator')" :text="getText('aggregator')" notranslate />
+            <DetailsRow
+              :label="$tr('author')"
+              :text="getText('author')"
+              notranslate
+            />
+            <DetailsRow
+              :label="$tr('provider')"
+              :text="getText('provider')"
+              notranslate
+            />
+            <DetailsRow
+              :label="$tr('aggregator')"
+              :text="getText('aggregator')"
+              notranslate
+            />
             <DetailsRow :label="$tr('license')">
-              <span v-if="noLicense" class="red--text">
-                <Icon color="red" small>error</Icon>
+              <span
+                v-if="noLicense"
+                class="red--text"
+              >
+                <Icon
+                  color="red"
+                  small
+                >error</Icon>
                 <span class="mx-1">{{ $tr('noLicenseError') }}</span>
               </span>
               <p v-else>
                 {{ licenseName }}
               </p>
-              <p v-if="noLicenseDescription" class="red--text">
-                <Icon color="red" small>
+              <p
+                v-if="noLicenseDescription"
+                class="red--text"
+              >
+                <Icon
+                  color="red"
+                  small
+                >
                   error
                 </Icon>
                 <span class="mx-1">{{ $tr('noLicenseDescriptionError') }}</span>
               </p>
-              <p v-else class="caption notranslate">
+              <p
+                v-else
+                class="caption notranslate"
+              >
                 {{ licenseDescription }}
               </p>
             </DetailsRow>
             <DetailsRow :label="$tr('copyrightHolder')">
-              <span v-if="noCopyrightHolder" class="red--text">
-                <Icon color="red" small>error</Icon>
+              <span
+                v-if="noCopyrightHolder"
+                class="red--text"
+              >
+                <Icon
+                  color="red"
+                  small
+                >error</Icon>
                 <span class="mx-1">{{ $tr('noCopyrightHolderError') }}</span>
               </span>
-              <span v-else class="notranslate">
+              <span
+                v-else
+                class="notranslate"
+              >
                 {{ getText('copyright_holder') }}
               </span>
             </DetailsRow>
 
             <!-- Files section -->
             <template v-if="isResource && !isExercise">
-              <div v-if="isResource" class="section-header">
+              <div
+                v-if="isResource"
+                class="section-header"
+              >
                 {{ $tr('files') }}
               </div>
               <DetailsRow :label="$tr('availableFormats')">
-                <span v-if="!primaryFiles.length" class="red--text">
-                  <Icon color="red" small>error</Icon>
+                <span
+                  v-if="!primaryFiles.length"
+                  class="red--text"
+                >
+                  <Icon
+                    color="red"
+                    small
+                  >error</Icon>
                   <span class="mx-1">{{ $tr('noFilesError') }}</span>
                 </span>
                 <ExpandableList
@@ -321,7 +511,11 @@
                   node.kind === 'audio'"
                 :label="$tr('subtitles')"
               >
-                <ExpandableList :noItemsText="defaultText" :items="subtitleFileLanguages" inline />
+                <ExpandableList
+                  :noItemsText="defaultText"
+                  :items="subtitleFileLanguages"
+                  inline
+                />
               </DetailsRow>
             </template>
           </template>
@@ -445,7 +639,7 @@
         return '-';
       },
       hasLearningActivities() {
-        return this.node && Object.keys(this.node.learning_activities).length > 0;
+        return this.node && Object.keys(this.node.learning_activities || []).length > 0;
       },
       assessmentItems() {
         return this.getAssessmentItems(this.nodeId);
@@ -591,7 +785,7 @@
         return formatter.format(list);
       },
       level(levels) {
-        const ids = Object.keys(levels);
+        const ids = Object.keys(levels || []);
         const matches = Object.keys(ContentLevels)
           .sort()
           .filter(k => ids.includes(ContentLevels[k]));
@@ -616,7 +810,7 @@
         }
       },
       accessibilityOptions(options) {
-        const ids = Object.keys(options);
+        const ids = Object.keys(options || []);
         const matches = Object.keys(AccessibilityCategories)
           .sort()
           .filter(k => ids.includes(AccessibilityCategories[k]));
@@ -627,7 +821,7 @@
         }
       },
       category(options) {
-        const ids = Object.keys(options);
+        const ids = Object.keys(options || []);
         const matches = Object.keys(Categories)
           .sort()
           .filter(k => ids.includes(Categories[k]));

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -180,7 +180,12 @@ export const constantStrings = createTranslator('ConstantStrings', {
 export const constantsTranslationMixin = {
   methods: {
     translateConstant(constant) {
-      return constantStrings.$tr(constant);
+      /*
+       * Prevent translation of unknown keys. Initially, translation
+       * would default to `ConstantStrings.<key>` if not found, which
+       * is not desired on the front-end.
+       */
+      return constant && constantStrings.$tr(constant);
     },
     translateLanguage(language) {
       return Languages.has(language) && Languages.get(language).native_name;

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -181,9 +181,8 @@ export const constantsTranslationMixin = {
   methods: {
     translateConstant(constant) {
       /*
-       * Prevent translation of unknown keys. Initially, translation
-       * would default to `ConstantStrings.<key>` if not found, which
-       * is not desired on the front-end.
+       * Prevent translation of null, undefined and empty keys. Initially, translation would
+       * default to `ConstantStrings.<key>` if not found, which is not desired on the front-end.
        */
       return constant && constantStrings.$tr(constant);
     },


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the continuous loading spinner when previewing a searched channel resource.


### Manual verification steps performed
- Select a channel
- Click "Add" button, then select "Import from other channels"
- Search for channel resources using a desired keyword
- Click on the result card(s) that come(s) up
-  Preview modal opens but spinner keeps on loading

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- Select a channel
- Click "Add" button, then select "import from other channels"
- Search for channel resources using a desired keyword
- Click on the result card(s) that come(s) up
- Preview modal should display information about the selection


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3956

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
