### PR TITLE
Update webpack for proper RTL build, using a placeholder module

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/styles/modulePlaceholder.js
+++ b/contentcuration/contentcuration/frontend/shared/styles/modulePlaceholder.js
@@ -1,0 +1,7 @@
+// This file is used as a placeholder, following the same pattern established in
+// jest_config/globalMocks/fileMock.js
+
+// It is used to help use properly overwrite the vuetify stylus files using webpack
+// (see also webpack.config.js > webpack.NormalModuleReplacementPlugin())
+
+'module-file-stub';

--- a/modulePlaceholder.js
+++ b/modulePlaceholder.js
@@ -1,0 +1,1 @@
+'module-file-stub';

--- a/modulePlaceholder.js
+++ b/modulePlaceholder.js
@@ -1,1 +1,0 @@
-'module-file-stub';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const webpack = require('webpack');
 const djangoProjectDir = path.resolve('contentcuration');
 const staticFilesDir = path.resolve(djangoProjectDir, 'contentcuration', 'static');
 const srcDir = path.resolve(djangoProjectDir, 'contentcuration', 'frontend');
+const dummyModule = path.resolve(srcDir, 'shared', 'styles', 'modulePlaceholder.js')
 
 const bundleOutputDir = path.resolve(staticFilesDir, 'studio');
 
@@ -41,6 +42,7 @@ module.exports = (env = {}) => {
     swDest: 'serviceWorker.js',
     exclude: dev ? [/./] : [/\.map$/, /^manifest.*\.js$/]
   });
+
 
   if (dev) {
     // Suppress the "InjectManifest has been called multiple times" warning by reaching into
@@ -117,7 +119,7 @@ module.exports = (env = {}) => {
     plugins: [
       new webpack.NormalModuleReplacementPlugin(
         /vuetify\/src\/stylus\//,
-        '../../../../../modulePlaceholder.js'
+        dummyModule
       ),
       new BundleTracker({
         filename: path.resolve(djangoProjectDir, 'build', 'webpack-stats.json'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,9 +115,10 @@ module.exports = (env = {}) => {
       modules: [rootNodeModules],
     },
     plugins: [
-      new webpack.IgnorePlugin({
-        resourceRegExp: /\.\.\/stylus\//,
-      }),
+      new webpack.NormalModuleReplacementPlugin(
+        /vuetify\/src\/stylus\//,
+        '../../../../../modulePlaceholder.js'
+      ),
       new BundleTracker({
         filename: path.resolve(djangoProjectDir, 'build', 'webpack-stats.json'),
       }),


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Makes an update to webpack to ensure that the /vuetify/src/stylus is properly overridden.


### Manual verification steps performed
Run a local version of the production environment - seems to work!

### Screenshots (if applicable)

https://github.com/learningequality/studio/assets/17235236/87faf765-50ae-42cc-9e8b-36ad4e4a46c4



## Reviewer guidance
### How can a reviewer test these changes?
```
yarn build
yarn run runserver
```
using Arabic

## References
Fixes reopened https://github.com/learningequality/studio/issues/3499

## Comments
The random empty placeholder file is 1) in a weird place and 2).... kind of confusing?  I just don't know a logical place to move it but can do so and update the path. 

(Also, since I will be out Friday, reviewer(s) pushing a change to this directly is 1000% fine with me)

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
