### PR TITLE
Update aggregate counts when adding, updating, copying, or moving nodes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,8 @@
 root = true
 
+[*]
+max_line_length = 100
+
 [*.js]
 indent_size = 2
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -97,7 +97,7 @@
                     >
                       {{ category(node.categories) }}
                     </span>
-                    <span v-if="(isTopic && node.coach_count) || isCoach">
+                    <span v-if="isTopic && node.coach_count">
                       <!-- for each learning activity -->
                       <VTooltip bottom lazy>
                         <template #activator="{ on }">

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
@@ -15,7 +15,15 @@ const parentId = '000000000000000000000000000000000000';
 describe('contentNode actions', () => {
   let store;
   let id;
-  const contentNodeDatum = { title: 'test', parent: parentId, lft: 1, tags: {} };
+  const contentNodeDatum = {
+    title: 'test',
+    parent: parentId,
+    lft: 1,
+    tags: {},
+    total_count: 0,
+    resource_count: 0,
+    coach_count: 0,
+  };
   beforeEach(async () => {
     await mockChannelScope('test-123');
     return ContentNode._add(contentNodeDatum).then(newId => {
@@ -65,6 +73,8 @@ describe('contentNode actions', () => {
         expect(Object.values(store.state.contentNode.contentNodesMap)).toEqual([
           {
             ...contentNodeDatum,
+            resource_count: 1,
+            total_count: 1,
           },
         ]);
       });
@@ -84,6 +94,8 @@ describe('contentNode actions', () => {
           thumbnail_encoding: {},
           ...contentNodeDatum,
           tags: [],
+          resource_count: 1,
+          total_count: 1,
         });
       });
     });

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/applyRemoteChanges.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/applyRemoteChanges.spec.js
@@ -1,0 +1,271 @@
+import { CHANGE_TYPES } from '../constants';
+import { ChangeDispatcher, ChangeStream, resourceCounts } from '../applyRemoteChanges';
+import Deferred from 'shared/utils/deferred';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+import { RolesNames } from 'shared/leUtils/Roles';
+
+function tick() {
+  return new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+}
+
+describe('ChangeStream', () => {
+  let dispatchers;
+  let changeStream;
+
+  beforeEach(() => {
+    dispatchers = [
+      {
+        apply: jest.fn(() => Promise.resolve()),
+      },
+      {
+        apply: jest.fn(() => Promise.resolve()),
+      },
+    ];
+    changeStream = new ChangeStream(dispatchers);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with the provided dispatchers', () => {
+      expect(changeStream._dispatchers).toBe(dispatchers);
+    });
+
+    it('should create a WritableStream instance', () => {
+      changeStream.init();
+      expect(changeStream._stream).toBeDefined();
+    });
+
+    it('should create a writer for the stream', () => {
+      changeStream.init();
+      expect(changeStream._writer).toBeDefined();
+    });
+  });
+
+  describe('write', () => {
+    let writeSpy;
+
+    beforeEach(() => {
+      dispatchers = [];
+      for (let i = 0; i < 2; i++) {
+        const deferred = new Deferred();
+        const dispatcher = {
+          deferred,
+          apply: jest.fn(() => deferred.promise()),
+        };
+        dispatchers.push(dispatcher);
+      }
+      changeStream = new ChangeStream(dispatchers);
+      changeStream.init();
+      writeSpy = jest.spyOn(changeStream._writer, 'write');
+    });
+
+    it('should acquire a lock and await the writer ready promise', async () => {
+      const changes = [{ id: 1 }, { id: 2 }];
+      const result = changeStream.write(changes);
+      const resultDeferred = Deferred.fromPromise(result);
+
+      await tick();
+
+      // All changes should be written to the stream sink
+      expect(writeSpy.mock.calls).toHaveLength(2);
+      expect(writeSpy).toHaveBeenCalledWith(changes[0]);
+      expect(writeSpy).toHaveBeenCalledWith(changes[1]);
+
+      // the write should be awaiting the dispatcher's apply
+      expect(dispatchers[0].apply).toHaveBeenCalledWith(changes[0]);
+      expect(dispatchers[1].apply).not.toHaveBeenCalledWith(changes[0]);
+
+      // The result should not be resolved yet, until all dispatchers have applied
+      expect(resultDeferred.isFulfilled).toBe(false);
+
+      for (const dispatcher of dispatchers) {
+        dispatcher.deferred.resolve();
+      }
+
+      // Should resolve, otherwise it'll hit the Jest timeout
+      await result;
+    });
+  });
+
+  describe('doWrite', () => {
+    it('should apply the change to each dispatcher', async () => {
+      const change = { id: 1 };
+      await changeStream.doWrite(change);
+
+      for (const dispatcher of dispatchers) {
+        expect(dispatcher.apply).toHaveBeenCalledWith(change);
+      }
+    });
+  });
+});
+
+describe('ChangeDispatcher', () => {
+  let changeDispatcher;
+
+  beforeEach(() => {
+    changeDispatcher = new ChangeDispatcher();
+  });
+
+  describe('apply', () => {
+    it('should call applyCreate if change type is CREATED and applyCreate is defined', async () => {
+      const change = { type: CHANGE_TYPES.CREATED };
+      const applyCreateResult = 'create result';
+      changeDispatcher.applyCreate = jest.fn().mockResolvedValue(applyCreateResult);
+
+      const result = await changeDispatcher.apply(change);
+
+      expect(changeDispatcher.applyCreate).toHaveBeenCalledWith(change);
+      expect(result).toBe(applyCreateResult);
+    });
+
+    it('should call applyUpdate if change type is UPDATED and applyUpdate is defined', async () => {
+      const change = { type: CHANGE_TYPES.UPDATED };
+      const applyUpdateResult = 'update result';
+      changeDispatcher.applyUpdate = jest.fn().mockResolvedValue(applyUpdateResult);
+
+      const result = await changeDispatcher.apply(change);
+
+      expect(changeDispatcher.applyUpdate).toHaveBeenCalledWith(change);
+      expect(result).toBe(applyUpdateResult);
+    });
+
+    it('should call applyDelete if change type is DELETED and applyDelete is defined', async () => {
+      const change = { type: CHANGE_TYPES.DELETED };
+      const applyDeleteResult = 'delete result';
+      changeDispatcher.applyDelete = jest.fn().mockResolvedValue(applyDeleteResult);
+
+      const result = await changeDispatcher.apply(change);
+
+      expect(changeDispatcher.applyDelete).toHaveBeenCalledWith(change);
+      expect(result).toBe(applyDeleteResult);
+    });
+
+    it('should call applyMove if change type is MOVED and applyMove is defined', async () => {
+      const change = { type: CHANGE_TYPES.MOVED };
+      const applyMoveResult = 'move result';
+      changeDispatcher.applyMove = jest.fn().mockResolvedValue(applyMoveResult);
+
+      const result = await changeDispatcher.apply(change);
+
+      expect(changeDispatcher.applyMove).toHaveBeenCalledWith(change);
+      expect(result).toBe(applyMoveResult);
+    });
+
+    it('should call applyCopy if change type is COPIED and applyCopy is defined', async () => {
+      const change = { type: CHANGE_TYPES.COPIED };
+      const applyCopyResult = 'copy result';
+      changeDispatcher.applyCopy = jest.fn().mockResolvedValue(applyCopyResult);
+
+      const result = await changeDispatcher.apply(change);
+
+      expect(changeDispatcher.applyCopy).toHaveBeenCalledWith(change);
+      expect(result).toBe(applyCopyResult);
+    });
+
+    it('should call applyPublish if change type is PUBLISHED and applyPublish is defined', async () => {
+      const change = { type: CHANGE_TYPES.PUBLISHED };
+      const applyPublishResult = 'publish result';
+      changeDispatcher.applyPublish = jest.fn().mockResolvedValue(applyPublishResult);
+
+      const result = await changeDispatcher.apply(change);
+
+      expect(changeDispatcher.applyPublish).toHaveBeenCalledWith(change);
+      expect(result).toBe(applyPublishResult);
+    });
+  });
+});
+
+describe('ResourceCounts', () => {
+  describe('_applyDiff', () => {
+    it('should return the correct diff when changedNode is a folder and multiplier is 1', () => {
+      const changedNode = {
+        kind: ContentKindsNames.TOPIC,
+        total_count: 10,
+        resource_count: 5,
+        coach_count: 3,
+      };
+      const multiplier = 1;
+      const ancestor = {
+        total_count: 100,
+        resource_count: 50,
+        coach_count: 30,
+      };
+
+      const diff = resourceCounts._applyDiff(changedNode, multiplier, ancestor);
+
+      expect(diff.total_count).toBe(110); // (1 * 10) + 100
+      expect(diff.resource_count).toBe(55); // (1 * 5) + 50
+      expect(diff.coach_count).toBe(33); // (1 * 3) + 30
+    });
+
+    it('should return the correct diff when changedNode is a folder and multiplier is -1', () => {
+      const changedNode = {
+        kind: ContentKindsNames.TOPIC,
+        total_count: 10,
+        resource_count: 5,
+        coach_count: 3,
+      };
+      const multiplier = -1;
+      const ancestor = {
+        total_count: 100,
+        resource_count: 50,
+        coach_count: 30,
+      };
+
+      const diff = resourceCounts._applyDiff(changedNode, multiplier, ancestor);
+
+      expect(diff.total_count).toBe(90); // (-1 * 10) + 100
+      expect(diff.resource_count).toBe(45); // (-1 * 5) + 50
+      expect(diff.coach_count).toBe(27); // (-1 * 3) + 30
+    });
+
+    it('should return the correct diff when changedNode is not a folder and counts are 0', () => {
+      const changedNode = {
+        kind: ContentKindsNames.AUDIO,
+        total_count: 0,
+        resource_count: 0,
+        coach_count: 0,
+        role_visibility: RolesNames.LEARNER,
+      };
+      const multiplier = 1;
+      const ancestor = {
+        total_count: 50,
+        resource_count: 20,
+        coach_count: 10,
+      };
+
+      const diff = resourceCounts._applyDiff(changedNode, multiplier, ancestor);
+
+      expect(diff.total_count).toBe(51); // 1 + 50
+      expect(diff.resource_count).toBe(21); // 1 + 20
+      expect(diff.coach_count).toBe(10); // No change
+    });
+
+    it('should return the correct diff when changedNode is not a folder but coach content', () => {
+      const changedNode = {
+        kind: ContentKindsNames.AUDIO,
+        total_count: 0,
+        resource_count: 0,
+        coach_count: 0,
+        role_visibility: RolesNames.COACH,
+      };
+      const multiplier = -1;
+      const ancestor = {
+        total_count: 50,
+        resource_count: 20,
+        coach_count: 10,
+      };
+
+      const diff = resourceCounts._applyDiff(changedNode, multiplier, ancestor);
+
+      expect(diff.total_count).toBe(49); // 50 - 1
+      expect(diff.resource_count).toBe(19); // 20 - 1
+      expect(diff.coach_count).toBe(9); // 10 - 1
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
@@ -188,6 +188,7 @@ describe('Change Types', () => {
       target: '2',
       position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
       parent: '3',
+      oldParent: '4',
       source: CLIENTID,
     });
     const rev = await change.saveChange();
@@ -195,7 +196,16 @@ describe('Change Types', () => {
     expect(persistedChange).toEqual({
       rev,
       channel_id,
-      ...pick(change, ['type', 'key', 'table', 'target', 'position', 'parent', 'source']),
+      ...pick(change, [
+        'type',
+        'key',
+        'table',
+        'target',
+        'position',
+        'parent',
+        'source',
+        'oldParent',
+      ]),
     });
   });
 

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -1,9 +1,12 @@
 import Dexie from 'dexie';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
-import { CHANGE_TYPES, TABLE_NAMES } from './constants';
+import { CHANGE_TYPES, TABLE_NAMES, LOCK_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
+import { acquireLock } from 'shared/data/locks';
+import { RolesNames } from 'shared/leUtils/Roles';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
 const { CREATED, DELETED, UPDATED, MOVED, PUBLISHED, SYNCED, DEPLOYED } = CHANGE_TYPES;
 
@@ -37,6 +40,10 @@ export function collectChanges(changes) {
   return collectedChanges;
 }
 
+function sortChanges(changes) {
+  return sortBy(changes, ['server_rev', 'rev']);
+}
+
 /**
  * @param {Object} change - The change object
  * @param {String|Function} args[] - string table names with callback at the end
@@ -50,98 +57,26 @@ function transaction(change, ...args) {
   });
 }
 
-function applyCreate(change) {
-  return transaction(change, () => {
-    const table = db.table(change.table);
-    return table
-      .put(change.obj, !table.schema.primKey.keyPath ? change.key : undefined)
-      .then(() => change.obj);
-  });
-}
-
-function applyUpdate(change) {
-  return transaction(change, () => {
-    return db
-      .table(change.table)
-      .where(':id')
-      .equals(change.key)
-      .modify(obj => applyMods(obj, change.mods));
-  });
-}
-
-function applyDelete(change) {
-  return transaction(change, () => {
-    return db.table(change.table).delete(change.key);
-  });
-}
-
-function applyMove(change) {
-  const resource = INDEXEDDB_RESOURCES[change.table];
-  if (!resource || !resource.tableMove) {
-    return Promise.resolve();
-  }
-
-  const { key, target, position } = change;
-  return resource.resolveTreeInsert({ id: key, target, position, isCreate: false }, data => {
-    return transaction(change, () => {
-      return resource.tableMove(data);
-    });
-  });
-}
-
-function applyCopy(change) {
-  const resource = INDEXEDDB_RESOURCES[change.table];
-  if (!resource || !resource.tableCopy) {
-    return Promise.resolve();
-  }
-
-  const { key, target, position, from_key } = change;
-  // copying takes the ID of the node to copy, so we use `from_key`
-  return resource.resolveTreeInsert({ id: from_key, target, position, isCreate: true }, data => {
-    return transaction(change, () => {
-      // Update the ID on the payload to match the received change, since isCreate=true
-      // would generate new IDs
-      data.payload.id = key;
-      return resource.tableCopy(data);
-    });
-  });
-}
-
-function applyPublish(change) {
-  if (change.table !== TABLE_NAMES.CHANNEL) {
-    return Promise.resolve();
-  }
-
-  // Publish changes associate with the channel, but we open a transaction on contentnode
-  return transaction(change, TABLE_NAMES.CONTENTNODE, () => {
-    return db
-      .table(TABLE_NAMES.CONTENTNODE)
-      .where({ channel_id: change.channel_id })
-      .modify({ changed: false, published: true });
-  });
-}
-
 /**
- * @see https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
- * @return {Promise<Array>}
+ * Class consolidating code related to mapping changes to the appropriate apply function
+ * and logging related errors
  */
-export default async function applyChanges(changes) {
-  const results = [];
-  for (const change of sortBy(changes, ['server_rev', 'rev'])) {
-    let result;
+export class ChangeDispatcher {
+  async apply(change) {
+    let result = null;
     try {
-      if (change.type === CHANGE_TYPES.CREATED) {
-        result = await applyCreate(change);
-      } else if (change.type === CHANGE_TYPES.UPDATED) {
-        result = await applyUpdate(change);
-      } else if (change.type === CHANGE_TYPES.DELETED) {
-        result = await applyDelete(change);
-      } else if (change.type === CHANGE_TYPES.MOVED) {
-        result = await applyMove(change);
-      } else if (change.type === CHANGE_TYPES.COPIED) {
-        result = await applyCopy(change);
-      } else if (change.type === CHANGE_TYPES.PUBLISHED) {
-        result = await applyPublish(change);
+      if (change.type === CHANGE_TYPES.CREATED && this.applyCreate) {
+        result = await this.applyCreate(change);
+      } else if (change.type === CHANGE_TYPES.UPDATED && this.applyUpdate) {
+        result = await this.applyUpdate(change);
+      } else if (change.type === CHANGE_TYPES.DELETED && this.applyDelete) {
+        result = await this.applyDelete(change);
+      } else if (change.type === CHANGE_TYPES.MOVED && this.applyMove) {
+        result = await this.applyMove(change);
+      } else if (change.type === CHANGE_TYPES.COPIED && this.applyCopy) {
+        result = await this.applyCopy(change);
+      } else if (change.type === CHANGE_TYPES.PUBLISHED && this.applyPublish) {
+        result = await this.applyPublish(change);
       }
     } catch (e) {
       logging.error(e, {
@@ -151,7 +86,319 @@ export default async function applyChanges(changes) {
         contentType: 'application/json',
       });
     }
+    return result;
+  }
+}
 
+class ReturnedChanges extends ChangeDispatcher {
+  /**
+   * @param {CreatedChange} change
+   * @return {Promise<void>}
+   */
+  applyCreate(change) {
+    return transaction(change, () => {
+      const table = db.table(change.table);
+      return table
+        .put(change.obj, !table.schema.primKey.keyPath ? change.key : undefined)
+        .then(() => change.obj);
+    });
+  }
+
+  /**
+   * @param {UpdatedChange} change
+   * @return {Promise<void>}
+   */
+  applyUpdate(change) {
+    return transaction(change, () => {
+      return db
+        .table(change.table)
+        .where(':id')
+        .equals(change.key)
+        .modify(obj => applyMods(obj, change.mods));
+    });
+  }
+
+  /**
+   * @param {DeletedChange} change
+   * @return {Promise<void>}
+   */
+  applyDelete(change) {
+    return transaction(change, () => {
+      return db.table(change.table).delete(change.key);
+    });
+  }
+
+  /**
+   * @param {MovedChange} change
+   * @return {Promise<void>}
+   */
+  applyMove(change) {
+    const resource = INDEXEDDB_RESOURCES[change.table];
+    if (!resource || !resource.tableMove) {
+      return Promise.resolve();
+    }
+
+    const { key, target, position } = change;
+    return resource.resolveTreeInsert({ id: key, target, position, isCreate: false }, data => {
+      return transaction(change, () => {
+        return resource.tableMove(data);
+      });
+    });
+  }
+
+  /**
+   * @param {CopiedChange} change
+   * @return {Promise<void>}
+   */
+  applyCopy(change) {
+    const resource = INDEXEDDB_RESOURCES[change.table];
+    if (!resource || !resource.tableCopy) {
+      return Promise.resolve();
+    }
+
+    const { key, target, position, from_key } = change;
+    // copying takes the ID of the node to copy, so we use `from_key`
+    return resource.resolveTreeInsert({ id: from_key, target, position, isCreate: true }, data => {
+      return transaction(change, () => {
+        // Update the ID on the payload to match the received change, since isCreate=true
+        // would generate new IDs
+        data.payload.id = key;
+        return resource.tableCopy(data);
+      });
+    });
+  }
+
+  /**
+   * @param {PublishedChange} change
+   * @return {Promise<void>}
+   */
+  applyPublish(change) {
+    if (change.table !== TABLE_NAMES.CHANNEL) {
+      return Promise.resolve();
+    }
+
+    // Publish changes associate with the channel, but we open a transaction on contentnode
+    return transaction(change, TABLE_NAMES.CONTENTNODE, () => {
+      return db
+        .table(TABLE_NAMES.CONTENTNODE)
+        .where({ channel_id: change.channel_id })
+        .modify({ changed: false, published: true });
+    });
+  }
+}
+
+/**
+ * Updates aggregate counts on ancestors when a change occurs
+ */
+class ResourceCounts extends ChangeDispatcher {
+  async apply(change) {
+    // Resource counts are only applicable to content nodes
+    if (change.table !== TABLE_NAMES.CONTENTNODE) {
+      return null;
+    }
+    // When there's a current transaction, delay until it's complete
+    if (Dexie.currentTransaction) {
+      return new Promise((resolve, reject) => {
+        Dexie.currentTransaction.on('complete', () => this.apply(change).then(resolve, reject));
+      });
+    }
+    return super.apply(change);
+  }
+
+  /**
+   * @return {ContentNode}
+   */
+  get resource() {
+    return INDEXEDDB_RESOURCES[TABLE_NAMES.CONTENTNODE];
+  }
+
+  /**
+   * @return {Dexie.Table}
+   */
+  get table() {
+    return this.resource.table;
+  }
+
+  /**
+   * Generates the diff to apply to ancestor nodes that updates their counts appropriately
+   *
+   * @typedef {{
+   *  kind: string,
+   *  total_count: number,
+   *  resource_count: number,
+   *  coach_count: number,
+   *  role_visibility: string
+   * }} Node
+   * @param {Node} changedNode
+   * @param {number} multiplier
+   * @param {{total_count: number, resource_count: number, coach_count: number}} ancestor
+   * @return {{total_count: number, resource_count: number, coach_count: number}}
+   * @private
+   */
+  _applyDiff(changedNode, multiplier, ancestor) {
+    const isFolder = changedNode.kind === ContentKindsNames.TOPIC;
+    return {
+      total_count: multiplier * (changedNode.total_count || 1) + ancestor.total_count,
+      resource_count:
+        multiplier * (isFolder ? changedNode.resource_count || 0 : 1) + ancestor.resource_count,
+      coach_count:
+        multiplier *
+          (isFolder
+            ? changedNode.coach_count || 0
+            : Number(changedNode.role_visibility === RolesNames.COACH)) +
+        ancestor.coach_count,
+    };
+  }
+
+  /**
+   * @param {CreatedChange} change
+   * @return {Promise<void>}
+   */
+  async applyCreate(change) {
+    await this.resource.updateAncestors(
+      { id: change.key, ignoreChanges: true },
+      this._applyDiff.bind(this, change.obj, 1)
+    );
+  }
+
+  /**
+   * @param {UpdatedChange} change
+   * @return {Promise<void>}
+   */
+  async applyUpdate(change) {
+    // If the role visibility hasn't changed, we don't need to update the ancestor counts
+    if (!change.mods.role_visibility) {
+      return;
+    }
+
+    await this.resource.updateAncestors({ id: change.key, ignoreChanges: true }, ancestor => {
+      return {
+        coach_count:
+          ancestor.coach_count + (change.mods.role_visibility === RolesNames.COACH ? 1 : -1),
+      };
+    });
+  }
+
+  /**
+   * @param {DeletedChange} change
+   * @return {Promise<void>}
+   */
+  async applyDelete(change) {
+    await this.resource.updateAncestors(
+      { id: change.key, ignoreChanges: true },
+      this._applyDiff.bind(this, change.oldObj, -1)
+    );
+  }
+
+  /**
+   * @param {MovedChange} change
+   * @return {Promise<void>}
+   */
+  async applyMove(change) {
+    // Only if the node is being moved to a new parent do we need to update the ancestor counts
+    if (change.oldParent === change.parent) {
+      return;
+    }
+
+    const node = await this.table.get(change.key);
+    await this.resource.updateAncestors(
+      { id: change.oldParent, includeSelf: true, ignoreChanges: true },
+      this._applyDiff.bind(this, node, -1)
+    );
+    await this.resource.updateAncestors(
+      { id: change.parent, includeSelf: true, ignoreChanges: true },
+      this._applyDiff.bind(this, node, 1)
+    );
+  }
+
+  /**
+   * @param {CopiedChange} change
+   * @return {Promise<void>}
+   */
+  async applyCopy(change) {
+    const node = await this.table.get(change.key);
+    await this.resource.updateAncestors(
+      { id: change.key, ignoreChanges: true },
+      this._applyDiff.bind(this, node, 1)
+    );
+  }
+}
+
+/**
+ * A wrapper class that uses a WritableStream to queue, process, and apply changes to the database
+ * through dispatcher class instances
+ */
+export class ChangeStream {
+  /**
+   * @param {ChangeDispatcher[]} dispatchers
+   */
+  constructor(dispatchers) {
+    this._dispatchers = dispatchers;
+    this._stream = null;
+    this._writer = null;
+  }
+
+  /**
+   * Delay initialization of the stream, otherwise this could get invoked before
+   * the ponyfill is loaded in our Jest test environment
+   */
+  init() {
+    this._stream = new WritableStream({
+      write: change => this.doWrite(change),
+    });
+    this._writer = this._stream.getWriter();
+  }
+
+  /**
+   * @param {Object[]} changes
+   * @return {Promise<void>}
+   */
+  write(changes) {
+    if (!this._stream) {
+      this.init();
+    }
+
+    return acquireLock({ name: LOCK_NAMES.APPLY_CHANGES }, async () => {
+      for (const change of sortChanges(changes)) {
+        // write to the queue but not necessarily applied yet
+        this._writer.write(change);
+      }
+      // return/await here ensures all changes are applied, which allows us to release the lock
+      return this._writer.ready;
+    });
+  }
+
+  /**
+   * @param {Object} change - A change object
+   * @return {Promise<void>}
+   */
+  async doWrite(change) {
+    for (const dispatcher of this._dispatchers) {
+      await dispatcher.apply(change);
+    }
+  }
+}
+
+const returnedChanges = new ReturnedChanges();
+/**
+ * Export resourceCounts instance to update aggregate counts on ancestors when a change occurs
+ * @type {ResourceCounts}
+ */
+export const resourceCounts = new ResourceCounts();
+/**
+ * Export changeStream instance to write returned changes to the database from sync requests
+ * @type {ChangeStream}
+ */
+export const changeStream = new ChangeStream([returnedChanges, resourceCounts]);
+
+/**
+ * @see https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/apply-changes.js
+ * @return {Promise<Array>}
+ */
+export default async function applyChanges(changes) {
+  const results = [];
+  for (const change of sortChanges(changes)) {
+    const result = await returnedChanges.apply(change);
     if (result) {
       results.push(result);
     }

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -6,6 +6,7 @@ import isUndefined from 'lodash/isUndefined';
 import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 import logging from '../logging';
+import { resourceCounts } from './applyRemoteChanges';
 import db, { CLIENTID } from 'shared/data/db';
 import { promiseChunk } from 'shared/utils/helpers';
 import {
@@ -208,7 +209,7 @@ function omitIgnoredSubFields(obj) {
 export class Change {
   constructor({ type, key, table, source } = {}) {
     this.setAndValidateLookup(type, 'type', CHANGE_TYPES_LOOKUP);
-    this.setAndValidateNotNull(key, 'key');
+    this.setAndValidateIsDefined(key, 'key');
     this.setAndValidateLookup(table, 'table', TABLE_NAMES_LOOKUP);
     if (!INDEXEDDB_RESOURCES[this.table].syncable) {
       const error = new ReferenceError(`${this.table} is not a syncable table`);
@@ -217,6 +218,7 @@ export class Change {
     }
     this.setAndValidateString(source, 'source');
   }
+
   get changeType() {
     return this.constructor.name;
   }
@@ -244,28 +246,24 @@ export class Change {
     }
     this[name] = value;
   }
-  validateNotUndefined(value, name) {
-    if (isUndefined(value)) {
+
+  validateIsDefined(value, name) {
+    if (isNull(value) || isUndefined(value)) {
       const error = new TypeError(
-        `${name} is required for a ${this.changeType} but it was undefined`
+        `${name} is required for a ${this.changeType} but it was ${
+          isNull(value) ? 'null' : 'undefined'
+        }`
       );
       logging.error(error, value);
       throw error;
     }
   }
-  setAndValidateNotUndefined(value, name) {
-    this.validateNotUndefined(value, name);
+
+  setAndValidateIsDefined(value, name) {
+    this.validateIsDefined(value, name);
     this[name] = value;
   }
-  setAndValidateNotNull(value, name) {
-    this.validateNotUndefined(value, name);
-    if (isNull(value)) {
-      const error = new TypeError(`${name} is required for a ${this.changeType} but it was null`);
-      logging.error(error, value);
-      throw error;
-    }
-    this[name] = value;
-  }
+
   validateObj(value, name) {
     if (!isPlainObject(value)) {
       const error = new TypeError(`${name} should be an object, but ${value} was passed instead`);
@@ -273,10 +271,12 @@ export class Change {
       throw error;
     }
   }
+
   setAndValidateObj(value, name, mapper = obj => obj) {
     this.validateObj(value, name);
     this[name] = mapper(value);
   }
+
   setAndValidateBoolean(value, name) {
     if (typeof value !== 'boolean') {
       const error = new TypeError(`${name} should be a boolean, but ${value} was passed instead`);
@@ -285,6 +285,7 @@ export class Change {
     }
     this[name] = value;
   }
+
   setAndValidateObjOrNull(value, name, mapper = obj => obj) {
     if (!isPlainObject(value) && !isNull(value)) {
       const error = new TypeError(
@@ -295,6 +296,7 @@ export class Change {
     }
     this[name] = mapper(value);
   }
+
   setAndValidateString(value, name) {
     if (typeof value !== 'string') {
       const error = new TypeError(`${name} should be a string, but ${value} was passed instead`);
@@ -303,13 +305,17 @@ export class Change {
     }
     this[name] = value;
   }
-  saveChange() {
+
+  async saveChange() {
     if (!this.channelOrUserIdSet) {
       throw new ReferenceError(
         `Attempted to save ${this.changeType} change for ${this.table} before setting channel_id and user_id`
       );
     }
-    return db[CHANGES_TABLE].add(this);
+    const rev = await db[CHANGES_TABLE].add(this);
+    // Do not await this
+    resourceCounts.apply(this);
+    return rev;
   }
 }
 
@@ -377,7 +383,7 @@ export class DeletedChange extends Change {
 }
 
 export class MovedChange extends Change {
-  constructor({ target, position, parent, ...fields }) {
+  constructor({ target, position, parent, oldParent, ...fields }) {
     fields.type = CHANGE_TYPES.MOVED;
     super(fields);
     if (this.table !== TABLE_NAMES.CONTENTNODE) {
@@ -385,9 +391,10 @@ export class MovedChange extends Change {
         `${this.changeType} is only supported by ${TABLE_NAMES.CONTENTNODE} table but ${this.table} was passed instead`
       );
     }
-    this.setAndValidateNotUndefined(target, 'target');
+    this.setAndValidateIsDefined(target, 'target');
     this.setAndValidateLookup(position, 'position', RELATIVE_TREE_POSITIONS_LOOKUP);
-    this.setAndValidateNotUndefined(parent, 'parent');
+    this.setAndValidateIsDefined(parent, 'parent');
+    this.setAndValidateIsDefined(oldParent, 'oldParent');
     this.setChannelAndUserId();
   }
 }
@@ -401,12 +408,12 @@ export class CopiedChange extends Change {
         `${this.changeType} is only supported by ${TABLE_NAMES.CONTENTNODE} table but ${this.table} was passed instead`
       );
     }
-    this.setAndValidateNotUndefined(from_key, 'from_key');
+    this.setAndValidateIsDefined(from_key, 'from_key');
     this.setAndValidateObj(mods, 'mods', omitIgnoredSubFields);
-    this.setAndValidateNotUndefined(target, 'target');
+    this.setAndValidateIsDefined(target, 'target');
     this.setAndValidateLookup(position, 'position', RELATIVE_TREE_POSITIONS_LOOKUP);
     this.setAndValidateObjOrNull(excluded_descendants, 'excluded_descendants');
-    this.setAndValidateNotUndefined(parent, 'parent');
+    this.setAndValidateIsDefined(parent, 'parent');
     this.setChannelAndUserId();
   }
 }
@@ -420,8 +427,8 @@ export class PublishedChange extends Change {
         `${this.changeType} is only supported by ${TABLE_NAMES.CHANNEL} table but ${this.table} was passed instead`
       );
     }
-    this.setAndValidateNotUndefined(version_notes, 'version_notes');
-    this.setAndValidateNotUndefined(language, 'language');
+    this.setAndValidateIsDefined(version_notes, 'version_notes');
+    this.setAndValidateIsDefined(language, 'language');
     this.setChannelAndUserId({ id: this.key });
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -74,3 +74,10 @@ export const LAST_FETCHED = '__last_fetch';
 export const CURRENT_USER = 'CURRENT_USER';
 
 export const MAX_REV_KEY = 'max_rev';
+
+export const LOCK_NAMES = {
+  SYNC: 'sync',
+  SYNC_CHANNEL: 'sync_channel:{channel_id}',
+  SYNC_USER: 'sync_user',
+  APPLY_CHANGES: 'apply_changes',
+};

--- a/contentcuration/contentcuration/frontend/shared/data/locks.js
+++ b/contentcuration/contentcuration/frontend/shared/data/locks.js
@@ -1,0 +1,24 @@
+/**
+ * Acquire an exclusive lock on the given name using the browser's Web Locks API,
+ * and then run the given async function.
+ *
+ * @param {string} name
+ * @param {boolean} exclusive
+ * @param {function(): Promise} asyncFunction
+ * @return {Promise<any>}
+ */
+export function acquireLock({ name, exclusive = false }, asyncFunction) {
+  // If the browser supports the Web Locks API
+  // https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+  if (navigator.locks) {
+    return navigator.locks.request(
+      name,
+      {
+        mode: exclusive ? 'exclusive' : 'shared',
+      },
+      asyncFunction
+    );
+  }
+  // Studio's supported browsers should support Web Locks but don't outright fail otherwise
+  return asyncFunction();
+}

--- a/contentcuration/contentcuration/frontend/shared/data/locks.js
+++ b/contentcuration/contentcuration/frontend/shared/data/locks.js
@@ -1,3 +1,5 @@
+import logging from 'shared/logging';
+
 /**
  * Acquire an exclusive lock on the given name using the browser's Web Locks API,
  * and then run the given async function.
@@ -18,6 +20,9 @@ export function acquireLock({ name, exclusive = false }, asyncFunction) {
       },
       asyncFunction
     );
+  } else {
+    // Track if clients aren't supporting the Web Locks API
+    logging.error(new Error('Web Locks API not supported by browser'));
   }
   // Studio's supported browsers should support Web Locks but don't outright fail otherwise
   return asyncFunction();

--- a/contentcuration/contentcuration/frontend/shared/utils/deferred.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/deferred.js
@@ -1,0 +1,67 @@
+/**
+ * Deferred promise
+ */
+export default class Deferred extends Promise {
+  /**
+   * @param {function(resolve, reject): void|null} executor
+   */
+  constructor(executor = null) {
+    let self_resolve, self_reject;
+    executor = executor || (() => {});
+
+    super(function(resolve, reject) {
+      self_resolve = resolve;
+      self_reject = reject;
+      executor(resolve, reject);
+    });
+
+    this._resolve = self_resolve;
+    this._reject = self_reject;
+
+    this.isResolved = false;
+    this.isRejected = false;
+  }
+
+  get isFulfilled() {
+    return this.isResolved || this.isRejected;
+  }
+
+  /**
+   * @param value
+   * @returns {Deferred}
+   */
+  resolve(value) {
+    this._resolve(value);
+    this.isResolved = true;
+    return this;
+  }
+
+  /**
+   * @param value
+   * @returns {Deferred}
+   */
+  reject(value) {
+    this._reject(value);
+    this.isRejected = true;
+    return this;
+  }
+
+  /**
+   * @returns {Promise}
+   */
+  promise() {
+    return new Promise((resolve, reject) => {
+      this.then(resolve, reject);
+    });
+  }
+
+  /**
+   * @param {Promise} promise
+   * @return {Deferred}
+   */
+  static fromPromise(promise) {
+    const deferred = new Deferred();
+    promise.then(deferred.resolve.bind(deferred), deferred.reject.bind(deferred));
+    return deferred;
+  }
+}

--- a/jest_config/jest.conf.js
+++ b/jest_config/jest.conf.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   transformIgnorePatterns: ['/node_modules/(?!vuetify|epubjs|kolibri-design-system|kolibri-constants|axios)'],
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
-  setupFilesAfterEnv: [path.resolve(__dirname, './setup')],
+  setupFilesAfterEnv: ['<rootDir>/jest_config/setup.js'],
   coverageDirectory: '<rootDir>/coverage',
   collectCoverageFrom: ['!**/node_modules/**'],
   verbose: false,

--- a/jest_config/setup.js
+++ b/jest_config/setup.js
@@ -9,7 +9,16 @@ import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import 'shared/i18n/setup';
 // Polyfill indexeddb
 import 'fake-indexeddb/auto';
+// Ponyfill webstreams
+import {ReadableStream, WritableStream, TransformStream, CountQueuingStrategy} from 'web-streams-polyfill/ponyfill/es2018';
 import jquery from 'jquery';
+
+window.jQuery = window.$ = jquery;
+window.ReadableStream = global.ReadableStream = ReadableStream;
+window.WritableStream = global.WritableStream = WritableStream;
+window.TransformStream = global.TransformStream = TransformStream;
+window.CountQueuingStrategy = global.CountQueuingStrategy = CountQueuingStrategy;
+
 import AnalyticsPlugin from 'shared/analytics/plugin';
 import { setupSchema } from 'shared/data';
 import * as resources from 'shared/data/resources';
@@ -33,8 +42,6 @@ global.afterEach(() => {
     return process.nextTick(resolve);
   });
 });
-
-window.jQuery = window.$ = jquery;
 
 window.storageBaseUrl = '/content/storage/';
 

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "npm-run-all": "^4.1.3",
     "stylus": "^0.59.0",
     "stylus-loader": "^7.1.2",
+    "web-streams-polyfill": "^3.2.1",
     "workbox-webpack-plugin": "^6.5.4"
   },
   "false": {},


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->
Supersedes: https://github.com/learningequality/studio/pull/3733

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
Adds logic that increments and decrements the `total_count`, `resource_count`, and `coach_count` when adding, updating, copying or moving nodes. The code processes change events, either caused by writes to indexedDB or changes from other users, and uses that information to update the ancestor node counts accordingly

### Manual verification steps performed
1. Create a new channel
2. Add a folder `Folder A`, then a `Folder B` inside of that, and `Folder C` inside of `B`
3. Upload a resource to `Folder C`
4. Go back to the `My Channels` page
5. Reopen the channel
6. Observe the resource count on `Folder A`
7. Duplicate the resource in `Folder C`
8. Repeat steps 4-6
9. Mark one of the resources in `Folder C` as coach content
10. Repeat steps 4-6, but verify the coach count shows correctly
11. Delete (move to trash) one of the resources in `Folder C`
12. Repeat steps 4-6

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
Deleting a node does not require any of this logic, since we move nodes to the trash tree before deleting them, but it does introduce some inconsistencies.
___

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3508
Fixes https://github.com/learningequality/studio/issues/2548
## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
