### PR TITLE
Display sync changes in channel edit toolbar

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -55,6 +55,7 @@
         </router-link>
       </VToolbarItems>
       <VSpacer />
+      <SavingIndicator />
       <OfflineText indicator />
       <ProgressModal />
       <div
@@ -310,6 +311,7 @@
   import SyncResourcesModal from '../sync/SyncResourcesModal';
   import ProgressModal from '../progress/ProgressModal';
   import PublishModal from '../../components/publish/PublishModal';
+  import SavingIndicator from '../../components/edit/SavingIndicator';
   import { DraggableRegions, DraggableUniverses, RouteNames } from '../../constants';
   import MainNavigationDrawer from 'shared/views/MainNavigationDrawer';
   import IconButton from 'shared/views/IconButton';
@@ -340,6 +342,7 @@
       ContentNodeIcon,
       DraggablePlaceholder,
       MessageDialog,
+      SavingIndicator,
     },
     mixins: [titleMixin],
     props: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -55,7 +55,7 @@
         </router-link>
       </VToolbarItems>
       <VSpacer />
-      <SavingIndicator />
+      <SavingIndicator v-if="!offline" />
       <OfflineText indicator />
       <ProgressModal />
       <div
@@ -306,7 +306,7 @@
 
 <script>
 
-  import { mapActions, mapGetters } from 'vuex';
+  import { mapActions, mapGetters, mapState } from 'vuex';
   import Clipboard from '../../components/Clipboard';
   import SyncResourcesModal from '../sync/SyncResourcesModal';
   import ProgressModal from '../progress/ProgressModal';
@@ -363,6 +363,9 @@
       };
     },
     computed: {
+      ...mapState({
+        offline: state => !state.connection.online,
+      }),
       ...mapGetters('contentNode', ['getContentNode']),
       ...mapGetters('currentChannel', ['currentChannel', 'canEdit', 'canManage', 'rootId']),
       rootNode() {

--- a/contentcuration/contentcuration/frontend/shared/__tests__/app.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/__tests__/app.spec.js
@@ -15,6 +15,7 @@ const USER_2 = { id: 1 };
 
 describe('startApp', () => {
   let store;
+  let cleanup;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -24,6 +25,10 @@ describe('startApp', () => {
   afterEach(async () => {
     global.user = undefined;
     await Session.table.clear();
+    if (cleanup) {
+      cleanup();
+    }
+    cleanup = undefined;
   });
 
   describe('for a guest', () => {
@@ -38,7 +43,7 @@ describe('startApp', () => {
       });
 
       it("the client database shouldn't be reset", async () => {
-        await startApp({ router, store });
+        cleanup = await startApp({ router, store });
         expect(resetDB).not.toHaveBeenCalled();
       });
     });
@@ -52,7 +57,7 @@ describe('startApp', () => {
       });
 
       it('the client database should be reset', async () => {
-        await startApp({ router, store });
+        cleanup = await startApp({ router, store });
         expect(resetDB).toHaveBeenCalledTimes(1);
       });
     });
@@ -70,7 +75,7 @@ describe('startApp', () => {
       });
 
       it("the client database shouldn't be reset", async () => {
-        await startApp({ router, store });
+        cleanup = await startApp({ router, store });
         expect(resetDB).not.toHaveBeenCalled();
       });
     });
@@ -84,7 +89,7 @@ describe('startApp', () => {
       });
 
       it("the client database shouldn't be reset", async () => {
-        await startApp({ router, store });
+        cleanup = await startApp({ router, store });
         expect(resetDB).not.toHaveBeenCalled();
       });
     });
@@ -98,7 +103,7 @@ describe('startApp', () => {
       });
 
       it('the client database should be reset', async () => {
-        await startApp({ router, store });
+        cleanup = await startApp({ router, store });
         expect(resetDB).toHaveBeenCalledTimes(1);
       });
     });

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -350,5 +350,8 @@ export default async function startApp({ store, router, index }) {
   // to the session state.
   injectVuexStore(store);
 
+  // Start listening for unsynced change events in IndexedDB
+  store.listenForIndexedDBChanges();
+
   rootVue = new Vue(config);
 }

--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -37,18 +37,10 @@ if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
   window.resetDB = resetDB;
 }
 
-function applyResourceListener(change) {
-  const resource = INDEXEDDB_RESOURCES[change.table];
-  if (resource && resource.listeners && resource.listeners[change.type]) {
-    resource.listeners[change.type](change);
-  }
-}
-
 export async function initializeDB() {
   try {
     setupSchema();
     await db.open();
-    db.on('changes', changes => changes.map(applyResourceListener));
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) {
         stopSyncing();

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -214,7 +214,6 @@ class IndexedDBResource {
     uuid = true,
     indexFields = [],
     syncable = false,
-    listeners = {},
     ...options
   } = {}) {
     this.tableName = tableName;
@@ -228,9 +227,6 @@ class IndexedDBResource {
     copyProperties(this, options);
     // By default these resources do not sync changes to the backend.
     this.syncable = syncable;
-    // An object for listening to specific change events on this resource in order to
-    // allow for side effects from changes - should be a map of change type to handler function.
-    this.listeners = listeners;
   }
 
   get table() {
@@ -977,13 +973,6 @@ export const Session = new IndexedDBResource({
   tableName: TABLE_NAMES.SESSION,
   idField: CURRENT_USER,
   uuid: false,
-  listeners: {
-    [CHANGE_TYPES.DELETED]: function() {
-      if (!window.location.pathname.endsWith(urls.accounts())) {
-        window.location = urls.accounts();
-      }
-    },
-  },
   get currentChannel() {
     return window.CHANNEL_EDIT_GLOBAL || {};
   },

--- a/contentcuration/contentcuration/frontend/shared/vuex/syncProgressPlugin/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/syncProgressPlugin/index.js
@@ -1,3 +1,4 @@
+import { liveQuery } from 'dexie';
 import syncProgressModule from './syncProgressModule';
 import db from 'shared/data/db';
 import { CHANGES_TABLE } from 'shared/data/constants';
@@ -5,18 +6,22 @@ import { CHANGES_TABLE } from 'shared/data/constants';
 const SyncProgressPlugin = store => {
   store.registerModule('syncProgress', syncProgressModule);
 
-  db.on('changes', function(changes) {
-    const changesTableUpdated = changes.some(change => change.table === CHANGES_TABLE);
-    if (!changesTableUpdated) {
-      return;
-    }
+  store.listenForIndexedDBChanges = () => {
+    const observable = liveQuery(() => {
+      return db[CHANGES_TABLE].toCollection()
+        .filter(c => !c.synced)
+        .first(Boolean);
+    });
 
-    db[CHANGES_TABLE].toCollection()
-      .filter(c => !c.synced)
-      .limit(1)
-      .count()
-      .then(count => store.commit('SET_UNSAVED_CHANGES', count > 0));
-  });
+    const subscription = observable.subscribe({
+      next(result) {
+        store.commit('SET_UNSAVED_CHANGES', result);
+      },
+      error() {
+        subscription.unsubscribe();
+      },
+    });
+  };
 };
 
 export default SyncProgressPlugin;

--- a/contentcuration/contentcuration/frontend/shared/vuex/syncProgressPlugin/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/syncProgressPlugin/index.js
@@ -21,6 +21,7 @@ const SyncProgressPlugin = store => {
         subscription.unsubscribe();
       },
     });
+    store.stopListeningForIndexedDBChanges = subscription.unsubscribe;
   };
 };
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Switches the Vuex plugin for monitoring unsynced changes to use a liveQuery rather than the Dexie Observable `db.on('changes'` in the hope of more reliability
* Switches the final use of the Resource listeners to use a liveQuery to increase reliability of redirect on logout
* Updates the SavingIndicator component to make it use the global state when no nodeIds prop is passed
* Adds the SavingIndicator component to the channel edit toolbar


### Manual verification steps performed
1. Checked that the vuex state properly updated when there were unsynced changes
2. Confirmed that the current beforeunload handler does properly alert if there are unsynced changes when closing the tab
3. Opened a second tab and logged out in that, confirmed that both tabs redirected to the accounts page
4. Made a change and quickly exited from the edit modal - confirmed that the SavingIndicator showed up properly

### Screenshots (if applicable)
Sequential screenshots after an edit was made:

![Screenshot from 2023-06-09 15-48-32](https://github.com/learningequality/studio/assets/1680573/2908b701-27a9-4a4a-80d1-0a394af1e9d0)

![Screenshot from 2023-06-09 15-48-41](https://github.com/learningequality/studio/assets/1680573/2c7913cf-b431-4aaa-af5d-8e6b5b4f82e3)

![Screenshot from 2023-06-09 15-48-46](https://github.com/learningequality/studio/assets/1680573/6aa1c462-b011-4848-8c24-0cd3b0a0ac6b)


### Does this introduce any tech-debt items?
This does currently mean that if no edit has been made in this browser session there is no indicator, but this seemed ok for now?
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
Fixes [#4100](https://github.com/learningequality/studio/issues/4100)

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
