### PR TITLE
Implementation to extract metadata from H5P Content Package

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -489,19 +489,19 @@
       },
       createNodesFromUploads(fileUploads) {
         fileUploads.forEach((file, index) => {
-          let title = file.original_filename
-            .split('.')
-            .slice(0, -1)
-            .join('.');
-          if (title === undefined) {
+          let title;
+          if (file.metadata.title) {
             title = file.metadata.title;
+          } else {
+            title = file.original_filename
+              .split('.')
+              .slice(0, -1)
+              .join('.');
           }
-          const language = file.metadata.language !== undefined ? file.metadata.language : null;
-          const author = file.metadata.authors !== undefined ? file.metadata.author : null;
-          const license = file.metadata.license !== undefined ? file.metadata.license : null;
+          console.log(file.metadata);
           this.createNode(
             FormatPresets.has(file.preset) && FormatPresets.get(file.preset).kind_id,
-            { title, language, author, license }
+            { title, ...file.metadata }
           ).then(newNodeId => {
             if (index === 0) {
               this.selected = [newNodeId];

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -489,13 +489,19 @@
       },
       createNodesFromUploads(fileUploads) {
         fileUploads.forEach((file, index) => {
-          const title = file.original_filename
+          let title = file.original_filename
             .split('.')
             .slice(0, -1)
             .join('.');
+          if (title === undefined) {
+            title = file.metadata.title;
+          }
+          const language = file.metadata.language !== undefined ? file.metadata.language : null;
+          const author = file.metadata.authors !== undefined ? file.metadata.author : null;
+          const license = file.metadata.license !== undefined ? file.metadata.license : null;
           this.createNode(
             FormatPresets.has(file.preset) && FormatPresets.get(file.preset).kind_id,
-            { title }
+            { title, language, author, license }
           ).then(newNodeId => {
             if (index === 0) {
               this.selected = [newNodeId];

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -498,7 +498,6 @@
               .slice(0, -1)
               .join('.');
           }
-          console.log(file.metadata);
           this.createNode(
             FormatPresets.has(file.preset) && FormatPresets.get(file.preset).kind_id,
             { title, ...file.metadata }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/__tests__/module.spec.js
@@ -1,3 +1,5 @@
+import JSZip from 'jszip';
+import { getH5PMetadata } from '../utils';
 import storeFactory from 'shared/vuex/baseStore';
 import { File, injectVuexStore } from 'shared/data/resources';
 import client from 'shared/client';
@@ -18,6 +20,27 @@ const testFile = {
 };
 
 const userId = 'some user';
+
+function get_metadata_file(data) {
+  const manifest = {
+    h5p: '1.0',
+    mainLibrary: 'content',
+    libraries: [
+      {
+        machineName: 'content',
+        majorVersion: 1,
+        minorVersion: 0,
+      },
+    ],
+    content: {
+      library: 'content',
+    },
+    ...data,
+  };
+  const manifestBlob = new Blob([JSON.stringify(manifest, null, 2)], { type: 'application/json' });
+  const manifestFile = new global.File([manifestBlob], 'h5p.json', { type: 'application/json' });
+  return manifestFile;
+}
 
 describe('file store', () => {
   let store;
@@ -119,6 +142,54 @@ describe('file store', () => {
         return store.dispatch('file/uploadFileToStorage', payload).then(() => {
           expect(client.put.mock.calls[0][0]).toBe(payload.url);
           client.post.mockRestore();
+        });
+      });
+    });
+    describe('H5P content file extract metadata', () => {
+      it('getH5PMetadata should check for h5p.json file', () => {
+        const zip = new JSZip();
+        return zip.generateAsync({ type: 'blob' }).then(async function(h5pBlob) {
+          await expect(Promise.resolve(getH5PMetadata(h5pBlob))).resolves.toThrowError(
+            'h5p.json not found in the H5P file.'
+          );
+        });
+      });
+      it('getH5PMetadata should exract metadata from h5p.json', async () => {
+        const manifestFile = get_metadata_file({ title: 'Test file' });
+        const zip = new JSZip();
+        zip.file('h5p.json', manifestFile);
+        await zip.generateAsync({ type: 'blob' }).then(async function(h5pBlob) {
+          await expect(Promise.resolve(getH5PMetadata(h5pBlob))).resolves.toEqual({
+            title: 'Test file',
+          });
+        });
+      });
+      it('getH5PMetadata should not extract und language', async () => {
+        const manifestFile = get_metadata_file({ title: 'Test file', language: 'und' });
+        const zip = new JSZip();
+        zip.file('h5p.json', manifestFile);
+        await zip.generateAsync({ type: 'blob' }).then(async function(h5pBlob) {
+          await expect(Promise.resolve(getH5PMetadata(h5pBlob))).resolves.toEqual({
+            title: 'Test file',
+          });
+        });
+      });
+      it('getH5PMetadata should exract metadata from h5p.json', async () => {
+        const manifestFile = get_metadata_file({
+          title: 'Test file',
+          language: 'en',
+          authors: 'author1',
+          license: 'license1',
+        });
+        const zip = new JSZip();
+        zip.file('h5p.json', manifestFile);
+        await zip.generateAsync({ type: 'blob' }).then(async function(h5pBlob) {
+          await expect(Promise.resolve(getH5PMetadata(h5pBlob))).resolves.toEqual({
+            title: 'Test file',
+            language: 'en',
+            author: 'author1',
+            license: 'license1',
+          });
         });
       });
     });

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/actions.js
@@ -198,6 +198,7 @@ export function uploadFile(context, { file, preset = null } = {}) {
       }); // End get upload url
     })
     .then(data => {
+      data.file.metadata = metadata;
       const fileObject = {
         ...data.file,
         loaded: 0,

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
@@ -19,7 +19,7 @@ export function getHash(file) {
     const spark = new SparkMD5.ArrayBuffer();
     let currentChunk = 0;
     const chunks = Math.ceil(file.size / CHUNK_SIZE);
-    fileReader.onload = function(e) {
+    fileReader.onload = function (e) {
       spark.append(e.target.result);
       currentChunk++;
 
@@ -65,21 +65,18 @@ export function storageUrl(checksum, file_format) {
 }
 
 export async function getH5PMetadata(fileInput, metadata) {
-  // const file = fileInput.files[0];
-  // console.log(typeof(files), file);
   const zip = new JSZip();
-  zip
+  return zip
     .loadAsync(fileInput)
-    .then(function(zip) {
+    .then(function (zip) {
       const h5pJson = zip.file('h5p.json');
-      // console.log(h5pJson);
       if (h5pJson) {
         return h5pJson.async('text');
       } else {
         throw new Error('h5p.json not found in the H5P file.');
       }
     })
-    .then(function(h5pContent) {
+    .then(function (h5pContent) {
       const data = JSON.parse(h5pContent);
       if (Object.prototype.hasOwnProperty.call(data, 'title')) {
         metadata.title = data['title'];
@@ -93,11 +90,11 @@ export async function getH5PMetadata(fileInput, metadata) {
       if (Object.prototype.hasOwnProperty.call(data, 'license')) {
         metadata.license = data['license'];
       }
+      return metadata
     })
-    .catch(function(error) {
-      console.error('Error loading or extracting H5P file:', error);
+    .catch(function (error) {
+      return error
     });
-  return metadata;
 }
 
 /**
@@ -132,7 +129,6 @@ export function extractMetadata(file, preset = null) {
   return new Promise(resolve => {
     if (isH5P) {
       getH5PMetadata(file, metadata);
-      console.log(metadata);
       resolve(metadata);
     } else {
       const mediaElement = document.createElement(isVideo ? 'video' : 'audio');

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
@@ -1,4 +1,5 @@
 import SparkMD5 from 'spark-md5';
+import JSZip from 'jszip';
 import { FormatPresetsList, FormatPresetsNames } from 'shared/leUtils/FormatPresets';
 
 const BLOB_SLICE = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice;
@@ -7,8 +8,10 @@ const MEDIA_PRESETS = [
   FormatPresetsNames.AUDIO,
   FormatPresetsNames.HIGH_RES_VIDEO,
   FormatPresetsNames.LOW_RES_VIDEO,
+  FormatPresetsNames.H5P,
 ];
 const VIDEO_PRESETS = [FormatPresetsNames.HIGH_RES_VIDEO, FormatPresetsNames.LOW_RES_VIDEO];
+const H5P_PRESETS = [FormatPresetsNames.H5P];
 
 export function getHash(file) {
   return new Promise((resolve, reject) => {
@@ -61,6 +64,42 @@ export function storageUrl(checksum, file_format) {
   return `/content/storage/${checksum[0]}/${checksum[1]}/${checksum}.${file_format}`;
 }
 
+export async function getH5PMetadata(fileInput, metadata) {
+  // const file = fileInput.files[0];
+  // console.log(typeof(files), file);
+  const zip = new JSZip();
+  zip
+    .loadAsync(fileInput)
+    .then(function(zip) {
+      const h5pJson = zip.file('h5p.json');
+      // console.log(h5pJson);
+      if (h5pJson) {
+        return h5pJson.async('text');
+      } else {
+        throw new Error('h5p.json not found in the H5P file.');
+      }
+    })
+    .then(function(h5pContent) {
+      const data = JSON.parse(h5pContent);
+      if (Object.prototype.hasOwnProperty.call(data, 'title')) {
+        metadata.Title = data['title'];
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'language') && data['language'] !== 'und') {
+        metadata.language = data['language'];
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'authors')) {
+        metadata.author = data['authors'];
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'license')) {
+        metadata.license = data['license'];
+      }
+    })
+    .catch(function(error) {
+      console.error('Error loading or extracting H5P file:', error);
+    });
+  return metadata;
+}
+
 /**
  * @param {{name: String, preset: String}} file
  * @param {String|null} preset
@@ -85,24 +124,32 @@ export function extractMetadata(file, preset = null) {
     return Promise.resolve(metadata);
   }
 
+  const isH5P = H5P_PRESETS.includes(metadata.preset);
+
   // Extract additional media metadata
   const isVideo = VIDEO_PRESETS.includes(metadata.preset);
 
   return new Promise(resolve => {
-    const mediaElement = document.createElement(isVideo ? 'video' : 'audio');
-    // Add a listener to read the metadata once it has loaded.
-    mediaElement.addEventListener('loadedmetadata', () => {
-      metadata.duration = Math.floor(mediaElement.duration);
-      // Override preset based off video resolution
-      if (isVideo) {
-        metadata.preset =
-          mediaElement.videoHeight >= 720
-            ? FormatPresetsNames.HIGH_RES_VIDEO
-            : FormatPresetsNames.LOW_RES_VIDEO;
-      }
+    if (isH5P) {
+      getH5PMetadata(file, metadata);
+      console.log(metadata);
       resolve(metadata);
-    });
-    // Set the src url on the media element
-    mediaElement.src = URL.createObjectURL(file);
+    } else {
+      const mediaElement = document.createElement(isVideo ? 'video' : 'audio');
+      // Add a listener to read the metadata once it has loaded.
+      mediaElement.addEventListener('loadedmetadata', () => {
+        metadata.duration = Math.floor(mediaElement.duration);
+        // Override preset based off video resolution
+        if (isVideo) {
+          metadata.preset =
+            mediaElement.videoHeight >= 720
+              ? FormatPresetsNames.HIGH_RES_VIDEO
+              : FormatPresetsNames.LOW_RES_VIDEO;
+        }
+        resolve(metadata);
+      });
+      // Set the src url on the media element
+      mediaElement.src = URL.createObjectURL(file);
+    }
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
@@ -82,7 +82,7 @@ export async function getH5PMetadata(fileInput, metadata) {
     .then(function(h5pContent) {
       const data = JSON.parse(h5pContent);
       if (Object.prototype.hasOwnProperty.call(data, 'title')) {
-        metadata.Title = data['title'];
+        metadata.title = data['title'];
       }
       if (Object.prototype.hasOwnProperty.call(data, 'language') && data['language'] !== 'und') {
         metadata.language = data['language'];

--- a/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/file/utils.js
@@ -19,7 +19,7 @@ export function getHash(file) {
     const spark = new SparkMD5.ArrayBuffer();
     let currentChunk = 0;
     const chunks = Math.ceil(file.size / CHUNK_SIZE);
-    fileReader.onload = function (e) {
+    fileReader.onload = function(e) {
       spark.append(e.target.result);
       currentChunk++;
 
@@ -64,11 +64,12 @@ export function storageUrl(checksum, file_format) {
   return `/content/storage/${checksum[0]}/${checksum[1]}/${checksum}.${file_format}`;
 }
 
-export async function getH5PMetadata(fileInput, metadata) {
+export async function getH5PMetadata(fileInput) {
   const zip = new JSZip();
+  const metadata = {};
   return zip
     .loadAsync(fileInput)
-    .then(function (zip) {
+    .then(function(zip) {
       const h5pJson = zip.file('h5p.json');
       if (h5pJson) {
         return h5pJson.async('text');
@@ -76,7 +77,7 @@ export async function getH5PMetadata(fileInput, metadata) {
         throw new Error('h5p.json not found in the H5P file.');
       }
     })
-    .then(function (h5pContent) {
+    .then(function(h5pContent) {
       const data = JSON.parse(h5pContent);
       if (Object.prototype.hasOwnProperty.call(data, 'title')) {
         metadata.title = data['title'];
@@ -90,10 +91,10 @@ export async function getH5PMetadata(fileInput, metadata) {
       if (Object.prototype.hasOwnProperty.call(data, 'license')) {
         metadata.license = data['license'];
       }
-      return metadata
+      return metadata;
     })
-    .catch(function (error) {
-      return error
+    .catch(function(error) {
+      return error;
     });
 }
 
@@ -128,7 +129,9 @@ export function extractMetadata(file, preset = null) {
 
   return new Promise(resolve => {
     if (isH5P) {
-      getH5PMetadata(file, metadata);
+      getH5PMetadata(file).then(data => {
+        if (data.constructor !== Error) Object.assign(metadata, ...data);
+      });
       resolve(metadata);
     } else {
       const mediaElement = document.createElement(isVideo ? 'video' : 'audio');

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "intl": "1.2.5",
     "jquery": "^2.2.4",
     "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
+    "jszip": "^3.10.1",
     "kolibri-constants": "^0.1.41",
     "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#e9a2ff34716bb6412fe99f835ded5b17345bab94",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8967,6 +8967,16 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 jszip@^3.7.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.0.tgz#faf3db2b4b8515425e34effcdbb086750a346061"


### PR DESCRIPTION
This code aims to extract metadata from H5P content package.
This Pr is a part of GSoC Project linked with the [issue #4081](https://github.com/learningequality/studio/issues/4081).

<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Checked if the uploaded file is h5p or not
- Extract metadata through `getH5PMetadata`

### Manual verification steps performed
1. Use jszip to load the uploaded H5P file asynchronously.
2. Once loaded, parse h5p.json file and read the file as text
3. Then parse the text to json so that we can extract the data.
4. Data extracted are:
   - title
   - language
   - authors
   - license 
<!--
### Screenshots (if applicable)
 If not applicable, please delete this section -->
<!--
### Does this introduce any tech-debt items?
 List anything that will need to be addressed later -->
<!--
___
## Reviewer guidance
### How can a reviewer test these changes?
 If not applicable, please delete this section -->

<!--
### Are there any risky areas that deserve extra testing?
If not applicable, please delete this section -->

<!--
## References

Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
<!--
## Comments
 Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
