### PR TITLE
Prevent options being a string rather than JSON

### DIFF
--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -263,6 +263,14 @@ class ExportChannelTestCase(StudioTestCase):
         assert completion_criteria_node.duration == 20
         assert non_completion_criteria_node.duration == 100
 
+    def test_completion_criteria_set(self):
+        completion_criteria_node = kolibri_models.ContentNode.objects.filter(title='Completion criteria test').first()
+
+        self.assertEqual(completion_criteria_node.options["completion_criteria"], {
+            "model": "time",
+            "threshold": 20
+        })
+
     def test_contentnode_channel_id_data(self):
         channel = kolibri_models.ChannelMetadata.objects.first()
         nodes = kolibri_models.ContentNode.objects.all()

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -349,7 +349,7 @@ def create_bare_contentnode(ccnode, default_language, channel_id, channel_name, 
             'license_description': kolibri_license.license_description if kolibri_license is not None else None,
             'coach_content': ccnode.role_visibility == roles.COACH,
             'duration': duration,
-            'options': json.dumps(options),
+            'options': options,
             # Fields for metadata labels
             "grade_levels": ",".join(grade_levels.keys()) if grade_levels else None,
             "resource_types": ",".join(resource_types.keys()) if resource_types else None,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Removes an unnecessary json.dumps during publish that was double wrapping the JSON

### Manual verification steps performed
1. Wrote a regression test.

Fixes #4141