### PR TITLE
Fixes undo button on snackbar

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -540,7 +540,7 @@ describe('ContentNode methods', () => {
 
   describe('tableMove method', () => {
     let node,
-      oldParent,
+      oldObj,
       parent,
       payload,
       change,
@@ -553,9 +553,9 @@ describe('ContentNode methods', () => {
         put: jest.fn(() => Promise.resolve()),
       };
       updated = true;
-      oldParent = { id: uuid4(), title: 'Parent' };
+      oldObj = { id: uuid4(), title: 'Parent' };
       parent = { id: uuid4(), root_id: uuid4(), title: 'Parent' };
-      node = { id: uuid4(), parent: oldParent.id, title: 'Source node' };
+      node = { id: uuid4(), parent: oldObj.id, title: 'Source node' };
       payload = { id: uuid4(), parent: parent.id, changed: true, lft: 1, title: 'Payload' };
       change = {
         key: payload.id,

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
@@ -182,30 +182,22 @@ describe('Change Types', () => {
   });
 
   it('should persist only the specified fields in the MovedChange', async () => {
+    const oldObj = { parent: '4' };
     const change = new MovedChange({
       key: '1',
       table: TABLE_NAMES.CONTENTNODE,
       target: '2',
       position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
       parent: '3',
-      oldParent: '4',
       source: CLIENTID,
+      oldObj,
     });
     const rev = await change.saveChange();
     const persistedChange = await db[CHANGES_TABLE].get(rev);
     expect(persistedChange).toEqual({
       rev,
       channel_id,
-      ...pick(change, [
-        'type',
-        'key',
-        'table',
-        'target',
-        'position',
-        'parent',
-        'source',
-        'oldParent',
-      ]),
+      ...pick(change, ['type', 'key', 'table', 'target', 'position', 'parent', 'source', 'oldObj']),
     });
   });
 
@@ -427,6 +419,7 @@ describe('Change Types Unhappy Paths', () => {
 
   // MovedChange
   it('should throw error when MovedChange is instantiated without target', () => {
+    const oldObj = { a: 1, b: 2 };
     expect(
       () =>
         new MovedChange({
@@ -434,11 +427,13 @@ describe('Change Types Unhappy Paths', () => {
           table: TABLE_NAMES.CONTENTNODE,
           position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
           source: CLIENTID,
+          oldObj,
         })
     ).toThrow(new TypeError('target is required for a MovedChange but it was undefined'));
   });
 
   it('should throw error when MovedChange is instantiated with incorrect position type', () => {
+    const oldObj = { a: 1, b: { c: 1 } };
     expect(
       () =>
         new MovedChange({
@@ -447,11 +442,13 @@ describe('Change Types Unhappy Paths', () => {
           target: '2',
           position: 'invalid',
           source: CLIENTID,
+          oldObj,
         })
     ).toThrow(new ReferenceError('invalid is not a valid position value'));
   });
 
   it('should throw error when MovedChange is instantiated without parent', () => {
+    const oldObj = { a: 1, b: 2, parent: 3 };
     expect(
       () =>
         new MovedChange({
@@ -460,6 +457,7 @@ describe('Change Types Unhappy Paths', () => {
           target: '2',
           position: RELATIVE_TREE_POSITIONS.LAST_CHILD,
           source: CLIENTID,
+          oldObj,
         })
     ).toThrow(new ReferenceError('parent is required for a MovedChange but it was undefined'));
   });

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -295,13 +295,13 @@ class ResourceCounts extends ChangeDispatcher {
    */
   async applyMove(change) {
     // Only if the node is being moved to a new parent do we need to update the ancestor counts
-    if (change.oldParent === change.parent) {
+    if (change.oldObj.parent === change.parent) {
       return;
     }
 
     const node = await this.table.get(change.key);
     await this.resource.updateAncestors(
-      { id: change.oldParent, includeSelf: true, ignoreChanges: true },
+      { id: change.oldObj.parent, includeSelf: true, ignoreChanges: true },
       this._applyDiff.bind(this, node, -1)
     );
     await this.resource.updateAncestors(

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -383,7 +383,7 @@ export class DeletedChange extends Change {
 }
 
 export class MovedChange extends Change {
-  constructor({ target, position, parent, oldParent, ...fields }) {
+  constructor({ oldObj, target, position, parent, ...fields }) {
     fields.type = CHANGE_TYPES.MOVED;
     super(fields);
     if (this.table !== TABLE_NAMES.CONTENTNODE) {
@@ -391,10 +391,10 @@ export class MovedChange extends Change {
         `${this.changeType} is only supported by ${TABLE_NAMES.CONTENTNODE} table but ${this.table} was passed instead`
       );
     }
+    this.setAndValidateObj(oldObj, 'oldObj', omitIgnoredSubFields);
     this.setAndValidateIsDefined(target, 'target');
     this.setAndValidateLookup(position, 'position', RELATIVE_TREE_POSITIONS_LOOKUP);
     this.setAndValidateIsDefined(parent, 'parent');
-    this.setAndValidateIsDefined(oldParent, 'oldParent');
     this.setChannelAndUserId();
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1395,7 +1395,6 @@ export const ContentNode = new TreeResource({
               // so that we can avoid doing fetches while such changes
               // are pending.
               parent: parent.id,
-              oldParent: isCreate ? null : node.parent,
               oldObj: isCreate ? null : node,
               table: this.tableName,
               source: CLIENTID,


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the failure  of the undo button to revert back the changes on delete a resource(s) in a channel.

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

https://github.com/learningequality/studio/assets/5203639/365ceefb-5e4e-4943-ae44-df45bb383c2b


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
No

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- Login into studio
- Select a particular channel
- Try to delete a resource by checking an item(s) and clicking on the "Delete" icon
- You will be presented with a Snackbar with a success message and an `UNDO` button to undo the changes made
- Click the undo button before the Snackbar dismisses.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4116 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [x] Automated test coverage is satisfactory
- [x] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
