### PR TITLE
Fixes incorrect folder order/layout for folders with long titles

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
@@ -25,7 +25,7 @@
           <VList v-for="(item, i) in collapsedItems" :key="`collapsed-${i}`">
             <VListTile :to="item.to">
               <VListTileTitle>
-                <slot name="item" :item="item" :index="i" :isLast="false"></slot>
+                <slot name="item" :item="item" :index="i" :isLast="false" :isFirst="items[0].id === item.id"></slot>
               </VListTileTitle>
             </VListTile>
           </VList>
@@ -47,7 +47,7 @@
         name="item"
         :item="item"
         :index="index"
-        :isFirst="index === 0"
+        :isFirst="items[0].id === item.id"
         :isLast="index === breadcrumbs.length - 1"
       ></slot>
     </VBreadcrumbsItem>
@@ -112,12 +112,13 @@
 
 </script>
 
-<style scoped>
+<style lang="less" scoped>
   /* Truncate text if the last item is too long */
   .breadcrumb:last-child {
     max-width: calc(100% - 76px);
   }
   /deep/ .v-breadcrumbs__item {
-    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/Breadcrumbs.vue
@@ -25,7 +25,14 @@
           <VList v-for="(item, i) in collapsedItems" :key="`collapsed-${i}`">
             <VListTile :to="item.to">
               <VListTileTitle>
-                <slot name="item" :item="item" :index="i" :isLast="false" :isFirst="items[0].id === item.id"></slot>
+                <slot 
+                  name="item" 
+                  :item="item" 
+                  :index="i" 
+                  :isLast="false" 
+                  :isFirst="items[0].id === item.id"
+                >
+                </slot>
               </VListTileTitle>
             </VListTile>
           </VList>
@@ -113,12 +120,15 @@
 </script>
 
 <style lang="less" scoped>
+
   /* Truncate text if the last item is too long */
   .breadcrumb:last-child {
     max-width: calc(100% - 76px);
   }
+
   /deep/ .v-breadcrumbs__item {
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
 </style>


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr updates the breadcrumb item `isFirst` property and adds the `isFirst` property to `VListTileTitle` in `Breadcrumbs.vue` which fixes the incorrect folder order/layout for folders with long titles.

### Screenshots (if applicable)
Before:
<img width="1439" alt="Screenshot 2023-06-19 at 9 08 38 AM" src="https://github.com/learningequality/studio/assets/46411498/0ccca59f-cfd1-4afe-b6ad-0772d2378fb0">

After:
<img width="1436" alt="Screenshot 2023-06-19 at 8 42 13 AM" src="https://github.com/learningequality/studio/assets/46411498/116d4e3b-0d28-458c-bcbe-f7120aeb54de">

<img width="1440" alt="Screenshot 2023-06-19 at 10 17 54 AM" src="https://github.com/learningequality/studio/assets/46411498/bcb4ae87-914e-484a-b4a9-300dbeb90a8b">

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Open a channel with multiple nested folders
2. Rename a folder so that it's name is longer than 50 characters
3. Navigate to the nested folders and also try resizing the browser window size
4. Confirm that only the first navigation item is the channel name and if the folder title is too long, it should be truncated

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4006 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
