### PR TITLE
Finalize public API integration with import search 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourceDrawer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourceDrawer.vue
@@ -19,6 +19,7 @@
         <ResourcePanel
           :nodeId="nodeId"
           :channelId="channelId"
+          :useRouting="useRouting"
           @close="$emit('close')"
         >
           <template #navigation>
@@ -63,6 +64,10 @@
         default: null,
       },
       permanent: {
+        type: Boolean,
+        default: true,
+      },
+      useRouting: {
         type: Boolean,
         default: true,
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -75,8 +75,8 @@
       >
         <VTab
           class="px-2"
-          :to="{ query: { tab: 'questions' } }"
           exact
+          @change="tab = 'questions'"
         >
           {{ $tr('questions') }}
           <Icon
@@ -90,8 +90,8 @@
         </VTab>
         <VTab
           class="px-2"
-          :to="{ query: { tab: 'details' } }"
           exact
+          @change="tab = 'details'"
         >
           {{ $tr('details') }}
           <Icon
@@ -587,11 +587,16 @@
         type: Boolean,
         default: false,
       },
+      useRouting: {
+        type: Boolean,
+        default: true,
+      },
     },
     data() {
       return {
         loading: false,
         showAnswers: false,
+        currentTab: 'details',
       };
     },
     computed: {
@@ -619,6 +624,10 @@
           if (!this.isExercise) {
             return;
           }
+          if (!this.useRouting) {
+            this.currentTab = value;
+            return;
+          }
           // If viewing an exercise, we need to synchronize the the route's
           // query params with the 'tab' value
           const newRoute = { query: { tab: value } };
@@ -629,8 +638,8 @@
           }
         },
         get() {
-          if (!this.isExercise) {
-            return 'details';
+          if (!this.isExercise || !this.useRouting) {
+            return this.currentTab;
           }
           return this.$route.query.tab || 'questions';
         },

--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -74,3 +74,9 @@ export const DraggableRegions = {
   TOPIC_VIEW: 'topicView',
   CLIPBOARD: 'clipboard',
 };
+
+/**
+ * Default page size for the import search page
+ * @type {number}
+ */
+export const ImportSearchPageSize = 15;

--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -79,4 +79,4 @@ export const DraggableRegions = {
  * Default page size for the import search page
  * @type {number}
  */
-export const ImportSearchPageSize = 15;
+export const ImportSearchPageSize = 10;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -158,6 +158,8 @@
       let params = {};
       const channelListType = this.$route.query.channel_list || ChannelListTypes.PUBLIC;
       if (channelListType === ChannelListTypes.PUBLIC) {
+        // TODO: load from public API instead
+        // TODO: challenging because of node_id->id and root_id->channel_id
         params = { published: true };
       }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -61,6 +61,7 @@
   import Checkbox from 'shared/views/form/Checkbox';
   import LoadingText from 'shared/views/LoadingText';
   import { constantsTranslationMixin } from 'shared/mixins';
+  import { ChannelListTypes } from 'shared/constants';
 
   export default {
     name: 'ContentTreeList',
@@ -154,8 +155,14 @@
     },
     mounted() {
       this.loading = true;
+      let params = {};
+      const channelListType = this.$route.query.channel_list || ChannelListTypes.PUBLIC;
+      if (channelListType === ChannelListTypes.PUBLIC) {
+        params = { published: true };
+      }
+
       return Promise.all([
-        this.loadChildren({ parent: this.topicId }),
+        this.loadChildren({ parent: this.topicId, ...params }),
         this.loadAncestors({ id: this.topicId }),
       ]).then(() => {
         this.loading = false;

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -27,6 +27,7 @@
       fixed
       :permanent="false"
       :nodeId="previewNode.id"
+      :useRouting="false"
       @close="showPreview = false"
     >
       <template #actions>

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -8,6 +8,7 @@ import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import { findLicense } from 'shared/utils/helpers';
 import { RolesNames } from 'shared/leUtils/Roles';
 import { isNodeComplete } from 'shared/utils/validation';
+import * as publicApi from 'shared/data/public';
 
 import db from 'shared/data/db';
 
@@ -34,6 +35,20 @@ export function loadContentNode(context, id) {
     });
 }
 
+/**
+ * @param context
+ * @param {string} id
+ * @param {string} nodeId - Note: this is `node_id` not `id`
+ * @param {string} rootId
+ * @return {Promise<{}>}
+ */
+export async function loadPublicContentNode(context, { id, nodeId, rootId }) {
+  const publicNode = await publicApi.getContentNode(nodeId);
+  const localNode = publicApi.convertContentNodeResponse(id, rootId, publicNode);
+  context.commit('ADD_CONTENTNODE', localNode);
+  return localNode;
+}
+
 export function loadContentNodeByNodeId(context, nodeId) {
   const channelId = context.rootState.currentChannel.currentChannelId;
   return loadContentNodes(context, { '[node_id+channel_id]__in': [[nodeId, channelId]] })
@@ -47,8 +62,12 @@ export function loadContentNodeByNodeId(context, nodeId) {
     });
 }
 
-export function loadChildren(context, { parent, ...params }) {
-  return loadContentNodes(context, { parent, ...params });
+export function loadChildren(context, { parent, published = null }) {
+  const params = { parent };
+  if (published !== null) {
+    params.published = published;
+  }
+  return loadContentNodes(context, params);
 }
 
 export function loadAncestors(context, { id }) {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -47,8 +47,8 @@ export function loadContentNodeByNodeId(context, nodeId) {
     });
 }
 
-export function loadChildren(context, { parent }) {
-  return loadContentNodes(context, { parent });
+export function loadChildren(context, { parent, ...params }) {
+  return loadContentNodes(context, { parent, ...params });
 }
 
 export function loadAncestors(context, { id }) {

--- a/contentcuration/contentcuration/frontend/shared/data/public.js
+++ b/contentcuration/contentcuration/frontend/shared/data/public.js
@@ -7,6 +7,7 @@
  *
  * See bottom of file for '@typedef's
  */
+import isString from 'lodash/isString';
 import isFunction from 'lodash/isFunction';
 import { RolesNames } from 'shared/leUtils/Roles';
 import { findLicense } from 'shared/utils/helpers';
@@ -72,7 +73,10 @@ const CONTENT_NODE_FIELD_MAP = {
         options['completion_criteria'] = {
           model: 'mastery',
           threshold: {
-            mastery_model: JSON.parse(assessmentMetadata['mastery_model']),
+            // TODO: remove JSON.parse, since we shouldn't be receiving strings from the API
+            mastery_model: isString(assessmentMetadata['mastery_model'])
+              ? JSON.parse(assessmentMetadata['mastery_model'])
+              : assessmentMetadata['mastery_model'],
           },
         };
       }


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Converts exercise mastery to completion criteria for a public API response
- Fixes issue previewing exercises in import search, caused by `?tab=` routing
- Rendering topics in search failed without `resource_count`
- Changes page size options to reduce likelihood of failed searches
- Changes default page size to 10 instead of 25
- Enforces page size is one of available options
- Adds hacks if we fail to side-load some nodes
- Only loads `published` nodes when browsing (not searching) through public channels

### Manual verification steps performed
Initially this was done to test fixes aimed at resolving JSON parsing issues
1. I manually edited `fetchResourceSearchResults` Vuex action to use same search API response as on `hotfixes`
2. I manually edited the public `ContentNodeViewset` to proxy requests to hotfixes
3. I observed the JSON issue hidden without Sentry reporting
4. Made other changes and verified things still worked locally

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
The hacky side-loading logic
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Create a channel with some content
2. Make the channel public
3. Publish the channel
4. Create a second channel
5. Use the import search to search for resources in the first channel
6. Preview resources from search
7. Select and review resources picked from search results
8. Verify you can complete importing the resource


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
https://github.com/learningequality/studio/pull/4137#issuecomment-1590774063



----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
