### PR TITLE
Fix publish regression and prevent superfluous data export

### DIFF
--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import os
 import random
 import string
@@ -302,8 +301,8 @@ class ExportChannelTestCase(StudioTestCase):
     def test_assessment_metadata(self):
         for i, exercise in enumerate(kolibri_models.ContentNode.objects.filter(kind="exercise")):
             asm = exercise.assessmentmetadata.first()
-            self.assertTrue(isinstance(json.loads(asm.assessment_item_ids), list))
-            mastery = json.loads(asm.mastery_model)
+            self.assertTrue(isinstance(asm.assessment_item_ids, list))
+            mastery = asm.mastery_model
             self.assertTrue(isinstance(mastery, dict))
             self.assertEqual(mastery["type"], exercises.DO_ALL if i == 0 else exercises.M_OF_N)
             self.assertEqual(mastery["m"], 3 if i == 0 else 1)

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -397,6 +397,12 @@ class ExportChannelTestCase(StudioTestCase):
             "n": 2,
             "mastery_model": exercises.M_OF_N,
         })
+        published_exercise = kolibri_models.ContentNode.objects.get(title="Mastery test")
+        self.assertEqual(published_exercise.options["completion_criteria"]["threshold"], {
+            "m": 1,
+            "n": 2,
+            "mastery_model": exercises.M_OF_N,
+        })
 
     def test_publish_no_modify_legacy_exercise_extra_fields(self):
         current_exercise = cc.ContentNode.objects.get(title="Legacy Mastery test")

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -526,9 +526,9 @@ def process_assessment_metadata(ccnode, kolibrinode):
     kolibrimodels.AssessmentMetaData.objects.create(
         id=uuid.uuid4(),
         contentnode=kolibrinode,
-        assessment_item_ids=json.dumps(assessment_item_ids),
+        assessment_item_ids=assessment_item_ids,
         number_of_assessments=assessment_items.count(),
-        mastery_model=json.dumps(mastery_model),
+        mastery_model=mastery_model,
         randomize=randomize,
         is_manipulable=ccnode.kind_id == content_kinds.EXERCISE,
     )

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -11,6 +11,7 @@ import traceback
 import uuid
 import zipfile
 from builtins import str
+from copy import deepcopy
 from itertools import chain
 
 from django.conf import settings
@@ -494,7 +495,7 @@ def process_assessment_metadata(ccnode, kolibrinode):
     randomize = extra_fields.get('randomize') if extra_fields.get('randomize') is not None else True
     assessment_item_ids = [a.assessment_id for a in assessment_items]
 
-    exercise_data = extra_fields.get('options').get('completion_criteria').get('threshold')
+    exercise_data = deepcopy(extra_fields.get('options').get('completion_criteria').get('threshold'))
 
     exercise_data_type = exercise_data.get('mastery_model', "")
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Removes all json.dumps that are now being written to JSONFields and so are unnecessary - updates tests accordingly
* Prevents assessment metadata processing from editing data that is later written into the exported channel database by doing a deepcopy of the dict - updates tests accordingly


### Manual verification steps performed
Just the automated tests.
