### PR TITLE
Skip broken exercises and properly report exceptions

### DIFF
--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -117,6 +117,18 @@ class ExportChannelTestCase(StudioTestCase):
         new_exercise.complete = True
         new_exercise.parent = current_exercise.parent
         new_exercise.save()
+
+        bad_container = create_node({'kind_id': 'topic', 'title': 'Bad topic container', 'children': []})
+        bad_container.complete = True
+        bad_container.parent = self.content_channel.main_tree
+        bad_container.save()
+
+        # exercise without mastery model, but marked as complete
+        broken_exercise = create_node({'kind_id': 'exercise', 'title': 'Bad mastery test', 'extra_fields': {}})
+        broken_exercise.complete = True
+        broken_exercise.parent = bad_container
+        broken_exercise.save()
+
         thumbnail_data = create_studio_file(thumbnail_bytes, preset="exercise_thumbnail", ext="png")
         file_obj = thumbnail_data["db_file"]
         file_obj.contentnode = new_exercise
@@ -246,6 +258,9 @@ class ExportChannelTestCase(StudioTestCase):
 
         for node in incomplete_nodes:
             assert kolibri_nodes.filter(pk=node.node_id).count() == 0
+
+        # bad exercise node should not be published (technically incomplete)
+        assert kolibri_models.ContentNode.objects.filter(title='Bad mastery test').count() == 0
 
     def test_tags_greater_than_30_excluded(self):
         tag_node = kolibri_models.ContentNode.objects.filter(title='kolibri tag test').first()

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -221,6 +221,17 @@ class TreeMapper:
 
         # Only process nodes that are either non-topics or have non-topic descendants
         if node.get_descendants(include_self=True).exclude(kind_id=content_kinds.TOPIC).exists() and node.complete:
+            # early validation to make sure we don't have any exercises without mastery models
+            # which should be unlikely when the node is complete, but just in case
+            if node.kind_id == content_kinds.EXERCISE:
+                try:
+                    # migrates and extracts the mastery model from the exercise
+                    _, mastery_model = parse_assessment_metadata(node)
+                    if not mastery_model:
+                        raise ValueError("Exercise does not have a mastery model")
+                except Exception as e:
+                    logging.warning("Unable to parse exercise {id} mastery model: {error}".format(id=node.pk, error=str(e)))
+                    return
 
             metadata = {}
 
@@ -242,12 +253,12 @@ class TreeMapper:
 
             kolibrinode = create_bare_contentnode(node, self.default_language, self.channel_id, self.channel_name, metadata)
 
-            if node.kind.kind == content_kinds.EXERCISE:
+            if node.kind_id == content_kinds.EXERCISE:
                 exercise_data = process_assessment_metadata(node, kolibrinode)
                 if self.force_exercises or node.changed or not \
                         node.files.filter(preset_id=format_presets.EXERCISE).exists():
                     create_perseus_exercise(node, kolibrinode, exercise_data, user_id=self.user_id)
-            elif node.kind.kind == content_kinds.SLIDESHOW:
+            elif node.kind_id == content_kinds.SLIDESHOW:
                 create_slideshow_manifest(node, user_id=self.user_id)
             elif node.kind_id == content_kinds.TOPIC:
                 for child in node.children.all():
@@ -486,18 +497,23 @@ def create_perseus_exercise(ccnode, kolibrinode, exercise_data, user_id=None):
         temppath and os.unlink(temppath)
 
 
-def process_assessment_metadata(ccnode, kolibrinode):
-    # Get mastery model information, set to default if none provided
-    assessment_items = ccnode.assessment_items.all().order_by('order')
+def parse_assessment_metadata(ccnode):
     extra_fields = ccnode.extra_fields
     if isinstance(extra_fields, basestring):
         extra_fields = json.loads(extra_fields)
     extra_fields = migrate_extra_fields(extra_fields) or {}
     randomize = extra_fields.get('randomize') if extra_fields.get('randomize') is not None else True
+    return randomize, extra_fields.get('options').get('completion_criteria').get('threshold')
+
+
+def process_assessment_metadata(ccnode, kolibrinode):
+    # Get mastery model information, set to default if none provided
+    assessment_items = ccnode.assessment_items.all().order_by('order')
     assessment_item_ids = [a.assessment_id for a in assessment_items]
 
-    exercise_data = deepcopy(extra_fields.get('options').get('completion_criteria').get('threshold'))
+    randomize, mastery_criteria = parse_assessment_metadata(ccnode)
 
+    exercise_data = deepcopy(mastery_criteria)
     exercise_data_type = exercise_data.get('mastery_model', "")
 
     mastery_model = {'type': exercise_data_type or exercises.M_OF_N}

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -960,6 +960,7 @@ def create_change_tracker(pk, table, channel_id, user, task_name):
         task_object.status = states.FAILURE
         task_object.traceback = traceback.format_exc()
         task_object.save()
+        raise
     finally:
         if task_object.status == states.STARTED:
             # No error reported, cleanup.

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -71,7 +71,7 @@ from contentcuration.viewsets.sync.constants import COPYING_FLAG
 from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.utils import generate_update_event
-
+from contentcuration.viewsets.sync.utils import log_sync_exception
 
 channel_query = Channel.objects.filter(main_tree__tree_id=OuterRef("tree_id"))
 
@@ -908,9 +908,11 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
         for copy in changes:
             # Copy change will have key, must also have other attributes, defined in `copy`
             # Just pass as keyword arguments here to let copy do the validation
-            copy_errors = self.copy(copy["key"], **copy)
-            if copy_errors:
-                copy.update({"errors": copy_errors})
+            try:
+                self.copy(copy["key"], **copy)
+            except Exception as e:
+                log_sync_exception(e, user=self.request.user, change=copy)
+                copy["errors"] = [str(e)]
                 errors.append(copy)
         return errors
 
@@ -924,23 +926,18 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
         excluded_descendants=None,
         **kwargs
     ):
-        try:
-            target, position = self.validate_targeting_args(target, position)
-        except ValidationError as e:
-            return str(e)
+        target, position = self.validate_targeting_args(target, position)
 
         try:
             source = self.get_queryset().get(pk=from_key)
         except ContentNode.DoesNotExist:
-            error = ValidationError("Copy source node does not exist")
-            return str(error)
+            raise ValidationError("Copy source node does not exist")
 
         # Affected channel for the copy is the target's channel
         channel_id = target.channel_id
 
         if ContentNode.filter_by_pk(pk=pk).exists():
-            error = ValidationError("Copy pk already exists")
-            return str(error)
+            raise ValidationError("Copy pk already exists")
 
         can_edit_source_channel = ContentNode.filter_edit_queryset(
             ContentNode.filter_by_pk(pk=source.id), user=self.request.user
@@ -968,8 +965,6 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
                 applied=True,
                 created_by_id=self.request.user.id,
             )
-
-        return None
 
     def perform_create(self, serializer, change=None):
         instance = serializer.save()

--- a/contentcuration/contentcuration/viewsets/sync/utils.py
+++ b/contentcuration/contentcuration/viewsets/sync/utils.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.conf import settings
+
 from contentcuration.utils.sentry import report_exception
 from contentcuration.viewsets.sync.constants import ALL_TABLES
 from contentcuration.viewsets.sync.constants import CHANNEL
@@ -92,7 +94,9 @@ def log_sync_exception(e, user=None, change=None, changes=None):
     elif changes is not None:
         contexts["changes"] = changes
 
-    report_exception(e, user=user, contexts=contexts)
+    # in production, we'll get duplicates in Sentry if we log the exception here.
+    if settings.DEBUG:
+        # make sure we leave a record in the logs just in case.
+        logging.exception(e)
 
-    # make sure we leave a record in the logs just in case.
-    logging.exception(e)
+    report_exception(e, user=user, contexts=contexts)


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updates the change tracker to re-raise exceptions, ensuring we can actually report them to Sentry
- Updates publishing to skip exercises that have missing/broken mastery criteria, as if they were incomplete
- Updates copy operation to match other types of changes, by using try/except to catch and attach errors

### Manual verification steps performed
1. Ran tests


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Resolves https://github.com/learningequality/studio/issues/4163

## Tech debt
<!-- Additional comments may be added here -->
Followup https://github.com/learningequality/studio/issues/4173

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
