### PR TITLE
Fix broken 'Go to location' link in Import Search

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -40,11 +40,12 @@ export function loadContentNode(context, id) {
  * @param {string} id
  * @param {string} nodeId - Note: this is `node_id` not `id`
  * @param {string} rootId
+ * @param {string} parent - The `id` not `node_id` of the parent
  * @return {Promise<{}>}
  */
-export async function loadPublicContentNode(context, { id, nodeId, rootId }) {
+export async function loadPublicContentNode(context, { id, nodeId, rootId, parent }) {
   const publicNode = await publicApi.getContentNode(nodeId);
-  const localNode = publicApi.convertContentNodeResponse(id, rootId, publicNode);
+  const localNode = publicApi.convertContentNodeResponse(id, rootId, parent, publicNode);
   context.commit('ADD_CONTENTNODE', localNode);
   return localNode;
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/importFromChannels/actions.js
@@ -41,6 +41,7 @@ export async function fetchResourceSearchResults(context, params) {
               id: node.id,
               nodeId: node.node_id,
               rootId: node.root_id,
+              parent: node.parent,
             },
             { root: true }
           )

--- a/contentcuration/contentcuration/frontend/shared/data/public.js
+++ b/contentcuration/contentcuration/frontend/shared/data/public.js
@@ -43,7 +43,6 @@ const CONTENT_NODE_FIELD_MAP = {
   node_id: 'id',
   content_id: 'content_id',
   channel_id: 'channel_id',
-  parent: 'parent',
   title: 'title',
   description: 'description',
   kind: 'kind',
@@ -108,16 +107,19 @@ const CONTENT_NODE_FIELD_MAP = {
  * Convert a content node from the public API into a content node for the Studio frontend
  * @param {string} id - the actual ID of the node on Studio's side
  * @param {string} root_id - the root content node ID
+ * @param {string} parent - the parent's ID
  * @param {PublicContentNode} publicNode
  * @return {{id}}
  */
-export function convertContentNodeResponse(id, root_id, publicNode) {
+export function convertContentNodeResponse(id, root_id, parent, publicNode) {
   const contentNode = {
     // the public API does not return the actual id, but 'node_id' as the id, so this requires
     // us to know what the actual id is
     id,
     // The public API returns the channel ID as the root_id
     root_id,
+    // the public API does not return the actual id, but 'node_id' as the id
+    parent,
   };
 
   // Convert the response node into a content node
@@ -130,7 +132,7 @@ export function convertContentNodeResponse(id, root_id, publicNode) {
   }
 
   // If the parent is the channel, then set the parent to the root_id
-  if (contentNode.parent === contentNode.channel_id) {
+  if (publicNode.parent === publicNode.channel_id) {
     contentNode.parent = root_id;
   }
   return contentNode;


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Adds `parent` when converting from public node format to Studio's IDs

### Manual verification steps performed
1. Create a channel
2. Add a topic and put content in the topic
3. Make the channel public
4. Publish the channel
5. Create a second channel
6. Use the import search to search for resources added to the topic in the first channel
7. Preview resources from search
8. Click the 'Go to location' and ensure it opens the correct topic and resource panel preview

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
It appears the search results are rendering in an order that is different than what is returned from the server.

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes: https://github.com/learningequality/studio/issues/4168

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
