### PR TITLE
Allow users to retry copy failures

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -66,7 +66,7 @@
 
         <template #copy-fail-retry-action>
           <span v-if="hasCopyingErrored">
-            <ActionLink :text="$tr('retryCopy')" @click="retryFailedCopy" />
+            <ActionLink class="copy-retry-btn" :text="$tr('retryCopy')" @click="retryFailedCopy" />
           </span>
         </template>
 
@@ -360,6 +360,10 @@
     flex: 1 1 auto;
     align-items: flex-start;
     justify-content: center;
+  }
+
+  .copy-retry-btn {
+    font-size: inherit;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -64,6 +64,22 @@
           </VListTileAction>
         </template>
 
+        <template #copy-fail-retry-action>
+          <span v-if="hasCopyingErrored">
+            <ActionLink :text="$tr('retryCopy')" @click="retryFailedCopy" />
+          </span>
+        </template>
+
+        <template #copy-fail-remove-action>
+          <IconButton
+            v-if="hasCopyingErrored"
+            icon="close"
+            :text="$tr('removeNode')"
+            size="small"
+            @click="removeFailedCopyNode"
+          />
+        </template>
+
         <template #context-menu="{ showContextMenu, positionX, positionY }">
           <ContentNodeContextMenu
             :show="showContextMenu"
@@ -81,7 +97,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapActions } from 'vuex';
 
   import ContentNodeListItem from './ContentNodeListItem';
   import ContentNodeOptions from './ContentNodeOptions';
@@ -89,9 +105,11 @@
   import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
-  import { COPYING_FLAG } from 'shared/data/constants';
+  import { ContentNode } from 'shared/data/resources';
   import { DragEffect, DropEffect, EffectAllowed } from 'shared/mixins/draggable/constants';
   import { DraggableRegions } from 'frontend/channelEdit/constants';
+  import { withChangeTracker } from 'shared/data/changes';
+  import { COPYING_STATUS, COPYING_STATUS_VALUES } from 'shared/data/constants';
 
   export default {
     name: 'ContentNodeEditListItem',
@@ -141,7 +159,11 @@
     },
     computed: {
       ...mapGetters('currentChannel', ['canEdit']),
-      ...mapGetters('contentNode', ['getContentNode']),
+      ...mapGetters('contentNode', [
+        'getContentNode',
+        'isNodeInCopyingState',
+        'hasNodeCopyingErrored',
+      ]),
       ...mapGetters('draggable', ['activeDraggableRegionId']),
       selected: {
         get() {
@@ -163,7 +185,10 @@
         return !this.copying;
       },
       copying() {
-        return this.contentNode[COPYING_FLAG];
+        return this.isNodeInCopyingState(this.nodeId);
+      },
+      hasCopyingErrored() {
+        return this.hasNodeCopyingErrored(this.nodeId);
       },
       dragEffect() {
         return DragEffect.SORT;
@@ -206,18 +231,57 @@
         this.selected = false;
       }
     },
+    methods: {
+      ...mapActions(['showSnackbar', 'clearSnackbar']),
+      ...mapActions('contentNode', [
+        'updateContentNode',
+        'waitForCopyingStatus',
+        'deleteContentNode',
+      ]),
+      retryFailedCopy: withChangeTracker(function(changeTracker) {
+        this.updateContentNode({
+          id: this.nodeId,
+          [COPYING_STATUS]: COPYING_STATUS_VALUES.COPYING,
+        });
+
+        this.showSnackbar({
+          duration: null,
+          text: this.$tr('creatingCopies'),
+          // TODO: determine how to cancel copying while it's in progress,
+          // TODO: if that's something we want
+          // actionText: this.$tr('cancel'),
+          // actionCallback: () => changeTracker.revert(),
+        });
+
+        ContentNode.retryCopyChange(this.nodeId);
+
+        return this.waitForCopyingStatus({
+          contentNodeId: this.nodeId,
+          startingRev: changeTracker._startingRev,
+        })
+          .then(() => {
+            this.showSnackbar({
+              text: this.$tr('copiedSnackbar'),
+              actionText: this.$tr('undo'),
+              actionCallback: () => changeTracker.revert(),
+            }).then(() => changeTracker.cleanUp());
+          })
+          .catch(() => {
+            this.clearSnackbar();
+            changeTracker.cleanUp();
+          });
+      }),
+      removeFailedCopyNode() {
+        return this.deleteContentNode(this.nodeId);
+      },
+    },
     $trs: {
       optionsTooltip: 'Options',
-      /* eslint-disable kolibri/vue-no-unused-translations */
-      /**
-       * Strings for handling copy failures
-       */
       removeNode: 'Remove',
       retryCopy: 'Retry',
       creatingCopies: 'Copying...',
       copiedSnackbar: 'Copy operation complete',
       undo: 'Undo',
-      /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.spec.js
@@ -30,7 +30,16 @@ const TOPIC_NODE = {
 
 function mountComponent(opts = {}) {
   return mount(ContentNodeListItem, {
-    store: createStore(),
+    store: createStore({
+      modules: {
+        contentNode: {
+          namespaced: true,
+          getters: {
+            isNodeInCopyingState: () => jest.fn(),
+          },
+        },
+      },
+    }),
     ...opts,
   });
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -418,18 +418,14 @@
     z-index: 2;
     display: flex;
     align-items: center;
+    align-self: center;
     min-width: max-content;
-    padding-top: 44px;
     pointer-events: auto;
     cursor: default;
 
     p,
     div {
       margin: 0;
-    }
-
-    .compact & {
-      padding-top: 12px;
     }
   }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -415,6 +415,7 @@
     z-index: 2;
     display: flex;
     align-items: center;
+    min-width: max-content;
     padding-top: 44px;
     pointer-events: auto;
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -167,21 +167,17 @@
                 </template>
                 <template v-else>
                   <div class="copying">
-
                     <p class="caption grey--text pr-2 pt-1">
                       <span :style="{ 'cursor': hasCopyingErrored ? 'default' : 'progress' }">
                         {{ copyingMessage }}
                       </span>
                       <slot name="copy-fail-retry-action"></slot>
                     </p>
-
                     <ContentNodeCopyTaskProgress
                       :node="node"
                       size="30"
                     />
-
                     <slot name="copy-fail-remove-action"></slot>
-
                   </div>
                   <div class="disabled-overlay"></div>
                 </template>
@@ -422,6 +418,10 @@
     padding-top: 44px;
     pointer-events: auto;
 
+    p {
+      flex-shrink: 0;
+    }
+
     p,
     div {
       margin: 0 2px;
@@ -481,6 +481,7 @@
   }
 
   .description-col {
+    flex-shrink: 1 !important;
     width: calc(100% - @thumbnail-width - 206px);
     word-break: break-word;
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -167,8 +167,11 @@
                 </template>
                 <template v-else>
                   <div class="copying">
-                    <p class="caption grey--text pr-2 pt-1">
-                      <span :style="{ 'cursor': hasCopyingErrored ? 'default' : 'progress' }">
+                    <p class="caption pr-3">
+                      <span
+                        class="grey--text"
+                        :style="{ 'cursor': hasCopyingErrored ? 'default' : 'progress' }"
+                      >
                         {{ copyingMessage }}
                       </span>
                       <slot name="copy-fail-retry-action"></slot>
@@ -418,14 +421,11 @@
     min-width: max-content;
     padding-top: 44px;
     pointer-events: auto;
-
-    p {
-      flex-shrink: 0;
-    }
+    cursor: default;
 
     p,
     div {
-      margin: 0 2px;
+      margin: 0;
     }
 
     .compact & {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.spec.js
@@ -34,6 +34,7 @@ const initWrapper = ({ getters = {}, mutations = {}, actions = {}, propsData = {
           getContentNode: () => jest.fn(),
           getContentNodeChildren: () => jest.fn(),
           nodeExpanded: () => jest.fn(),
+          isNodeInCopyingState: () => jest.fn(),
           ...getters,
         },
         mutations: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -104,8 +104,9 @@
                     >
                       <ContentNodeCopyTaskProgress
                         class="progress-loader"
-                        :taskId="taskId"
+                        :node="node"
                         size="24"
+                        showTooltip
                       />
                     </VFlex>
                     <VFlex
@@ -194,7 +195,6 @@
   import DraggableItem from 'shared/views/draggable/DraggableItem';
   import DraggableHandle from 'shared/views/draggable/DraggableHandle';
   import { titleMixin } from 'shared/mixins';
-  import { COPYING_FLAG, TASK_ID } from 'shared/data/constants';
   import { DropEffect, EffectAllowed } from 'shared/mixins/draggable/constants';
   import { objectValuesValidator } from 'shared/mixins/draggable/utils';
 
@@ -263,7 +263,12 @@
       ...mapGetters('currentChannel', ['canEdit']),
       ...mapState('draggable', ['activeDraggableUniverse']),
       ...mapGetters('draggable', ['deepestActiveDraggable']),
-      ...mapGetters('contentNode', ['getContentNode', 'getContentNodeChildren', 'nodeExpanded']),
+      ...mapGetters('contentNode', [
+        'getContentNode',
+        'getContentNodeChildren',
+        'nodeExpanded',
+        'isNodeInCopyingState',
+      ]),
       node() {
         return this.getContentNode(this.nodeId);
       },
@@ -301,10 +306,7 @@
         return EffectAllowed.NONE;
       },
       copying() {
-        return this.node && this.node[COPYING_FLAG];
-      },
-      taskId() {
-        return this.node && this.node[TASK_ID];
+        return this.node && this.isNodeInCopyingState(this.node.id);
       },
       activeDropEffect() {
         // Don't allow dropping into itself

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -32,6 +32,7 @@ const GETTERS = {
     getContentNodeChildren: () => jest.fn(),
     getContentNodeAncestors: () => jest.fn(),
     getContentNode: () => jest.fn(),
+    isNodeInCopyingState: () => jest.fn(),
   },
 };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -246,11 +246,10 @@
     ContentKindLearningActivityDefaults,
   } from 'shared/leUtils/ContentKinds';
   import { titleMixin, routerMixin } from 'shared/mixins';
-  import { COPYING_FLAG, RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
+  import { RELATIVE_TREE_POSITIONS } from 'shared/data/constants';
   import { DraggableTypes, DropEffect } from 'shared/mixins/draggable/constants';
   import { DraggableFlags } from 'shared/vuex/draggablePlugin/module/constants';
   import DraggableRegion from 'shared/views/draggable/DraggableRegion';
-  import { ContentNode } from 'shared/data/resources';
 
   export default {
     name: 'CurrentTopicView',
@@ -302,6 +301,7 @@
         'getContentNodeAncestors',
         'getTopicAndResourceCounts',
         'getContentNodeChildren',
+        'isNodeInCopyingState',
       ]),
       ...mapGetters('clipboard', ['getCopyTrees']),
       ...mapGetters('draggable', ['activeDraggableRegionId']),
@@ -323,7 +323,9 @@
         },
         set(value) {
           if (value) {
-            this.selected = this.children.filter(node => !node[COPYING_FLAG]).map(node => node.id);
+            this.selected = this.children
+              .filter(node => !this.isNodeInCopyingState(node.id))
+              .map(node => node.id);
             this.trackClickEvent('Select all');
           } else {
             this.selected = [];
@@ -420,13 +422,14 @@
       },
     },
     methods: {
-      ...mapActions(['showSnackbar']),
+      ...mapActions(['showSnackbar', 'clearSnackbar']),
       ...mapActions(['setViewMode', 'addViewModeOverride', 'removeViewModeOverride']),
       ...mapActions('contentNode', [
         'createContentNode',
         'loadAncestors',
         'moveContentNodes',
         'copyContentNode',
+        'waitForCopyingStatus',
       ]),
       ...mapActions('clipboard', ['copyAll']),
       clearSelections() {
@@ -646,12 +649,30 @@
           )
         ).then(nodes => {
           this.clearSelections();
-          ContentNode.waitForCopying(nodes.map(n => n.id)).then(() => {
-            this.showSnackbar({
-              text: this.$tr('copiedItems'),
-              actionText: this.$tr('undo'),
-              actionCallback: () => changeTracker.revert(),
-            }).then(() => changeTracker.cleanUp());
+          Promise.allSettled(
+            nodes.map(n =>
+              this.waitForCopyingStatus({
+                contentNodeId: n.id,
+                startingRev: changeTracker._startingRev,
+              })
+            )
+          ).then(results => {
+            let isAllCopySuccess = true;
+            for (const result of results) {
+              if (result.status === 'rejected') {
+                isAllCopySuccess = false;
+              }
+            }
+            if (isAllCopySuccess) {
+              this.showSnackbar({
+                text: this.$tr('copiedItems'),
+                actionText: this.$tr('undo'),
+                actionCallback: () => changeTracker.revert(),
+              }).then(() => changeTracker.cleanUp());
+            } else {
+              this.clearSnackbar();
+              changeTracker.cleanUp();
+            }
           });
         });
       }),

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -80,6 +80,7 @@
   import ResourceDrawer from '../../components/ResourceDrawer';
   import { routerMixin } from 'shared/mixins';
   import FullscreenModal from 'shared/views/FullscreenModal';
+  import { withChangeTracker } from 'shared/data/changes';
 
   const IMPORT_ROUTES = [
     RouteNames.IMPORT_FROM_CHANNELS,
@@ -180,7 +181,7 @@
       this.updateTitleForPage();
     },
     methods: {
-      ...mapActions('contentNode', ['copyContentNodes']),
+      ...mapActions('contentNode', ['copyContentNodes', 'waitForCopyingStatus']),
       ...mapMutations('importFromChannels', {
         selectNode: 'SELECT_NODE',
         deselectNode: 'DESELECT_NODE',
@@ -209,7 +210,7 @@
           },
         });
       },
-      handleClickImport() {
+      handleClickImport: withChangeTracker(function(changeTracker) {
         const nodeIds = this.selected.map(({ id }) => id);
         // Grab the source nodes from Vuex, since search should have loaded them into it
         const sourceNodes = nodeIds.map(id => this.getContentNode(id));
@@ -217,7 +218,7 @@
           id__in: nodeIds,
           target: this.$route.params.destNodeId,
           sourceNodes,
-        }).then(() => {
+        }).then(nodes => {
           // When exiting, do not show snackbar when clearing selections
           this.showSnackbar = false;
           this.$store.commit('importFromChannels/CLEAR_NODES');
@@ -227,8 +228,17 @@
               nodeId: this.$route.params.destNodeId,
             },
           });
+
+          return Promise.allSettled(
+            nodes.map(n =>
+              this.waitForCopyingStatus({
+                contentNodeId: n.id,
+                startingRev: changeTracker._startingRev,
+              })
+            )
+          );
         });
-      },
+      }),
       // Using a click method here instead of :to attribute because
       // it prevents the close button from getting clicked on the route change
       goBackToBrowse() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -56,7 +56,6 @@
   import { RouteNames } from '../constants';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import LoadingText from 'shared/views/LoadingText';
-  import { COPYING_FLAG } from 'shared/data/constants';
 
   export default {
     name: 'NodePanel',
@@ -84,7 +83,11 @@
     computed: {
       ...mapGetters(['isCompactViewMode', 'isComfortableViewMode']),
       ...mapGetters('currentChannel', ['rootId', 'canEdit']),
-      ...mapGetters('contentNode', ['getContentNode', 'getContentNodeChildren']),
+      ...mapGetters('contentNode', [
+        'getContentNode',
+        'getContentNodeChildren',
+        'isNodeInCopyingState',
+      ]),
       node() {
         return this.getContentNode(this.parentId);
       },
@@ -138,7 +141,7 @@
       },
       onNodeDoubleClick(node) {
         // Don't try to navigate to nodes that are still copying
-        if (!node[COPYING_FLAG]) {
+        if (!this.isNodeInCopyingState(node.id)) {
           if (node.kind === ContentKindsNames.TOPIC) {
             this.goToTopic(node.id);
           } else {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/progress/ContentNodeCopyTaskProgress.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/progress/ContentNodeCopyTaskProgress.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div :style="{ 'cursor': hasCopyingErrored ? 'default' : 'progress' }">
+  <div :style="{ 'cursor': copying && !hasCopyingErrored ? 'progress' : 'default' }">
     <VProgressCircular
       v-if="copying && !hasCopyingErrored"
       indeterminate
@@ -8,7 +8,7 @@
       v-bind="$attrs"
     />
     <VTooltip
-      v-else-if="copying && hasCopyingErrored && showTooltip"
+      v-else-if="hasCopyingErrored && showTooltip"
       bottom
       lazy
     >
@@ -20,7 +20,7 @@
       <span>{{ $tr('copyErrorTopic') }}</span>
     </VTooltip>
     <Icon
-      v-else-if="copying && hasCopyingErrored && !showTooltip"
+      v-else-if="hasCopyingErrored && !showTooltip"
       color="red"
     >
       error

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -2,7 +2,13 @@ import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
 import { NEW_OBJECT, NOVALUE } from 'shared/constants';
 import client from 'shared/client';
-import { RELATIVE_TREE_POSITIONS, CHANGES_TABLE, TABLE_NAMES } from 'shared/data/constants';
+import {
+  RELATIVE_TREE_POSITIONS,
+  CHANGES_TABLE,
+  TABLE_NAMES,
+  COPYING_STATUS,
+  COPYING_STATUS_VALUES,
+} from 'shared/data/constants';
 import { ContentNode } from 'shared/data/resources';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import { findLicense } from 'shared/utils/helpers';
@@ -221,8 +227,12 @@ function generateContentNodeData({
   learning_activities = NOVALUE,
   categories = NOVALUE,
   suggested_duration = NOVALUE,
+  [COPYING_STATUS]: copy_status_value = NOVALUE,
 } = {}) {
   const contentNodeData = {};
+  if (copy_status_value !== NOVALUE) {
+    contentNodeData[COPYING_STATUS] = copy_status_value;
+  }
   if (title !== NOVALUE) {
     contentNodeData.title = title;
   }
@@ -387,6 +397,16 @@ export function deleteContentNodes(context, contentNodeIds) {
       return deleteContentNode(context, id);
     })
   );
+}
+
+export function waitForCopyingStatus(context, { contentNodeId, startingRev }) {
+  return ContentNode.waitForCopying(contentNodeId, startingRev).catch(e => {
+    context.dispatch('updateContentNode', {
+      id: contentNodeId,
+      [COPYING_STATUS]: COPYING_STATUS_VALUES.FAILED,
+    });
+    return Promise.reject(e);
+  });
 }
 
 export function copyContentNode(

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -7,6 +7,7 @@ import { parseNode } from './utils';
 import { getNodeDetailsErrors, getNodeFilesErrors } from 'shared/utils/validation';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import { NEW_OBJECT } from 'shared/constants';
+import { COPYING_STATUS, COPYING_STATUS_VALUES } from 'shared/data/constants';
 
 function sorted(nodes) {
   return sortBy(nodes, ['lft']);
@@ -45,6 +46,31 @@ export function getContentNodeDescendants(state, getters) {
 export function hasChildren(state, getters) {
   return function(id) {
     return getters.getContentNode(id).total_count > 0;
+  };
+}
+
+/**
+ * Whether the contentnode's interactivity should be disabled or not while copying?
+ * When the contentnode is copying or the copying has failed, we need
+ * to keep interactivity disabled. Hence, the FAILED condition is also there.
+ */
+export function isNodeInCopyingState(state, getters) {
+  return function(contentNodeId) {
+    const contentNode = getters.getContentNode(contentNodeId);
+    return (
+      contentNode[COPYING_STATUS] === COPYING_STATUS_VALUES.COPYING ||
+      contentNode[COPYING_STATUS] === COPYING_STATUS_VALUES.FAILED
+    );
+  };
+}
+
+/**
+ * Whether the contentnode's copying has errored or not?
+ */
+export function hasNodeCopyingErrored(state, getters) {
+  return function(contentNodeId) {
+    const contentNode = getters.getContentNode(contentNodeId);
+    return contentNode[COPYING_STATUS] === COPYING_STATUS_VALUES.FAILED;
   };
 }
 

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -4,7 +4,8 @@ import find from 'lodash/find';
 import { Store } from 'vuex';
 import {
   RELATIVE_TREE_POSITIONS,
-  COPYING_FLAG,
+  COPYING_STATUS,
+  COPYING_STATUS_VALUES,
   TASK_ID,
   CHANGES_TABLE,
   CHANGE_TYPES,
@@ -666,7 +667,7 @@ describe('ContentNode methods', () => {
         source_node_id: node.node_id,
         channel_id: parent.channel_id,
         root_id: parent.root_id,
-        [COPYING_FLAG]: true,
+        [COPYING_STATUS]: COPYING_STATUS_VALUES.COPYING,
         [TASK_ID]: null,
       };
       await expect(ContentNode.tableCopy({ node, parent, payload })).resolves.toMatchObject(

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/changes.spec.js
@@ -16,7 +16,8 @@ import {
   TABLE_NAMES,
   RELATIVE_TREE_POSITIONS,
   LAST_FETCHED,
-  COPYING_FLAG,
+  COPYING_STATUS,
+  COPYING_STATUS_VALUES,
   TASK_ID,
 } from 'shared/data/constants';
 import db from 'shared/data/db';
@@ -124,7 +125,7 @@ describe('Change Types', () => {
       b: 3,
       [LAST_FETCHED]: new Date(),
       [TASK_ID]: '18292183921',
-      [COPYING_FLAG]: true,
+      [COPYING_STATUS]: COPYING_STATUS_VALUES.COPYING,
     };
     const change = new UpdatedChange({
       key: '1',
@@ -152,7 +153,7 @@ describe('Change Types', () => {
       b: 2,
       [LAST_FETCHED]: new Date(),
       [TASK_ID]: '18292183921',
-      [COPYING_FLAG]: true,
+      [COPYING_STATUS]: COPYING_STATUS_VALUES.COPYING,
     };
     const change = new UpdatedChange({
       key: '1',

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -17,7 +17,7 @@ import {
   RELATIVE_TREE_POSITIONS,
   RELATIVE_TREE_POSITIONS_LOOKUP,
   LAST_FETCHED,
-  COPYING_FLAG,
+  COPYING_STATUS,
   TASK_ID,
 } from 'shared/data/constants';
 import { INDEXEDDB_RESOURCES } from 'shared/data/registry';
@@ -199,7 +199,7 @@ export class ChangeTracker {
 // These fields should not be included in change objects that we
 // store in the changes table for syncing to the backend
 // as they are only used for tracking state locally
-const ignoredSubFields = [COPYING_FLAG, LAST_FETCHED, TASK_ID];
+const ignoredSubFields = [COPYING_STATUS, LAST_FETCHED, TASK_ID];
 
 function omitIgnoredSubFields(obj) {
   return omit(obj, ignoredSubFields);

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -64,8 +64,14 @@ export const RELATIVE_TREE_POSITIONS = {
 
 export const RELATIVE_TREE_POSITIONS_LOOKUP = invert(RELATIVE_TREE_POSITIONS);
 
+export const COPYING_STATUS_VALUES = {
+  COPYING: 'COPYING',
+  FAILED: 'FAILED',
+  SUCCESS: 'SUCCESS',
+};
+
 // Special fields used for frontend specific handling
-export const COPYING_FLAG = '__COPYING';
+export const COPYING_STATUS = '__COPYING_STATUS';
 export const TASK_ID = '__TASK_ID';
 export const LAST_FETCHED = '__last_fetch';
 

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1654,6 +1654,8 @@ export const ContentNode = new TreeResource({
   /**
    * Waits for copying of contentnode to complete for id referenced in `id`.
    * @param {string} id
+   * @param {Number} startingRev -- the revision from which we start looking for
+   *                                success or failure change objects.
    * @returns {Promise<void>}
    */
   waitForCopying(id, startingRev) {

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -18,7 +18,8 @@ import {
   CHANGES_TABLE,
   RELATIVE_TREE_POSITIONS,
   TABLE_NAMES,
-  COPYING_FLAG,
+  COPYING_STATUS,
+  COPYING_STATUS_VALUES,
   TASK_ID,
   CURRENT_USER,
   MAX_REV_KEY,
@@ -299,12 +300,12 @@ class IndexedDBResource {
           .map(datum => {
             const id = this.getIdValue(datum);
             datum[LAST_FETCHED] = now;
-            // Persist TASK_ID and COPYING_FLAG attributes when directly fetching from the server
+            // Persist TASK_ID and COPYING_STATUS attributes when directly fetching from the server
             if (currentMap[id] && currentMap[id][TASK_ID]) {
               datum[TASK_ID] = currentMap[id][TASK_ID];
             }
-            if (currentMap[id] && currentMap[id][COPYING_FLAG]) {
-              datum[COPYING_FLAG] = currentMap[id][COPYING_FLAG];
+            if (currentMap[id] && currentMap[id][COPYING_STATUS]) {
+              datum[COPYING_STATUS] = currentMap[id][COPYING_STATUS];
             }
             // If we have an updated change, apply the modifications here
             if (
@@ -1507,6 +1508,53 @@ export const ContentNode = new TreeResource({
     });
   },
 
+  /**
+   * Figures out the new target and position for the failed copy node.
+   * And then queues a CopyChange object for syncing to the backend.
+   * @param {string} id
+   * @returns {Promise}
+   */
+  retryCopyChange(id) {
+    // Get the latest change for contentnode `id` that has an error and is of copy type.
+    const change = db[CHANGES_TABLE].orderBy('rev')
+      .filter(
+        change =>
+          change.key === id &&
+          change.table === this.tableName &&
+          (change.errors || change.errors === '') &&
+          change.type === CHANGE_TYPES.COPIED
+      )
+      .last();
+
+    // Figure out the new target and position.
+    return this.table.get(id).then(failedCopyNode => {
+      const target = this.table
+        .orderBy('lft')
+        .filter(
+          node =>
+            node.id !== id &&
+            node.parent === failedCopyNode.parent &&
+            node.lft <= failedCopyNode.lft &&
+            node[COPYING_STATUS] !== COPYING_STATUS_VALUES.FAILED &&
+            node[COPYING_STATUS] !== COPYING_STATUS_VALUES.COPYING
+        )
+        .last();
+
+      return Promise.all([change, target]).then(([change, target]) => {
+        if (target) {
+          change.target = target.id;
+          change.position = RELATIVE_TREE_POSITIONS.RIGHT;
+        } else {
+          change.target = failedCopyNode.parent;
+          change.position = RELATIVE_TREE_POSITIONS.FIRST_CHILD;
+        }
+
+        // Fire up the change object to sync.
+        this._saveAndQueueChange(new CopiedChange(change));
+      });
+    });
+  },
+
   async tableCopy({ node, parent, payload }) {
     payload = {
       ...node,
@@ -1522,7 +1570,7 @@ export const ContentNode = new TreeResource({
       root_id: parent.root_id,
       // Set this node as copying until we get confirmation from the
       // backend that it has finished copying
-      [COPYING_FLAG]: true,
+      [COPYING_STATUS]: COPYING_STATUS_VALUES.COPYING,
       // Set to null, but this should update to a task id to track the copy
       // task once it has been initiated
       [TASK_ID]: null,
@@ -1571,25 +1619,58 @@ export const ContentNode = new TreeResource({
   getChannelId: getChannelFromChannelScope,
 
   /**
-   * Waits for copying of content nodes to complete for all ids referenced in `ids` array
-   * @param {string[]} ids
+   * Waits for copying of contentnode to complete for id referenced in `id`.
+   * @param {string} id
    * @returns {Promise<void>}
    */
-  waitForCopying(ids) {
-    const observable = Dexie.liveQuery(() => {
-      return this.table
+  waitForCopying(id, startingRev) {
+    const observable = Dexie.liveQuery(async () => {
+      let copy_success_flag = 0;
+      let change_error_flag = 0;
+
+      copy_success_flag = await this.table
         .where('id')
-        .anyOf(ids)
-        .filter(node => !node[COPYING_FLAG])
-        .toArray();
+        .equals(id)
+        .filter(node => node[COPYING_STATUS] === COPYING_STATUS_VALUES.SUCCESS)
+        .count();
+
+      if (copy_success_flag === 1) {
+        return {
+          copy_success_flag,
+          change_error_flag,
+        };
+      }
+
+      change_error_flag = await db[CHANGES_TABLE].where('[table+key]')
+        .equals([this.tableName, id])
+        .filter(change => {
+          if (
+            (change['errors'] || change['errors'] === '') &&
+            change['type'] === CHANGE_TYPES.COPIED
+          ) {
+            if (!startingRev || change['rev'] > startingRev) {
+              return true;
+            }
+          }
+          return false;
+        })
+        .count();
+
+      return {
+        copy_success_flag,
+        change_error_flag,
+      };
     });
 
     return new Promise((resolve, reject) => {
       const subscription = observable.subscribe({
         next(result) {
-          if (result.length === ids.length) {
+          if (result.copy_success_flag) {
             subscription.unsubscribe();
             resolve();
+          } else if (result.change_error_flag) {
+            subscription.unsubscribe();
+            reject();
           }
         },
         error() {

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -915,8 +915,9 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
                 log_sync_exception(e, user=self.request.user, change=copy)
                 copy["errors"] = [str(e)]
                 errors.append(copy)
-                failed_copy_node = self.get_queryset().get(pk=copy["key"])
-                failed_copy_node.delete()
+                failed_copy_node = self.get_queryset().filter(pk=copy["key"]).first()
+                if failed_copy_node is not None:
+                    failed_copy_node.delete()
         return errors
 
     def copy(

--- a/contentcuration/contentcuration/viewsets/sync/constants.py
+++ b/contentcuration/contentcuration/viewsets/sync/constants.py
@@ -55,7 +55,15 @@ ALL_TABLES = set(
 )
 
 
-# Key to use for whether a node is currently copying
-COPYING_FLAG = "__COPYING"
+# Enum for copying states
+class COPYING_STATUS_VALUES:
+    COPYING = "COPYING"
+    FAILED = "FAILED"
+    SUCCESS = "SUCCESS"
+
+
+# Key to track copying status
+COPYING_STATUS = "__COPYING_STATUS"
+
 # Key for tracking id of async task that is relevant to this indexedDB row
 TASK_ID = "__TASK_ID"


### PR DESCRIPTION
## Summary

This PR brings in the capability to retry failed copies and detection of failing copies.

### Manual verification steps performed

To generate copy error state on the frontend, I raised an exception from the backend copy function. These are the checks I've performed:-
 
1. Checked whether error in the `changesForSyncing` table are detected.
3. Checked whether importing from channels errors out.
4. Checked whether copying completes.
5. Checked whether retrying completes successfully when the exception is removed from the backend code.
6. Checked whether after multiple failures, retrying still reaches success upon exception removal.
7. Copying multiple nodes together by selecting them works as expected.
8. When copy is failed, the node can be removed.

### Screenshots (if applicable)

The below screenshot is the current design, it's matching with the expected design. (thanks to sir @bjester for helping me out fix the design).

![image](https://github.com/learningequality/studio/assets/26724128/ddbc634e-dece-4a9a-b5e3-ccdbc973cb80)

The below is the UI design that is expected.

![image](https://user-images.githubusercontent.com/6668144/110513952-a2975b00-80bb-11eb-9dda-4c078facce96.png)

### Does this introduce any tech-debt items?

Possible tech-debts:-

- the CSS that is used to prevent wrapping `retry` action can be refactored to make it responsive and robust.
- due to the current architecture, copy error state doesn't persist across sessions. 

___
## Reviewer guidance

Does manual verification steps checks out green? 


## References

Closes https://github.com/learningequality/studio/issues/2850.
Closes https://github.com/learningequality/studio/issues/3914.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
