### PR TITLE
Refactor the default completion and duration content completion optio…

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/__tests__/utils.spec.js
@@ -8,6 +8,7 @@ import {
   importedChannelLink,
   secondsToHms,
   getCompletionCriteriaLabels,
+  getCompletionDataFromNode,
 } from '../utils';
 import router from '../router';
 import { RouteNames } from '../constants';
@@ -475,6 +476,76 @@ describe('channelEdit utils', () => {
   });
 
   describe(`getCompletionCriteriaLabels`, () => {
+    describe(`setting default values for completion and duration`, () => {
+      describe(`for audio and video content`, () => {
+        it(`returns 'When time spent is equal to duration' completion label and  duration label equal to the file length in hh:mm:ss format`, () => {
+          expect(
+            getCompletionCriteriaLabels(
+              {
+                extra_fields: {
+                  options: {},
+                },
+                kind: 'audio',
+              },
+              [{ duration: 100 }]
+            )
+          ).toEqual({
+            completion: 'When time spent is equal to duration',
+            duration: '01:40',
+          });
+        });
+        it(`returns 'When time spent is equal to duration' completion label and  duration label equal to the file length in hh:mm:ss format`, () => {
+          expect(
+            getCompletionCriteriaLabels(
+              {
+                extra_fields: {
+                  options: {},
+                },
+                kind: 'video',
+              },
+              [{ duration: 100 }]
+            )
+          ).toEqual({
+            completion: 'When time spent is equal to duration',
+            duration: '01:40',
+          });
+        });
+      });
+      describe(`for documents`, () => {
+        it(`returns 'Viewed in its entirety' completion label and empty duration label`, () => {
+          expect(
+            getCompletionCriteriaLabels(
+              {
+                extra_fields: {
+                  options: {},
+                },
+                kind: 'document',
+              },
+              []
+            )
+          ).toEqual({
+            completion: 'Viewed in its entirety',
+            duration: '-',
+          });
+        });
+      });
+      describe(`for exercises`, () => {
+        it(`sets the Completion Criteria model to 'mastery'`, () => {
+          expect(
+            getCompletionDataFromNode(
+              {
+                extra_fields: {
+                  options: {},
+                },
+                kind: 'exercise',
+              },
+              []
+            ).completionModel
+          ).toEqual('mastery');
+        });
+      });
+    });
+
     describe(`for 'reference' completion criteria`, () => {
       it(`returns 'Reference material' completion label and empty duration label`, () => {
         expect(

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -532,12 +532,7 @@
   import sortBy from 'lodash/sortBy';
   import { mapActions, mapGetters } from 'vuex';
   import camelCase from 'lodash/camelCase';
-  import {
-    isImportedContent,
-    importedChannelLink,
-    getCompletionCriteriaLabels,
-    getAudioVideoDefaultDuration,
-  } from '../utils';
+  import { isImportedContent, importedChannelLink, getCompletionCriteriaLabels } from '../utils';
   import FilePreview from '../views/files/FilePreview';
   import { ContentLevels, Categories, AccessibilityCategories } from '../../shared/constants';
   import AssessmentItemPreview from './AssessmentItemPreview/AssessmentItemPreview';
@@ -619,10 +614,7 @@
         return getCompletionCriteriaLabels(this.node).completion;
       },
       duration() {
-        if (this.isAudioVideo) {
-          return getAudioVideoDefaultDuration(this.files);
-        }
-        return getCompletionCriteriaLabels(this.node).duration;
+        return getCompletionCriteriaLabels(this.node, this.files).duration;
       },
       files() {
         return sortBy(this.getContentNodeFiles(this.nodeId), f => f.preset.order);
@@ -672,11 +664,6 @@
       },
       isResource() {
         return !this.isTopic && !this.isExercise;
-      },
-      isAudioVideo() {
-        return (
-          this.node.kind === ContentKindsNames.AUDIO || this.node.kind === ContentKindsNames.VIDEO
-        );
       },
       isImported() {
         return isImportedContent(this.node);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -532,7 +532,12 @@
   import sortBy from 'lodash/sortBy';
   import { mapActions, mapGetters } from 'vuex';
   import camelCase from 'lodash/camelCase';
-  import { isImportedContent, importedChannelLink, getCompletionCriteriaLabels } from '../utils';
+  import {
+    isImportedContent,
+    importedChannelLink,
+    getCompletionCriteriaLabels,
+    getAudioVideoDefaultDuration,
+  } from '../utils';
   import FilePreview from '../views/files/FilePreview';
   import { ContentLevels, Categories, AccessibilityCategories } from '../../shared/constants';
   import AssessmentItemPreview from './AssessmentItemPreview/AssessmentItemPreview';
@@ -614,6 +619,9 @@
         return getCompletionCriteriaLabels(this.node).completion;
       },
       duration() {
+        if (this.isAudioVideo) {
+          return getAudioVideoDefaultDuration(this.files);
+        }
         return getCompletionCriteriaLabels(this.node).duration;
       },
       files() {
@@ -664,6 +672,11 @@
       },
       isResource() {
         return !this.isTopic && !this.isExercise;
+      },
+      isAudioVideo() {
+        return (
+          this.node.kind === ContentKindsNames.AUDIO || this.node.kind === ContentKindsNames.VIDEO
+        );
       },
       isImported() {
         return isImportedContent(this.node);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/CompletionOptions.vue
@@ -100,6 +100,12 @@
 <script>
 
   import get from 'lodash/get';
+  import {
+    defaultCompletionCriteriaModels,
+    defaultCompletionCriteriaThresholds,
+    CompletionOptionsDropdownMap,
+    completionCriteriaToDropdownMap,
+  } from '../../utils';
   import MasteryCriteriaMofNFields from './MasteryCriteriaMofNFields';
   import ActivityDuration from './ActivityDuration.vue';
   import MasteryCriteriaGoal from './MasteryCriteriaGoal';
@@ -124,59 +130,6 @@
 
   const DEFAULT_SHORT_ACTIVITY = 600;
   const DEFAULT_LONG_ACTIVITY = 3000;
-
-  const defaultCompletionCriteriaModels = {
-    [ContentKindsNames.VIDEO]: CompletionCriteriaModels.TIME,
-    [ContentKindsNames.AUDIO]: CompletionCriteriaModels.TIME,
-    [ContentKindsNames.DOCUMENT]: CompletionCriteriaModels.PAGES,
-    [ContentKindsNames.H5P]: CompletionCriteriaModels.DETERMINED_BY_RESOURCE,
-    [ContentKindsNames.HTML5]: CompletionCriteriaModels.APPROX_TIME,
-    [ContentKindsNames.EXERCISE]: CompletionCriteriaModels.MASTERY,
-  };
-
-  const defaultCompletionCriteriaThresholds = {
-    // Audio and Video threshold defaults are dynamic based
-    // on the duration of the file itself.
-    [ContentKindsNames.DOCUMENT]: '100%',
-    [ContentKindsNames.HTML5]: 300,
-    // We cannot set an automatic default threshold for exercises.
-  };
-
-  const completionCriteriaToDropdownMap = {
-    [CompletionCriteriaModels.TIME]: CompletionDropdownMap.completeDuration,
-    [CompletionCriteriaModels.APPROX_TIME]: CompletionDropdownMap.completeDuration,
-    [CompletionCriteriaModels.PAGES]: CompletionDropdownMap.allContent,
-    [CompletionCriteriaModels.DETERMINED_BY_RESOURCE]: CompletionDropdownMap.determinedByResource,
-    [CompletionCriteriaModels.MASTERY]: CompletionDropdownMap.goal,
-    [CompletionCriteriaModels.REFERENCE]: CompletionDropdownMap.reference,
-  };
-
-  const CompletionOptionsDropdownMap = {
-    [ContentKindsNames.DOCUMENT]: [
-      CompletionDropdownMap.allContent,
-      CompletionDropdownMap.completeDuration,
-      CompletionDropdownMap.reference,
-    ],
-    [ContentKindsNames.EXERCISE]: [CompletionDropdownMap.goal, CompletionDropdownMap.practiceQuiz],
-    [ContentKindsNames.HTML5]: [
-      CompletionDropdownMap.completeDuration,
-      CompletionDropdownMap.determinedByResource,
-      CompletionDropdownMap.reference,
-    ],
-    [ContentKindsNames.H5P]: [
-      CompletionDropdownMap.determinedByResource,
-      CompletionDropdownMap.completeDuration,
-      CompletionDropdownMap.reference,
-    ],
-    [ContentKindsNames.VIDEO]: [
-      CompletionDropdownMap.completeDuration,
-      CompletionDropdownMap.reference,
-    ],
-    [ContentKindsNames.AUDIO]: [
-      CompletionDropdownMap.completeDuration,
-      CompletionDropdownMap.reference,
-    ],
-  };
 
   export default {
     name: 'CompletionOptions',

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -314,9 +314,7 @@ export function isLongActivity(node) {
  * @returns {Object} { completion, duration }
  */
 export function getCompletionCriteriaLabels(node = {}, files = []) {
-  console.log('labels');
   if (!node && !files) {
-    console.log('none');
     return;
   }
 
@@ -331,8 +329,6 @@ export function getCompletionCriteriaLabels(node = {}, files = []) {
     completion: '-',
     duration: '-',
   };
-
-  console.log('filesss', files);
 
   switch (completionModel) {
     case CompletionCriteriaModels.REFERENCE:

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -239,30 +239,24 @@ export function secondsToHms(seconds) {
 }
 
 /**
- * Set a default completion model for audiovisual content
+ * Set a default duration for audiovisual content
  * equal to the file length in seconds (parsed), or a fallback placeholder
  *
- * @param {Object} node
- * @returns {String|Number} {from options in the map above}
+ * @param {Array} files
+ * @returns {String|Number} {human-readable duration}
  */
 export function getAudioVideoDefaultDuration(files) {
   return files && files[0] ? secondsToHms(files[0].duration) : '-';
 }
 
-export function generateDefaultThreshold(node) {
-  if (node.kind !== ContentKindsNames.AUDIO || node.kind !== ContentKindsNames.VIDEO) {
-    return defaultCompletionCriteriaThresholds[node.kind];
-  }
-}
-
 /**
- * Set a default completion model for non-audiovisual content
- * the default completion for audio video is the duration of the file length
+ * Set a default completion threshold for audiovisual content
+ * equal to the file's duration
  *
  * @param {Object} node
- * @returns {String|Number} {from options in the map above}
+ * @returns {String|Number} {human-readable threshold}
  */
-export function generateDefaultModel(node) {
+export function generateDefaultThreshold(node) {
   if (node.kind !== ContentKindsNames.AUDIO || node.kind !== ContentKindsNames.VIDEO) {
     return defaultCompletionCriteriaThresholds[node.kind];
   }
@@ -319,8 +313,10 @@ export function isLongActivity(node) {
  * @param {Object} node
  * @returns {Object} { completion, duration }
  */
-export function getCompletionCriteriaLabels(node) {
-  if (!node) {
+export function getCompletionCriteriaLabels(node = {}, files = []) {
+  console.log('labels');
+  if (!node && !files) {
+    console.log('none');
     return;
   }
 
@@ -336,6 +332,8 @@ export function getCompletionCriteriaLabels(node) {
     duration: '-',
   };
 
+  console.log('filesss', files);
+
   switch (completionModel) {
     case CompletionCriteriaModels.REFERENCE:
       labels.completion = metadataStrings.$tr('reference');
@@ -343,10 +341,10 @@ export function getCompletionCriteriaLabels(node) {
 
     case CompletionCriteriaModels.TIME:
       labels.completion = metadataStrings.$tr('completeDuration');
-      if (suggestedDuration) {
+      if (node.kind === ContentKindsNames.AUDIO || node.kind === ContentKindsNames.VIDEO) {
+        labels.duration = getAudioVideoDefaultDuration(files);
+      } else if (suggestedDuration) {
         labels.duration = secondsToHms(suggestedDuration);
-      } else {
-        getAudioVideoDefaultDuration(node);
       }
       break;
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR refactors the default completion and duration model logic - previously only used in the EditModal to help with 


### Manual verification steps performed
1. Default completion criteria are visible on the "devsetup" generated sample resources, where such completion data has not been added 
2. Testing with the EditModal to ensure functionality is still present 
3. Previewing the resource panel to ensure changes made in the EditModal are accurately reflected for all content types

### Screenshots (if applicable)
There are a great deal of permutations, so I have not included them all, but a few samples - 
<img width="949" alt="Screenshot 2023-07-02 at 5 28 15 PM" src="https://github.com/learningequality/studio/assets/17235236/00176327-64d2-4a02-bd5e-d23ae9e7b47c">
<img width="953" alt="Screenshot 2023-07-02 at 5 28 59 PM" src="https://github.com/learningequality/studio/assets/17235236/f7450c8a-3a2f-40ab-8a3f-e064fcf68263">
<img width="946" alt="Screenshot 2023-07-02 at 5 28 44 PM" src="https://github.com/learningequality/studio/assets/17235236/95b07e1c-0155-403f-a24d-543202d4932b">


### Does this introduce any tech-debt items?
I don't think so! Hopefully it rather helps reduce it. 

___
## Reviewer guidance
### How can a reviewer test these changes?
For code review: 
1. Run `yarn run devsetup` and see the default completion and duration values for the different content types (note that there are not default 'duration' values for anything other than audio/video content) 
2. Add your own content and see the default values displaying within the edit modal and, when saved, in the Resource Panel 
3. Add your own content and change the default values 

### Are there any risky areas that deserve extra testing?
The EditModal should be fully regression tested by QA team to ensure it is still working as expected.


## References
Fixes #4180 

## Comments
I have tried to keep this as simple as possible for release - there might be other optimizations we could add later (i.e. do we want an empty duration to display at all by default?) but that did not seem to be critical at this point.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
