### PR TITLE
Prevent source edits for copied/imported resources

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -246,7 +246,7 @@
               ref="author"
               :items="authors"
               :label="$tr('authorLabel')"
-              :readonly="disableAuthEdits"
+              :readonly="disableSourceEdits"
               maxlength="200"
               counter
               autoSelectFirst
@@ -267,7 +267,7 @@
               ref="provider"
               :items="providers"
               :label="$tr('providerLabel')"
-              :readonly="disableAuthEdits"
+              :readonly="disableSourceEdits"
               maxlength="200"
               counter
               :placeholder="getPlaceholder('provider')"
@@ -288,7 +288,7 @@
               ref="aggregator"
               :items="aggregators"
               :label="$tr('aggregatorLabel')"
-              :readonly="disableAuthEdits"
+              :readonly="disableSourceEdits"
               maxlength="200"
               counter
               autoSelectFirst
@@ -309,7 +309,7 @@
               ref="license"
               v-model="licenseItem"
               :required="isUnique(license) && isUnique(license_description) && !disableAuthEdits"
-              :readonly="disableAuthEdits"
+              :readonly="disableSourceEdits"
               :placeholder="getPlaceholder('license')"
               :descriptionPlaceholder="getPlaceholder('license_description')"
               @focus="trackClick('License')"
@@ -328,7 +328,7 @@
               :rules="copyrightHolderRules"
               :placeholder="getPlaceholder('copyright_holder')"
               autoSelectFirst
-              :readonly="disableAuthEdits"
+              :readonly="disableSourceEdits"
               box
               :value="copyright_holder && copyright_holder.toString()"
               @input.native="(e) => (copyright_holder = e.srcElement.value)"
@@ -657,6 +657,9 @@
       /* COMPUTED PROPS */
       disableAuthEdits() {
         return this.nodes.some(node => node.freeze_authoring_data);
+      },
+      disableSourceEdits() {
+        return this.disableAuthEdits || this.isImported;
       },
       detectedImportText() {
         const count = this.nodes.filter(node => node.freeze_authoring_data).length;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -246,7 +246,7 @@
               ref="author"
               :items="authors"
               :label="$tr('authorLabel')"
-              :readonly="disableSourceEdits"
+              :disabled="disableSourceEdits"
               maxlength="200"
               counter
               autoSelectFirst
@@ -267,7 +267,7 @@
               ref="provider"
               :items="providers"
               :label="$tr('providerLabel')"
-              :readonly="disableSourceEdits"
+              :disabled="disableSourceEdits"
               maxlength="200"
               counter
               :placeholder="getPlaceholder('provider')"
@@ -288,7 +288,7 @@
               ref="aggregator"
               :items="aggregators"
               :label="$tr('aggregatorLabel')"
-              :readonly="disableSourceEdits"
+              :disabled="disableSourceEdits"
               maxlength="200"
               counter
               autoSelectFirst
@@ -309,7 +309,7 @@
               ref="license"
               v-model="licenseItem"
               :required="isUnique(license) && isUnique(license_description) && !disableAuthEdits"
-              :readonly="disableSourceEdits"
+              :disabled="disableSourceEdits"
               :placeholder="getPlaceholder('license')"
               :descriptionPlaceholder="getPlaceholder('license_description')"
               @focus="trackClick('License')"
@@ -328,7 +328,7 @@
               :rules="copyrightHolderRules"
               :placeholder="getPlaceholder('copyright_holder')"
               autoSelectFirst
-              :readonly="disableSourceEdits"
+              :disabled="disableSourceEdits"
               box
               :value="copyright_holder && copyright_holder.toString()"
               @input.native="(e) => (copyright_holder = e.srcElement.value)"


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr Prevent "Source" fields edits for copied/imported resources. Also please see this [comment](https://github.com/learningequality/studio/issues/3111#issuecomment-1599071565) for context on fix made

### Manual verification steps performed
Please see issues #3111  and #4090. 

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
No
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Create a channel A and channel B.
2. Upload a file in channel A and then import the same file in channel B.
3. Edit all details of the file in channel B.
5. You should not be able to edit any of the fields under the "Source" section of the edit form.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/3111 and https://github.com/learningequality/studio/issues/4090

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
