### PR TITLE
Fix to ignore language settings for kolibri public APIs

### DIFF
--- a/contentcuration/contentcuration/middleware/locale.py
+++ b/contentcuration/contentcuration/middleware/locale.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.middleware.locale import LocaleMiddleware
+from django.utils import translation
 
 LOCALE_EXEMPT = "_locale_exempt"
 
@@ -15,6 +17,8 @@ class KolibriStudioLocaleMiddleware(LocaleMiddleware):
     def process_view(self, request, callback, callback_args, callback_kwargs):
         if self._is_exempt(callback):
             setattr(request, LOCALE_EXEMPT, True)
+            translation.activate(settings.LANGUAGE_CODE)
+            request.LANGUAGE_CODE = translation.get_language()
         return None
 
     def process_response(self, request, response):


### PR DESCRIPTION
## Summary

Kolibri public APIs were not ignoring language settings because our custom middleware allowed language settings to get applied. This PR fixes that by setting the default language before the view function runs.


### Manual verification steps performed

1. Change the UI language to something other than English.
1. Query the public API for something that doesn't exist, e.g. https://unstable.studio.learningequality.org/api/public/v2/contentnode/8e6574944e1949c197faa22ff3c918dc/
1. Observe the detail message is still indeed in English.

___
## Reviewer guidance
Performing manual verification steps should provide good confidence.


## References

Closes https://github.com/learningequality/studio/issues/4118.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
