### PR TITLE
Empty channels publish handling

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1971,6 +1971,9 @@ class ContentNode(MPTTModel, models.Model):
     def copy(self):
         return self.copy_to()
 
+    def is_publishable(self):
+        return self.complete and self.get_descendants(include_self=True).exclude(kind_id=content_kinds.TOPIC).exists()
+
     class Meta:
         verbose_name = "Topic"
         verbose_name_plural = "Topics"

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -429,6 +429,29 @@ class ExportChannelTestCase(StudioTestCase):
         })
 
 
+class EmptyChannelTestCase(StudioTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(EmptyChannelTestCase, cls).setUpClass()
+        cls.patch_copy_db = patch('contentcuration.utils.publish.save_export_database')
+        cls.patch_copy_db.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(EmptyChannelTestCase, cls).tearDownClass()
+        cls.patch_copy_db.stop()
+
+    def test_publish_empty_channel(self):
+        content_channel = channel()
+        set_channel_icon_encoding(content_channel)
+        content_channel.main_tree.complete = True
+        content_channel.main_tree.save()
+        content_channel.main_tree.get_descendants().exclude(kind_id="topic").delete()
+        with self.assertRaises(ValueError):
+            create_content_database(content_channel, True, self.admin_user.id, True)
+
+
 class ChannelExportUtilityFunctionTestCase(StudioTestCase):
     @classmethod
     def setUpClass(cls):

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -29,6 +29,7 @@ from .testdata import node as create_node
 from .testdata import slideshow
 from .testdata import thumbnail_bytes
 from contentcuration import models as cc
+from contentcuration.utils.publish import ChannelIncompleteError
 from contentcuration.utils.publish import convert_channel_thumbnail
 from contentcuration.utils.publish import create_content_database
 from contentcuration.utils.publish import create_slideshow_manifest
@@ -448,7 +449,7 @@ class EmptyChannelTestCase(StudioTestCase):
         content_channel.main_tree.complete = True
         content_channel.main_tree.save()
         content_channel.main_tree.get_descendants().exclude(kind_id="topic").delete()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ChannelIncompleteError):
             create_content_database(content_channel, True, self.admin_user.id, True)
 
 

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -9,6 +9,7 @@ import pytest
 from django.core.management import call_command
 from django.db import connections
 from kolibri_content import models as kolibri_models
+from kolibri_content.router import cleanup_content_database_connection
 from kolibri_content.router import get_active_content_database
 from kolibri_content.router import set_active_content_database
 from le_utils.constants import exercises
@@ -216,8 +217,7 @@ class ExportChannelTestCase(StudioTestCase):
 
     def tearDown(self):
         # Clean up datbase connection after the test
-        connections[self.tempdb].close()
-        del connections.databases[self.tempdb]
+        cleanup_content_database_connection(self.tempdb)
         super(ExportChannelTestCase, self).tearDown()
         set_active_content_database(None)
         if os.path.exists(self.tempdb):

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -74,6 +74,10 @@ class NoNodesChangedError(Exception):
     pass
 
 
+class ChannelIncompleteError(Exception):
+    pass
+
+
 class SlowPublishError(Exception):
     """
     Used to track slow Publishing operations. We don't raise this error,
@@ -196,7 +200,7 @@ class TreeMapper:
         progress_tracker=None,
     ):
         if not root_node.is_publishable():
-            raise ValueError("Attempted to publish a channel with an incomplete root node or no resources")
+            raise ChannelIncompleteError("Attempted to publish a channel with an incomplete root node or no resources")
 
         self.root_node = root_node
         task_percent_total = 80.0

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -195,8 +195,8 @@ class TreeMapper:
         force_exercises=False,
         progress_tracker=None,
     ):
-        if not root_node.complete:
-            raise ValueError("Attempted to publish a channel with an incomplete root node")
+        if not root_node.is_publishable():
+            raise ValueError("Attempted to publish a channel with an incomplete root node or no resources")
 
         self.root_node = root_node
         task_percent_total = 80.0
@@ -220,7 +220,7 @@ class TreeMapper:
         logging.debug("Mapping node with id {id}".format(id=node.pk))
 
         # Only process nodes that are either non-topics or have non-topic descendants
-        if node.get_descendants(include_self=True).exclude(kind_id=content_kinds.TOPIC).exists() and node.complete:
+        if node.is_publishable():
             # early validation to make sure we don't have any exercises without mastery models
             # which should be unlikely when the node is complete, but just in case
             if node.kind_id == content_kinds.EXERCISE:

--- a/contentcuration/kolibri_content/router.py
+++ b/contentcuration/kolibri_content/router.py
@@ -72,6 +72,16 @@ def get_content_database_connection(alias=None):
     return connections[alias].connection
 
 
+def cleanup_content_database_connection(alias):
+    try:
+        connection = connections[alias]
+        connection.close()
+        del connections.databases[alias]
+    except (ConnectionDoesNotExist, KeyError):
+        # Already cleaned up, nothing to do here!
+        pass
+
+
 class ContentDBRouter(object):
     """A router that decides what content database to read from based on a thread-local variable."""
 
@@ -158,6 +168,7 @@ class using_content_database(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         set_active_content_database(self.previous_alias)
+        cleanup_content_database_connection(self.alias)
 
     def __call__(self, querying_func):
         # allow using the context manager as a decorator

--- a/contentcuration/kolibri_public/tests/test_mapper.py
+++ b/contentcuration/kolibri_public/tests/test_mapper.py
@@ -2,9 +2,9 @@ import os
 import tempfile
 
 from django.core.management import call_command
-from django.db import connections
 from django.test import TestCase
 from kolibri_content import models as kolibri_content_models
+from kolibri_content.router import cleanup_content_database_connection
 from kolibri_content.router import get_active_content_database
 from kolibri_content.router import using_content_database
 from kolibri_public import models as kolibri_public_models
@@ -116,8 +116,7 @@ class ChannelMapperTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         # Clean up datbase connection after the test
-        connections[cls.tempdb].close()
-        del connections.databases[cls.tempdb]
+        cleanup_content_database_connection(cls.tempdb)
         super(ChannelMapperTest, cls).tearDownClass()
         if os.path.exists(cls.tempdb):
             os.remove(cls.tempdb)


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds preemptive handling of channels that are completely empty, to prevent Integrity Errors caused by trying to create a ChannelMetadata object when there is no root node to make a Foreign Key to
* Adds a regression test to handle this
* Adds some better clean up of database connections that are created by the content database context manager - otherwise tests that test errors in the publishing process always produce errors during teardown
* Migrates to a custom exception class for errors raised when the root node is not publishable, so it can be specially handled to not set the channel as publishable again

### Manual verification steps performed
1. Created a regression test that replicated the issue
2. Fixed the issue
3. Reran the test
4. Profit!

## Reviewer guidance
### How can a reviewer test these changes?
This doesn't do anything about how someone was able to publish a channel while in this state, I think there's still more to work on there, but we should at least handle these things a bit better until we can fix that up better.

## References
Fixes [#4214](https://github.com/learningequality/studio/issues/4214)

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
