### PR TITLE
Prevent errors when creating already existing tag through model entries.

### DIFF
--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -487,6 +487,7 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
                 tag_id_map[tag.id] = new_tag.id
                 tags_to_create.append(new_tag)
 
+        # TODO: Can cleanup the above and change the below to use ignore_conflicts=True
         ContentTag.objects.bulk_create(tags_to_create)
 
         mappings_to_create = [
@@ -499,7 +500,10 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
             for mapping in node_tags_mappings
         ]
 
-        self.model.tags.through.objects.bulk_create(mappings_to_create)
+        # rtibbles: For reasons I have not been able to discern, under certain circumstances
+        # these mappings can already exist in the database. This is a workaround to prevent
+        # this from breaking copying.
+        self.model.tags.through.objects.bulk_create(mappings_to_create, ignore_conflicts=True)
 
     def _copy_assessment_items(self, source_copy_id_map):
         from contentcuration.models import File

--- a/contentcuration/contentcuration/db/models/manager.py
+++ b/contentcuration/contentcuration/db/models/manager.py
@@ -500,9 +500,9 @@ class CustomContentNodeTreeManager(TreeManager.from_queryset(CustomTreeQuerySet)
             for mapping in node_tags_mappings
         ]
 
-        # rtibbles: For reasons I have not been able to discern, under certain circumstances
-        # these mappings can already exist in the database. This is a workaround to prevent
-        # this from breaking copying.
+        # In the case that we are copying a node that is in the weird state of having a tag
+        # that is duplicated (with a channel tag and a null channel tag) this can cause an error
+        # so we ignore conflicts here to ignore the duplicate tags.
         self.model.tags.through.objects.bulk_create(mappings_to_create, ignore_conflicts=True)
 
     def _copy_assessment_items(self, source_copy_id_map):


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds `ignore_conflicts=True` when bulk creating Tag through objects to prevent errors from duplicated entries which break copying, but are not an issue.
* Adds a TODO for future cleanup of Tag creation to leverage the same

### Manual verification steps performed
I couldn't reproduce this so went for the minimal fix - as long as the Python tests pass, I think this is adequately covered by automated tests.


## References
Fixes #4221

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
