### PR TITLE
Fix bitmask filtering by multiple labels for AND rather than OR

### DIFF
--- a/contentcuration/kolibri_public/models.py
+++ b/contentcuration/kolibri_public/models.py
@@ -29,7 +29,15 @@ class ContentNodeQueryset(TreeQuerySet):
         annotations = {}
         for bitmask_fieldname, bits in bits.items():
             annotation_fieldname = "{}_{}".format(bitmask_fieldname, "masked")
-            filters[annotation_fieldname + "__gt"] = 0
+            # To get the correct result, i.e. an AND that all the labels are present,
+            # we need to check that the aggregated value is euqal to the bits.
+            # If we wanted an OR (which would check for any being present),
+            # we would have to use GREATER THAN 0 here.
+            filters[annotation_fieldname] = bits
+            # This ensures that the annotated value is the result of the AND operation
+            # so if all the values are present, the result will be the same as the bits
+            # but if any are missing, it will not be equal to the bits, but will only be
+            # 0 if none of the bits are present.
             annotations[annotation_fieldname] = F(bitmask_fieldname).bitand(bits)
 
         return self.annotate(**annotations).filter(**filters)


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Code copied from Kolibri was doing OR filtering for multiple metadata labels rather than AND
* This has been fixed in Kolibri in https://github.com/learningequality/kolibri/pull/10986/commits/f832ef0201569db19c2cffcf5b395bbfbb297306
* This copies that fix to Studio

### Manual verification steps performed
This is currently reliant on the regression tests in Kolibri to guarantee this behaviour.

## References
This is required to finalize the fix for the issues described here: https://github.com/learningequality/kolibri/issues/10975#issuecomment-1634875196 where selecting multiple categories or learning activities would show resources that matched ANY, not ALL.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
