### PR TITLE
Fixes undo of copying

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -160,12 +160,8 @@ export class ChangeTracker {
           change.type === CHANGE_TYPES.COPIED ||
           (change.type === CHANGE_TYPES.MOVED && !change.oldObj)
         ) {
-          // Get the primary key's field name off the table to make sure we delete by
-          // the change key
-          return resource.table
-            .where(resource.table.schema.primKey.keyPath)
-            .equals(change.key)
-            .delete();
+          // Use resource's delete method to propogate sync object to backend.
+          return resource.delete(change.key);
         } else if (change.type === CHANGE_TYPES.UPDATED || change.type === CHANGE_TYPES.DELETED) {
           // If we updated or deleted it, we just want the old stuff back
           return resource.table.put(change.oldObj);

--- a/contentcuration/contentcuration/frontend/shared/vuex/indexedDBPlugin/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/indexedDBPlugin/index.js
@@ -116,7 +116,7 @@ export default function IndexedDBPlugin(db, listeners = []) {
       }
       // omit the last fetched attribute used only in resource layer
       const mods = omit(obj, [LAST_FETCHED]);
-      if (Object.keys(mods).length === 0) {
+      if (Object.keys(mods).length === 0 && change.type === CHANGE_TYPES.UPDATED) {
         return;
       }
       events.emit(getEventName(change.table, change.type), {


### PR DESCRIPTION
## Summary
This PR fixes undo of copying. The problem was that the delete operation wasn't triggering vuex state update.


### Manual verification steps performed
1. Create a channel then create a contentnode.
2. Attempt its copying.
3. Wait for copy to finish, when snackbar appears upon copy completion, click on 'UNDO'.
4. See whether the node gets removed or not. Refresh the page and make sure the node doesn't show up. 
___
## Reviewer guidance
Performing manual verification steps should make the PR good to merge.


## References
Closes https://github.com/learningequality/studio/issues/4204.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
