### PR TITLE
Fixes incorrect value for Practice quiz

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -6,6 +6,7 @@ import { metadataStrings, constantStrings } from 'shared/mixins';
 import {
   AssessmentItemTypes,
   CompletionCriteriaModels,
+  ContentModalities,
   SHORT_LONG_ACTIVITY_MIDPOINT,
   CompletionDropdownMap,
 } from 'shared/constants';
@@ -280,18 +281,20 @@ export function getCompletionDataFromNode(node) {
     return;
   }
 
-  const completionCriteria = node.extra_fields?.options?.completion_criteria
-    ? JSON.parse(JSON.stringify(node.extra_fields?.options?.completion_criteria))
-    : null;
+  const extraFields = node?.extra_fields || {};
+  const options = extraFields?.options || {};
+  const completionCriteria = options?.completion_criteria || null;
   const threshold = completionCriteria?.threshold || generateDefaultThreshold(node);
   const model = completionCriteria?.model || defaultCompletionCriteriaModels[node.kind];
-  const suggestedDurationType = node.extra_fields?.suggested_duration_type;
+  const modality = options?.modality || null;
+  const suggestedDurationType = extraFields?.suggested_duration_type;
   const suggestedDuration = node.suggested_duration;
 
   return {
     completionModel: model,
     completionThreshold: threshold,
     masteryModel: threshold?.mastery_model,
+    modality,
     suggestedDurationType,
     suggestedDuration,
   };
@@ -323,11 +326,11 @@ export function getCompletionCriteriaLabels(node = {}, files = []) {
   if (!node && !files) {
     return;
   }
-
   const {
     completionModel,
     completionThreshold,
     masteryModel,
+    modality,
     suggestedDuration,
   } = getCompletionDataFromNode(node);
 
@@ -374,6 +377,11 @@ export function getCompletionCriteriaLabels(node = {}, files = []) {
           m: completionThreshold.m,
           n: completionThreshold.n,
         });
+      } else if (
+        masteryModel === MasteryModelsNames.DO_ALL &&
+        modality === ContentModalities.QUIZ
+      ) {
+        labels.completion = metadataStrings.$tr('practiceQuiz');
       } else {
         labels.completion = constantStrings.$tr(masteryModel);
       }


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the incorrect value displayed when `Practice quiz` is selected as the `Completion` type for a new Exercise.


### Manual verification steps performed
1. Sign in to Studio and open a channel
2. Create an exercise and set the Completion to `Practice quiz`.
3. The resource metadata window show `Practice quiz` as `Completion` value.
4. Edit the completion process to another type and that no regressions are present

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

https://github.com/learningequality/studio/assets/5203639/21be1885-9f02-47d0-9aa3-5423611e86b5


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
No

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
After setting up the project's development dependencies, and ensuring that Studio is running locally;

1.  Sign in to Studio and open a channel
2. Create an exercise and set the Completion to `Practice quiz`.
3. The resource metadata window show `Practice quiz` as `Completion` value.
4. Edit the completion process to another type and that no regressions are present


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
Not really, but ensuring the changes made have not broken the behavior of the other `Completion` types.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/4215

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
