### PR TITLE
Fix missing attributes from change objects

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -26,8 +26,8 @@ const commonFields = ['type', 'key', 'table', 'rev', 'channel_id', 'user_id'];
 const ChangeTypeMapFields = {
   [CHANGE_TYPES.CREATED]: commonFields.concat(['obj']),
   [CHANGE_TYPES.UPDATED]: commonFields.concat(['mods']),
-  [CHANGE_TYPES.DELETED]: commonFields,
-  [CHANGE_TYPES.MOVED]: commonFields.concat(['target', 'position']),
+  [CHANGE_TYPES.DELETED]: commonFields.concat(['oldObj']),
+  [CHANGE_TYPES.MOVED]: commonFields.concat(['target', 'position', 'oldObj', 'parent']),
   [CHANGE_TYPES.COPIED]: commonFields.concat([
     'from_key',
     'mods',


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

This PR fixes frontend errors due to missing attributes on change objects. Particularly fixes the move and delete operations. `oldObj` and `parent` were missing in move operation and `oldObj` was missing for delete operation.

### Manual verification steps performed
1. Create a channel.
2. Share it with another user.
3. Create several nodes, and move the nodes.
4. The changes should be reflected on other user's frontend without any console errors.

___
## Reviewer guidance
### How can a reviewer test these changes?
Performing manual verification steps should be enough.


## References
Closes https://github.com/learningequality/studio/issues/4209.


----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
