### PR TITLE
Super Duper Fast Import Search :rocket:

### DIFF
--- a/contentcuration/search/viewsets/contentnode.py
+++ b/contentcuration/search/viewsets/contentnode.py
@@ -16,11 +16,9 @@ from search.models import ContentNodeFullTextSearch
 from search.utils import get_fts_search_query
 
 from contentcuration.models import Channel
-from contentcuration.models import File
 from contentcuration.utils.pagination import ValuesViewsetPageNumberPagination
 from contentcuration.viewsets.base import ReadOnlyValuesViewset
 from contentcuration.viewsets.base import RequiredFilterSet
-from contentcuration.viewsets.common import NotNullMapArrayAgg
 from contentcuration.viewsets.common import UUIDFilter
 from contentcuration.viewsets.common import UUIDInFilter
 
@@ -105,16 +103,8 @@ class SearchContentNodeViewSet(ReadOnlyValuesViewset):
         "content_id": "contentnode__content_id",
         "node_id": "contentnode__node_id",
         "root_id": "channel__main_tree_id",
-        "title": "contentnode__title",
-        "description": "contentnode__description",
-        "author": "contentnode__author",
-        "provider": "contentnode__provider",
         "kind": "contentnode__kind__kind",
-        "thumbnail_encoding": "contentnode__thumbnail_encoding",
-        "published": "contentnode__published",
-        "modified": "contentnode__modified",
         "parent": "contentnode__parent_id",
-        "changed": "contentnode__changed",
         "public": "channel__public",
     }
 
@@ -148,10 +138,6 @@ class SearchContentNodeViewSet(ReadOnlyValuesViewset):
         """
         Annotates thumbnails, resources count and original channel name.
         """
-        thumbnails = File.objects.filter(
-            contentnode=OuterRef("contentnode__id"), preset__thumbnail=True
-        )
-
         descendant_resources_count = ExpressionWrapper(((F("contentnode__rght") - F("contentnode__lft") - Value(1)) / Value(2)), output_field=IntegerField())
 
         original_channel_name = Coalesce(
@@ -169,11 +155,6 @@ class SearchContentNodeViewSet(ReadOnlyValuesViewset):
 
         queryset = queryset.annotate(
             resource_count=descendant_resources_count,
-            thumbnail_checksum=Subquery(thumbnails.values("checksum")[:1]),
-            thumbnail_extension=Subquery(
-                thumbnails.values("file_format__extension")[:1]
-            ),
-            content_tags=NotNullMapArrayAgg("contentnode__tags__tag_name"),
             original_channel_name=original_channel_name,
         )
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR makes import from other channel search super fast (reduced query time by almost half) by removing annotations that are no longer needed due to Kolibri public API providing those information.


### Manual verification steps performed
Just make sure that import search works.
___
## Reviewer guidance
### How can a reviewer test these changes?
Making sure that import search works should make this PR good to go.




## References
Closes https://github.com/learningequality/studio/issues/4266.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
