### PR TITLE
Fixes incorrectly truncated channel titles in 'Channel/source' and 'Language' dropdowns

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -29,7 +29,7 @@
         <template #item="{ item }">
           <VTooltip bottom lazy>
             <template #activator="{ on }">
-              <span class="text-truncate" v-on="on">{{ languageText(item) }}</span>
+              <span class="text-truncate" dir="auto" v-on="on">{{ languageText(item) }}</span>
             </template>
             <span>{{ languageText(item) }}</span>
           </VTooltip>

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -23,7 +23,7 @@
         <template #item="{ item, tile }">
           <Checkbox v-bind="tile.props" class="ma-0">
             <template #label>
-              <span :class="{ notranslate }" :style="getEllipsisStyle()">
+              <span :class="{ notranslate }" :style="getEllipsisStyle()" dir="auto">
                 {{ getText(item) }}
               </span>
             </template>


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the incorrectly truncated channel titles in 'Channel/source' and 'Language' dropdowna in the 'Import from channels' page search filters by adding the `dir="auto"` attribute to the dropdowns to allow for automatic handling of the text directions.

### Manual verification steps performed
1. Go to https://hotfixes.studio.learningequality.org/en/accounts/#/ and sign in
2. Change the language to Arabic.
3. Open a channel and select the 'Import from channels' option
4. Perform a search and observe the channel titles and languages(the long texts) in the 'Channel/source' and 'Language' drop-downs respectively.

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
**After:**
<img width="642" alt="Screenshot 2023-09-21 at 23 00 00" src="https://github.com/learningequality/studio/assets/5203639/be2b1323-1453-4a0d-aa4d-47442481d2a3">

<img width="635" alt="Screenshot 2023-09-21 at 23 00 23" src="https://github.com/learningequality/studio/assets/5203639/ee0be8ab-02a6-45f1-a000-83319716409e">



### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

1. Go to http://localhost:8080/en/accounts/#/ and sign in
2. If you need more channels. you can use the command below;
  - `python manage.py restore_channel <channelId> --download-url https://studio.learningequality.org/ --editor <userEmail>`
3. Change the language to Arabic.
4. Open a channel and select the 'Import from channels' option
5. Perform a search and observe the channel titles and languages(the long texts) in the 'Channel/source' and 'Language' drop-downs respectively.

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/4286

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
