### PR TITLE
Changed the router-link tag to KrouterLink

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -11,9 +11,9 @@
       <VToolbarSideIcon @click="drawer = true" />
       <VToolbarTitle>
         {{ $tr('deploy') }} <span class="notranslate">{{ currentChannel.name }}</span>
-        <router-link :to="rootTreeRoute" class="body-1 pl-2" data-test="root-tree-link">
+        <KRouterLink :to="rootTreeRoute" class="body-1 pl-2" data-test="root-tree-link">
           {{ $tr('backToViewing') }}
-        </router-link>
+        </KRouterLink>
       </VToolbarTitle>
 
       <VSpacer />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -20,7 +20,7 @@
         v-if="$vuetify.breakpoint.smAndUp"
         class="ml-4"
       >
-        <router-link
+        <KRouterLink
           :to="viewChannelDetailsLink"
           @click="trackClickEvent('Summary')"
         >
@@ -29,8 +29,8 @@
             icon="info"
             :text="$tr('channelDetails')"
           />
-        </router-link>
-        <router-link
+        </KRouterLink>
+        <KRouterLink
           :to="editChannelLink"
           @click="trackClickEvent('Edit channel')"
         >
@@ -52,7 +52,7 @@
               :text="$tr('editChannel')"
             />
           </VBadge>
-        </router-link>
+        </KRouterLink>
       </VToolbarItems>
       <VSpacer />
       <SavingIndicator v-if="!offline" />

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -11,11 +11,11 @@
         <VLayout align-center justify-start>
           <Icon>build</Icon>
           <span class="pl-1">
-            <router-link
+            <KRouterLink
               :to="stagingTreeLink"
               :style="{ 'text-decoration': 'underline' }"
               data-test="staging-tree-link"
-            >{{ $tr('updatedResourcesReadyForReview') }}</router-link>
+            >{{ $tr('updatedResourcesReadyForReview') }}</KRouterLink>
             (<time :datetime="channelModifiedDate">{{ prettyChannelModifiedDate }}</time>)
           </span>
         </VLayout>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -88,7 +88,7 @@
           </VTooltip>
           <VSpacer />
           <VFlex shrink>
-            <router-link
+            <KRouterLink
               v-if="!libraryMode"
               :to="channelDetailsLink"
             >
@@ -103,7 +103,7 @@
                 @mouseleave.native="hideHighlight = false"
               />
 
-            </router-link>
+            </KRouterLink>
 
             <IconButton
               v-if="!allowEdit && channel.published"


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->


This pull request replaces occurrences of the `router-Link` tag with `KrouterLink`.

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

https://github.com/learningequality/kolibri-design-system/issues/219


## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

If this pull request is accepted and merged, I plan to submit additional pull requests addressing other issue with more extensive changes. The current pull request contains only minor modifications related to that issue.


### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [x] All user-facing strings are translated properly
- [x] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [x] All UI components are LTR and RTL compliant
- [x] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [x] Automated test coverage is satisfactory
- [x] PR is fully functional
- [x] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
