### PR TITLE
Add instance ID to public API response

### DIFF
--- a/contentcuration/kolibri_public/tests/test_public_v1_api.py
+++ b/contentcuration/kolibri_public/tests/test_public_v1_api.py
@@ -30,6 +30,7 @@ class PublicAPITestCase(BaseAPITestCase):
         response = self.client.get(reverse("info"))
         self.assertEqual(response.data["application"], "studio")
         self.assertEqual(response.data["device_name"], "Kolibri Studio")
+        self.assertEqual(response.data["instance_id"], "ef896e7b7bbf5a359371e6f7afd28742")
 
     def test_empty_public_channels(self):
         """

--- a/contentcuration/kolibri_public/views_v1.py
+++ b/contentcuration/kolibri_public/views_v1.py
@@ -1,6 +1,7 @@
 import json
 
 from django.conf import settings
+from django.contrib.sites.models import Site
 from django.db.models import Q
 from django.db.models import TextField
 from django.db.models import Value
@@ -8,6 +9,7 @@ from django.http import HttpResponseNotFound
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import cache_page
 from kolibri_content.constants.schema_versions import MIN_CONTENT_SCHEMA_VERSION
+from le_utils.uuidv5 import generate_ecosystem_namespaced_uuid
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
 from rest_framework.decorators import permission_classes
@@ -120,6 +122,20 @@ device_info_keys = {
 }
 
 DEVICE_INFO_VERSION = "3"
+INSTANCE_ID = None
+
+
+def get_instance_id():
+    """
+    Returns a namespaced UUID for Studio based of the domain. The current site is configured
+    through Django settings
+    :return: A uuid
+    """
+    global INSTANCE_ID
+
+    if INSTANCE_ID is None:
+        INSTANCE_ID = generate_ecosystem_namespaced_uuid(Site.objects.get_current().domain).hex
+    return INSTANCE_ID
 
 
 def get_device_info(version=DEVICE_INFO_VERSION):
@@ -136,7 +152,7 @@ def get_device_info(version=DEVICE_INFO_VERSION):
     all_info = {
         "application": "studio",
         "kolibri_version": "0.16.0",
-        "instance_id": None,
+        "instance_id": get_instance_id(),
         'device_name': "Kolibri Studio",
         "operating_system": None,
         "subset_of_users_device": False,


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Adds instance ID to the public info API response, using `le-utils` function for generating it used in both Kolibri and now Studio

### Manual verification steps performed
1. Added the instance ID
2. Updated test to check it
3. Verified test passed
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- Tests pass?
- `api/public/info` returns it?

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
https://github.com/learningequality/le-utils/pull/111

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
