### PR TITLE
Fix the incorrect retrieval query in return_tasks function

### DIFF
--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -125,16 +125,16 @@ class SyncView(APIView):
     def return_tasks(self, request, channel_revs):
         sql_query = """
         WITH CustomTaskCTE AS (
-                SELECT c.*, t.task_name, t.traceback, t.status
-                FROM contentcuration_customtaskmetadata c
-                INNER JOIN django_celery_results_taskresult t ON c.task_id = t.task_id
-                WHERE c.channel_id = ANY(%(channel_ids)s::uuid[])
-            )
-            SELECT t.task_id, t.task_name, t.traceback, c.progress, c.channel_id, t.status
-            FROM CustomTaskCTE c
-            JOIN django_celery_results_taskresult t ON c.task_id = t.task_id
-            WHERE t.status = ANY(%(statuses)s)
-            AND t.task_name NOT IN %(exclude_task_names)s;
+            SELECT c.*, t.task_name, t.traceback, t.status
+            FROM contentcuration_customtaskmetadata c
+            INNER JOIN django_celery_results_taskresult t
+            ON c.task_id = t.task_id
+            WHERE c.channel_id = ANY(%(channel_ids)s::uuid[])
+            AND t.status = ANY(%(statuses)s)
+            AND t.task_name NOT IN %(exclude_task_names)s
+        )
+        SELECT t.task_id, t.task_name, t.traceback, c.progress, c.channel_id, t.status
+        FROM CustomTaskCTE c
         """
 
         params = {

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -4,7 +4,6 @@ and deals with processing all the changes to make appropriate
 bulk creates, updates, and deletes.
 """
 from celery import states
-from django.db import connection
 from django.db.models import Q
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -13,11 +12,13 @@ from rest_framework.views import APIView
 
 from contentcuration.models import Change
 from contentcuration.models import Channel
+from contentcuration.models import CustomTaskMetadata
 from contentcuration.tasks import apply_channel_changes_task
 from contentcuration.tasks import apply_user_changes_task
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import CREATED
-
+from django_celery_results.models import TaskResult
+from django_cte import With , CTEQuerySet
 
 class SyncView(APIView):
     authentication_classes = (SessionAuthentication,)
@@ -123,46 +124,22 @@ class SyncView(APIView):
         return {"changes": changes, "errors": errors, "successes": successes}
 
     def return_tasks(self, request, channel_revs):
-        sql_query = """
-        WITH CustomTaskCTE AS (
-            SELECT c.*, t.task_name, t.traceback, t.status
-            FROM contentcuration_customtaskmetadata c
-            INNER JOIN django_celery_results_taskresult t
-            ON c.task_id = t.task_id
-            WHERE c.channel_id = ANY(%(channel_ids)s::uuid[])
-            AND t.status = ANY(%(statuses)s)
-            AND t.task_name NOT IN %(exclude_task_names)s
-        )
-        SELECT c.task_id, c.task_name, c.traceback, c.progress, c.channel_id, c.status
-        FROM CustomTaskCTE c
-        """
-
-        params = {
-            'channel_ids': list(channel_revs.keys()),
-            'statuses': [states.STARTED, states.FAILURE],
-            'exclude_task_names': (apply_channel_changes_task.name, apply_user_changes_task.name)
-        }
-
-        with connection.cursor() as cursor:
-            cursor.execute(sql_query, params)
-            result = cursor.fetchall()
+        custom_task_cte = With(CustomTaskMetadata.objects.filter(channel_id__in=channel_revs.keys()))
+        task_result_querySet = CTEQuerySet(model=TaskResult)
+        query = custom_task_cte.join(task_result_querySet,
+                task_id=custom_task_cte.col.task_id)\
+                .with_cte(custom_task_cte)\
+                .filter(status__in=[states.STARTED, states.FAILURE],)\
+                .exclude(
+                    task_name__in=[apply_channel_changes_task.name, apply_user_changes_task.name]
+                ).annotate(
+                    progress = custom_task_cte.col.progress,
+                    channel_id = custom_task_cte.col.channel_id,
+                )
 
         response_payload = {
-            "tasks": [],
+            "tasks": query.values("task_id", "task_name", "traceback", "progress", "channel_id", "status"),
         }
-
-        for row in result:
-            task_data = {
-                "task_id": row[0],
-                "task_name": row[1],
-                "traceback": row[2],
-                "progress": row[3],
-                "channel_id": row[4],
-                "status": row[5],
-            }
-
-            response_payload["tasks"].append(task_data)
-
         return response_payload
 
     def post(self, request):

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -133,7 +133,7 @@ class SyncView(APIView):
             AND t.status = ANY(%(statuses)s)
             AND t.task_name NOT IN %(exclude_task_names)s
         )
-        SELECT t.task_id, t.task_name, t.traceback, c.progress, c.channel_id, t.status
+        SELECT c.task_id, c.task_name, c.traceback, c.progress, c.channel_id, c.status
         FROM CustomTaskCTE c
         """
 


### PR DESCRIPTION
## Summary
- Fix the incomplete query for fetching the TaskResult and CustomTaskMetadata in return tasks.


### Manual verification steps performed
1. Trigger a task other than apply_channel_changes, apply_user_changes.
2. Sync does not crash now and returns tasks correctly.

### Does this introduce any tech-debt items?
As there is no foreign key relation between the TaskResult and CustomTaskMetadata models the retrieval for both of them takes more than 2 queries fetching and filtering the same object.


## References
closes #4323

### Contributor's Checklist
PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
