### PR TITLE
Fix timeout caused by nginx

### DIFF
--- a/deploy/nginx.conf.jinja2
+++ b/deploy/nginx.conf.jinja2
@@ -82,6 +82,7 @@ http {
             proxy_pass         http://studio;
             proxy_redirect     off;
             proxy_set_header   Host $host;
+            proxy_read_timeout 100s;
         }
 
         location /content/ {

--- a/k8s/images/nginx/Dockerfile
+++ b/k8s/images/nginx/Dockerfile
@@ -6,13 +6,13 @@ COPY /k8s/images/nginx/download_sigil.sh /tmp/download_sigil.sh
 RUN chmod +x /tmp/download_sigil.sh
 RUN /tmp/download_sigil.sh
 
-FROM nginx:1.11
+FROM nginx:1.25
 
 RUN rm /etc/nginx/conf.d/*      # if there's stuff here, nginx won't read sites-enabled
 ADD deploy/nginx.conf.jinja2 /etc/nginx/nginx.conf.jinja2
 ADD k8s/images/nginx/entrypoint.sh /usr/bin
 
 # install the templating binary
-COPY --from=0 /tmp/sigil /usr/bin
+COPY --from=0 /tmp/sigil /usr/bin/
 
 CMD entrypoint.sh

--- a/k8s/images/nginx/Dockerfile
+++ b/k8s/images/nginx/Dockerfile
@@ -1,9 +1,10 @@
 FROM byrnedo/alpine-curl
 
 # download all extra deps we need for the production container
-
 # templating executable
-RUN curl -L "https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_$(uname -sm|tr \  _).tgz" \ | tar -zxC /usr/bin
+COPY /k8s/images/nginx/download_sigil.sh /tmp/download_sigil.sh
+RUN chmod +x /tmp/download_sigil.sh
+RUN /tmp/download_sigil.sh
 
 FROM nginx:1.11
 
@@ -12,6 +13,6 @@ ADD deploy/nginx.conf.jinja2 /etc/nginx/nginx.conf.jinja2
 ADD k8s/images/nginx/entrypoint.sh /usr/bin
 
 # install the templating binary
-COPY --from=0 /usr/bin/sigil /usr/bin
+COPY --from=0 /tmp/sigil /usr/bin
 
 CMD entrypoint.sh

--- a/k8s/images/nginx/download_sigil.sh
+++ b/k8s/images/nginx/download_sigil.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+export SIGIL_VERSION=0.10.1
+export OS=`sh -c "uname -s | tr '[:upper:]' '[:lower:]'"`
+export ARCH=`sh -c "uname -m | tr '[:upper:]' '[:lower:]' | sed 's/aarch64/arm64/'"`
+
+
+curl -L "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/gliderlabs-sigil_${SIGIL_VERSION}_${OS}_${ARCH}.tgz" | tar -zxC /tmp
+mv /tmp/gliderlabs-sigil-${ARCH} /tmp/sigil


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Fixes https://github.com/learningequality/infrastructure/issues/452. Nginx is the source of the timeout. Extends this to 300 seconds (5 minutes).


First commit is to update and cleanup Sigil, the templating engine we use for nginx.