### PR TITLE
Quick edit modal for content title and description

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -1,94 +1,92 @@
 <template>
 
-  <div>
-    <DraggableItem
-      :draggableId="contentNode.id"
-      :draggableMetadata="contentNode"
-      :dragEffect="dragEffect"
-      :dropEffect="draggableDropEffect"
-      :beforeStyle="dragBeforeStyle"
-      :afterStyle="dragAfterStyle"
-    >
-      <template #default>
-        <ContentNodeListItem
-          :node="contentNode"
-          :compact="compact"
-          :comfortable="comfortable"
-          :active="active"
-          :canEdit="canEdit"
-          :draggableHandle="{
-            grouped: selected,
-            draggable,
-            draggableMetadata: contentNode,
-            effectAllowed: draggableEffectAllowed,
-          }"
-          :aria-selected="selected"
-          class="content-node-edit-item"
-          @infoClick="$emit('infoClick', $event)"
-          @topicChevronClick="$emit('topicChevronClick', $event)"
-        >
-          <template #actions-start="{ hover }">
-            <VListTileAction class="handle-col" :aria-hidden="!hover" @click.stop>
-              <transition name="fade">
-                <VBtn :disabled="copying" flat icon>
-                  <Icon color="#686868">
-                    drag_indicator
-                  </Icon>
-                </VBtn>
-              </transition>
-            </VListTileAction>
-            <VListTileAction class="mx-2 select-col" @click.stop>
-              <Checkbox
-                v-model="selected"
-                :disabled="copying"
-                class="mt-0 pt-0"
-                @dblclick.stop
-              />
-            </VListTileAction>
-          </template>
-
-          <template #actions-end>
-            <VListTileAction class="action-icon px-1" @click.stop>
-              <transition name="fade">
-                <IconButton
-                  icon="edit"
-                  size="small"
-                  :text="$tr('editTooltip')"
-                  :disabled="copying"
-                  @click.stop
-                  @click="$emit('editTitleDescription')"
-                />
-              </transition>
-            </VListTileAction>
-            <VListTileAction :aria-hidden="!active" class="action-icon px-1">
-              <Menu v-model="activated">
-                <template #activator="{ on }">
-                  <IconButton
-                    icon="optionsVertical"
-                    :text="$tr('optionsTooltip')"
-                    size="small"
-                    :disabled="copying"
-                    v-on="on"
-                    @click.stop
-                  />
-                </template>
-                <ContentNodeOptions v-if="!copying" :nodeId="nodeId" />
-              </Menu>
-            </VListTileAction>
-          </template>
-
-          <template #context-menu="{ showContextMenu, positionX, positionY }">
-            <ContentNodeContextMenu
-              :show="showContextMenu"
-              :positionX="positionX"
-              :positionY="positionY"
-              :nodeId="nodeId"
+  <DraggableItem
+    :draggableId="contentNode.id"
+    :draggableMetadata="contentNode"
+    :dragEffect="dragEffect"
+    :dropEffect="draggableDropEffect"
+    :beforeStyle="dragBeforeStyle"
+    :afterStyle="dragAfterStyle"
+  >
+    <template #default>
+      <ContentNodeListItem
+        :node="contentNode"
+        :compact="compact"
+        :comfortable="comfortable"
+        :active="active"
+        :canEdit="canEdit"
+        :draggableHandle="{
+          grouped: selected,
+          draggable,
+          draggableMetadata: contentNode,
+          effectAllowed: draggableEffectAllowed,
+        }"
+        :aria-selected="selected"
+        class="content-node-edit-item"
+        @infoClick="$emit('infoClick', $event)"
+        @topicChevronClick="$emit('topicChevronClick', $event)"
+      >
+        <template #actions-start="{ hover }">
+          <VListTileAction class="handle-col" :aria-hidden="!hover" @click.stop>
+            <transition name="fade">
+              <VBtn :disabled="copying" flat icon>
+                <Icon color="#686868">
+                  drag_indicator
+                </Icon>
+              </VBtn>
+            </transition>
+          </VListTileAction>
+          <VListTileAction class="mx-2 select-col" @click.stop>
+            <Checkbox
+              v-model="selected"
+              :disabled="copying"
+              class="mt-0 pt-0"
+              @dblclick.stop
             />
-          </template>
-        </ContentNodeListItem>
-      </template>
-    </DraggableItem>
-  </div>
+          </VListTileAction>
+        </template>
+
+        <template #actions-end>
+          <VListTileAction class="action-icon px-1" @click.stop>
+            <transition name="fade">
+              <IconButton
+                icon="edit"
+                size="small"
+                :text="$tr('editTooltip')"
+                :disabled="copying"
+                @click.stop
+                @click="$emit('editTitleDescription')"
+              />
+            </transition>
+          </VListTileAction>
+          <VListTileAction :aria-hidden="!active" class="action-icon px-1">
+            <Menu v-model="activated">
+              <template #activator="{ on }">
+                <IconButton
+                  icon="optionsVertical"
+                  :text="$tr('optionsTooltip')"
+                  size="small"
+                  :disabled="copying"
+                  v-on="on"
+                  @click.stop
+                />
+              </template>
+              <ContentNodeOptions v-if="!copying" :nodeId="nodeId" />
+            </Menu>
+          </VListTileAction>
+        </template>
+
+        <template #context-menu="{ showContextMenu, positionX, positionY }">
+          <ContentNodeContextMenu
+            :show="showContextMenu"
+            :positionX="positionX"
+            :positionY="positionY"
+            :nodeId="nodeId"
+          />
+        </template>
+      </ContentNodeListItem>
+    </template>
+  </DraggableItem>
 
 </template>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -105,10 +105,10 @@
   import ContentNodeListItem from './ContentNodeListItem';
   import ContentNodeOptions from './ContentNodeOptions';
   import ContentNodeContextMenu from './ContentNodeContextMenu';
+  import EditTitleDescriptionModal from './quickEdit/EditTitleDescriptionModal.vue';
   import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
-  import EditTitleDescriptionModal from './quickEdit/EditTitleDescriptionModal.vue';
   import { COPYING_FLAG } from 'shared/data/constants';
   import { DragEffect, DropEffect, EffectAllowed } from 'shared/mixins/draggable/constants';
   import { DraggableRegions } from 'frontend/channelEdit/constants';
@@ -160,7 +160,7 @@
         activated: false,
         showQuickEdit: {
           titleDescription: false,
-        }
+        },
       };
     },
     computed: {
@@ -224,16 +224,16 @@
         });
       },
     },
-    methods: {
-      showTitleDescriptionModal() {
-        this.showQuickEdit.titleDescription = true;
-      },
-    },
     beforeDestroy() {
       // Unselect before removing
       if (this.selected) {
         this.selected = false;
       }
+    },
+    methods: {
+      showTitleDescriptionModal() {
+        this.showQuickEdit.titleDescription = true;
+      },
     },
     $trs: {
       optionsTooltip: 'Options',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -56,7 +56,7 @@
                   :text="$tr('editTooltip')"
                   :disabled="copying"
                   @click.stop
-                  @click="showTitleDescriptionModal"
+                  @click="$emit('editTitleDescription')"
                 />
               </transition>
             </VListTileAction>
@@ -88,11 +88,6 @@
         </ContentNodeListItem>
       </template>
     </DraggableItem>
-    <EditTitleDescriptionModal
-      v-if="showQuickEdit.titleDescription"
-      :node="contentNode"
-      @close="showQuickEdit.titleDescription = false"
-    />
   </div>
 
 </template>
@@ -105,7 +100,6 @@
   import ContentNodeListItem from './ContentNodeListItem';
   import ContentNodeOptions from './ContentNodeOptions';
   import ContentNodeContextMenu from './ContentNodeContextMenu';
-  import EditTitleDescriptionModal from './quickEdit/EditTitleDescriptionModal.vue';
   import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
@@ -122,7 +116,6 @@
       ContentNodeContextMenu,
       Checkbox,
       IconButton,
-      EditTitleDescriptionModal,
     },
     props: {
       nodeId: {
@@ -158,9 +151,6 @@
     data() {
       return {
         activated: false,
-        showQuickEdit: {
-          titleDescription: false,
-        },
       };
     },
     computed: {
@@ -229,11 +219,6 @@
       if (this.selected) {
         this.selected = false;
       }
-    },
-    methods: {
-      showTitleDescriptionModal() {
-        this.showQuickEdit.titleDescription = true;
-      },
     },
     $trs: {
       optionsTooltip: 'Options',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -1,39 +1,34 @@
 <template>
 
-  <div
-    @click.stop
-    @dblclick.stop
+  <KModal
+    :title="$tr('editTitleDescription')"
+    :submitText="$tr('saveAction')"
+    :cancelText="$tr('cancelAction')"
+    data-test="edit-title-description-modal"
+    @submit="handleSave"
+    @cancel="close"
   >
-    <KModal
-      :title="$tr('editTitleDescription')"
-      :submitText="$tr('saveAction')"
-      :cancelText="$tr('cancelAction')"
-      data-test="edit-title-description-modal"
-      @submit="handleSave"
-      @cancel="close"
-    >
-      <KTextbox
-        v-model="title"
-        data-test="title-input"
-        autofocus
-        showInvalidText
-        :maxlength="200"
-        :label="$tr('titleLabel')"
-        :invalid="!!titleError"
-        :invalidText="titleError"
-        @input="titleError = ''"
-        @blur="validateTitle"
-      />
-      <KTextbox
-        v-model="description"
-        data-test="description-input"
-        textArea
-        :maxlength="400"
-        :label="$tr('descriptionLabel')"
-        style="margin-top: 0.5em"
-      />
-    </KModal>
-  </div>
+    <KTextbox
+      v-model="title"
+      data-test="title-input"
+      autofocus
+      showInvalidText
+      :maxlength="200"
+      :label="$tr('titleLabel')"
+      :invalid="!!titleError"
+      :invalidText="titleError"
+      @input="titleError = ''"
+      @blur="validateTitle"
+    />
+    <KTextbox
+      v-model="description"
+      data-test="description-input"
+      textArea
+      :maxlength="400"
+      :label="$tr('descriptionLabel')"
+      style="margin-top: 0.5em"
+    />
+  </KModal>
 
 </template>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -1,34 +1,36 @@
 <template>
 
-  <KModal
-    :title="$tr('editTitleDescription')"
-    :submitText="$tr('saveAction')"
-    :cancelText="$tr('cancelAction')"
-    data-test="edit-title-description-modal"
-    @submit="handleSave"
-    @cancel="close"
-  >
-    <KTextbox
-      v-model="title"
-      data-test="title-input"
-      autofocus
-      showInvalidText
-      :maxlength="200"
-      :label="$tr('titleLabel')"
-      :invalid="!!titleError"
-      :invalidText="titleError"
-      @input="titleError = ''"
-      @blur="validateTitle"
-    />
-    <KTextbox
-      v-model="description"
-      data-test="description-input"
-      textArea
-      :maxlength="400"
-      :label="$tr('descriptionLabel')"
-      style="margin-top: 0.5em"
-    />
-  </KModal>
+  <div>
+    <KModal
+      :title="$tr('editTitleDescription')"
+      :submitText="$tr('saveAction')"
+      :cancelText="$tr('cancelAction')"
+      data-test="edit-title-description-modal"
+      @submit="handleSave"
+      @cancel="close"
+    >
+      <KTextbox
+        v-model="title"
+        data-test="title-input"
+        autofocus
+        showInvalidText
+        :maxlength="200"
+        :label="$tr('titleLabel')"
+        :invalid="!!titleError"
+        :invalidText="titleError"
+        @input="titleError = ''"
+        @blur="validateTitle"
+      />
+      <KTextbox
+        v-model="description"
+        data-test="description-input"
+        textArea
+        :maxlength="400"
+        :label="$tr('descriptionLabel')"
+        style="margin-top: 0.5em"
+      />
+    </KModal>
+  </div>
 
 </template>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -11,22 +11,22 @@
       @cancel="close"
     >
       <KTextbox
-        v-model="title"
-        :label="$tr('titleLabel')"
-        :invalid="!!errors.title"
-        :invalidText="errors.title"
-        showInvalidText
         autofocus
-        @input="errors.title = ''"
+        showInvalidText
+        v-model="title"
+        :maxlength="200"
+        :label="$tr('titleLabel')"
+        :invalid="!!titleError"
+        :invalidText="titleError"
+        @input="titleError = ''"
+        @blur="validateTitle"
       />
       <KTextbox
-        v-model="description"
-        :label="$tr('descriptionLabel')"
-        :invalid="!!errors.description"
-        :invalidText="errors.description"
         textArea
-        showInvalidText
-        @input="errors.description = ''"
+        v-model="description"
+        :maxlength="400"
+        :label="$tr('descriptionLabel')"
+        style="margin-top: 0.5em"
       />
     </KModal>
   </div>
@@ -35,7 +35,7 @@
 
 <script>
 
-  import { mapGetters, mapActions } from 'vuex';
+  import { mapActions } from 'vuex';
 
   export default {
     props: {
@@ -48,34 +48,35 @@
       return {
         title: this.node.title || '',
         description: this.node.description || '',
-        errors: {},
+        titleError: '',
       };
     },
     methods: {
       ...mapActions('contentNode', [
         'updateContentNode',
       ]),
+      validateTitle() {
+        if (this.title.trim().length === 0) {
+          this.titleError = this.$tr('fieldRequired');
+          return false;
+        }
+        return true;
+      },
       close() {
         this.$emit('close');
       },
       handleSave() {
-        const { title, description } = this;
-        const errors = {};
-
-        if (!title) {
-          errors.title = this.$tr('fieldRequired');
-        }
-
-        if (Object.keys(errors).length) {
-          this.errors = errors;
+        if (!this.validateTitle()) {
           return;
         }
 
+        const { node, title, description } = this;
         this.updateContentNode({
-          id: this.node.id,
-          title,
-          description,
+          id: node.id,
+          title: title.trim(),
+          description: description.trim(),
         });
+
         this.close();
       },
     },
@@ -89,6 +90,3 @@
     },
   }
 </script>
-
-
-<style scoped lang="scss"></style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div
     @click.stop
     @dblclick.stop
@@ -11,9 +12,9 @@
       @cancel="close"
     >
       <KTextbox
+        v-model="title"
         autofocus
         showInvalidText
-        v-model="title"
         :maxlength="200"
         :label="$tr('titleLabel')"
         :invalid="!!titleError"
@@ -22,14 +23,15 @@
         @blur="validateTitle"
       />
       <KTextbox
-        textArea
         v-model="description"
+        textArea
         :maxlength="400"
         :label="$tr('descriptionLabel')"
         style="margin-top: 0.5em"
       />
     </KModal>
   </div>
+
 </template>
 
 
@@ -38,6 +40,7 @@
   import { mapActions } from 'vuex';
 
   export default {
+    name: 'EditTitleDescriptionModal',
     props: {
       node: {
         type: Object,
@@ -52,9 +55,7 @@
       };
     },
     methods: {
-      ...mapActions('contentNode', [
-        'updateContentNode',
-      ]),
+      ...mapActions('contentNode', ['updateContentNode']),
       validateTitle() {
         if (this.title.trim().length === 0) {
           this.titleError = this.$tr('fieldRequired');
@@ -90,5 +91,6 @@
       fieldRequired: 'Field is required',
       editedTitleDescription: 'Edited title and description',
     },
-  }
+  };
+
 </script>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -77,6 +77,7 @@
           description: description.trim(),
         });
 
+        this.$store.dispatch('showSnackbarSimple', this.$tr('editedTitleDescription'));
         this.close();
       },
     },
@@ -87,6 +88,7 @@
       saveAction: 'Save',
       cancelAction: 'Cancel',
       fieldRequired: 'Field is required',
+      editedTitleDescription: 'Edited title and description',
     },
   }
 </script>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -41,6 +41,7 @@
 <script>
 
   import { mapActions } from 'vuex';
+  import { getTitleValidators, getInvalidText } from 'shared/utils/validation';
 
   export default {
     name: 'EditTitleDescriptionModal',
@@ -60,17 +61,14 @@
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
       validateTitle() {
-        if (this.title.trim().length === 0) {
-          this.titleError = this.$tr('fieldRequired');
-          return false;
-        }
-        return true;
+        this.titleError = getInvalidText(getTitleValidators(), this.title);
       },
       close() {
         this.$emit('close');
       },
       handleSave() {
-        if (!this.validateTitle()) {
+        this.validateTitle();
+        if (this.titleError) {
           return;
         }
 
@@ -91,7 +89,6 @@
       descriptionLabel: 'Description',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      fieldRequired: 'Field is required',
       editedTitleDescription: 'Edited title and description',
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -8,11 +8,13 @@
       :title="$tr('editTitleDescription')"
       :submitText="$tr('saveAction')"
       :cancelText="$tr('cancelAction')"
+      data-test="edit-title-description-modal"
       @submit="handleSave"
       @cancel="close"
     >
       <KTextbox
         v-model="title"
+        data-test="title-input"
         autofocus
         showInvalidText
         :maxlength="200"
@@ -24,6 +26,7 @@
       />
       <KTextbox
         v-model="description"
+        data-test="description-input"
         textArea
         :maxlength="400"
         :label="$tr('descriptionLabel')"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -1,0 +1,94 @@
+<template>
+  <div
+    @click.stop
+    @dblclick.stop
+  >
+    <KModal
+      :title="$tr('editTitleDescription')"
+      :submitText="$tr('saveAction')"
+      :cancelText="$tr('cancelAction')"
+      @submit="handleSave"
+      @cancel="close"
+    >
+      <KTextbox
+        v-model="title"
+        :label="$tr('titleLabel')"
+        :invalid="!!errors.title"
+        :invalidText="errors.title"
+        showInvalidText
+        autofocus
+        @input="errors.title = ''"
+      />
+      <KTextbox
+        v-model="description"
+        :label="$tr('descriptionLabel')"
+        :invalid="!!errors.description"
+        :invalidText="errors.description"
+        textArea
+        showInvalidText
+        @input="errors.description = ''"
+      />
+    </KModal>
+  </div>
+</template>
+
+
+<script>
+
+  import { mapGetters, mapActions } from 'vuex';
+
+  export default {
+    props: {
+      node: {
+        type: Object,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        title: this.node.title || '',
+        description: this.node.description || '',
+        errors: {},
+      };
+    },
+    methods: {
+      ...mapActions('contentNode', [
+        'updateContentNode',
+      ]),
+      close() {
+        this.$emit('close');
+      },
+      handleSave() {
+        const { title, description } = this;
+        const errors = {};
+
+        if (!title) {
+          errors.title = this.$tr('fieldRequired');
+        }
+
+        if (Object.keys(errors).length) {
+          this.errors = errors;
+          return;
+        }
+
+        this.updateContentNode({
+          id: this.node.id,
+          title,
+          description,
+        });
+        this.close();
+      },
+    },
+    $trs: {
+      editTitleDescription: 'Edit Title and Description',
+      titleLabel: 'Title',
+      descriptionLabel: 'Description',
+      saveAction: 'Save',
+      cancelAction: 'Cancel',
+      fieldRequired: 'Field is required',
+    },
+  }
+</script>
+
+
+<style scoped lang="scss"></style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/EditTitleDescriptionModal.vue
@@ -40,23 +40,33 @@
 
 <script>
 
-  import { mapActions } from 'vuex';
+  import { mapActions, mapGetters } from 'vuex';
   import { getTitleValidators, getInvalidText } from 'shared/utils/validation';
 
   export default {
     name: 'EditTitleDescriptionModal',
     props: {
-      node: {
-        type: Object,
+      nodeId: {
+        type: String,
         required: true,
       },
     },
     data() {
       return {
-        title: this.node.title || '',
-        description: this.node.description || '',
+        title: '',
+        description: '',
         titleError: '',
       };
+    },
+    computed: {
+      ...mapGetters('contentNode', ['getContentNode']),
+      contentNode() {
+        return this.getContentNode(this.nodeId);
+      },
+    },
+    created() {
+      this.title = this.contentNode.title || '';
+      this.description = this.contentNode.description || '';
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
@@ -72,9 +82,9 @@
           return;
         }
 
-        const { node, title, description } = this;
+        const { nodeId, title, description } = this;
         this.updateContentNode({
-          id: node.id,
+          id: nodeId,
           title: title.trim(),
           description: description.trim(),
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/__tests__/EditTitleDescriptionModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/__tests__/EditTitleDescriptionModal.spec.js
@@ -1,0 +1,175 @@
+import { mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import EditTitleDescriptionModal from '../EditTitleDescriptionModal.vue';
+
+const node = {
+  id: 'test-id',
+  title: 'test-title',
+  description: 'test-description',
+};
+
+let store;
+let contentNodeActions;
+let generalActions;
+
+describe('EditTitleDescriptionModal', () => {
+  beforeEach(() => {
+    contentNodeActions = {
+      updateContentNode: jest.fn(),
+    };
+    generalActions = {
+      showSnackbarSimple: jest.fn(),
+    };
+    store = new Vuex.Store({
+      actions: generalActions,
+      modules: {
+        contentNode: {
+          namespaced: true,
+          actions: contentNodeActions,
+        },
+      },
+    });
+  });
+
+  test('smoke test', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      propsData: {
+        node,
+      },
+    });
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  test('should display the correct title and description on first render', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      propsData: {
+        node,
+      },
+    });
+
+    expect(wrapper.find('[data-test="title-input"]').vm.$props.value).toBe(node.title);
+    expect(wrapper.find('[data-test="description-input"]').vm.$props.value).toBe(node.description);
+  });
+
+  test('should call updateContentNode on success submit', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+    expect(contentNodeActions.updateContentNode).toHaveBeenCalled();
+  });
+
+  test('should call updateContentNode with the correct parameters on success submit', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    const newTitle = 'new-title';
+    const newDescription = 'new-description';
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', 'new-title');
+    wrapper.find('[data-test="description-input"]').vm.$emit('input', 'new-description');
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+      id: node.id,
+      title: newTitle,
+      description: newDescription,
+    });
+  });
+
+  test('should let update even if description is empty', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    const newTitle = 'new-title';
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', 'new-title');
+    wrapper.find('[data-test="description-input"]').vm.$emit('input', '');
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+      id: node.id,
+      title: newTitle,
+      description: '',
+    });
+  });
+
+  test('should validate title on blur', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', '');
+    wrapper.find('[data-test="title-input"]').vm.$emit('blur');
+
+    expect(wrapper.find('[data-test="title-input"]').vm.$props.invalidText).toBeTruthy();
+  });
+
+  test('should validate title on submit', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', '');
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    expect(wrapper.find('[data-test="title-input"]').vm.$props.invalidText).toBeTruthy();
+  });
+
+  test("should show 'Edited title and description' on a snackbar on success submit", () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+    expect(generalActions.showSnackbarSimple).toHaveBeenCalledWith(
+      expect.anything(),
+      'Edited title and description'
+    );
+  });
+
+  test("should emit 'close' event on success submit", () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+    expect(wrapper.emitted().close).toBeTruthy();
+  });
+
+  test('should emit close event on cancel', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        node,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('cancel');
+    expect(wrapper.emitted().close).toBeTruthy();
+  });
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/__tests__/EditTitleDescriptionModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/quickEdit/__tests__/EditTitleDescriptionModal.spec.js
@@ -2,8 +2,10 @@ import { mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import EditTitleDescriptionModal from '../EditTitleDescriptionModal.vue';
 
+const nodeId = 'test-id';
+
 const node = {
-  id: 'test-id',
+  id: nodeId,
   title: 'test-title',
   description: 'test-description',
 };
@@ -26,6 +28,9 @@ describe('EditTitleDescriptionModal', () => {
         contentNode: {
           namespaced: true,
           actions: contentNodeActions,
+          getters: {
+            getContentNode: () => () => node,
+          },
         },
       },
     });
@@ -33,8 +38,9 @@ describe('EditTitleDescriptionModal', () => {
 
   test('smoke test', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
+      store,
       propsData: {
-        node,
+        nodeId,
       },
     });
     expect(wrapper.isVueInstance()).toBe(true);
@@ -42,8 +48,9 @@ describe('EditTitleDescriptionModal', () => {
 
   test('should display the correct title and description on first render', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
+      store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -55,7 +62,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -67,7 +74,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -79,7 +86,7 @@ describe('EditTitleDescriptionModal', () => {
     wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
 
     expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
-      id: node.id,
+      id: nodeId,
       title: newTitle,
       description: newDescription,
     });
@@ -89,7 +96,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -100,7 +107,7 @@ describe('EditTitleDescriptionModal', () => {
     wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
 
     expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
-      id: node.id,
+      id: nodeId,
       title: newTitle,
       description: '',
     });
@@ -110,7 +117,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -124,7 +131,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -138,7 +145,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -153,7 +160,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 
@@ -165,7 +172,7 @@ describe('EditTitleDescriptionModal', () => {
     const wrapper = mount(EditTitleDescriptionModal, {
       store,
       propsData: {
-        node,
+        nodeId,
       },
     });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -175,6 +175,7 @@
             @select="selected = [...selected, $event]"
             @deselect="selected = selected.filter(id => id !== $event)"
             @scroll="scroll"
+            @editTitleDescription="showTitleDescriptionModal"
           />
         </DraggableRegion>
       </VFadeTransition>
@@ -223,6 +224,11 @@
       </ResourceDrawer>
     </VLayout>
 
+    <EditTitleDescriptionModal
+      v-if="editTitleDescriptionModal"
+      :nodeId="editTitleDescriptionModal.nodeId"
+      @close="editTitleDescriptionModal = null"
+    />
   </VContainer>
 
 </template>
@@ -235,6 +241,7 @@
   import ContentNodeOptions from '../components/ContentNodeOptions';
   import ResourceDrawer from '../components/ResourceDrawer';
   import { RouteNames, viewModes, DraggableRegions, DraggableUniverses } from '../constants';
+  import EditTitleDescriptionModal from '../components/quickEdit/EditTitleDescriptionModal';
   import NodePanel from './NodePanel';
   import IconButton from 'shared/views/IconButton';
   import ToolBar from 'shared/views/ToolBar';
@@ -264,6 +271,7 @@
       Checkbox,
       MoveModal,
       DraggableRegion,
+      EditTitleDescriptionModal,
     },
     mixins: [titleMixin, routerMixin],
     props: {
@@ -282,6 +290,7 @@
         loadingAncestors: false,
         elevated: false,
         moveModalOpen: false,
+        editTitleDescriptionModal: null,
       };
     },
     computed: {
@@ -682,6 +691,11 @@
       },
       trackViewMode(mode) {
         this.$analytics.trackAction('general', mode);
+      },
+      showTitleDescriptionModal(nodeId) {
+        this.editTitleDescriptionModal = {
+          nodeId,
+        };
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -41,6 +41,7 @@
           @infoClick="goToNodeDetail(child.id)"
           @topicChevronClick="goToTopic(child.id)"
           @dblclick.native="onNodeDoubleClick(child)"
+          @editTitleDescription="$emit('editTitleDescription', child.id)"
         />
       </template>
     </VList>

--- a/contentcuration/contentcuration/frontend/shared/utils/validation.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/validation.js
@@ -244,6 +244,21 @@ export function getActivityDurationValidators() {
   ];
 }
 
+/**
+ * Get invalid text for a given value using a list of validators.
+ * @param {Array<Function>} validators
+ * @param {*} value Value to validate.
+ * @returns {String}  Translated error message of the first validator that returns an error.
+                      Empty string if value is valid.
+ */
+export function getInvalidText(validators, value) {
+  return (
+    validators
+      .map(validator => translateValidator(validator)(value))
+      .find(validation => validation !== true) || ''
+  );
+}
+
 // Node validation
 // These functions return an array of error codes
 export function getNodeTitleErrors(node) {

--- a/package.json
+++ b/package.json
@@ -129,9 +129,5 @@
   "browserslist": [
     "> 1%",
     "Firefox ESR"
-  ],
-  "volta": {
-    "node": "16.20.2",
-    "yarn": "1.22.21"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -129,5 +129,9 @@
   "browserslist": [
     "> 1%",
     "Firefox ESR"
-  ]
+  ],
+  "volta": {
+    "node": "16.20.2",
+    "yarn": "1.22.21"
+  }
 }


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Add a quick edit modal to edit content nodes titles and descriptions.

### Screenshots

https://github.com/learningequality/studio/assets/51239030/079589cd-fb94-41e8-b5c2-2c0d939f2342



## Reviewer guidance
### How can a reviewer test these changes?
1. Go to update a channel content
2. Click on the edit button besides the menu button of a content node.

## References

Closes #3413

## Comments

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
