### PR TITLE
Quick edit modal for content language

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -5,10 +5,21 @@
     :submitText="$tr('saveAction')"
     :cancelText="$tr('cancelAction')"
     data-test="edit-langugage"
+    :submitDisabled="!selectedLanguage"
     @submit="handleSave"
     @cancel="close"
   >
-    <div>
+    <p>
+      {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+    </p>
+    <KTextbox
+      autofocus
+      v-model="searchQuery"
+      data-test="search-input"
+      :label="$tr('selectLanguage')"
+      style="margin-top: 0.5em"
+    />
+    <div ref="languages" class="languages-options">
       <KRadioButton
         v-for="language in languageOptions"
         :key="language.id"
@@ -24,8 +35,9 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapActions } from 'vuex';
   import { LanguagesList } from 'shared/leUtils/Languages';
+  import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
   export default {
     name: 'EditLanguageModal',
@@ -38,21 +50,58 @@
     data() {
       return {
         selectedLanguage: '',
+        searchQuery: '',
+        updateDescendants: false,
       };
     },
     computed: {
-      ...mapGetters('contentNode', ['getContentNodeChildren']),
-      languageOptions() {
-        return LanguagesList;
+      ...mapGetters('contentNode', ['getContentNodes']),
+      nodes() {
+        return this.getContentNodes(this.nodeIds);
       },
+      isTopicSelected() {
+        return this.nodes.some(node => node.kind === ContentKindsNames.TOPIC);
+      },
+      isMultipleNodesLanguages() {
+        const languages = new Set(
+          this.nodes
+            .map(node => node.language)
+            .filter(Boolean)
+        );
+        return languages.size > 1;
+      },
+      languageOptions() {
+        const searchQuery = this.searchQuery.trim().toLowerCase();
+        if (!this.searchQuery) {
+          return LanguagesList;
+        }
+        const criteria = ['id', 'native_name', 'readable_name'];
+        return LanguagesList.filter(lang => (
+          criteria.some(key => (
+            lang[key]?.toLowerCase().includes(searchQuery)
+          ))
+        ));
+      },
+    },
+    created() {
+      const languages = [...new Set(
+        this.nodes.map(node => node.language)
+      )];
+      if (languages.length === 1) {
+        this.selectedLanguage = languages[0] || '';
+      }
     },
     mounted() {
-      console.log('Aa', this.nodeIds, this.getContentNodeChildren(this.nodeIds[0]));
+      if (this.selectedLanguage) {
+        // Search for the selected KRadioButton and scroll to it
+        const selectedRadio = this.$refs.languages.querySelector(
+          `input[value="${this.selectedLanguage}"]`
+        );
+        selectedRadio?.scrollIntoView?.();
+      }
     },
-    methods: {
-      validateLanguage() {
-        return true;
-      },
+    methods: {  
+      ...mapActions('contentNode', ['updateContentNode']),
       languageText(langObject) {
         return this.$tr('languageItemText', {
           language: langObject.native_name,
@@ -62,10 +111,28 @@
       close() {
         this.$emit('close');
       },
-      handleSave() {
-        if (!this.validateLanguage()) {
+      async handleSave() {
+        if (!this.selectedLanguage) {
           return;
         }
+
+        await Promise.all(
+          this.nodes.map(node => {
+            if (
+              this.updateDescendants &&
+              node.kind === ContentKindsNames.TOPIC
+            ) { // will update with the new function to update all descendants
+              return this.updateContentNode({
+                id: node.id,
+                language: this.selectedLanguage,
+              });
+            }
+            return this.updateContentNode({
+              id: node.id,
+              language: this.selectedLanguage,
+            });
+          })
+        );
 
         this.$store.dispatch(
           'showSnackbarSimple',
@@ -81,7 +148,16 @@
       cancelAction: 'Cancel',
       editedLanguage:
         'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
+      selectLanguage: 'Select / Type Language',
+      resourcesSelected: '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
     },
   };
 
 </script>
+
+<style scoped>
+  .languages-options {
+    height: 350px;
+    overflow-y: auto;
+  }
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -1,4 +1,5 @@
 <template>
+
   <KModal
     :title="$tr('editLanguage')"
     :submitText="$tr('saveAction')"
@@ -17,13 +18,14 @@
       />
     </div>
   </KModal>
+
 </template>
 
 
 <script>
-  import { LanguagesList } from 'shared/leUtils/Languages';
 
   import { mapGetters } from 'vuex';
+  import { LanguagesList } from 'shared/leUtils/Languages';
 
   export default {
     name: 'EditLanguageModal',
@@ -32,10 +34,6 @@
         type: Array,
         required: true,
       },
-    },
-    mounted() {
-      console.log("nodeIds", this.nodeIds[0]);
-      console.log("getContentNodeChildren", this.getContentNodeChildren(this.nodeIds[0]));
     },
     data() {
       return {
@@ -48,12 +46,18 @@
         return LanguagesList;
       },
     },
+    mounted() {
+      console.log('Aa', this.nodeIds, this.getContentNodeChildren(this.nodeIds[0]));
+    },
     methods: {
       validateLanguage() {
         return true;
       },
       languageText(langObject) {
-        return this.$tr('languageItemText', { language: langObject.native_name, code: langObject.id });
+        return this.$tr('languageItemText', {
+          language: langObject.native_name,
+          code: langObject.id,
+        });
       },
       close() {
         this.$emit('close');
@@ -63,7 +67,10 @@
           return;
         }
 
-        this.$store.dispatch('showSnackbarSimple', this.$tr('editedLanguage', { count: this.nodes.length }));
+        this.$store.dispatch(
+          'showSnackbarSimple',
+          this.$tr('editedLanguage', { count: this.nodes.length })
+        );
         this.close();
       },
     },
@@ -72,8 +79,8 @@
       languageItemText: '{language} ({code})',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      fieldRequired: 'Field is required',
-      editedLanguage: 'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
+      editedLanguage:
+        'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -4,13 +4,16 @@
     :title="$tr('editLanguage')"
     :submitText="$tr('saveAction')"
     :cancelText="$tr('cancelAction')"
-    data-test="edit-langugage"
+    data-test="edit-language-modal"
     :submitDisabled="!selectedLanguage"
     @submit="handleSave"
     @cancel="close"
   >
-    <p>
+    <p data-test="resources-selected-message">
       {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+    </p>
+    <p v-if="isMultipleNodeLanguages" data-test="different-languages-message">
+      {{ $tr('differentLanguages') }}
     </p>
     <KTextbox
       autofocus
@@ -19,7 +22,21 @@
       :label="$tr('selectLanguage')"
       style="margin-top: 0.5em"
     />
-    <div ref="languages" class="languages-options">
+    <template v-if="isTopicSelected">
+      <KCheckbox
+        v-model="updateDescendants"
+        data-test="update-descendants-checkbox"
+        :label="$tr('updateDescendantsCheckbox')"
+      />
+      <hr
+        :style="dividerStyle"
+      >
+    </template>
+    <div
+      ref="languages"
+      class="languages-options"
+      data-test="language-options-list"
+    >
       <KRadioButton
         v-for="language in languageOptions"
         :key="language.id"
@@ -62,7 +79,7 @@
       isTopicSelected() {
         return this.nodes.some(node => node.kind === ContentKindsNames.TOPIC);
       },
-      isMultipleNodesLanguages() {
+      isMultipleNodeLanguages() {
         const languages = new Set(
           this.nodes
             .map(node => node.language)
@@ -81,6 +98,13 @@
             lang[key]?.toLowerCase().includes(searchQuery)
           ))
         ));
+      },
+      dividerStyle() {
+        return {
+          border: 0,
+          borderBottom: `1px solid ${this.$themeTokens.fineLine}`,
+          margin: '1em 0',
+        };
       },
     },
     created() {
@@ -150,6 +174,8 @@
         'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
       selectLanguage: 'Select / Type Language',
       resourcesSelected: '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
+      differentLanguages: 'The selected resources have different languages set. Choosing an option below will apply the language to all the selected resources',
+      updateDescendantsCheckbox: 'Apply to all resources and folders nested within the selected folders',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <KModal
+    :title="$tr('editLanguage')"
+    :submitText="$tr('saveAction')"
+    :cancelText="$tr('cancelAction')"
+    data-test="edit-langugage"
+    @submit="handleSave"
+    @cancel="close"
+  >
+    <div>
+      <KRadioButton
+        v-for="language in languageOptions"
+        :key="language.id"
+        v-model="selectedLanguage"
+        :value="language.id"
+        :label="languageText(language)"
+      />
+    </div>
+  </KModal>
+</template>
+
+
+<script>
+  import { LanguagesList } from 'shared/leUtils/Languages';
+
+  import { mapGetters } from 'vuex';
+
+  export default {
+    name: 'EditLanguageModal',
+    props: {
+      nodeIds: {
+        type: Array,
+        required: true,
+      },
+    },
+    mounted() {
+      console.log("nodeIds", this.nodeIds[0]);
+      console.log("getContentNodeChildren", this.getContentNodeChildren(this.nodeIds[0]));
+    },
+    data() {
+      return {
+        selectedLanguage: '',
+      };
+    },
+    computed: {
+      ...mapGetters('contentNode', ['getContentNodeChildren']),
+      languageOptions() {
+        return LanguagesList;
+      },
+    },
+    methods: {
+      validateLanguage() {
+        return true;
+      },
+      languageText(langObject) {
+        return this.$tr('languageItemText', { language: langObject.native_name, code: langObject.id });
+      },
+      close() {
+        this.$emit('close');
+      },
+      handleSave() {
+        if (!this.validateLanguage()) {
+          return;
+        }
+
+        this.$store.dispatch('showSnackbarSimple', this.$tr('editedLanguage', { count: this.nodes.length }));
+        this.close();
+      },
+    },
+    $trs: {
+      editLanguage: 'Edit Language',
+      languageItemText: '{language} ({code})',
+      saveAction: 'Save',
+      cancelAction: 'Cancel',
+      fieldRequired: 'Field is required',
+      editedLanguage: 'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
+    },
+  };
+
+</script>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -16,8 +16,8 @@
       {{ $tr('differentLanguages') }}
     </p>
     <KTextbox
-      autofocus
       v-model="searchQuery"
+      autofocus
       data-test="search-input"
       :label="$tr('selectLanguage')"
       style="margin-top: 0.5em"
@@ -80,11 +80,7 @@
         return this.nodes.some(node => node.kind === ContentKindsNames.TOPIC);
       },
       isMultipleNodeLanguages() {
-        const languages = new Set(
-          this.nodes
-            .map(node => node.language)
-            .filter(Boolean)
-        );
+        const languages = new Set(this.nodes.map(node => node.language).filter(Boolean));
         return languages.size > 1;
       },
       languageOptions() {
@@ -93,11 +89,9 @@
           return LanguagesList;
         }
         const criteria = ['id', 'native_name', 'readable_name'];
-        return LanguagesList.filter(lang => (
-          criteria.some(key => (
-            lang[key]?.toLowerCase().includes(searchQuery)
-          ))
-        ));
+        return LanguagesList.filter(lang =>
+          criteria.some(key => lang[key]?.toLowerCase().includes(searchQuery))
+        );
       },
       dividerStyle() {
         return {
@@ -108,9 +102,7 @@
       },
     },
     created() {
-      const languages = [...new Set(
-        this.nodes.map(node => node.language)
-      )];
+      const languages = [...new Set(this.nodes.map(node => node.language))];
       if (languages.length === 1) {
         this.selectedLanguage = languages[0] || '';
       }
@@ -124,7 +116,7 @@
         selectedRadio?.scrollIntoView?.();
       }
     },
-    methods: {  
+    methods: {
       ...mapActions('contentNode', ['updateContentNode']),
       languageText(langObject) {
         return this.$tr('languageItemText', {
@@ -142,10 +134,8 @@
 
         await Promise.all(
           this.nodes.map(node => {
-            if (
-              this.updateDescendants &&
-              node.kind === ContentKindsNames.TOPIC
-            ) { // will update with the new function to update all descendants
+            if (this.updateDescendants && node.kind === ContentKindsNames.TOPIC) {
+              // will update with the new function to update all descendants
               return this.updateContentNode({
                 id: node.id,
                 language: this.selectedLanguage,
@@ -173,9 +163,12 @@
       editedLanguage:
         'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
       selectLanguage: 'Select / Type Language',
-      resourcesSelected: '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
-      differentLanguages: 'The selected resources have different languages set. Choosing an option below will apply the language to all the selected resources',
-      updateDescendantsCheckbox: 'Apply to all resources and folders nested within the selected folders',
+      resourcesSelected:
+        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
+      differentLanguages:
+        'The selected resources have different languages set. Choosing an option below will apply the language to all the selected resources',
+      updateDescendantsCheckbox:
+        'Apply to all resources and folders nested within the selected folders',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -90,7 +90,7 @@
         }
         const criteria = ['id', 'native_name', 'readable_name'];
         return LanguagesList.filter(lang =>
-          criteria.some(key => lang[key]?.toLowerCase().includes(searchQuery))
+          criteria.some(key => lang[key] && lang[key].toLowerCase().includes(searchQuery))
         );
       },
       dividerStyle() {
@@ -113,7 +113,9 @@
         const selectedRadio = this.$refs.languages.querySelector(
           `input[value="${this.selectedLanguage}"]`
         );
-        selectedRadio?.scrollIntoView?.();
+        if (selectedRadio && selectedRadio.scrollIntoView) {
+          selectedRadio.scrollIntoView();
+        }
       }
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
@@ -73,14 +73,14 @@
       close() {
         this.$emit('close');
       },
-      handleSave() {
+      async handleSave() {
         this.validateTitle();
         if (this.titleError) {
           return;
         }
 
         const { nodeId, title, description } = this;
-        this.updateContentNode({
+        await this.updateContentNode({
           id: nodeId,
           title: title.trim(),
           description: description.trim(),

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
@@ -1,0 +1,253 @@
+import { mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import EditLanguageModal from '../EditLanguageModal';
+import { LanguagesList } from 'shared/leUtils/Languages';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+
+const nodes = [
+  { id: 'test-en-res', language: 'en' },
+  { id: 'test-es-res', language: 'es' },
+  { id: 'test-nolang-res', language: '' },
+  { id: 'test-en-topic', language: 'en', kind: ContentKindsNames.TOPIC },
+];
+
+let store;
+let contentNodeActions;
+let generalActions;
+
+const makeWrapper = nodeIds => {
+  return mount(EditLanguageModal, {
+    store,
+    propsData: {
+      nodeIds,
+    },
+  });
+};
+
+describe('EditTitleDescriptionModal', () => {
+  beforeEach(() => {
+    contentNodeActions = {
+      updateContentNode: jest.fn(),
+    };
+    generalActions = {
+      showSnackbarSimple: jest.fn(),
+    };
+    store = new Vuex.Store({
+      actions: generalActions,
+      modules: {
+        contentNode: {
+          namespaced: true,
+          actions: contentNodeActions,
+          getters: {
+            getContentNodes: () => ids => nodes.filter(node => ids.includes(node.id)),
+          },
+        },
+      },
+    });
+  });
+
+  test('smoke test', () => {
+    const wrapper = makeWrapper(['test-en-res']);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  describe('Selected language on first render', () => {
+    test('no language should be selected if a single node does not have a language', () => {
+      const wrapper = makeWrapper(['test-nolang-res']);
+
+      const checkboxes = wrapper.findAll('input[type="radio"]');
+      checkboxes.wrappers.forEach(checkbox => {
+        expect(checkbox.element.checked).toBeFalsy();
+      });
+    });
+
+    test('no language should be selected if just a single node among multiple nodes does not have language', () => {
+      const wrapper = makeWrapper(['test-en-res', 'test-nolang-res']);
+
+      const checkboxes = wrapper.findAll('input[type="radio"]');
+      checkboxes.wrappers.forEach(checkbox => {
+        expect(checkbox.element.checked).toBeFalsy();
+      });
+    });
+
+    test('no language should be selected if there are multiple languages set', () => {
+      const wrapper = makeWrapper(['test-en-res', 'test-es-res']);
+
+      const checkboxes = wrapper.findAll('input[type="radio"]');
+      checkboxes.wrappers.forEach(checkbox => {
+        expect(checkbox.element.checked).toBeFalsy();
+      });
+    });
+
+    test('the common language should be selected if all nodes have the same language', () => {
+      const wrapper = makeWrapper(['test-en-res', 'test-en-topic']);
+
+      const checkbox = wrapper.find('input[value="en"]');
+      expect(checkbox.element.checked).toBeTruthy();
+    });
+  });
+
+  test('should render the message of the number of resources selected', () => {
+    const wrapper = makeWrapper(['test-en-res', 'test-es-res']);
+
+    const resourcesCounter = wrapper.find('[data-test="resources-selected-message"]');
+    expect(resourcesCounter.exists()).toBeTruthy();
+    expect(resourcesCounter.text()).toContain('2');
+  });
+
+  test('should render the message of the number of resources selected - 2', () => {
+    const wrapper = makeWrapper(['test-en-res', 'test-es-res', 'test-en-topic', 'test-nolang-res']);
+
+    const resourcesCounter = wrapper.find('[data-test="resources-selected-message"]');
+    expect(resourcesCounter.exists()).toBeTruthy();
+    expect(resourcesCounter.text()).toContain('4');
+  });
+
+  test('should filter languages options based on search query', () => {
+    const wrapper = makeWrapper(['test-en-topic']);
+
+    wrapper.find('[data-test="search-input"]').vm.$emit('input', 'es');
+
+    const optionsList = wrapper.find('[data-test="language-options-list"]');
+    const options = optionsList.findAll('input[type="radio"]');
+    options.wrappers.forEach(option => {
+      const language = LanguagesList.find(lang => lang.id === option.element.value);
+      expect(
+        language.id.toLowerCase().includes('es') ||
+          language.native_name.toLowerCase().includes('es') ||
+          language.readable_name.toLowerCase().includes('es')
+      ).toBeTruthy();
+    });
+  });
+
+  test('should display information message about different languages if there are multiple languages set', () => {
+    const wrapper = makeWrapper(['test-en-res', 'test-es-res']);
+
+    expect(wrapper.find('[data-test="different-languages-message"]').exists()).toBeTruthy();
+  });
+
+  test('shouldnt display information message about different languages if only one language is set', () => {
+    const wrapper = makeWrapper(['test-en-res', 'test-en-topic']);
+
+    expect(wrapper.find('[data-test="different-languages-message"]').exists()).toBeFalsy();
+  });
+
+  test('the submit button should be disabled if no language is selected', () => {
+    const wrapper = makeWrapper(['test-en-res', 'test-es-res']);
+
+    const buttons = wrapper.findAll('button').wrappers;
+    const submitButton = buttons.find(button => button.text() === 'Save');
+
+    expect(submitButton.element.disabled).toBeTruthy();
+  });
+
+  test('the submit button should be enabled if a language is selected', () => {
+    const wrapper = makeWrapper(['test-en-res', 'test-es-res']);
+
+    const buttons = wrapper.findAll('button').wrappers;
+    const submitButton = buttons.find(button => button.text() === 'Save');
+
+    wrapper.find('input[value="en"]').setChecked(true);
+
+    expect(submitButton.element.disabled).toBeFalsy();
+  });
+
+  test('should call updateContentNode with the right language on success submit', async () => {
+    const wrapper = makeWrapper(['test-en-res']);
+
+    wrapper.find('input[value="en"]').setChecked(true);
+    wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
+
+    setTimeout(() => {
+      // wait async
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'test-es-res',
+        language: 'en',
+      });
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'test-en-res',
+        language: 'en',
+      });
+    }, 0);
+  });
+
+  test('should emit close event on success submit', () => {
+    const wrapper = makeWrapper(['test-en-res']);
+
+    wrapper.find('input[value="en"]').setChecked(true);
+    wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
+
+    setTimeout(() => {
+      // wait async
+      expect(wrapper.emitted('close')).toBeTruthy();
+    }, 0);
+  });
+
+  test('should emit close event on cancel', () => {
+    const wrapper = makeWrapper(['test-en-res']);
+
+    wrapper.find('[data-test="edit-language-modal"]').vm.$emit('cancel');
+
+    setTimeout(() => {
+      // wait async
+      expect(wrapper.emitted('close')).toBeTruthy();
+    }, 0);
+  });
+
+  test('should show a confirmation snackbar on success submit', () => {
+    const wrapper = makeWrapper(['test-en-res']);
+
+    wrapper.find('input[value="en"]').setChecked(true);
+    wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
+
+    setTimeout(() => {
+      // wait async
+      expect(generalActions.showSnackbarSimple).toHaveBeenCalled();
+    }, 0);
+  });
+
+  describe('topic nodes present', () => {
+    test('should display the checkbox to apply change to descendants if a topic is present', () => {
+      const wrapper = makeWrapper(['test-en-topic', 'test-en-res']);
+
+      expect(wrapper.find('[data-test="update-descendants-checkbox"]').exists()).toBeTruthy();
+    });
+
+    test('should not display the checkbox to apply change to descendants if a topic is not present', () => {
+      const wrapper = makeWrapper(['test-en-res']);
+
+      expect(wrapper.find('[data-test="update-descendants-checkbox"]').exists()).toBeFalsy();
+    });
+
+    test('should call updateContentNode with the right language on success submit if the user does not check the checkbox', () => {
+      const wrapper = makeWrapper(['test-en-topic', 'test-en-res']);
+
+      wrapper.find('input[value="es"]').setChecked(true);
+      wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
+
+      setTimeout(() => {
+        // wait async
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'test-en-topic',
+          language: 'es',
+        });
+      });
+    });
+
+    test('should call updateContentNode with the right language on success submit if the user checks the checkbox', () => {
+      const wrapper = makeWrapper(['test-en-topic', 'test-en-res']);
+
+      wrapper.find('input[value="es"]').setChecked(true);
+      wrapper.find('[data-test="update-descendants-checkbox"] input').setChecked(true);
+      wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
+
+      setTimeout(() => {
+        // wait async
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'test-en-topic',
+          language: 'es',
+        });
+      });
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
@@ -152,14 +152,13 @@ describe('EditTitleDescriptionModal', () => {
     expect(submitButton.element.disabled).toBeFalsy();
   });
 
-  test('should call updateContentNode with the right language on success submit', async () => {
+  test('should call updateContentNode with the right language on success submit', () => {
     const wrapper = makeWrapper(['test-en-res']);
 
     wrapper.find('input[value="en"]').setChecked(true);
     wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
 
-    setTimeout(() => {
-      // wait async
+    const animationFrameId = requestAnimationFrame(() => {
       expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
         id: 'test-es-res',
         language: 'en',
@@ -168,7 +167,8 @@ describe('EditTitleDescriptionModal', () => {
         id: 'test-en-res',
         language: 'en',
       });
-    }, 0);
+      cancelAnimationFrame(animationFrameId);
+    });
   });
 
   test('should emit close event on success submit', () => {
@@ -177,10 +177,10 @@ describe('EditTitleDescriptionModal', () => {
     wrapper.find('input[value="en"]').setChecked(true);
     wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
 
-    setTimeout(() => {
-      // wait async
+    const animationFrameId = requestAnimationFrame(() => {
       expect(wrapper.emitted('close')).toBeTruthy();
-    }, 0);
+      cancelAnimationFrame(animationFrameId);
+    });
   });
 
   test('should emit close event on cancel', () => {
@@ -188,10 +188,10 @@ describe('EditTitleDescriptionModal', () => {
 
     wrapper.find('[data-test="edit-language-modal"]').vm.$emit('cancel');
 
-    setTimeout(() => {
-      // wait async
+    const animationFrameId = requestAnimationFrame(() => {
       expect(wrapper.emitted('close')).toBeTruthy();
-    }, 0);
+      cancelAnimationFrame(animationFrameId);
+    });
   });
 
   test('should show a confirmation snackbar on success submit', () => {
@@ -200,10 +200,10 @@ describe('EditTitleDescriptionModal', () => {
     wrapper.find('input[value="en"]').setChecked(true);
     wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
 
-    setTimeout(() => {
-      // wait async
+    const animationFrameId = requestAnimationFrame(() => {
       expect(generalActions.showSnackbarSimple).toHaveBeenCalled();
-    }, 0);
+      cancelAnimationFrame(animationFrameId);
+    });
   });
 
   describe('topic nodes present', () => {
@@ -225,12 +225,12 @@ describe('EditTitleDescriptionModal', () => {
       wrapper.find('input[value="es"]').setChecked(true);
       wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
 
-      setTimeout(() => {
-        // wait async
+      const animationFrameId = requestAnimationFrame(() => {
         expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
           id: 'test-en-topic',
           language: 'es',
         });
+        cancelAnimationFrame(animationFrameId);
       });
     });
 
@@ -241,12 +241,12 @@ describe('EditTitleDescriptionModal', () => {
       wrapper.find('[data-test="update-descendants-checkbox"] input').setChecked(true);
       wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
 
-      setTimeout(() => {
-        // wait async
+      const animationFrameId = requestAnimationFrame(() => {
         expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
           id: 'test-en-topic',
           language: 'es',
         });
+        cancelAnimationFrame(animationFrameId);
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditTitleDescriptionModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditTitleDescriptionModal.spec.js
@@ -150,10 +150,13 @@ describe('EditTitleDescriptionModal', () => {
     });
 
     wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
-    expect(generalActions.showSnackbarSimple).toHaveBeenCalledWith(
-      expect.anything(),
-      'Edited title and description'
-    );
+
+    setTimeout(() => {
+      expect(generalActions.showSnackbarSimple).toHaveBeenCalledWith(
+        expect.anything(),
+        'Edited title and description'
+      );
+    }, 0);
   });
 
   test("should emit 'close' event on success submit", () => {
@@ -165,7 +168,10 @@ describe('EditTitleDescriptionModal', () => {
     });
 
     wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
-    expect(wrapper.emitted().close).toBeTruthy();
+
+    setTimeout(() => {
+      expect(wrapper.emitted().close).toBeTruthy();
+    }, 0);
   });
 
   test('should emit close event on cancel', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditTitleDescriptionModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditTitleDescriptionModal.spec.js
@@ -151,12 +151,13 @@ describe('EditTitleDescriptionModal', () => {
 
     wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
 
-    setTimeout(() => {
+    const animationFrameId = requestAnimationFrame(() => {
       expect(generalActions.showSnackbarSimple).toHaveBeenCalledWith(
         expect.anything(),
         'Edited title and description'
       );
-    }, 0);
+      cancelAnimationFrame(animationFrameId);
+    });
   });
 
   test("should emit 'close' event on success submit", () => {
@@ -169,9 +170,10 @@ describe('EditTitleDescriptionModal', () => {
 
     wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
 
-    setTimeout(() => {
+    const animationFrameId = requestAnimationFrame(() => {
       expect(wrapper.emitted().close).toBeTruthy();
-    }, 0);
+      cancelAnimationFrame(animationFrameId);
+    });
   });
 
   test('should emit close event on cancel', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
@@ -6,6 +6,11 @@
       :nodeId="nodeIds[0]"
       @close="close"
     />
+    <EditLanguageModal
+      v-if="isLanguageOpen"
+      :nodeIds="nodeIds"
+      @close="close"
+    />
   </div>
 
 </template>
@@ -15,11 +20,13 @@
 
   import { mapGetters, mapMutations } from 'vuex';
   import { QuickEditModals } from '../../constants';
-  import EditTitleDescriptionModal from './EditTitleDescriptionModal.vue';
+  import EditLanguageModal from './EditLanguageModal';
+  import EditTitleDescriptionModal from './EditTitleDescriptionModal';
 
   export default {
     name: 'QuickEditModal',
     components: {
+      EditLanguageModal,
       EditTitleDescriptionModal,
     },
     computed: {
@@ -40,6 +47,9 @@
       },
       isTitleDescriptionOpen() {
         return this.openedModal === QuickEditModals.TITLE_DESCRIPTION;
+      },
+      isLanguageOpen() {
+        return this.openedModal === QuickEditModals.LANGUAGE;
       },
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -241,7 +241,13 @@
   import MoveModal from '../components/move/MoveModal';
   import ContentNodeOptions from '../components/ContentNodeOptions';
   import ResourceDrawer from '../components/ResourceDrawer';
-  import { RouteNames, viewModes, DraggableRegions, DraggableUniverses, QuickEditModals } from '../constants';
+  import {
+    RouteNames,
+    viewModes,
+    DraggableRegions,
+    DraggableUniverses,
+    QuickEditModals,
+  } from '../constants';
   import NodePanel from './NodePanel';
   import IconButton from 'shared/views/IconButton';
   import ToolBar from 'shared/views/ToolBar';
@@ -488,7 +494,6 @@
         });
       },
       editLanguage(nodeIds) {
-        console.log("nodeIds", nodeIds);
         this.trackClickEvent('Edit language');
         this.openQuickEditModal({
           modal: QuickEditModals.LANGUAGE,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -75,6 +75,13 @@
             data-test="delete-selected-btn"
             @click="removeNodes(selected)"
           />
+          <IconButton
+            v-if="canEdit"
+            icon="language"
+            :text="$tr('editLanguageButton')"
+            data-test="change-langugage-btn"
+            @click="editLanguage(selected)"
+          />
         </div>
       </VSlideXTransition>
 
@@ -229,12 +236,12 @@
 
 <script>
 
-  import { mapActions, mapGetters, mapState } from 'vuex';
+  import { mapActions, mapGetters, mapState, mapMutations } from 'vuex';
   import get from 'lodash/get';
   import MoveModal from '../components/move/MoveModal';
   import ContentNodeOptions from '../components/ContentNodeOptions';
   import ResourceDrawer from '../components/ResourceDrawer';
-  import { RouteNames, viewModes, DraggableRegions, DraggableUniverses } from '../constants';
+  import { RouteNames, viewModes, DraggableRegions, DraggableUniverses, QuickEditModals } from '../constants';
   import NodePanel from './NodePanel';
   import IconButton from 'shared/views/IconButton';
   import ToolBar from 'shared/views/ToolBar';
@@ -429,6 +436,9 @@
         'copyContentNode',
       ]),
       ...mapActions('clipboard', ['copyAll']),
+      ...mapMutations('contentNode', {
+        openQuickEditModal: 'SET_QUICK_EDIT_MODAL_OPEN',
+      }),
       clearSelections() {
         this.selected = [];
       },
@@ -475,6 +485,14 @@
           params: {
             detailNodeIds: ids.join(','),
           },
+        });
+      },
+      editLanguage(nodeIds) {
+        console.log("nodeIds", nodeIds);
+        this.trackClickEvent('Edit language');
+        this.openQuickEditModal({
+          modal: QuickEditModals.LANGUAGE,
+          nodeIds,
         });
       },
       treeLink(params) {
@@ -696,6 +714,7 @@
       importFromChannels: 'Import from channels',
       addButton: 'Add',
       editButton: 'Edit',
+      editLanguageButton: 'Edit language',
       optionsButton: 'Options',
       copyToClipboardButton: 'Copy to clipboard',
       [viewModes.DEFAULT]: 'Default view',


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Add a quick edit modal to edit content nodes languages. Also add an checkbox to update descendants languages, but this does not work for now until #4372 is merged.

### Screenshots

https://github.com/learningequality/studio/assets/51239030/d78536f3-373f-48da-b939-aac0c0b32388
___
## Reviewer guidance
### How can a reviewer test these changes?

1. Go to update a channel content
2. Click on the "Edit Language" option on the content node menu.
3. Or you can select multiple content nodes and select "Edit language" on the bulk toolbar.

## References
Closes #3415

## Comments
The "clear" button on the search textbox should be included on KDS first, and we should add just a prop in this code.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
