### PR TITLE
UI Modal for Flagging ContentNodes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -1,80 +1,93 @@
 <template>
 
-  <DraggableItem
-    :draggableId="contentNode.id"
-    :draggableMetadata="contentNode"
-    :dragEffect="dragEffect"
-    :dropEffect="draggableDropEffect"
-    :beforeStyle="dragBeforeStyle"
-    :afterStyle="dragAfterStyle"
-  >
-    <template #default>
-      <ContentNodeListItem
-        :node="contentNode"
-        :compact="compact"
-        :comfortable="comfortable"
-        :active="active"
-        :canEdit="canEdit"
-        :draggableHandle="{
-          grouped: selected,
-          draggable,
-          draggableMetadata: contentNode,
-          effectAllowed: draggableEffectAllowed,
-        }"
-        :aria-selected="selected"
-        class="content-node-edit-item"
-        @infoClick="$emit('infoClick', $event)"
-        @topicChevronClick="$emit('topicChevronClick', $event)"
-      >
-        <template #actions-start="{ hover }">
-          <VListTileAction class="handle-col" :aria-hidden="!hover" @click.stop>
-            <transition name="fade">
-              <VBtn :disabled="copying" flat icon>
-                <Icon color="#686868">
-                  drag_indicator
-                </Icon>
-              </VBtn>
-            </transition>
-          </VListTileAction>
-          <VListTileAction class="mx-2 select-col" @click.stop>
-            <Checkbox
-              v-model="selected"
-              :disabled="copying"
-              class="mt-0 pt-0"
-              @dblclick.stop
-            />
-          </VListTileAction>
-        </template>
+  <div>
+    <DraggableItem
+      :draggableId="contentNode.id"
+      :draggableMetadata="contentNode"
+      :dragEffect="dragEffect"
+      :dropEffect="draggableDropEffect"
+      :beforeStyle="dragBeforeStyle"
+      :afterStyle="dragAfterStyle"
+    >
+      <template #default>
+        <ContentNodeListItem
+          :node="contentNode"
+          :compact="compact"
+          :comfortable="comfortable"
+          :active="active"
+          :canEdit="canEdit"
+          :draggableHandle="{
+            grouped: selected,
+            draggable,
+            draggableMetadata: contentNode,
+            effectAllowed: draggableEffectAllowed,
+          }"
+          :aria-selected="selected"
+          class="content-node-edit-item"
+          @infoClick="$emit('infoClick', $event)"
+          @topicChevronClick="$emit('topicChevronClick', $event)"
+        >
+          <template #actions-start="{ hover }">
+            <VListTileAction class="handle-col" :aria-hidden="!hover" @click.stop>
+              <transition name="fade">
+                <VBtn :disabled="copying" flat icon>
+                  <Icon color="#686868">
+                    drag_indicator
+                  </Icon>
+                </VBtn>
+              </transition>
+            </VListTileAction>
+            <VListTileAction class="mx-2 select-col" @click.stop>
+              <Checkbox
+                v-model="selected"
+                :disabled="copying"
+                class="mt-0 pt-0"
+                @dblclick.stop
+              />
+            </VListTileAction>
+          </template>
 
-        <template #actions-end>
-          <VListTileAction :aria-hidden="!active" class="action-icon px-1">
-            <Menu v-model="activated">
-              <template #activator="{ on }">
-                <IconButton
-                  icon="optionsVertical"
-                  :text="$tr('optionsTooltip')"
-                  size="small"
-                  :disabled="copying"
-                  v-on="on"
-                  @click.stop
+          <template #actions-end>
+            <VListTileAction :aria-hidden="!active" class="action-icon px-1">
+              <Menu v-model="activated">
+                <template #activator="{ on }">
+                  <IconButton
+                    icon="optionsVertical"
+                    :text="$tr('optionsTooltip')"
+                    size="small"
+                    :disabled="copying"
+                    v-on="on"
+                    @click.stop
+                  />
+                </template>
+                <ContentNodeOptions
+                  v-if="!copying"
+                  :nodeId="nodeId"
+                  @node-flagged="showFlagFeedbackModal = true"
                 />
-              </template>
-              <ContentNodeOptions v-if="!copying" :nodeId="nodeId" />
-            </Menu>
-          </VListTileAction>
-        </template>
+              </Menu>
+            </VListTileAction>
+          </template>
 
-        <template #context-menu="{ showContextMenu, positionX, positionY }">
-          <ContentNodeContextMenu
-            :show="showContextMenu"
-            :positionX="positionX"
-            :positionY="positionY"
-            :nodeId="nodeId"
-          />
-        </template>
-      </ContentNodeListItem>
-    </template>
-  </DraggableItem>
+          <template #context-menu="{ showContextMenu, positionX, positionY }">
+            <ContentNodeContextMenu
+              :show="showContextMenu"
+              :positionX="positionX"
+              :positionY="positionY"
+              :nodeId="nodeId"
+            />
+          </template>
+        </ContentNodeListItem>
+      </template>
+    </DraggableItem>
+
+    <FlagFeedbackModal
+      v-if="showFlagFeedbackModal"
+      v-model="showFlagFeedbackModal"
+      :nodeId="nodeId"
+    />
+
+  </div>
 
 </template>
 
@@ -85,6 +98,7 @@
 
   import ContentNodeListItem from './ContentNodeListItem';
   import ContentNodeOptions from './ContentNodeOptions';
+  import FlagFeedbackModal from './FlagFeedbackModal';
   import ContentNodeContextMenu from './ContentNodeContextMenu';
   import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
@@ -102,6 +116,7 @@
       ContentNodeContextMenu,
       Checkbox,
       IconButton,
+      FlagFeedbackModal,
     },
     props: {
       nodeId: {
@@ -137,6 +152,7 @@
     data() {
       return {
         activated: false,
+        showFlagFeedbackModal: false,
       };
     },
     computed: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -31,6 +31,9 @@
     <VListTile v-if="canEdit" @click="removeNode()">
       <VListTileTitle>{{ $tr('remove') }}</VListTileTitle>
     </VListTile>
+    <VListTile v-if="canShowFlagOption" @click="$emit('node-flagged')">
+      <VListTileTitle>{{ $tr('flag') }}</VListTileTitle>
+    </VListTile>
   </VList>
 
 </template>
@@ -69,8 +72,9 @@
       };
     },
     computed: {
-      ...mapGetters('currentChannel', ['canEdit', 'trashId']),
+      ...mapGetters('currentChannel', ['canEdit', 'trashId', 'currentChannel']),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeDescendants']),
+      ...mapGetters(['isAdmin', 'isAIFeatureEnabled']),
       node() {
         return this.getContentNode(this.nodeId);
       },
@@ -94,6 +98,11 @@
             detailNodeId: this.nodeId,
           },
         };
+      },
+      canShowFlagOption() {
+        return (
+          this.isAIFeatureEnabled && !this.isTopic && (!this.currentChannel.edit || this.isAdmin)
+        );
       },
     },
     watch: {
@@ -222,6 +231,7 @@
       copiedSnackbar: 'Copy operation complete',
       copiedToClipboardSnackbar: 'Copied to clipboard',
       removedItems: 'Sent to trash',
+      flag: 'Flag content',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/FlagFeedbackModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/FlagFeedbackModal.vue
@@ -1,0 +1,129 @@
+<template>
+
+  <KModal
+    :title="$tr('flagFeedBackModalTitle')"
+    :submitText="$tr('flagSubmitButtonLabel')"
+    :cancelText="$tr('flagCancelButtonLabel')"
+    :submitDisabled="isSubmitDisabled"
+    @cancel="modalShowing = false"
+    @submit="handleSubmit"
+    @dblclick.native.capture.stop
+  >
+    <VList>
+      <VListTile @click.stop>
+        <VListTileAction>
+          <VCheckbox v-model="reportViolent" color="primary" />
+        </VListTileAction>
+        <VListTileContent @click="reportViolent = !reportViolent">
+          <VListTileTitle>{{ $tr('reportViolentTitle') }}</VListTileTitle>
+        </VListTileContent>
+      </VListTile>
+
+      <VListTile @click.stop>
+        <VListTileAction>
+          <VCheckbox v-model="reportHateful" color="primary" />
+        </VListTileAction>
+        <VListTileContent @click="reportHateful = !reportHateful">
+          <VListTileTitle>{{ $tr('reportHatefulTitle') }}</VListTileTitle>
+        </VListTileContent>
+      </VListTile>
+
+      <VListTile @click.stop>
+        <VListTileAction>
+          <VCheckbox v-model="reportHarmful" color="primary" />
+        </VListTileAction>
+        <VListTileContent @click="reportHarmful = !reportHarmful">
+          <VListTileTitle>{{ $tr('reportHarmfulTitle') }}</VListTileTitle>
+        </VListTileContent>
+      </VListTile>
+
+      <VListTile @click.stop>
+        <VListTileAction>
+          <VCheckbox v-model="reportSpam" color="primary" />
+        </VListTileAction>
+        <VListTileContent @click="reportSpam = !reportSpam">
+          <VListTileTitle>{{ $tr('reportSpamTitle') }}</VListTileTitle>
+        </VListTileContent>
+      </VListTile>
+
+      <VListTile @click.stop>
+        <VListTileAction>
+          <VCheckbox v-model="reportSexual" color="primary" />
+        </VListTileAction>
+        <VListTileContent @click="reportSexual = !reportSexual">
+          <VListTileTitle>{{ $tr('reportSexualTitle') }}</VListTileTitle>
+        </VListTileContent>
+      </VListTile>
+    </VList>
+  </KModal>
+
+</template>
+
+<script>
+
+  import { mapGetters } from 'vuex';
+
+  export default {
+    name: 'FlagFeedbackModal',
+    props: {
+      nodeId: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        reportViolent: false,
+        reportHateful: false,
+        reportHarmful: false,
+        reportSpam: false,
+        reportSexual: false,
+      };
+    },
+    computed: {
+      ...mapGetters('contentNode', ['getContentNode']),
+      targetContentNode() {
+        return this.getContentNode(this.nodeId);
+      },
+      modalShowing: {
+        get() {
+          return this.value;
+        },
+        set(value) {
+          this.$emit('input', value);
+        },
+      },
+      reportList() {
+        return [
+          this.reportViolent,
+          this.reportHateful,
+          this.reportHarmful,
+          this.reportSpam,
+          this.reportSexual,
+        ];
+      },
+      isSubmitDisabled() {
+        const anyOneCheckboxTick = this.reportList.some(report => report === true);
+        return !anyOneCheckboxTick; // if any one checkbox is tick, enable submit.
+      },
+    },
+    methods: {
+      handleSubmit() {
+        /* NOTE: This is just a placeholder method. It will be implemented after
+        feedbackApiUtils PR is merged. */
+        console.log(`Node with title "${this.targetContentNode.title}" is flagged!`);
+      },
+    },
+    $trs: {
+      flagFeedBackModalTitle: 'Flag content',
+      reportViolentTitle: 'Violent or repulsive content',
+      reportHatefulTitle: 'Hateful or abusive content',
+      reportHarmfulTitle: 'Harmful or dangerous acts',
+      reportSpamTitle: 'Spam or misleading',
+      reportSexualTitle: 'Sexual Content',
+      flagCancelButtonLabel: 'Cancel',
+      flagSubmitButtonLabel: 'Flag',
+    },
+  };
+
+</script>


### PR DESCRIPTION
## Summary
This PR --

- Adds a `Flag content` option to the contentnode three-dot menu.
- Introduces a UI Modal upon click of `Flag content` option that shows checkboxes for reporting a node.

TO DO -- 

- [ ] Implement `handleSubmit()` method. Can only be done after https://github.com/learningequality/studio/pull/4373 is merged.

## Manual verification steps performed

Manual verification mainly revolves around checking when and when not `Flag content` option is shown. So let's divide it into two parts -- first for normal users and second for admins.

### For normal non-admin users
Flag option should show only when these three conditions meet -- AI feature flag is enabled for user, node is not of topic kind and user does not have edit permissions on the channel, that is, all public channels that user have not created themselves.

So to test the above conditions follow the below steps --
1. Log in as admin.
1. Enable ai feature flag for a normal user e.g. for user@b.com 
1. Create a channel with two nodes -- a topic node and a video file node.
1. Publish that channel and make that channel public.
1. Logout & login as user now.
1. Go to content library and open that public channel.
1. Click on three-dot menu of topic contentnode, `Flag content` option should not be there.
1. Click on three-dot menu of video contentnode, `Flag content` option should be there. 
1. Done! 

### For admin users
Flag option should show in ALL channels when -- AI feature flag is enabled for admin and node is not of topic kind.

So to test the above conditions follow the below steps --
1. Log in as a normal user.
2. Create a channel with two nodes -- a topic node and a video file node.
3. Log out and login as admin.
4. Enable ai feature flag for admin.
5. Go to administration -> channels.
6. Visit that unpublished channel.
7. Click on three-dot menu of topic contentnode, `Flag content` option should not be there.
8. Click on three-dot menu of video contentnode, `Flag content` option should be there. 
9. Done!

## Screenshots (if applicable)

### 1. `Flag content` option UI

![image](https://github.com/learningequality/studio/assets/26724128/94532318-86d2-4467-b2b3-0fc5c595083b)

### 2. Flag modal UI

![image](https://github.com/learningequality/studio/assets/26724128/27a5dc19-9086-490c-9622-266c72d651fa)

___

## Reviewer guidance

Performing manual verification steps should make us confident about the changes.


## References
Closes https://github.com/learningequality/studio/issues/4367.
Closes https://github.com/learningequality/studio/issues/4365.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
