### PR TITLE
[fix] Import applied language filter

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -72,7 +72,7 @@
     mixins: [constantsTranslationMixin],
     data() {
       return {
-        languageFilter: '',
+        languageFilter: null,
         channels: [],
         pageCount: 0,
         loading: false,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -72,7 +72,6 @@
     mixins: [constantsTranslationMixin],
     data() {
       return {
-        languageFilter: '',
         channels: [],
         pageCount: 0,
         loading: false,
@@ -95,6 +94,21 @@
           this.loadPage();
         },
       },
+      languageFilter: {
+        get() {
+          return this.$route.query.languages || '';
+        },
+        set(languages) {
+          this.$router.push({
+            ...this.$route,
+            query: {
+              ...this.$route.query,
+              languages,
+            },
+          });
+          this.loadPage();
+        },
+      },
       channelFilterOptions() {
         return Object.values(ChannelListTypes).map(value => {
           return {
@@ -106,9 +120,6 @@
     },
     watch: {
       '$route.query.page'() {
-        this.loadPage();
-      },
-      languageFilter() {
         this.loadPage();
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -78,7 +78,6 @@
         loading: false,
       };
     },
-    emits: ['updateLanguage'],
     computed: {
       ...mapState('currentChannel', ['currentChannelId']),
       channelFilter: {
@@ -110,8 +109,8 @@
         this.loadPage();
       },
       languageFilter() {
-        this.$emit('updateLanguage', this.languageFilter);
         this.loadPage();
+        this.$emit('update-language', this.languageFilter);
       },
     },
     mounted() {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -72,11 +72,13 @@
     mixins: [constantsTranslationMixin],
     data() {
       return {
+        languageFilter: '',
         channels: [],
         pageCount: 0,
         loading: false,
       };
     },
+    emits: ['updateLanguage'],
     computed: {
       ...mapState('currentChannel', ['currentChannelId']),
       channelFilter: {
@@ -94,21 +96,6 @@
           this.loadPage();
         },
       },
-      languageFilter: {
-        get() {
-          return this.$route.query.languages || '';
-        },
-        set(languages) {
-          this.$router.push({
-            ...this.$route,
-            query: {
-              ...this.$route.query,
-              languages,
-            },
-          });
-          this.loadPage();
-        },
-      },
       channelFilterOptions() {
         return Object.values(ChannelListTypes).map(value => {
           return {
@@ -120,6 +107,10 @@
     },
     watch: {
       '$route.query.page'() {
+        this.loadPage();
+      },
+      languageFilter() {
+        this.$emit('updateLanguage', this.languageFilter);
         this.loadPage();
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -142,7 +142,6 @@
         clearNodes: 'CLEAR_NODES',
       }),
       handleBackToBrowse() {
-        this.languages = '';
         this.$router.push(this.backToBrowseRoute);
       },
       updateLanguageQuery(language) {
@@ -161,6 +160,7 @@
               last: this.$route.query.last || this.$route.path,
             },
           });
+          this.languages = '';
           this.clearNodes();
           this.$analytics.trackAction('import_modal', 'Search');
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -48,7 +48,7 @@
         <!-- Search or Topics Browsing -->
         <ChannelList
           v-if="isBrowsing && !$route.params.channelId"
-          @updateLanguage="updateLanguageQuery"
+          @update-language="updateLanguageQuery"
         />
         <ContentTreeList
           v-else-if="isBrowsing"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -97,7 +97,7 @@
         searchTerm: '',
         topicNode: null,
         copyNode: null,
-        languages: '',
+        languageFromChannelList: null,
       };
     },
     computed: {
@@ -145,7 +145,7 @@
         this.$router.push(this.backToBrowseRoute);
       },
       updateLanguageQuery(language) {
-        this.languages = language;
+        this.languageFromChannelList = language;
       },
       handleSearchTerm() {
         if (this.searchIsValid) {
@@ -156,11 +156,11 @@
             },
             query: {
               ...this.$route.query,
-              ...(this.languages !== '' ? { languages: this.languages } : ''),
+              ...(this.isBrowsing ? { languages: this.languageFromChannelList } : {}),
               last: this.$route.query.last || this.$route.path,
             },
           });
-          this.languages = '';
+          this.languageFromChannelList = null;
           this.clearNodes();
           this.$analytics.trackAction('import_modal', 'Search');
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -48,6 +48,7 @@
         <!-- Search or Topics Browsing -->
         <ChannelList
           v-if="isBrowsing && !$route.params.channelId"
+          @updateLanguage="updateLanguageQuery"
         />
         <ContentTreeList
           v-else-if="isBrowsing"
@@ -96,6 +97,7 @@
         searchTerm: '',
         topicNode: null,
         copyNode: null,
+        languages: '',
       };
     },
     computed: {
@@ -140,7 +142,11 @@
         clearNodes: 'CLEAR_NODES',
       }),
       handleBackToBrowse() {
+        this.languages = '';
         this.$router.push(this.backToBrowseRoute);
+      },
+      updateLanguageQuery(language) {
+        this.languages = language;
       },
       handleSearchTerm() {
         if (this.searchIsValid) {
@@ -151,6 +157,7 @@
             },
             query: {
               ...this.$route.query,
+              ...(this.languages !== '' ? { languages: this.languages } : ''),
               last: this.$route.query.last || this.$route.path,
             },
           });


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
When the new search page opens, the filter is not applied, to tackle this issue, we are using the 'languages' param which is then imported by the language filter.

### Manual verification steps performed
1. Import from other channels
2. Select a language and search item and click Search
3. The new page will have the selected language

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

Before:
https://github.com/learningequality/studio/issues/4089#issue-1720351313

After:
![CPT2401032206-1528x627](https://github.com/learningequality/studio/assets/84982038/c58bc256-9e50-4c26-877d-2e01c79a4dfc)

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
At present, upon clicking 'back to browse,' the language selection is not retained. It resets to nothing. This decision was made due to the introduction of a new page where users can select multiple languages. Fetching the previously selected language(s) might lead to errors due to this change in the user flow. 
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Import from other channels
2. Select a language and search item and click Search
3. The new page will have the selected language


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Addresses #4089

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
