### PR TITLE
Quick edit modal to edit "what you will need"

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -1,0 +1,191 @@
+<template>
+
+  <KModal
+    :title="$tr('editResourcesNeededTitle')"
+    :submitText="$tr('saveAction')"
+    :cancelText="$tr('cancelAction')"
+    data-test="edit-resources-needed-modal"
+    @submit="handleSave"
+    @cancel="close"
+  >
+    <p data-test="resources-selected-message">
+      {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+    </p>
+    <template v-if="isTopicSelected">
+      <KCheckbox
+        v-model="updateDescendants"
+        data-test="update-descendants-checkbox"
+        :label="$tr('updateDescendantsCheckbox')"
+      />
+      <hr
+        :style="dividerStyle"
+      >
+    </template>
+    <div
+      data-test="requirements-options-list"
+    >
+      <KCheckbox
+        v-for="resource in resourcesOptions"
+        :key="resource.value"
+        data-test="category-checkbox"
+        :label="resource.label"
+        :checked="isCheckboxSelected(resource)"
+        :indeterminate="isCheckboxIndeterminate(resource)"
+        @change="value => onSelectResource(resource, value)"
+      />
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { mapGetters, mapActions } from 'vuex';
+  import { ResourcesNeededTypes, ResourcesNeededOptions } from 'shared/constants';
+  import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+  import { metadataTranslationMixin } from 'shared/mixins';
+
+  export default {
+    name: 'EditLanguageModal',
+    props: {
+      nodeIds: {
+        type: Array,
+        required: true,
+      },
+    },
+    mixins: [metadataTranslationMixin],
+    data() {
+      return {
+        updateDescendants: false,
+        /**
+         * selectedResources is an object with the following structure:
+         * {
+         *  [resource]: true | [nodeId1, nodeId2, ...]
+         * }
+         * If the value is true, it means that the resource is selected for all nodes
+         * If the value is an array of nodeIds, it means that the resource is selected
+         * just for those nodes
+         */
+        selectedResources: {},
+      };
+    },
+    computed: {
+      ...mapGetters('contentNode', ['getContentNodes']),
+      nodes() {
+        return this.getContentNodes(this.nodeIds);
+      },
+      isTopicSelected() {
+        return this.nodes.some(node => node.kind === ContentKindsNames.TOPIC);
+      },
+      resourcesOptions() {
+        return ResourcesNeededOptions.map(key => ({
+          label: this.translateMetadataString(key),
+          value: ResourcesNeededTypes[key],
+        }));
+      },
+      dividerStyle() {
+        return {
+          border: 0,
+          borderBottom: `1px solid ${this.$themeTokens.fineLine}`,
+          margin: '1em 0',
+        };
+      },
+    },
+    created() {
+      const resourcesNodes = {};
+      this.nodes.forEach(node => {
+        Object.entries(node.learner_needs || {})
+          .filter(entry => entry[1] === true)
+          .forEach(([resource]) => {
+            resourcesNodes[resource] = resourcesNodes[resource] || [];
+            resourcesNodes[resource].push(node.id);
+          });
+      });
+      console.log("resourcesNodes", resourcesNodes);
+      Object.entries(resourcesNodes).forEach(([key, nodeIds]) => {
+        if (nodeIds.length === this.nodeIds.length) {
+          this.selectedResources[key] = true;
+        } else {
+          this.selectedResources[key] = nodeIds;
+        }
+      });
+    },
+    methods: {
+      ...mapActions('contentNode', ['updateContentNode']),
+      close() {
+        this.$emit('close');
+      },
+      isCheckboxSelected(resource) {
+        return (
+          this.selectedResources[resource.value] &&
+          this.selectedResources[resource.value] === true
+        )
+      },
+      isCheckboxIndeterminate(resource) {
+        return (
+          this.selectedResources[resource.value] &&
+          this.selectedResources[resource.value] !== true
+        )
+      },
+      onSelectResource(resource, value) {
+        if (value) {
+          this.selectedResources = {
+            ...this.selectedResources,
+            [resource.value]: true,
+          };
+        } else {
+          const newSelectedResources = { ...this.selectedResources };
+          delete newSelectedResources[resource.value];
+          this.selectedResources = newSelectedResources;
+        }
+      },
+      async handleSave() {
+        await Promise.all(
+          this.nodes.map(node => {
+            const resources = {};
+            Object.entries(this.selectedResources).forEach(([key, value]) => {
+              if (value === true || value.includes(node.id)) {
+                resources[key] = true;
+              }
+            });
+            if (this.updateDescendants && node.kind === ContentKindsNames.TOPIC) {
+              // will update with the new function to update all descendants
+              return this.updateContentNode({
+                id: node.id,
+                learner_needs: resources,
+              });
+            }
+            return this.updateContentNode({
+              id: node.id,
+              learner_needs: resources,
+            });
+          })
+        );
+        this.$store.dispatch(
+          'showSnackbarSimple',
+          this.$tr('editedResourcesNeeded', { count: this.nodes.length })
+        );
+        this.close();
+      },
+    },
+    $trs: {
+      editResourcesNeededTitle: 'What will you need?',
+      saveAction: 'Save',
+      cancelAction: 'Cancel',
+      editedResourcesNeeded:
+        'Edited \'what will you need\' for {count, number, integer} {count, plural, one {resource} other {resources}}',
+      selectLanguage: 'Select / Type Language',
+      resourcesSelected:
+        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
+      differentLanguages:
+        'The selected resources have different languages set. Choosing an option below will apply the language to all the selected resources',
+      updateDescendantsCheckbox:
+        'Apply to all resources and folders nested within the selected folders',
+    },
+  };
+
+</script>
+
+<style scoped>
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -27,7 +27,7 @@
       <KCheckbox
         v-for="resource in resourcesOptions"
         :key="resource.value"
-        data-test="category-checkbox"
+        data-test="resource-checkbox"
         :label="resource.label"
         :checked="isCheckboxSelected(resource)"
         :indeterminate="isCheckboxIndeterminate(resource)"
@@ -47,14 +47,14 @@
   import { metadataTranslationMixin } from 'shared/mixins';
 
   export default {
-    name: 'EditLanguageModal',
+    name: 'EditResourcesNeededModal',
+    mixins: [metadataTranslationMixin],
     props: {
       nodeIds: {
         type: Array,
         required: true,
       },
     },
-    mixins: [metadataTranslationMixin],
     data() {
       return {
         updateDescendants: false,
@@ -102,7 +102,6 @@
             resourcesNodes[resource].push(node.id);
           });
       });
-      console.log("resourcesNodes", resourcesNodes);
       Object.entries(resourcesNodes).forEach(([key, nodeIds]) => {
         if (nodeIds.length === this.nodeIds.length) {
           this.selectedResources[key] = true;
@@ -118,15 +117,13 @@
       },
       isCheckboxSelected(resource) {
         return (
-          this.selectedResources[resource.value] &&
-          this.selectedResources[resource.value] === true
-        )
+          this.selectedResources[resource.value] && this.selectedResources[resource.value] === true
+        );
       },
       isCheckboxIndeterminate(resource) {
         return (
-          this.selectedResources[resource.value] &&
-          this.selectedResources[resource.value] !== true
-        )
+          this.selectedResources[resource.value] && this.selectedResources[resource.value] !== true
+        );
       },
       onSelectResource(resource, value) {
         if (value) {
@@ -174,12 +171,9 @@
       saveAction: 'Save',
       cancelAction: 'Cancel',
       editedResourcesNeeded:
-        'Edited \'what will you need\' for {count, number, integer} {count, plural, one {resource} other {resources}}',
-      selectLanguage: 'Select / Type Language',
+        "Edited 'what will you need' for {count, number, integer} {count, plural, one {resource} other {resources}}",
       resourcesSelected:
         '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
-      differentLanguages:
-        'The selected resources have different languages set. Choosing an option below will apply the language to all the selected resources',
       updateDescendantsCheckbox:
         'Apply to all resources and folders nested within the selected folders',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -13,9 +13,10 @@
     </p>
     <template v-if="isTopicSelected">
       <KCheckbox
-        v-model="updateDescendants"
+        :checked="updateDescendants"
         data-test="update-descendants-checkbox"
         :label="$tr('updateDescendantsCheckbox')"
+        @change="value => updateDescendants = value"
       />
       <hr
         :style="dividerStyle"
@@ -111,7 +112,7 @@
       });
     },
     methods: {
-      ...mapActions('contentNode', ['updateContentNode']),
+      ...mapActions('contentNode', ['updateContentNode', 'updateContentNodeDescendants']),
       close() {
         this.$emit('close');
       },
@@ -148,7 +149,7 @@
             });
             if (this.updateDescendants && node.kind === ContentKindsNames.TOPIC) {
               // will update with the new function to update all descendants
-              return this.updateContentNode({
+              return this.updateContentNodeDescendants({
                 id: node.id,
                 learner_needs: resources,
               });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -22,7 +22,7 @@
       >
     </template>
     <div
-      data-test="requirements-options-list"
+      data-test="resources-options-list"
     >
       <KCheckbox
         v-for="resource in resourcesOptions"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
@@ -243,10 +243,13 @@ describe('EditTitleDescriptionModal', () => {
       wrapper.find('[data-test="edit-language-modal"]').vm.$emit('submit');
 
       const animationFrameId = requestAnimationFrame(() => {
-        expect(contentNodeActions.updateContentNodeDescendants).toHaveBeenCalledWith(expect.anything(), {
-          id: 'test-en-topic',
-          language: 'es',
-        });
+        expect(contentNodeActions.updateContentNodeDescendants).toHaveBeenCalledWith(
+          expect.anything(),
+          {
+            id: 'test-en-topic',
+            language: 'es',
+          }
+        );
         cancelAnimationFrame(animationFrameId);
       });
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditResourcesNeededModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditResourcesNeededModal.spec.js
@@ -69,6 +69,7 @@ describe('EditResourcesNeededModal', () => {
     };
     contentNodeActions = {
       updateContentNode: jest.fn(),
+      updateContentNodeDescendants: jest.fn(),
     };
     generalActions = {
       showSnackbarSimple: jest.fn(),
@@ -257,7 +258,7 @@ describe('EditResourcesNeededModal', () => {
       });
     });
 
-    test('should call updateContentNode on success submit if the user checks the checkbox', () => {
+    test('should call updateContentNodeDescendants on success submit if the user checks the checkbox', () => {
       nodes['node1'].kind = ContentKindsNames.TOPIC;
 
       const wrapper = makeWrapper(['node1']);
@@ -266,10 +267,13 @@ describe('EditResourcesNeededModal', () => {
       wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('submit');
 
       const animationFrameId = requestAnimationFrame(() => {
-        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
-          id: 'node1',
-          learner_needs: {},
-        });
+        expect(contentNodeActions.updateContentNodeDescendants).toHaveBeenCalledWith(
+          expect.anything(),
+          {
+            id: 'node1',
+            learner_needs: {},
+          }
+        );
         cancelAnimationFrame(animationFrameId);
       });
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditResourcesNeededModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditResourcesNeededModal.spec.js
@@ -1,0 +1,277 @@
+import Vuex from 'vuex';
+import { mount } from '@vue/test-utils';
+import EditResourcesNeededModal from '../EditResourcesNeededModal';
+import { ResourcesNeededTypes } from 'shared/constants';
+import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+
+let nodes;
+
+let store;
+let contentNodeActions;
+let generalActions;
+
+const makeWrapper = nodeIds => {
+  return mount(EditResourcesNeededModal, {
+    store,
+    propsData: {
+      nodeIds,
+    },
+    methods: {
+      translateMetadataString: value => {
+        return value;
+      },
+    },
+  });
+};
+
+const CheckboxValue = {
+  UNCHECKED: 'UNCHECKED',
+  CHECKED: 'CHECKED',
+  INDETERMINATE: 'INDETERMINATE',
+};
+
+const resourcesLookup = {};
+Object.entries(ResourcesNeededTypes).forEach(([key, value]) => {
+  resourcesLookup[key] = value;
+});
+
+const getResourcesValues = wrapper => {
+  const resources = {};
+  const checkboxes = wrapper.findAll('[data-test="resource-checkbox"]');
+  checkboxes.wrappers.forEach(checkbox => {
+    const { label, checked, indeterminate } = checkbox.vm.$props || {};
+    let value;
+    if (indeterminate) {
+      value = CheckboxValue.INDETERMINATE;
+    } else if (checked) {
+      value = CheckboxValue.CHECKED;
+    } else {
+      value = CheckboxValue.UNCHECKED;
+    }
+    resources[resourcesLookup[label]] = value;
+  });
+  return resources;
+};
+
+const findResourceCheckbox = (wrapper, resource) => {
+  const checkboxes = wrapper.findAll('[data-test="resource-checkbox"]');
+  return checkboxes.wrappers.find(checkbox => {
+    const { label } = checkbox.vm.$props || {};
+    return resourcesLookup[label] === resource;
+  });
+};
+
+describe('EditResourcesNeededModal', () => {
+  beforeEach(() => {
+    nodes = {
+      node1: { id: 'node1' },
+      node2: { id: 'node2' },
+    };
+    contentNodeActions = {
+      updateContentNode: jest.fn(),
+    };
+    generalActions = {
+      showSnackbarSimple: jest.fn(),
+    };
+    store = new Vuex.Store({
+      actions: generalActions,
+      modules: {
+        contentNode: {
+          namespaced: true,
+          actions: contentNodeActions,
+          getters: {
+            getContentNodes: () => ids => ids.map(id => nodes[id]),
+          },
+        },
+      },
+    });
+  });
+
+  test('smoke test', () => {
+    const wrapper = makeWrapper(['node1']);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  describe('Selected resources on first render', () => {
+    test('no resource should be selected if a single node does not have needed resources set', () => {
+      const wrapper = makeWrapper(['node1']);
+
+      const resourcesValues = getResourcesValues(wrapper);
+      expect(
+        Object.values(resourcesValues).every(value => value === CheckboxValue.UNCHECKED)
+      ).toBeTruthy();
+    });
+
+    test('specific resources should be selected depending on the learner needs set for a single node', () => {
+      nodes['node1'].learner_needs = {
+        [ResourcesNeededTypes.INTERNET]: true,
+        [ResourcesNeededTypes.PEERS]: true,
+      };
+
+      const wrapper = makeWrapper(['node1']);
+
+      const resourcesValues = getResourcesValues(wrapper);
+      const {
+        [ResourcesNeededTypes.INTERNET]: internetValue,
+        [ResourcesNeededTypes.PEERS]: peersValue,
+        ...otherResourcesValues
+      } = resourcesValues;
+      expect(
+        Object.values(otherResourcesValues).every(value => value === CheckboxValue.UNCHECKED)
+      ).toBeTruthy();
+      expect(internetValue).toBe(CheckboxValue.CHECKED);
+      expect(peersValue).toBe(CheckboxValue.CHECKED);
+    });
+
+    test('checkbox resource should be checked if all nodes have the same resources needed set', () => {
+      nodes['node1'].learner_needs = {
+        [ResourcesNeededTypes.INTERNET]: true,
+        [ResourcesNeededTypes.PEERS]: true,
+      };
+      nodes['node2'].learner_needs = {
+        [ResourcesNeededTypes.INTERNET]: true,
+        [ResourcesNeededTypes.PEERS]: true,
+      };
+
+      const wrapper = makeWrapper(['node1', 'node2']);
+
+      const resourcesValues = getResourcesValues(wrapper);
+      const {
+        [ResourcesNeededTypes.INTERNET]: internetValue,
+        [ResourcesNeededTypes.PEERS]: peersValue,
+      } = resourcesValues;
+      expect(internetValue).toBe(CheckboxValue.CHECKED);
+      expect(peersValue).toBe(CheckboxValue.CHECKED);
+    });
+
+    test('checkbox resource should be indeterminate if not all nodes have the same learner needs set', () => {
+      nodes['node1'].learner_needs = {
+        [ResourcesNeededTypes.INTERNET]: true,
+      };
+
+      const wrapper = makeWrapper(['node1', 'node2']);
+
+      const resourcesValues = getResourcesValues(wrapper);
+      const { [ResourcesNeededTypes.INTERNET]: internetValue } = resourcesValues;
+      expect(internetValue).toBe(CheckboxValue.INDETERMINATE);
+    });
+  });
+
+  test('should render the message of the number of resources selected', () => {
+    const wrapper = makeWrapper(['node1', 'node2']);
+
+    const resourcesCounter = wrapper.find('[data-test="resources-selected-message"]');
+    expect(resourcesCounter.exists()).toBeTruthy();
+    expect(resourcesCounter.text()).toContain('2');
+  });
+
+  test('should call updateContentNode with the right resources on submit', () => {
+    const wrapper = makeWrapper(['node1', 'node2']);
+
+    const peersCheckbox = findResourceCheckbox(wrapper, ResourcesNeededTypes.PEERS);
+    peersCheckbox.element.click();
+    const internetCheckbox = findResourceCheckbox(wrapper, ResourcesNeededTypes.INTERNET);
+    internetCheckbox.element.click();
+
+    const animationFrameId = requestAnimationFrame(() => {
+      wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('submit');
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'node1',
+        learner_needs: {
+          [ResourcesNeededTypes.PEERS]: true,
+          [ResourcesNeededTypes.INTERNET]: true,
+        },
+      });
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'node2',
+        learner_needs: {
+          [ResourcesNeededTypes.PEERS]: true,
+          [ResourcesNeededTypes.INTERNET]: true,
+        },
+      });
+      cancelAnimationFrame(animationFrameId);
+    });
+  });
+
+  test('should emit close event on success submit', () => {
+    const wrapper = makeWrapper(['node1']);
+
+    wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('submit');
+
+    const animationFrameId = requestAnimationFrame(() => {
+      expect(wrapper.emitted('close')).toBeTruthy();
+      cancelAnimationFrame(animationFrameId);
+    });
+  });
+
+  test('should emit close event on cancel', () => {
+    const wrapper = makeWrapper(['node1']);
+
+    wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('cancel');
+
+    const animationFrameId = requestAnimationFrame(() => {
+      expect(wrapper.emitted('close')).toBeTruthy();
+      cancelAnimationFrame(animationFrameId);
+    });
+  });
+
+  test('should show a confirmation snackbar on success submit', () => {
+    const wrapper = makeWrapper(['node1']);
+
+    wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('submit');
+
+    const animationFrameId = requestAnimationFrame(() => {
+      expect(generalActions.showSnackbarSimple).toHaveBeenCalled();
+      cancelAnimationFrame(animationFrameId);
+    });
+  });
+
+  describe('topic nodes present', () => {
+    test('should display the checkbox to apply change to descendants if a topic is present', () => {
+      nodes['node1'].kind = ContentKindsNames.TOPIC;
+
+      const wrapper = makeWrapper(['node1', 'node2']);
+
+      expect(wrapper.find('[data-test="update-descendants-checkbox"]').exists()).toBeTruthy();
+    });
+
+    test('should not display the checkbox to apply change to descendants if a topic is not present', () => {
+      const wrapper = makeWrapper(['node1', 'node2']);
+
+      expect(wrapper.find('[data-test="update-descendants-checkbox"]').exists()).toBeFalsy();
+    });
+
+    test('should call updateContentNode on success submit if the user does not check the checkbox', () => {
+      nodes['node1'].kind = ContentKindsNames.TOPIC;
+
+      const wrapper = makeWrapper(['node1']);
+
+      wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('submit');
+
+      const animationFrameId = requestAnimationFrame(() => {
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node1',
+          learner_needs: {},
+        });
+        cancelAnimationFrame(animationFrameId);
+      });
+    });
+
+    test('should call updateContentNode on success submit if the user checks the checkbox', () => {
+      nodes['node1'].kind = ContentKindsNames.TOPIC;
+
+      const wrapper = makeWrapper(['node1']);
+
+      wrapper.find('[data-test="update-descendants-checkbox"] input').setChecked(true);
+      wrapper.find('[data-test="edit-resources-needed-modal"]').vm.$emit('submit');
+
+      const animationFrameId = requestAnimationFrame(() => {
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node1',
+          learner_needs: {},
+        });
+        cancelAnimationFrame(animationFrameId);
+      });
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
@@ -11,6 +11,11 @@
       :nodeIds="nodeIds"
       @close="close"
     />
+    <EditResourcesNeededModal
+      v-if="isResourcesNeededOpen"
+      :nodeIds="nodeIds"
+      @close="close"
+    />
   </div>
 
 </template>
@@ -21,12 +26,14 @@
   import { mapGetters, mapMutations } from 'vuex';
   import { QuickEditModals } from '../../constants';
   import EditLanguageModal from './EditLanguageModal';
+  import EditResourcesNeededModal from './EditResourcesNeededModal';
   import EditTitleDescriptionModal from './EditTitleDescriptionModal';
 
   export default {
     name: 'QuickEditModal',
     components: {
       EditLanguageModal,
+      EditResourcesNeededModal,
       EditTitleDescriptionModal,
     },
     computed: {
@@ -51,6 +58,9 @@
       isLanguageOpen() {
         return this.openedModal === QuickEditModals.LANGUAGE;
       },
+      isResourcesNeededOpen() {
+        return this.openedModal === QuickEditModals.WHAT_IS_NEEDED;
+      }
     },
     methods: {
       ...mapMutations('contentNode', {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
@@ -60,7 +60,7 @@
       },
       isResourcesNeededOpen() {
         return this.openedModal === QuickEditModals.WHAT_IS_NEEDED;
-      }
+      },
     },
     methods: {
       ...mapMutations('contentNode', {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/ResourcesNeededOptions.vue
@@ -24,18 +24,9 @@
 
 <script>
 
-  import { ResourcesNeededTypes } from 'shared/constants';
+  import { ResourcesNeededTypes, ResourcesNeededOptions } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
   import DropdownWrapper from 'shared/views/form/DropdownWrapper';
-
-  const dropdownItems = [
-    'PEERS',
-    'TEACHER',
-    'INTERNET',
-    'SPECIAL_SOFTWARE',
-    'PAPER_PENCIL',
-    'OTHER_SUPPLIES',
-  ];
 
   export default {
     name: 'ResourcesNeededOptions',
@@ -57,7 +48,7 @@
         },
       },
       resources() {
-        return dropdownItems.map(key => ({
+        return ResourcesNeededOptions.map(key => ({
           text: this.translateMetadataString(key),
           value: ResourcesNeededTypes[key],
         }));

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -82,6 +82,13 @@
             data-test="change-langugage-btn"
             @click="editLanguage(selected)"
           />
+          <IconButton
+            v-if="canEdit"
+            icon="dashboard"
+            :text="$tr('editWhatIsNeededButton')"
+            data-test="change-resources-neded-btn"
+            @click="editResourcesNeeded(selected)"
+          />
         </div>
       </VSlideXTransition>
 
@@ -500,6 +507,13 @@
           nodeIds,
         });
       },
+      editResourcesNeeded(nodeIds) {
+        this.trackClickEvent('Edit what is needed');
+        this.openQuickEditModal({
+          modal: QuickEditModals.WHAT_IS_NEEDED,
+          nodeIds,
+        });
+      },
       treeLink(params) {
         return {
           name: RouteNames.TREE_VIEW,
@@ -720,6 +734,7 @@
       addButton: 'Add',
       editButton: 'Edit',
       editLanguageButton: 'Edit language',
+      editWhatIsNeededButton: 'Edit \'what is needed\'',
       optionsButton: 'Options',
       copyToClipboardButton: 'Copy to clipboard',
       [viewModes.DEFAULT]: 'Default view',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -734,7 +734,7 @@
       addButton: 'Add',
       editButton: 'Edit',
       editLanguageButton: 'Edit language',
-      editWhatIsNeededButton: 'Edit \'what is needed\'',
+      editWhatIsNeededButton: "Edit 'what is needed'",
       optionsButton: 'Options',
       copyToClipboardButton: 'Copy to clipboard',
       [viewModes.DEFAULT]: 'Default view',

--- a/contentcuration/contentcuration/frontend/shared/utils/helpers.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/helpers.js
@@ -432,7 +432,13 @@ export function memoizeDebounce(func, wait = 0, options = {}) {
  * be considered a valid value.
  */
 export function cleanBooleanMaps(contentNode) {
-  const booleanMapFields = ['grade_levels', 'learner_needs', 'accessibility_labels', 'learning_activities', 'categories'];
+  const booleanMapFields = [
+    'grade_levels',
+    'learner_needs',
+    'accessibility_labels',
+    'learning_activities',
+    'categories',
+  ];
   booleanMapFields.forEach(field => {
     if (contentNode[field]) {
       Object.keys(contentNode[field]).forEach(key => {


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
Add a quick edit modal to edit content nodes learner needs.


### Screenshots (if applicable)

https://github.com/learningequality/studio/assets/51239030/0add180e-cf01-410a-8231-bbd5ebb8112f

___
## Reviewer guidance
### How can a reviewer test these changes?

1. Go to update a channel content
2. Click on the "Edit 'what is needed'" option on the content node menu.
3. Or you can select multiple content nodes and select "Edit 'what is needed" on the bulk toolbar.

## References
Closes #3422

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
