### PR TITLE
Changed components to KComponents

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -153,12 +153,12 @@
                 </VListTileContent>
                 <template v-if="!copying">
                   <VListTileAction class="actions-end-col">
-                    <IconButton
+                    <KIconButton
                       v-if="isTopic"
                       :aria-hidden="hover"
                       data-test="btn-chevron"
                       icon="chevronRight"
-                      :text="$tr('openTopic')"
+                      :tooltip="$tr('openTopic')"
                       size="small"
                       @click="$emit('topicChevronClick')"
                     />
@@ -209,7 +209,6 @@
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import { RolesNames } from 'shared/leUtils/Roles';
   import ImageOnlyThumbnail from 'shared/views/files/ImageOnlyThumbnail';
-  import IconButton from 'shared/views/IconButton';
   import ToggleText from 'shared/views/ToggleText';
   import ContextMenuCloak from 'shared/views/ContextMenuCloak';
   import DraggableHandle from 'shared/views/draggable/DraggableHandle';
@@ -223,7 +222,6 @@
       DraggableHandle,
       ContextMenuCloak,
       ImageOnlyThumbnail,
-      IconButton,
       ContentNodeValidator,
       ContentNodeChangedIcon,
       ToggleText,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -73,9 +73,10 @@
               v-on="on"
             >
               {{ $formatNumber(errorsInChannel) }}
-              <Icon color="amber">
-                warning
-              </Icon>
+              <KIcon 
+                icon="warningIncomplete"
+              />
+                
             </div>
           </template>
           <span>{{ $tr('incompleteDescendantsText', { count: errorsInChannel }) }}</span>

--- a/contentcuration/contentcuration/frontend/shared/views/AppBar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/AppBar.vue
@@ -31,21 +31,35 @@
           <Menu>
             <template #activator="{ on }">
               <VBtn flat style="text-transform: none;" v-on="on">
-                <Icon>person</Icon>
+                <KIconButton
+                  disabled="true"
+                  icon="person"
+                  color="white"
+                />
                 <span class="mx-2 subheading">{{ user.first_name }}</span>
-                <Icon>arrow_drop_down</Icon>
+                <KIconButton
+                  disabled="true"
+                  icon="dropdown"
+                  color="white"
+                />
               </VBtn>
             </template>
             <VList>
               <VListTile v-if="user.is_admin" :href="administrationLink">
                 <VListTileAction>
-                  <Icon>people</Icon>
+                  <KIconButton
+                    disabled="true"
+                    icon="people"
+                  />
                 </VListTileAction>
                 <VListTileTitle v-text="$tr('administration')" />
               </VListTile>
               <VListTile :href="settingsLink">
                 <VListTileAction>
-                  <Icon>settings</Icon>
+                  <KIconButton
+                    disabled="true"
+                    icon="settings"
+                  />
                 </VListTileAction>
                 <VListTileTitle v-text="$tr('settings')" />
               </VListTile>
@@ -53,7 +67,10 @@
                 @click="showLanguageModal = true"
               >
                 <VListTileAction>
-                  <Icon>language</Icon>
+                  <KIconButton
+                    disabled="true"
+                    icon="language"
+                  />
                 </VListTileAction>
                 <VListTileTitle v-text="$tr('changeLanguage')" />
               </VListTile>
@@ -62,13 +79,19 @@
                 target="_blank"
               >
                 <VListTileAction>
-                  <Icon>open_in_new</Icon>
+                  <KIconButton
+                    disabled="true"
+                    icon="openNewTab"
+                  />
                 </VListTileAction>
                 <VListTileTitle v-text="$tr('help')" />
               </VListTile>
               <VListTile @click="logout">
                 <VListTileAction>
-                  <Icon>exit_to_app</Icon>
+                  <KIconButton
+                    disabled="true"
+                    icon="logout"
+                  />
                 </VListTileAction>
                 <VListTileTitle v-text="$tr('logOut')" />
               </VListTile>

--- a/contentcuration/contentcuration/frontend/shared/views/MainNavigationDrawer.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/MainNavigationDrawer.vue
@@ -10,7 +10,10 @@
     >
       <VToolbar color="primary" dark>
         <VBtn flat icon :tabindex="handleclickTab" @click="drawer = false">
-          <Icon>clear</Icon>
+          <KIconButton
+            icon="clear"
+            color="white"
+          />
         </VBtn>
         <VToolbarTitle class="notranslate">
           Kolibri Studio
@@ -19,7 +22,10 @@
       <VList>
         <VListTile :href="channelsLink" :tabindex="handleclickTab">
           <VListTileAction>
-            <Icon>home</Icon>
+            <KIconButton
+              disabled="true"
+              icon="home"
+            />
           </VListTileAction>
           <VListTileContent class="subheading">
             <VListTileTitle>{{ $tr('channelsLink') }}</VListTileTitle>
@@ -27,7 +33,10 @@
         </VListTile>
         <VListTile v-if="user.is_admin" :href="administrationLink" :tabindex="handleclickTab">
           <VListTileAction>
-            <Icon>people</Icon>
+            <KIconButton
+              disabled="true"
+              icon="people"
+            />
           </VListTileAction>
           <VListTileContent class="subheading">
             <VListTileTitle>{{ $tr('administrationLink') }}</VListTileTitle>
@@ -36,7 +45,10 @@
         </VListTile>
         <VListTile :href="settingsLink" :tabindex="handleclickTab" @click="trackClick('Settings')">
           <VListTileAction>
-            <Icon>settings</Icon>
+            <KIconButton
+              disabled="true"
+              icon="settings"
+            />
           </VListTileAction>
           <VListTileContent class="subheading">
             <VListTileTitle>{{ $tr('settingsLink') }}</VListTileTitle>
@@ -44,7 +56,10 @@
         </VListTile>
         <VListTile @click="openLanguageModal">
           <VListTileAction>
-            <Icon>language</Icon>
+            <KIconButton
+              disabled="true"
+              icon="language"
+            />
           </VListTileAction>
           <VListTileContent class="subheading">
             <VListTileTitle v-text="$tr('changeLanguage')" />
@@ -57,7 +72,10 @@
           @click="trackClick('Help')"
         >
           <VListTileAction>
-            <Icon>open_in_new</Icon>
+            <KIconButton
+              disabled="true"
+              icon="openNewTab"
+            />
           </VListTileAction>
           <VListTileContent class="subheading">
             <VListTileTitle>{{ $tr('helpLink') }}</VListTileTitle>
@@ -65,7 +83,10 @@
         </VListTile>
         <VListTile @click="logout">
           <VListTileAction>
-            <Icon>exit_to_app</Icon>
+            <KIconButton
+              disabled="true"
+              icon="logout"
+            />
           </VListTileAction>
           <VListTileContent class="subheading">
             <VListTileTitle>{{ $tr('logoutLink') }}</VListTileTitle>


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
Updated IconButton to use KComponents (KIcon & KIconButton) instead. This is the part of a series of changes, to be made under [Issue #219](https://github.com/learningequality/kolibri-design-system/issues/219) in Kolibri Design System.
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
https://github.com/learningequality/kolibri-design-system/issues/219




### Screenshots (if applicable)
![change](https://github.com/learningequality/studio/assets/95405559/48284266-dee2-4d6c-bc3c-e45d8ad9667e)
![Screenshot-12](https://github.com/learningequality/studio/assets/95405559/1d9a5a2b-4879-45aa-bf8b-786065ed1a63)


The icons that have been changed


### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->




Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
