### PR TITLE
admin-panel collection error resolved

### DIFF
--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -75,8 +75,10 @@ class ChannelSetViewSet(ValuesViewset):
     field_map = {"secret_token": "secret_token__token"}
 
     def get_queryset(self):
+        queryset = super(ChannelSetViewSet, self).get_queryset()
         user_id = not self.request.user.is_anonymous and self.request.user.id
-        queryset = super(ChannelSetViewSet, self).get_queryset().annotate( edit=Exists( User.channel_sets.through.objects.filter( user_id=user_id, channelset_id=OuterRef("id") ) ) ).filter(edit=True)
+        edit = Exists(User.channel_sets.through.objects.filter(user_id=user_id, channelset_id=OuterRef("id")))
+        queryset = queryset.annotate(edit=edit).filter(edit=True)
         return queryset
 
     def annotate_queryset(self, queryset):

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -78,6 +78,7 @@ class ChannelSetViewSet(ValuesViewset):
         queryset = super(ChannelSetViewSet, self).get_queryset()
         user_id = not self.request.user.is_anonymous and self.request.user.id
         edit = Exists(User.channel_sets.through.objects.filter(user_id=user_id, channelset_id=OuterRef("id")))
+        queryset = queryset.filter(edit=True)
         return queryset.annotate(edit=edit)
 
     def annotate_queryset(self, queryset):

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -75,11 +75,9 @@ class ChannelSetViewSet(ValuesViewset):
     field_map = {"secret_token": "secret_token__token"}
 
     def get_queryset(self):
-        queryset = super(ChannelSetViewSet, self).get_queryset()
         user_id = not self.request.user.is_anonymous and self.request.user.id
-        edit = Exists(User.channel_sets.through.objects.filter(user_id=user_id, channelset_id=OuterRef("id")))
-        queryset = queryset.filter(edit=True)
-        return queryset.annotate(edit=edit)
+        queryset = super(ChannelSetViewSet, self).get_queryset().annotate( edit=Exists( User.channel_sets.through.objects.filter( user_id=user_id, channelset_id=OuterRef("id") ) ) ).filter(edit=True)
+        return queryset
 
     def annotate_queryset(self, queryset):
         return queryset.annotate(


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->
Fixes : #4145 

## Summary
Description:
In the current setup, the frontend was fetching and displaying all channels without properly handling the edit flag or checking if the channels were associated with the current user_id. This inconsistency led to sporadic issues where channels would sometimes show up in the admin list and sometimes not.

Changes Made:

Modified the frontend logic to only fetch and display channels where edit is set to true or the user_id matches the current user.
Ensured proper handling to prevent channels from being displayed inconsistently in the admin list.


### Manual verification steps performed
1. Step 1
2. Step 2
3. ...

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
