### PR TITLE
Make ContentNode Menus Keyboard accessible

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
@@ -2,8 +2,8 @@
 
   <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute>
     <VCard>
-      <slot :showMenu="value">
-        <ContentNodeOptions v-if="value" :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />
+      <slot v-if="value">
+        <ContentNodeOptions :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />
       </slot>
     </VCard>
   </Menu>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeContextMenu.vue
@@ -2,8 +2,8 @@
 
   <Menu v-model="value" :position-x="positionX" :position-y="positionY" absolute>
     <VCard>
-      <slot>
-        <ContentNodeOptions :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />
+      <slot :showMenu="value">
+        <ContentNodeOptions v-if="value" :nodeId="nodeId" :hideDetailsLink="hideDetailsLink" />
       </slot>
     </VCard>
   </Menu>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -71,7 +71,7 @@
                   @click.stop
                 />
               </template>
-              <ContentNodeOptions v-if="!copying" :nodeId="nodeId" />
+              <ContentNodeOptions v-if="!copying && activated" :nodeId="nodeId" />
             </Menu>
           </VListTileAction>
         </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -216,31 +216,31 @@
         };
       },
     },
-    beforeMount() {
-      this.lastFocus = document.activeElement;
-    },
-    mounted() {
-        const animationFrame1 = requestAnimationFrame(() => {
-          const animationFrame2 = requestAnimationFrame(() => {
-            const { optionsList } = this.$refs;
-            const firstOption = optionsList.$el.querySelector('a');
-            if (firstOption) {
-              firstOption.focus();
-            }
-            cancelAnimationFrame(animationFrame2);
-          });
-          cancelAnimationFrame(animationFrame1);
-        });
-    },
-    destroyed() {
-      this.lastFocus && this.lastFocus.focus();
-    },
     watch: {
       moveModalOpen(open) {
         if (open) {
           this.trackAction('Move');
         }
       },
+    },
+    beforeMount() {
+      this.lastFocus = document.activeElement;
+    },
+    mounted() {
+      const animationFrame1 = requestAnimationFrame(() => {
+        const animationFrame2 = requestAnimationFrame(() => {
+          const { optionsList } = this.$refs;
+          const firstOption = optionsList.$el.querySelector('a');
+          if (firstOption) {
+            firstOption.focus();
+          }
+          cancelAnimationFrame(animationFrame2);
+        });
+        cancelAnimationFrame(animationFrame1);
+      });
+    },
+    destroyed() {
+      this.lastFocus && this.lastFocus.focus();
     },
     methods: {
       ...mapMutations('contentNode', {
@@ -310,7 +310,7 @@
         return () => {};
       },
       quickEditModalFactory(modal) {
-        return ($event) => {
+        return $event => {
           this.openQuickEditModal({
             modal,
             nodeIds: [this.nodeId],

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -124,7 +124,6 @@
                         v-else
                         v-model="showMenu"
                         data-test="editMenu"
-
                       >
                         <template #activator="{ on }">
                           <IconButton
@@ -145,12 +144,10 @@
                       :nodeId="nodeId"
                       data-test="contextMenu"
                     >
-                      <template #default="{ showMenu }">
-                        <div class="caption grey--text pt-2 px-3" :class="getTitleClass(node)">
-                          {{ getTitle(node) }}
-                        </div>
-                        <ContentNodeOptions v-if="showMenu" :nodeId="nodeId" />
-                      </template>
+                      <div class="caption grey--text pt-2 px-3" :class="getTitleClass(node)">
+                        {{ getTitle(node) }}
+                      </div>
+                      <ContentNodeOptions :nodeId="nodeId" />
                     </ContentNodeContextMenu>
                   </VLayout>
                 </DraggableHandle>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/StudioTree/StudioTree.vue
@@ -122,7 +122,9 @@
                       />
                       <Menu
                         v-else
+                        v-model="showMenu"
                         data-test="editMenu"
+
                       >
                         <template #activator="{ on }">
                           <IconButton
@@ -132,7 +134,7 @@
                             @click.stop
                           />
                         </template>
-                        <ContentNodeOptions :nodeId="nodeId" />
+                        <ContentNodeOptions v-if="showMenu" :nodeId="nodeId" />
                       </Menu>
                     </VFlex>
                     <ContentNodeContextMenu
@@ -143,10 +145,12 @@
                       :nodeId="nodeId"
                       data-test="contextMenu"
                     >
-                      <div class="caption grey--text pt-2 px-3" :class="getTitleClass(node)">
-                        {{ getTitle(node) }}
-                      </div>
-                      <ContentNodeOptions :nodeId="nodeId" />
+                      <template #default="{ showMenu }">
+                        <div class="caption grey--text pt-2 px-3" :class="getTitleClass(node)">
+                          {{ getTitle(node) }}
+                        </div>
+                        <ContentNodeOptions v-if="showMenu" :nodeId="nodeId" />
+                      </template>
                     </ContentNodeContextMenu>
                   </VLayout>
                 </DraggableHandle>
@@ -257,6 +261,7 @@
         draggableSize: 5,
         draggableExpanded: false,
         debouncedLoad: null,
+        showMenu: false,
       };
     },
     computed: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -11,7 +11,7 @@
             <VFlex class="font-weight-bold text-truncate" shrink :class="getTitleClass(item)">
               {{ getTitle(item) }}
             </VFlex>
-            <Menu v-if="item.displayNodeOptions">
+            <Menu v-if="item.displayNodeOptions" v-model="breadcrumbsMenu">
               <template #activator="{ on }">
                 <IconButton
                   icon="dropdown"
@@ -19,7 +19,7 @@
                   v-on="on"
                 />
               </template>
-              <ContentNodeOptions v-if="node" :nodeId="topicId" />
+              <ContentNodeOptions v-if="node && breadcrumbsMenu" :nodeId="topicId" />
             </Menu>
           </VLayout>
           <span v-else class="grey--text" :class="getTitleClass(item)">
@@ -210,7 +210,7 @@
             :text="$tr('editButton')"
             @click="editNodes([detailNodeId])"
           />
-          <Menu>
+          <Menu v-model="resourceDrawerMenu">
             <template #activator="{ on }">
               <IconButton
                 size="small"
@@ -220,6 +220,7 @@
               />
             </template>
             <ContentNodeOptions
+              v-if="resourceDrawerMenu"
               :nodeId="detailNodeId"
               hideDetailsLink
               hideEditLink
@@ -302,6 +303,8 @@
         loadingAncestors: false,
         elevated: false,
         moveModalOpen: false,
+        breadcrumbsMenu: false,
+        resourceDrawerMenu: false,
       };
     },
     computed: {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Catch keyboard focus when contentNode menus are opened. Added conditional render to menus since Vuetify just mounts the menu once by default, and this does not allow the `mounted` or `destroyed` hooks to be executed.


### Manual verification steps performed

Verified that these menus are keyboard-accesible now:
1. ContentNode menus.
2.  ContentNode deails menus.
3. Breadcrumbs menus.
4. StudioTree elements menus.
5. StudioTree elements context menu.
6. ContentNode context menu.


### Screenshots (if applicable)

https://github.com/learningequality/studio/assets/51239030/745e28d5-9acd-4116-8115-2a2c775e76c4

___
## Reviewer guidance
### How can a reviewer test these changes?
1. Open a channel
2. Navigate to contentNodes Menus with the keyboard

## References
Closes #4369

## Comments
Keyboard navigation is not entirely consistent for now (the outline color changes for example) But this would be solved when the menu is updated to `KDropdownMenu`.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
