### PR TITLE
 Improve errors reporting in edit modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -74,7 +74,7 @@
                     :key="index"
                     @click="handleErrorClick(error)"
                   >
-                    <a class="error-ref">  {{ error }} </a>
+                    <a class="error-ref"> {{ $tr(error) }} </a>
                   </li>
                 </ul>
               </VAlert>
@@ -108,11 +108,11 @@
   import Tabs from 'shared/views/Tabs';
 
   const EditFields = {
-    TITLE: 'Title',
-    LICENSE: 'License',
-    COPYRIGHT_HOLDER: 'Copyright holder',
-    COMPLETION: 'Completion',
-    LEARNING_ACTIVITY: 'Learning activity',
+    TITLE: 'titleLabel',
+    LICENSE: 'licenseLabel',
+    COPYRIGHT_HOLDER: 'copyrightHolderLabel',
+    COMPLETION: 'completionLabel',
+    LEARNING_ACTIVITY: 'learningActivityLabel',
   };
 
   export default {
@@ -325,6 +325,11 @@
       errorBannerText: 'Please provide the required information',
       editingMultipleCount:
         'Editing details for {topicCount, plural,\n =1 {# folder}\n other {# folders}}, {resourceCount, plural,\n =1 {# resource}\n other {# resources}}',
+      titleLabel: 'Title',
+      licenseLabel: 'License',
+      copyrightHolderLabel: 'Copyright holder',
+      completionLabel: 'Completion',
+      learningActivityLabel: 'Learning activity',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -181,8 +181,7 @@
         return this.$tr('editingMultipleCount', totals);
       },
       areDetailsValid() {
-        this.setErrors(this.getNodeDetailsErrorsList(this.nodeIds[0]));
-
+        this.setErrors(this.nodeIds[0]);
         return !this.oneSelected || this.getContentNodeDetailsAreValid(this.nodeIds[0]);
       },
       areAssessmentItemsValid() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditView.vue
@@ -74,7 +74,7 @@
                     :key="index"
                     @click="handleErrorClick(error)"
                   >
-                    {{ error }}
+                    <a class="error-ref">  {{ error }} </a>
                   </li>
                 </ul>
               </VAlert>
@@ -106,6 +106,14 @@
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import ToolBar from 'shared/views/ToolBar';
   import Tabs from 'shared/views/Tabs';
+
+  const EditFields = {
+    TITLE: 'Title',
+    LICENSE: 'License',
+    COPYRIGHT_HOLDER: 'Copyright holder',
+    COMPLETION: 'Completion',
+    LEARNING_ACTIVITY: 'Learning activity',
+  };
 
   export default {
     name: 'EditView',
@@ -245,51 +253,49 @@
       },
       handleErrorClick(error) {
         const errorRefs = {
-          Title: 'title',
-          License: 'license',
-          'Copyright holder': 'copyright_holder',
-          Completion: 'randomize',
-          'Learning Activity': 'learning_activities',
+          [EditFields.TITLE]: 'title',
+          [EditFields.LICENSE]: 'license',
+          [EditFields.COPYRIGHT_HOLDER]: 'copyright_holder',
+          [EditFields.COMPLETION]: 'randomize',
+          [EditFields.LEARNING_ACTIVITY]: 'learning_activities',
         };
 
         const errorRef = errorRefs[error];
-
         const targetElement = this.$refs.detailsTab.$refs[errorRef];
-
-        console.log(targetElement, 'target');
 
         if (!targetElement) {
           console.error(`Target element ref not found for error: ${error}`);
+          return;
         }
 
         const nativeElement = targetElement.$el;
-
-        if (nativeElement.scrollIntoView) {
-          nativeElement.scrollIntoView({ behavior: 'smooth' });
-        }
+        const containerElement = this.$refs.editview;
+        const position = nativeElement.getBoundingClientRect();
+        const offsetY = position.top - nativeElement.clientHeight - 50; //  additional padding of 50 to adjust position.
+        containerElement.scrollTo({ top: offsetY, behavior: 'smooth' });
       },
-      setErrors(errorTags) {
-        const errorsTagList = this.getNodeDetailsErrorsList(errorTags);
+      setErrors(nodeId) {
+        const errorsTagList = this.getNodeDetailsErrorsList(nodeId);
         // fetch unique errors
         // set that to errorsList
         const errorRefs = {
-          TITLE_REQUIRED: 'Title',
-          LICENSE_REQUIRED: 'License',
-          COPYRIGHT_HOLDER_REQUIRED: 'Copyright holder',
-          MASTERY_MODEL_REQUIRED: 'Completion',
-          MASTERY_MODEL_M_REQUIRED: 'Completion',
-          MASTERY_MODEL_M_WHOLE_NUMBER: 'Completion',
-          MASTERY_MODEL_M_GT_ZERO: 'Completion',
-          MASTERY_MODEL_M_LTE_N: 'Completion',
-          MASTERY_MODEL_N_REQUIRED: 'Completion',
-          MASTERY_MODEL_N_WHOLE_NUMBER: 'Completion',
-          MASTERY_MODEL_N_GT_ZERO: 'Completion',
-          LEARNING_ACTIVITY_REQUIRED: 'Learning Activity',
+          TITLE_REQUIRED: EditFields.TITLE,
+          LICENSE_REQUIRED: EditFields.LICENSE,
+          COPYRIGHT_HOLDER_REQUIRED: EditFields.COPYRIGHT_HOLDER,
+          MASTERY_MODEL_REQUIRED: EditFields.COMPLETION,
+          MASTERY_MODEL_M_REQUIRED: EditFields.COMPLETION,
+          MASTERY_MODEL_M_WHOLE_NUMBER: EditFields.COMPLETION,
+          MASTERY_MODEL_M_GT_ZERO: EditFields.COMPLETION,
+          MASTERY_MODEL_M_LTE_N: EditFields.COMPLETION,
+          MASTERY_MODEL_N_REQUIRED: EditFields.COMPLETION,
+          MASTERY_MODEL_N_WHOLE_NUMBER: EditFields.COMPLETION,
+          MASTERY_MODEL_N_GT_ZERO: EditFields.COMPLETION,
+          LEARNING_ACTIVITY_REQUIRED: EditFields.LEARNING_ACTIVITY,
         };
 
         const uniqueErrorsSet = new Set();
         for (const error of errorsTagList) {
-          if (Object.prototype.hasOwnProperty.call(errorRefs, error)) {
+          if (errorRefs[error]) {
             uniqueErrorsSet.add(errorRefs[error]);
           }
         }
@@ -366,6 +372,11 @@
     min-width: 100%;
     max-height: inherit;
     overflow: auto;
+  }
+
+  .error-ref {
+    color: inherit;
+    text-decoration: underline;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -129,6 +129,13 @@ export function getContentNodeDetailsAreValid(state) {
   };
 }
 
+export function getNodeDetailsErrorsList(state) {
+  return function(contentNodeId) {
+    const contentNode = state.contentNodesMap[contentNodeId];
+    return getNodeDetailsErrors(contentNode);
+  };
+}
+
 export function getContentNodeFilesAreValid(state, getters, rootState, rootGetters) {
   return function(contentNodeId) {
     const contentNode = state.contentNodesMap[contentNodeId];


### PR DESCRIPTION

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
The approach used to improve error reporting in the edit modal is by getting all the errors list. Mapping that errorsList with their names and reference objects. Using that reference object we'll be using scrollIntoView to allow the user to direct themselves to the required input left blank.

### Manual verification steps performed
1. Click on a channel
2. Access and edit resources
3. The Edit details tab will open

### Screenshots (if applicable)
![image](https://github.com/learningequality/studio/assets/84982038/0dfa49da-d5df-4598-bafb-e68398c6e5bb)

### Does this introduce any tech-debt items?

Some changes that needs to add to the current PR are: 
- Some CSS properties need to be added to the list of errors such as hover cursor, and underlining.
-  The `scrollIntoView` moves into view a bit below the actual input element.
- If there is only 1 issue then the scrollIntoView will scroll to that one target element.

### Reference

The PR is in reference with issue: https://github.com/learningequality/studio/issues/2924
___

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Click on a channel
2. Access and edit resources
3. The Edit details tab will open

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
