### PR TITLE
Updated Components to KComponents

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -93,23 +93,23 @@
               :to="channelDetailsLink"
             >
 
-              <IconButton
+              <KIconButton
                 :color="$themeTokens.primary"
                 data-test="details-button"
                 class="mr-1"
                 icon="info"
-                :text="$tr('details')"
+                :tooltip="$tr('details')"
                 @mouseenter.native="hideHighlight = true"
                 @mouseleave.native="hideHighlight = false"
               />
 
             </KRouterLink>
 
-            <IconButton
+            <KIconButton
               v-if="!allowEdit && channel.published"
               class="mr-1"
               icon="copy"
-              :text="$tr('copyToken')"
+              :tooltip="$tr('copyToken')"
               data-test="token-button"
               @click.stop.prevent="tokenDialog = true"
               @mouseenter.native="hideHighlight = true"
@@ -145,7 +145,10 @@
                   @click.stop
                 >
                   <VListTileAvatar>
-                    <Icon>edit</Icon>
+                    <KIconButton
+                      disabled="true"
+                      icon="edit"
+                    />
                   </VListTileAvatar>
                   <VListTileTitle>{{ $tr('editChannel') }}</VListTileTitle>
                 </VListTile>
@@ -155,7 +158,10 @@
                   @click="tokenDialog = true"
                 >
                   <VListTileAvatar>
-                    <Icon>content_copy</Icon>
+                    <KIconButton
+                      disabled="true"
+                      icon="copy"
+                    />
                   </VListTileAvatar>
                   <VListTileTitle>{{ $tr('copyToken') }}</VListTileTitle>
                 </VListTile>
@@ -190,7 +196,10 @@
                   @click.stop="deleteDialog = true"
                 >
                   <VListTileAvatar>
-                    <Icon>delete</Icon>
+                    <KIconButton
+                      disabled="true"
+                      icon="delete"
+                    />
                   </VListTileAvatar>
                   <VListTileTitle>{{ $tr('deleteChannel') }}</VListTileTitle>
                 </VListTile>
@@ -232,7 +241,6 @@
   import ChannelTokenModal from 'shared/views/channel/ChannelTokenModal';
   import Thumbnail from 'shared/views/files/Thumbnail';
   import Languages from 'shared/leUtils/Languages';
-  import IconButton from 'shared/views/IconButton';
 
   export default {
     name: 'ChannelItem',
@@ -240,7 +248,6 @@
       ChannelStar,
       ChannelTokenModal,
       Thumbnail,
-      IconButton,
     },
     props: {
       channelId: {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -198,7 +198,7 @@
                   <VListTileAvatar>
                     <KIconButton
                       disabled="true"
-                      icon="delete"
+                      icon="trash"
                     />
                   </VListTileAvatar>
                   <VListTileTitle>{{ $tr('deleteChannel') }}</VListTileTitle>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelStar.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelStar.vue
@@ -2,10 +2,10 @@
 
   <!-- Adding div wrapper as tests fail when VTooltip is the root -->
   <div style="display: inline-block;">
-    <IconButton
+    <KIconButton
       data-test="button"
       :icon="bookmark ? 'star' : 'starBorder'"
-      :text="starText"
+      :tooltip="starText"
       v-bind="$attrs"
       @click="toggleStar"
     />
@@ -16,13 +16,10 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
-  import IconButton from 'shared/views/IconButton';
 
   export default {
     name: 'ChannelStar',
-    components: {
-      IconButton,
-    },
+
     props: {
       channelId: {
         type: String,


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
Updated IconButton to use KComponents (KIcon & KIconButton) instead. This is the part of a series of changes, to be made under [Issue #219](https://github.com/learningequality/kolibri-design-system/issues/219) in Kolibri Design System.
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
https://github.com/learningequality/kolibri-design-system/issues/219




### Screenshots (if applicable)
![changes new 2](https://github.com/learningequality/studio/assets/95405559/66035332-3f99-4c25-b0f5-2f14e5913c04)
![changes new](https://github.com/learningequality/studio/assets/95405559/9625d2e5-42b4-46bd-a7cf-1f1366183800)



The icons that have been changed

## Comments
Could not find the Bin icon under [Icons](https://design-system.learningequality.org/icons/l), so used delete icon for `Delete Channel` dropdown option.
### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->




Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
