### PR TITLE
update django_bulk_update with inbuilt bulk_update

### DIFF
--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -233,7 +233,7 @@ def sync_node_assessment_items(node, original):  # noqa C901
         node.changed = True
 
     if ai_to_update:
-        AssessmentItem.objects.bulk_update(ai_to_update, ['assessment_item_fields'])
+        AssessmentItem.objects.bulk_update(ai_to_update, list(assessment_item_fields))
         node.changed = True
 
     if files_to_delete:

--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -4,7 +4,6 @@ import copy
 import logging
 
 from django.db.models import Q
-from django_bulk_update.helper import bulk_update
 from le_utils.constants import content_kinds
 from le_utils.constants import format_presets
 
@@ -234,7 +233,7 @@ def sync_node_assessment_items(node, original):  # noqa C901
         node.changed = True
 
     if ai_to_update:
-        bulk_update(ai_to_update, update_fields=assessment_item_fields)
+        AssessmentItem.objects.bulk_update(ai_to_update, update_fields=['assessment_item_fields'])
         node.changed = True
 
     if files_to_delete:

--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -233,7 +233,7 @@ def sync_node_assessment_items(node, original):  # noqa C901
         node.changed = True
 
     if ai_to_update:
-        AssessmentItem.objects.bulk_update(ai_to_update, update_fields=['assessment_item_fields'])
+        AssessmentItem.objects.bulk_update(ai_to_update, ['assessment_item_fields'])
         node.changed = True
 
     if files_to_delete:

--- a/contentcuration/contentcuration/viewsets/assessmentitem.py
+++ b/contentcuration/contentcuration/viewsets/assessmentitem.py
@@ -2,7 +2,6 @@ import json
 import re
 
 from django.db import transaction
-from django_bulk_update.helper import bulk_update
 from le_utils.constants import exercises
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
@@ -193,7 +192,7 @@ class AssessmentItemSerializer(BulkModelSerializer):
                 raise ValidationError(
                     "Attempted to set files to an assessment item that do not have a file on the server"
                 )
-            bulk_update(source_files)
+            File.objects.bulk_update(source_files, ['assessment_item'])
 
     def create(self, validated_data):
         with transaction.atomic():

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -322,7 +322,8 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
             self.missing_keys = set(all_validated_data_by_id.keys())\
                 .difference(updated_keys)
 
-        self.child.Meta.model.objects.bulk_update(updated_objects, list(properties_to_update))
+        if len(properties_to_update) > 0:
+            self.child.Meta.model.objects.bulk_update(updated_objects, list(properties_to_update))
 
         return updated_objects
 

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -9,7 +9,6 @@ from django.db.models import Q
 from django.db.utils import IntegrityError
 from django.http import Http404
 from django.http.request import HttpRequest
-from django_bulk_update.helper import bulk_update
 from django_celery_results.models import TaskResult
 from django_filters.constants import EMPTY_VALUES
 from django_filters.rest_framework import DjangoFilterBackend
@@ -323,7 +322,7 @@ class BulkListSerializer(SimpleReprMixin, ListSerializer):
             self.missing_keys = set(all_validated_data_by_id.keys())\
                 .difference(updated_keys)
 
-        bulk_update(updated_objects, update_fields=properties_to_update)
+        self.child.Meta.model.objects.bulk_update(updated_objects, list(properties_to_update))
 
         return updated_objects
 

--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,6 @@ django-redis
 django-prometheus
 future
 sentry-sdk
-django-bulk-update
 html5lib==1.1
 pillow==9.4.0
 python-dateutil>=2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,8 +65,6 @@ django==3.2.23
     #   django-s3-storage
     #   djangorestframework
     #   jsonfield
-django-bulk-update==2.2.0
-    # via -r requirements.in
 django-celery-results==2.4.0
     # via -r requirements.in
 django-cte==1.2.1


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

I have remove django_bulk_update function in 2 files:
- contentcuration/contentcuration/utils/sync.py
- contentcuration/contentcuration/viewsets/assessmentitem.py

### Manual verification steps performed
1. pytest command used for testing

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- Pytest command to check whether functionalities are working 

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References

- https://docs.djangoproject.com/en/3.2/ref/models/querysets/#bulk-update
- Referencing issue https://github.com/learningequality/studio/issues/4409

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that do not apply to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
