### PR TITLE
Quick edit modal to edit Source

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -6,10 +6,13 @@
       :title="$tr('editAttribution')"
       :submitText="$tr('saveAction')"
       :cancelText="$tr('cancelAction')"
-      data-test="edit-title-description-modal"
+      data-test="edit-source-modal"
       @submit="handleSave"
       @cancel="close"
     >
+      <p data-test="resources-selected-message">
+        {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+      </p>
       <div class="form-item">
         <div class="input-container">
           <KTextbox
@@ -212,6 +215,7 @@
       close() {
         this.$emit('close');
       },
+      validate() {},
       async handleSave() {
         if (!this.isEditable) {
           return this.close();
@@ -252,6 +256,8 @@
       aggregatorLabel: 'Aggregator',
       aggregatorToolTip:
         'Website or org hosting the content collection but not necessarily the creator or copyright holder',
+      resourcesSelected:
+        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
       copyrightHolderLabel: 'Copyright holder',
       cannotEditPublic: 'Cannot edit for public channel resources',
       editOnlyLocal: 'Edits will be reflected only for local resources',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -53,8 +53,8 @@
       <div class="form-item">
         <div class="input-container">
           <LicenseDropdown
-            box
             v-model="licenseItem"
+            box
             :disabled="!isEditable"
           />
         </div>
@@ -90,10 +90,10 @@
 <script>
 
   import { mapActions, mapGetters } from 'vuex';
+  import { isDisableSourceEdits } from '../../utils';
   import { nonUniqueValue } from 'shared/constants';
   import HelpTooltip from 'shared/views/HelpTooltip';
   import LicenseDropdown from 'shared/views/LicenseDropdown';
-  import { isDisableSourceEdits } from '../../utils';
 
   function generateGetterSetter(key) {
     return {
@@ -107,32 +107,38 @@
         this[key] = value;
       },
     };
-  };
+  }
 
   function mapFormGettersSetters(keys) {
     return keys.reduce((acc, key) => {
-      return {
-        ...acc,
-        [`${key}_value`]: generateGetterSetter(key),
-      };
+      acc[`${key}_value`] = generateGetterSetter(key);
+      return acc;
     }, {});
   }
 
-  const sourceKeys = ['author', 'provider', 'aggregator', 'license', 'license_description', 'copyright_holder'];
+  const sourceKeys = [
+    'author',
+    'provider',
+    'aggregator',
+    'license',
+    'license_description',
+    'copyright_holder',
+  ];
 
   export default {
-    name: 'EditTitleDescriptionModal',
+    name: 'EditSourceModal',
+    components: {
+      HelpTooltip,
+      LicenseDropdown,
+    },
     props: {
       nodeIds: {
         type: Array,
         required: true,
       },
     },
-    components: {
-      HelpTooltip,
-      LicenseDropdown,
-    },
     data() {
+      /* eslint-disable  kolibri/vue-no-unused-properties */
       return {
         author: '',
         provider: '',
@@ -158,7 +164,7 @@
           return {
             license,
             license_description,
-          }
+          };
         },
         set(value) {
           this.license = value.license;
@@ -166,18 +172,13 @@
         },
       },
       isEditable() {
-        // If at least one is editable
         return this.nodes.some(node => !isDisableSourceEdits(node));
       },
       hasSomeEditDisabled() {
         return this.nodes.some(node => isDisableSourceEdits(node));
       },
       hasError() {
-        return (
-          this.licenseError ||
-          this.licenseDescriptionError ||
-          this.copyrightHolderError
-        );
+        return this.licenseError || this.licenseDescriptionError || this.copyrightHolderError;
       },
       helpText() {
         if (!this.isEditable) {
@@ -187,12 +188,12 @@
           return this.$tr('editOnlyLocal');
         }
         return '';
-      }
+      },
     },
     created() {
       const values = {};
-      this.nodes.forEach((node) => {
-        sourceKeys.forEach((prop) => {
+      this.nodes.forEach(node => {
+        sourceKeys.forEach(prop => {
           if (node[prop]) {
             if (!values[prop]) {
               values[prop] = node[prop];
@@ -202,7 +203,7 @@
           }
         });
       });
-      sourceKeys.forEach((prop) => {
+      sourceKeys.forEach(prop => {
         this[prop] = values[prop] || '';
       });
     },
@@ -221,22 +222,24 @@
         }
         const nodesToEdit = this.nodes.filter(node => !isDisableSourceEdits(node));
         await Promise.all(
-          nodesToEdit
-            .map(node => {
-              const payload = {
-                id: node.id,
-              };
-              sourceKeys.forEach((prop) => {
-                const value = this[prop];
-                if (value !== nonUniqueValue) {
-                  payload[prop] = value;
-                }
-              });
-              return this.updateContentNode(payload);
-            })
+          nodesToEdit.map(node => {
+            const payload = {
+              id: node.id,
+            };
+            sourceKeys.forEach(prop => {
+              const value = this[prop];
+              if (value !== nonUniqueValue) {
+                payload[prop] = value;
+              }
+            });
+            return this.updateContentNode(payload);
+          })
         );
 
-        this.$store.dispatch('showSnackbarSimple', this.$tr('editedAttribution', { count: nodesToEdit.length }));
+        this.$store.dispatch(
+          'showSnackbarSimple',
+          this.$tr('editedAttribution', { count: nodesToEdit.length })
+        );
         this.close();
       },
     },
@@ -255,7 +258,8 @@
       mixed: 'Mixed',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      editedAttribution: 'Edited attribution for {count, number, integer} {count, plural, one {resource} other {resources}}',
+      editedAttribution:
+        'Edited attribution for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 
@@ -265,29 +269,35 @@
 
   .form-item {
     position: relative;
+
     &:not(:last-of-type) {
       margin-bottom: 10px;
     }
-    & > p.help {
+
+    > p.help {
       position: absolute;
-      bottom: 0px;
+      bottom: 0;
       left: 10px;
-      color: var(--v-text-lighten4);
-      font-size: 12px;
       margin-bottom: 14px;
+      font-size: 12px;
+      color: var(--v-text-lighten4);
     }
+
     .input-container {
+      position: relative;
       display: flex;
       align-items: flex-start;
-      position: relative;
-      & > div {
+
+      > div {
         width: 100%;
       }
+
       /deep/ .v-icon {
-        margin: 14px 0 0 8px;
         position: absolute;
         right: 12px;
+        margin: 14px 0 0 8px;
       }
+
       /deep/ input {
         padding-right: 40px;
       }

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -1,0 +1,174 @@
+<template>
+
+  <div>
+    <KModal
+      v-if="!isAboutLicensesModalOpen"
+      :title="$tr('editAttribution')"
+      :submitText="$tr('saveAction')"
+      :cancelText="$tr('cancelAction')"
+      data-test="edit-title-description-modal"
+      @submit="handleSave"
+      @cancel="close"
+    >
+      <div class="input-container">
+        <KTextbox
+          v-model="author"
+          autofocus
+          data-test="author-input"
+          :maxlength="200"
+          :label="$tr('authorLabel')"
+        />
+        <HelpTooltip :text="$tr('authorToolTip')" top :small="false" />
+      </div>
+      <div class="input-container">
+        <KTextbox
+          v-model="provider"
+          autofocus
+          data-test="provider-input"
+          :maxlength="200"
+          :label="$tr('providerLabel')"
+        />
+        <HelpTooltip :text="$tr('providerToolTip')" top :small="false" />
+      </div>
+      <div class="input-container">
+        <KTextbox
+          v-model="aggregator"
+          autofocus
+          data-test="aggregator-input"
+          :maxlength="200"
+          :label="$tr('aggregatorLabel')"
+        />
+        <HelpTooltip :text="$tr('aggregatorToolTip')" top :small="false" />
+      </div>
+      <LicenseDropdown box/>
+      <div class="input-container">
+        <KTextbox
+          v-model="copyrightHolder"
+          autofocus
+          data-test="copyright-holder-input"
+          showInvalidText
+          :maxlength="200"
+          :label="$tr('copyrightHolderLabel')"
+          :invalid="!!copyrightHolderError"
+          :invalidText="copyrightHolderError"
+          @input="copyrightHolderError = ''"
+          @blur="() => {}"
+        />
+      </div>
+    </KModal>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapActions, mapGetters } from 'vuex';
+  import HelpTooltip from 'shared/views/HelpTooltip';
+  import LicenseDropdown from 'shared/views/LicenseDropdown';
+  import { getTitleValidators, getInvalidText } from 'shared/utils/validation';
+
+  export default {
+    name: 'EditTitleDescriptionModal',
+    props: {
+      nodeId: {
+        type: String,
+        required: true,
+      },
+    },
+    components: {
+      HelpTooltip,
+      LicenseDropdown,
+    },
+    data() {
+      return {
+        author: '',
+        provider: '',
+        aggregator: '',
+        license: '',
+        licenseDescription: '',
+        copyrightHolder: '',
+        licenseError: '',
+        licenseDescriptionError: '',
+        copyrightHolderError: '',
+      };
+    },
+    computed: {
+      ...mapGetters(['isAboutLicensesModalOpen']),
+      ...mapGetters('contentNode', ['getContentNodes']),
+      nodes() {
+        return this.getContentNodes(this.nodeIds);
+      },
+    },
+    created() {
+      this.title = this.contentNode.title || '';
+      this.description = this.contentNode.description || '';
+    },
+    methods: {
+      ...mapActions('contentNode', ['updateContentNode']),
+      validateTitle() {
+        this.titleError = getInvalidText(getTitleValidators(), this.title);
+      },
+      close() {
+        this.$emit('close');
+      },
+      async handleSave() {
+        this.validateTitle();
+        if (this.titleError) {
+          return;
+        }
+
+        const { nodeId, title, description } = this;
+        await this.updateContentNode({
+          id: nodeId,
+          title: title.trim(),
+          description: description.trim(),
+        });
+
+        this.$store.dispatch('showSnackbarSimple', this.$tr('editedAttribution', { count: this.nodes.length }));
+        this.close();
+      },
+    },
+    $trs: {
+      editAttribution: 'Edit Attribution',
+      authorLabel: 'Author',
+      authorToolTip: 'Person or organization who created this content',
+      providerLabel: 'Provider',
+      providerToolTip: 'Organization that commissioned or is distributing the content',
+      aggregatorLabel: 'Aggregator',
+      aggregatorToolTip:
+        'Website or org hosting the content collection but not necessarily the creator or copyright holder',
+      copyrightHolderLabel: 'Copyright holder',
+      cannotEditPublic: 'Cannot edit for public channel resources',
+      editOnlyLocal: 'Edits will be reflected only for local resources',
+      mixedLabel: 'Mixed',
+      saveAction: 'Save',
+      cancelAction: 'Cancel',
+      editedAttribution: 'Edited attribution for {count, number, integer} {count, plural, one {resource} other {resources}}',
+    },
+  };
+
+</script>
+
+<style lang="scss" scoped>
+
+  .input-container {
+    display: flex;
+    align-items: flex-start;
+    &:not(:last-of-type) {
+      margin-bottom: 10px;
+    }
+    & > div {
+      width: 100%;
+    }
+    /deep/ .v-icon {
+      margin: 14px 0 0 8px;
+      position: absolute;
+      right: 36px;
+    }
+    /deep/ input {
+      padding-right: 40px;
+    }
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -40,10 +40,15 @@
         />
         <HelpTooltip :text="$tr('aggregatorToolTip')" top :small="false" />
       </div>
-      <LicenseDropdown box/>
+      <div class="input-container">
+        <LicenseDropdown
+          v-model="licenseItem"
+          box
+        />
+      </div>
       <div class="input-container">
         <KTextbox
-          v-model="copyrightHolder"
+          v-model="copyright_holder"
           autofocus
           data-test="copyright-holder-input"
           showInvalidText
@@ -71,8 +76,8 @@
   export default {
     name: 'EditTitleDescriptionModal',
     props: {
-      nodeId: {
-        type: String,
+      nodeIds: {
+        type: Array,
         required: true,
       },
     },
@@ -86,8 +91,8 @@
         provider: '',
         aggregator: '',
         license: '',
-        licenseDescription: '',
-        copyrightHolder: '',
+        license_description: '',
+        copyright_holder: '',
         licenseError: '',
         licenseDescriptionError: '',
         copyrightHolderError: '',
@@ -99,10 +104,37 @@
       nodes() {
         return this.getContentNodes(this.nodeIds);
       },
+      licenseItem: {
+        get() {
+          return {
+            license: this.license,
+            license_description: this.license_description,
+          }
+        },
+        set(value) {
+          this.license = value.license;
+          this.license_description = value.license_description;
+        },
+      },
     },
     created() {
-      this.title = this.contentNode.title || '';
-      this.description = this.contentNode.description || '';
+      console.log('EditSourceModal created', this.nodes);
+      const sourceProps = ['author', 'provider', 'aggregator', 'license', 'license_description', 'copyright_holder'];
+      const values = {};
+      this.nodes.forEach((node) => {
+        sourceProps.forEach((prop) => {
+          if (node[prop]) {
+            if (!values[prop]) {
+              values[prop] = node[prop];
+            } else if (values[prop] !== node[prop]) {
+              values[prop] = 'Mixed';
+            }
+          }
+        });
+      });
+      sourceProps.forEach((prop) => {
+        this[prop] = values[prop] || '';
+      });
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
@@ -128,6 +160,7 @@
         this.$store.dispatch('showSnackbarSimple', this.$tr('editedAttribution', { count: this.nodes.length }));
         this.close();
       },
+      getPropertyValue() {},
     },
     $trs: {
       editAttribution: 'Edit Attribution',
@@ -155,6 +188,7 @@
   .input-container {
     display: flex;
     align-items: flex-start;
+    position: relative;
     &:not(:last-of-type) {
       margin-bottom: 10px;
     }
@@ -164,7 +198,7 @@
     /deep/ .v-icon {
       margin: 14px 0 0 8px;
       position: absolute;
-      right: 36px;
+      right: 12px;
     }
     /deep/ input {
       padding-right: 40px;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -58,6 +58,7 @@
           <LicenseDropdown
             v-model="licenseItem"
             box
+            :required="isEditable"
             :disabled="!isEditable"
           />
         </div>
@@ -77,7 +78,7 @@
             :invalidText="copyrightHolderError"
             :disabled="!isEditable"
             @input="copyrightHolderError = ''"
-            @blur="() => {}"
+            @blur="validateCopyrightHolder"
           />
         </div>
         <p v-if="helpText" class="help">
@@ -97,6 +98,7 @@
   import { nonUniqueValue } from 'shared/constants';
   import HelpTooltip from 'shared/views/HelpTooltip';
   import LicenseDropdown from 'shared/views/LicenseDropdown';
+  import { getCopyrightHolderValidators, getInvalidText } from 'shared/utils/validation';
 
   function generateGetterSetter(key) {
     return {
@@ -149,10 +151,9 @@
         license: '',
         license_description: '',
         copyright_holder: '',
-        licenseError: '',
-        licenseDescriptionError: '',
         copyrightHolderError: '',
       };
+      /* eslint-enable  kolibri/vue-no-unused-properties */
     },
     computed: {
       ...mapGetters(['isAboutLicensesModalOpen']),
@@ -181,7 +182,7 @@
         return this.nodes.some(node => isDisableSourceEdits(node));
       },
       hasError() {
-        return this.licenseError || this.licenseDescriptionError || this.copyrightHolderError;
+        return this.copyrightHolderError;
       },
       helpText() {
         if (!this.isEditable) {
@@ -215,7 +216,19 @@
       close() {
         this.$emit('close');
       },
-      validate() {},
+      validateCopyrightHolder() {
+        if (this.copyright_holder === nonUniqueValue) {
+          return;
+        }
+        this.copyrightHolderError = getInvalidText(
+          getCopyrightHolderValidators(),
+          this.copyright_holder
+        );
+      },
+      validate() {
+        // License is required, but it is handled by the LicenseDropdown component
+        this.validateCopyrightHolder();
+      },
       async handleSave() {
         if (!this.isEditable) {
           return this.close();

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditSourceModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditSourceModal.spec.js
@@ -1,0 +1,228 @@
+import { mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import EditSourceModal from '../EditSourceModal';
+import { LicensesList } from 'shared/leUtils/Licenses';
+import { constantsTranslationMixin } from 'shared/mixins';
+import EditTitleDescriptionModal from '../EditTitleDescriptionModal';
+
+const nodeId = 'test-id';
+
+let nodes;
+
+let store;
+let contentNodeActions;
+let generalActions;
+let generalGetters;
+
+const MIXED_VALUE = 'mixed';
+
+const getLicenseId = translatedLicense => {
+  if (translatedLicense === 'Mixed') {
+    return MIXED_VALUE;
+  }
+  const translatedLicenses = LicensesList.reduce((acc, license) => {
+    const { translateConstant } = constantsTranslationMixin.methods;
+    acc[translateConstant(license.license_name)] = license.id;
+    return acc;
+  }, {});
+  return translatedLicenses[translatedLicense];
+};
+
+const getSourceValues = wrapper => {
+  return {
+    author: wrapper.find('[data-test="author-input"] input').element.value,
+    provider: wrapper.find('[data-test="provider-input"] input').element.value,
+    aggregator: wrapper.find('[data-test="aggregator-input"] input').element.value,
+    license: getLicenseId(wrapper.find('.v-select__selections').element.textContent),
+    license_description: wrapper.find('.license-description textarea')?.element?.value,
+    copyright_holder: wrapper.find('[data-test="copyright-holder-input"] input').element.value,
+  };
+};
+
+const makeWrapper = nodeIds => {
+  return mount(EditSourceModal, {
+    store,
+    propsData: {
+      nodeIds,
+    },
+  });
+};
+
+describe('EditSourceModal', () => {
+  beforeEach(() => {
+    nodes = {
+      node1: { id: 'node1' },
+      node2: { id: 'node2' },
+    };
+    contentNodeActions = {
+      updateContentNode: jest.fn(),
+    };
+    generalActions = {
+      showSnackbarSimple: jest.fn(),
+    };
+    generalGetters = {
+      isAboutLicensesModalOpen: () => false,
+    };
+    store = new Vuex.Store({
+      actions: generalActions,
+      getters: generalGetters,
+      modules: {
+        contentNode: {
+          namespaced: true,
+          actions: contentNodeActions,
+          getters: {
+            getContentNodes: () => ids => ids.map(id => nodes[id]),
+          },
+        },
+      },
+    });
+  });
+
+  test('smoke test', () => {
+    const wrapper = makeWrapper(['node1']);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  describe('Selected source on first render', () => {
+    test.only('should display the correct source values when 1 node is selected', async () => {
+      nodes['node1'].author = 'author1';
+      nodes['node1'].license = 9;
+      nodes['node1'].license_description = 'abdcds';
+      const wrapper = makeWrapper(['node1']);
+
+      console.log('aaa wrapper html', wrapper.html());
+      console.log('aaa', getSourceValues(wrapper));
+      expect(true).toBe(true);
+    });
+  });
+
+  test('should call updateContentNode on success submit', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+    expect(contentNodeActions.updateContentNode).toHaveBeenCalled();
+  });
+
+  test('should call updateContentNode with the correct parameters on success submit', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    const newTitle = 'new-title';
+    const newDescription = 'new-description';
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', 'new-title');
+    wrapper.find('[data-test="description-input"]').vm.$emit('input', 'new-description');
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+      id: nodeId,
+      title: newTitle,
+      description: newDescription,
+    });
+  });
+
+  test('should let update even if description is empty', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    const newTitle = 'new-title';
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', 'new-title');
+    wrapper.find('[data-test="description-input"]').vm.$emit('input', '');
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+      id: nodeId,
+      title: newTitle,
+      description: '',
+    });
+  });
+
+  test('should validate title on blur', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', '');
+    wrapper.find('[data-test="title-input"]').vm.$emit('blur');
+
+    expect(wrapper.find('[data-test="title-input"]').vm.$props.invalidText).toBeTruthy();
+  });
+
+  test('should validate title on submit', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    wrapper.find('[data-test="title-input"]').vm.$emit('input', '');
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    expect(wrapper.find('[data-test="title-input"]').vm.$props.invalidText).toBeTruthy();
+  });
+
+  test("should show 'Edited title and description' on a snackbar on success submit", () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    const animationFrameId = requestAnimationFrame(() => {
+      expect(generalActions.showSnackbarSimple).toHaveBeenCalledWith(
+        expect.anything(),
+        'Edited title and description'
+      );
+      cancelAnimationFrame(animationFrameId);
+    });
+  });
+
+  test("should emit 'close' event on success submit", () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('submit');
+
+    const animationFrameId = requestAnimationFrame(() => {
+      expect(wrapper.emitted().close).toBeTruthy();
+      cancelAnimationFrame(animationFrameId);
+    });
+  });
+
+  test('should emit close event on cancel', () => {
+    const wrapper = mount(EditTitleDescriptionModal, {
+      store,
+      propsData: {
+        nodeId,
+      },
+    });
+
+    wrapper.find('[data-test="edit-title-description-modal"]').vm.$emit('cancel');
+    expect(wrapper.emitted().close).toBeTruthy();
+  });
+});

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditSourceModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditSourceModal.spec.js
@@ -48,8 +48,14 @@ const makeWrapper = nodeIds => {
 describe('EditSourceModal', () => {
   beforeEach(() => {
     nodes = {
-      node1: { id: 'node1' },
-      node2: { id: 'node2' },
+      node1: {
+        id: 'node1',
+        copyright_holder: 'Test',
+      },
+      node2: {
+        id: 'node2',
+        copyright_holder: 'Test',
+      },
     };
     contentNodeActions = {
       updateContentNode: jest.fn(),
@@ -188,6 +194,14 @@ describe('EditSourceModal', () => {
   });
 
   describe('On submit', () => {
+    test('should not call updateContentNode on submit if copyright holder is missing', () => {
+      nodes['node1'].copyright_holder = '';
+      const wrapper = makeWrapper(['node1']);
+      wrapper.find('[data-test="edit-source-modal"]').vm.$emit('submit');
+
+      expect(contentNodeActions.updateContentNode).not.toHaveBeenCalled();
+    });
+
     test('should call updateContentNode on success submit for all editable nodes', () => {
       const wrapper = makeWrapper(['node1', 'node2']);
       wrapper.find('[data-test="edit-source-modal"]').vm.$emit('submit');

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
@@ -31,6 +31,11 @@
       :nodeIds="nodeIds"
       @close="close"
     />
+    <EditSourceModal
+      v-if="isEditSourceOpen"
+      :nodeIds="nodeIds"
+      @close="close"
+    />
     <EditAudienceModal
       v-if="isAudienceOpen"
       :nodeIds="nodeIds"
@@ -45,6 +50,7 @@
 
   import { mapGetters, mapMutations } from 'vuex';
   import { QuickEditModals } from '../../constants';
+  import EditSourceModal from './EditSourceModal';
   import EditLevelsModal from './EditLevelsModal';
   import EditLanguageModal from './EditLanguageModal';
   import EditAudienceModal from './EditAudienceModal';
@@ -56,6 +62,7 @@
   export default {
     name: 'QuickEditModal',
     components: {
+      EditSourceModal,
       EditLevelsModal,
       EditLanguageModal,
       EditAudienceModal,
@@ -97,6 +104,9 @@
       },
       isLearningActivitiesOpen() {
         return this.openedModal === QuickEditModals.LEARNING_ACTIVITIES;
+      },
+      isEditSourceOpen() {
+        return this.openedModal === QuickEditModals.SOURCE;
       },
       isAudienceOpen() {
         return this.openedModal === QuickEditModals.AUDIENCE;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -374,7 +374,7 @@
   import ContentNodeThumbnail from '../../views/files/thumbnails/ContentNodeThumbnail';
   import FileUpload from '../../views/files/FileUpload';
   import SubtitlesList from '../../views/files/supplementaryLists/SubtitlesList';
-  import { isImportedContent, importedChannelLink } from '../../utils';
+  import { isImportedContent, isDisableSourceEdits, importedChannelLink } from '../../utils';
   import AccessibilityOptions from './AccessibilityOptions.vue';
   import LevelsOptions from './LevelsOptions.vue';
   import ResourcesNeededOptions from './ResourcesNeededOptions.vue';
@@ -659,7 +659,7 @@
         return this.nodes.some(node => node.freeze_authoring_data);
       },
       disableSourceEdits() {
-        return this.disableAuthEdits || this.isImported;
+        return this.nodes.some(isDisableSourceEdits);
       },
       detectedImportText() {
         const count = this.nodes.filter(node => node.freeze_authoring_data).length;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -122,6 +122,9 @@
           </VFlex>
         </VLayout>
       </BottomBar>
+      <AboutLicensesModal
+        v-if="isAboutLicensesModalOpen"
+      />
     </VDialog>
 
     <!-- Dialog for catching unsaved changes -->
@@ -187,6 +190,7 @@
   import { fileSizeMixin, routerMixin } from 'shared/mixins';
   import FileStorage from 'shared/views/files/FileStorage';
   import MessageDialog from 'shared/views/MessageDialog';
+  import AboutLicensesModal from 'shared/views/AboutLicensesModal';
   import ResizableNavigationDrawer from 'shared/views/ResizableNavigationDrawer';
   import Uploader from 'shared/views/files/Uploader';
   import LoadingText from 'shared/views/LoadingText';
@@ -216,6 +220,7 @@
       SavingIndicator,
       ToolBar,
       BottomBar,
+      AboutLicensesModal,
     },
     mixins: [fileSizeMixin, routerMixin],
     props: {
@@ -248,6 +253,7 @@
       };
     },
     computed: {
+      ...mapGetters(['isAboutLicensesModalOpen']),
       ...mapGetters('contentNode', ['getContentNode', 'getContentNodeIsValid']),
       ...mapGetters('assessmentItem', ['getAssessmentItems']),
       ...mapGetters('currentChannel', ['currentChannel', 'canEdit']),

--- a/contentcuration/contentcuration/frontend/channelEdit/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/getters.js
@@ -10,6 +10,10 @@ export function isComfortableViewMode(state) {
   return viewMode === viewModes.COMFORTABLE;
 }
 
+export function isAboutLicensesModalOpen(state) {
+  return state.aboutLicensesModalOpen;
+};
+
 // Convenience function to format strings like "Page Name - Channel Name"
 // for tab titles
 export function appendChannelName(state, getters) {

--- a/contentcuration/contentcuration/frontend/channelEdit/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/getters.js
@@ -12,7 +12,7 @@ export function isComfortableViewMode(state) {
 
 export function isAboutLicensesModalOpen(state) {
   return state.aboutLicensesModalOpen;
-};
+}
 
 // Convenience function to format strings like "Page Name - Channel Name"
 // for tab titles

--- a/contentcuration/contentcuration/frontend/channelEdit/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/mutations.js
@@ -5,3 +5,7 @@ export function SET_VIEW_MODE(state, viewMode) {
 export function SET_VIEW_MODE_OVERRIDES(state, overrides) {
   state.viewModeOverrides = overrides;
 }
+
+export function SET_SHOW_ABOUT_LICENSES(state, isOpen) {
+  state.aboutLicensesModalOpen = isOpen;
+}

--- a/contentcuration/contentcuration/frontend/channelEdit/store.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/store.js
@@ -31,6 +31,8 @@ export const STORE_CONFIG = {
        * to override the current `viewMode`.
        */
       viewModeOverrides: [],
+
+      aboutLicensesModalOpen: false,
     };
   },
   actions,

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -203,6 +203,13 @@ export function isImportedContent(node) {
   );
 }
 
+export function isDisableSourceEdits(node) {
+  return (
+    node.freeze_authoring_data ||
+    isImportedContent(node)
+  );
+}
+
 export function importedChannelLink(node, router) {
   if (node && isImportedContent(node)) {
     const channelURI = window.Urls.channel(node.original_channel_id);

--- a/contentcuration/contentcuration/frontend/channelEdit/utils.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/utils.js
@@ -204,10 +204,7 @@ export function isImportedContent(node) {
 }
 
 export function isDisableSourceEdits(node) {
-  return (
-    node.freeze_authoring_data ||
-    isImportedContent(node)
-  );
+  return node.freeze_authoring_data || isImportedContent(node);
 }
 
 export function importedChannelLink(node, router) {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -112,6 +112,13 @@
           />
           <IconButton
             v-if="canEdit && !isTopicSelected"
+            icon="person"
+            :text="$tr('editSourceButton')"
+            data-test="change-learning-activities-btn"
+            @click="editSource(selected)"
+          />
+          <IconButton
+            v-if="canEdit && !isTopicSelected"
             icon="socialSciencesResource"
             :text="$tr('editAudienceButton')"
             data-test="change-audience-btn"
@@ -583,6 +590,13 @@
           nodeIds,
         });
       },
+      editSource(nodeIds) {
+        this.trackClickEvent('Edit source');
+        this.openQuickEditModal({
+          modal: QuickEditModals.SOURCE,
+          nodeIds,
+        });
+      },
       treeLink(params) {
         return {
           name: RouteNames.TREE_VIEW,
@@ -820,6 +834,7 @@
       importFromChannels: 'Import from channels',
       addButton: 'Add',
       editButton: 'Edit',
+      editSourceButton: 'Edit source',
       editLevelsButton: 'Edit Levels',
       editLanguageButton: 'Edit Language',
       editAudienceButton: 'Edit Audience',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -225,6 +225,9 @@
       @syncing="syncInProgress"
     />
     <QuickEditModal />
+    <AboutLicensesModal
+      v-if="isAboutLicensesModalOpen"
+    />
     <MessageDialog
       v-model="showDeleteModal"
       :header="$tr('deleteTitle')"
@@ -321,6 +324,7 @@
   import ChannelTokenModal from 'shared/views/channel/ChannelTokenModal';
   import OfflineText from 'shared/views/OfflineText';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
+  import AboutLicensesModal from 'shared/views/AboutLicensesModal';
   import MessageDialog from 'shared/views/MessageDialog';
   import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
   import { titleMixin } from 'shared/mixins';
@@ -345,6 +349,7 @@
       MessageDialog,
       SavingIndicator,
       QuickEditModal,
+      AboutLicensesModal,
     },
     mixins: [titleMixin],
     props: {
@@ -368,6 +373,7 @@
       ...mapState({
         offline: state => !state.connection.online,
       }),
+      ...mapGetters(['isAboutLicensesModalOpen']),
       ...mapGetters('contentNode', ['getContentNode']),
       ...mapGetters('currentChannel', ['currentChannel', 'canEdit', 'canManage', 'rootId']),
       rootNode() {

--- a/contentcuration/contentcuration/frontend/shared/views/AboutLicensesModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/AboutLicensesModal.vue
@@ -1,4 +1,5 @@
 <template>
+
   <KModal
     :title="$tr('licenseInfoHeader')"
     :cancelText="$tr('close')"
@@ -6,10 +7,10 @@
   >
     <div v-for="(license, index) in licences" :key="index" class="mb-4 mt-3">
       <h2 class="font-weight-bold mb-1 subheading">
-        {{  license.name  }}
+        {{ license.name }}
       </h2>
       <p class="body-1 grey--text mb-1">
-        {{  license.description  }}
+        {{ license.description }}
       </p>
       <p v-if="license.license_url">
         <ActionLink
@@ -20,26 +21,26 @@
       </p>
     </div>
   </KModal>
+
 </template>
 
 <script>
+
+  import { mapMutations } from 'vuex';
   import { constantsTranslationMixin } from 'shared/mixins';
   import { LicensesList } from 'shared/leUtils/Licenses';
-  import { mapMutations } from 'vuex';
 
   export default {
     name: 'AboutLicensesModal',
     mixins: [constantsTranslationMixin],
     computed: {
       licences() {
-        return LicensesList
-          .filter(license => license.id)
-          .map(license => ({
-            ...license,
-            name: this.translateConstant(license.license_name),
-            description: this.translateConstant(license.license_name + '_description'),
-          }));
-      }
+        return LicensesList.filter(license => license.id).map(license => ({
+          ...license,
+          name: this.translateConstant(license.license_name),
+          description: this.translateConstant(license.license_name + '_description'),
+        }));
+      },
     },
     methods: {
       ...mapMutations({
@@ -56,6 +57,6 @@
       learnMoreButton: 'Learn More',
       licenseInfoHeader: 'About licenses',
     },
-  }
+  };
 
 </script>

--- a/contentcuration/contentcuration/frontend/shared/views/AboutLicensesModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/AboutLicensesModal.vue
@@ -1,0 +1,61 @@
+<template>
+  <KModal
+    :title="$tr('licenseInfoHeader')"
+    :cancelText="$tr('close')"
+    @cancel="closeModal()"
+  >
+    <div v-for="(license, index) in licences" :key="index" class="mb-4 mt-3">
+      <h2 class="font-weight-bold mb-1 subheading">
+        {{  license.name  }}
+      </h2>
+      <p class="body-1 grey--text mb-1">
+        {{  license.description  }}
+      </p>
+      <p v-if="license.license_url">
+        <ActionLink
+          :href="getLicenseUrl(license)"
+          target="_blank"
+          :text="$tr('learnMoreButton')"
+        />
+      </p>
+    </div>
+  </KModal>
+</template>
+
+<script>
+  import { constantsTranslationMixin } from 'shared/mixins';
+  import { LicensesList } from 'shared/leUtils/Licenses';
+  import { mapMutations } from 'vuex';
+
+  export default {
+    name: 'AboutLicensesModal',
+    mixins: [constantsTranslationMixin],
+    computed: {
+      licences() {
+        return LicensesList
+          .filter(license => license.id)
+          .map(license => ({
+            ...license,
+            name: this.translateConstant(license.license_name),
+            description: this.translateConstant(license.license_name + '_description'),
+          }));
+      }
+    },
+    methods: {
+      ...mapMutations({
+        closeModal: 'SET_SHOW_ABOUT_LICENSES',
+      }),
+      getLicenseUrl(license) {
+        const isCC = license.license_url.includes('creativecommons.org');
+        const language = window.languageCode || 'en';
+        return isCC ? `${license.license_url}deed.${language}` : license.license_url;
+      },
+    },
+    $trs: {
+      close: 'Close',
+      learnMoreButton: 'Learn More',
+      licenseInfoHeader: 'About licenses',
+    },
+  }
+
+</script>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -4,9 +4,9 @@
     <DropdownWrapper component="VLayout" class="license-dropdown" row align-center>
       <template #default="{ attach, menuProps }">
         <VSelect
-          box
           ref="license"
           v-model="license"
+          box
           :items="licenses"
           :label="$tr('licenseLabel')"
           color="primary"
@@ -60,8 +60,6 @@
 
 <script>
 
-  const MIXED_VALUE = 'mixed';
-
   import { mapMutations } from 'vuex';
   import {
     getLicenseValidators,
@@ -73,6 +71,8 @@
   import { LicensesList } from 'shared/leUtils/Licenses';
   import { constantsTranslationMixin } from 'shared/mixins';
   import DropdownWrapper from 'shared/views/form/DropdownWrapper';
+
+  const MIXED_VALUE = 'mixed';
 
   export default {
     name: 'LicenseDropdown',
@@ -195,33 +195,41 @@
 </script>
 
 <style lang="scss" scoped>
+
   .with-trailing-input-icon {
     /deep/ .v-input__append-inner {
       margin-right: 32px;
     }
+
     /deep/ .v-input__append-outer {
       position: absolute;
       right: 12px;
     }
+
     /deep/ .v-input__control > .v-input__slot {
       background: #e9e9e9 !important;
+
       &::before {
         border-color: rgba(0, 0, 0, 0.12) !important;
       }
     }
+
     /deep/ .v-icon {
-      margin: unset !important;
       position: unset !important;
+      margin: unset !important;
     }
+
     &.v-input--has-state {
       /deep/ .v-input__control > .v-input__slot::before {
-        border-color: currentColor  !important;
+        border-color: currentcolor !important;
       }
     }
+
     &:hover {
       /deep/ .v-input__control > .v-input__slot::before {
         border-color: rgba(0, 0, 0, 0.3) !important;
       }
     }
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -4,6 +4,7 @@
     <DropdownWrapper component="VLayout" class="license-dropdown" row align-center>
       <template #default="{ attach, menuProps }">
         <VSelect
+          box
           ref="license"
           v-model="license"
           :items="licenses"
@@ -16,28 +17,21 @@
           :readonly="readonly"
           :rules="licenseRules"
           :placeholder="placeholder"
-          :menu-props="menuProps"
+          :menu-props="{ ...menuProps, maxHeight: 250 }"
           class="ma-0"
-          box
+          :class="{ 'with-trailing-input-icon': box }"
           :attach="attach"
           @focus="$emit('focus')"
         >
           <template #append-outer>
-            <InfoModal :header="$tr('licenseInfoHeader')" :items="licenses">
-              <template #header="{ item }">
-                {{ translate(item) }}
-              </template>
-              <template #description="{ item }">
-                {{ translateDescription(item) }}
-                <p v-if="item.license_url" class="mt-1">
-                  <ActionLink
-                    :href="getLicenseUrl(item)"
-                    target="_blank"
-                    :text="$tr('learnMoreButton')"
-                  />
-                </p>
-              </template>
-            </InfoModal>
+            <Icon
+              class="info-icon"
+              color="primary"
+              data-test="info-icon"
+              @click="setShowAboutLicenses(true)"
+            >
+              help
+            </Icon>
           </template>
         </VSelect>
       </template>
@@ -65,7 +59,7 @@
 
 <script>
 
-  import InfoModal from './InfoModal.vue';
+  import { mapMutations } from 'vuex';
   import {
     getLicenseValidators,
     getLicenseDescriptionValidators,
@@ -80,7 +74,6 @@
     name: 'LicenseDropdown',
     components: {
       DropdownWrapper,
-      InfoModal,
     },
     filters: {},
     mixins: [constantsTranslationMixin],
@@ -112,6 +105,10 @@
       descriptionPlaceholder: {
         type: String,
         default: '',
+      },
+      box: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {
@@ -156,33 +153,45 @@
       },
     },
     methods: {
+      ...mapMutations({
+        setShowAboutLicenses: 'SET_SHOW_ABOUT_LICENSES',
+      }),
       translate(item) {
         return (item.id && item.id !== '' && this.translateConstant(item.license_name)) || '';
-      },
-      translateDescription(item) {
-        return (
-          (item.id &&
-            item.id !== '' &&
-            this.translateConstant(item.license_name + '_description')) ||
-          ''
-        );
-      },
-      getLicenseUrl(item) {
-        const isCC = item.license_url.includes('creativecommons.org');
-        const language = window.languageCode || 'en';
-        return isCC ? `${item.license_url}deed.${language}` : item.license_url;
       },
     },
     $trs: {
       licenseLabel: 'License',
       licenseDescriptionLabel: 'License description',
-      learnMoreButton: 'Learn More',
-      licenseInfoHeader: 'About licenses',
     },
   };
 
 </script>
 
-<style lang="less" scoped>
-
+<style lang="scss" scoped>
+  .with-trailing-input-icon {
+    /deep/ .v-input__append-inner {
+      margin-right: 32px;
+    }
+    /deep/ .v-input__append-outer {
+      position: absolute;
+      right: 12px;
+    }
+    /deep/ .v-input__control > .v-input__slot {
+      background: #e9e9e9 !important;
+      &::before {
+        border-color: rgba(0, 0, 0, 0.12) !important;
+      }
+    }
+    &.v-input--has-state {
+      /deep/ .v-input__control > .v-input__slot::before {
+        border-color: currentColor  !important;
+      }
+    }
+    &:hover {
+      /deep/ .v-input__control > .v-input__slot::before {
+        border-color: rgba(0, 0, 0, 0.3) !important;
+      }
+    }
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -183,6 +183,10 @@
         border-color: rgba(0, 0, 0, 0.12) !important;
       }
     }
+    /deep/ .v-icon {
+      margin: unset !important;
+      position: unset !important;
+    }
     &.v-input--has-state {
       /deep/ .v-input__control > .v-input__slot::before {
         border-color: currentColor  !important;


### PR DESCRIPTION

## Summary
### Description of the change(s) you made
Add a quick edit modal to edit resources attribution/source.

### Screenshots (if applicable)

https://github.com/learningequality/studio/assets/51239030/1095ea36-de96-450f-a430-dd706aff152c



___
## Reviewer guidance
### How can a reviewer test these changes?
1. Go to update a channel content
2. Click on the "Edit source" option on the content node menu of a resource (non-folder).
3. Or select multiple resources (non-folders) and select "Edit Source" from bulk toolbar.


## References
Closes #3420

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [x] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ x If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
