### PR TITLE
refac: Replace `Checkbox` with `KCheckbox`

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -64,8 +64,8 @@
           {{ $tr('usageLabel') }}*
         </h1>
         <div v-for="option in usageOptions" :key="option.id">
-          <Checkbox
-            v-model="form.uses"
+          <KCheckbox
+            :checked="form.uses"
             :label="option.label"
             :value="option.id"
           />

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelItem.vue
@@ -2,12 +2,12 @@
 
   <tr :class="channel.deleted ? 'red--text' : 'black--text'">
     <td v-if="$vuetify.breakpoint.smAndDown" class="pt-2">
-      <Checkbox v-model="selected" />
+      <KCheckbox :checked="selected" />
     </td>
     <td>
       <VLayout align-center justify-start fill-height>
         <VFlex v-if="$vuetify.breakpoint.mdAndUp" shrink class="pb-3 pt-3">
-          <Checkbox v-model="selected" />
+          <KCheckbox :checked="selected" />
         </VFlex>
         <VFlex shrink>
           <VTooltip v-if="channel.public && !channel.deleted" bottom z-index="200" lazy>
@@ -177,14 +177,12 @@
   import { RouteNames } from '../../constants';
   import ChannelActionsDropdown from './ChannelActionsDropdown';
   import { fileSizeMixin } from 'shared/mixins';
-  import Checkbox from 'shared/views/form/Checkbox';
 
   export default {
     name: 'ChannelItem',
     components: {
       ChannelActionsDropdown,
       ClipboardChip,
-      Checkbox,
     },
     mixins: [fileSizeMixin],
     props: {

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
@@ -59,9 +59,9 @@
       </template>
       <template #headerCell="{ header }">
         <div style="display: inline-block; width: min-content;" @click.stop>
-          <Checkbox
+          <KCheckbox
             v-if="header.class === 'first'"
-            v-model="selectAll"
+            :checked="selectAll"
             class="ma-0"
             :indeterminate="Boolean(selected.length) && selected.length !== channels.length"
           />
@@ -105,7 +105,6 @@
   import ChannelItem from './ChannelItem';
   import { channelExportMixin } from 'shared/views/channel/mixins';
   import { routerMixin } from 'shared/mixins';
-  import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
 
@@ -124,7 +123,6 @@
   export default {
     name: 'ChannelTable',
     components: {
-      Checkbox,
       ChannelItem,
       LanguageDropdown,
       IconButton,

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
@@ -2,12 +2,12 @@
 
   <tr :class="user.is_active ? '' : 'red--text'">
     <td v-if="$vuetify.breakpoint.smAndDown" class="pt-2">
-      <Checkbox v-model="selected" />
+      <KCheckbox :checked="selected" />
     </td>
     <td>
       <VLayout align-center justify-start fill-height>
         <VFlex v-if="$vuetify.breakpoint.mdAndUp" shrink class="pb-3 pt-3">
-          <Checkbox v-model="selected" />
+          <KCheckbox :checked="selected" />
         </VFlex>
         <VFlex shrink>
           <VTooltip v-if="user.is_admin" bottom z-index="200" lazy>
@@ -99,12 +99,10 @@
   import UserActionsDropdown from './UserActionsDropdown';
   import UserStorage from './UserStorage';
   import { fileSizeMixin } from 'shared/mixins';
-  import Checkbox from 'shared/views/form/Checkbox';
 
   export default {
     name: 'UserItem',
     components: {
-      Checkbox,
       UserActionsDropdown,
       UserStorage,
     },

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -68,9 +68,9 @@
 
       <template #headerCell="{ header }">
         <div style="display: inline-block; width: min-content;" @click.stop>
-          <Checkbox
+          <KCheckbox
             v-if="header.class === 'first'"
-            v-model="selectAll"
+            :checked="selectAll"
             class="ma-0"
             :indeterminate="Boolean(selected.length) && selected.length !== users.length"
           />
@@ -109,7 +109,6 @@
   import UserItem from './UserItem';
   import { routerMixin } from 'shared/mixins';
   import IconButton from 'shared/views/IconButton';
-  import Checkbox from 'shared/views/form/Checkbox';
   import CountryField from 'shared/views/form/CountryField';
 
   const userFilters = {
@@ -124,7 +123,6 @@
   export default {
     name: 'UserTable',
     components: {
-      Checkbox,
       IconButton,
       EmailUsersDialog,
       UserItem,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentEditor/AssessmentEditor.vue
@@ -2,8 +2,8 @@
 
   <VContainer fluid>
     <template v-if="sortedItems && sortedItems.length">
-      <Checkbox
-        v-model="displayAnswersPreview"
+      <KCheckbox
+        :checked="displayAnswersPreview"
         :label="$tr('showAnswers')"
         class="mb-4"
         data-test="showAnswersCheckbox"
@@ -132,7 +132,6 @@
   import AssessmentItemToolbar from '../AssessmentItemToolbar';
   import AssessmentItemEditor from '../AssessmentItemEditor/AssessmentItemEditor';
   import AssessmentItemPreview from '../AssessmentItemPreview/AssessmentItemPreview';
-  import Checkbox from 'shared/views/form/Checkbox';
   import { AssessmentItemTypes, DELAYED_VALIDATION } from 'shared/constants';
 
   function areItemsEqual(item1, item2) {
@@ -151,7 +150,6 @@
       AssessmentItemToolbar,
       AssessmentItemEditor,
       AssessmentItemPreview,
-      Checkbox,
     },
     props: {
       nodeId: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemPreview/AssessmentItemPreview.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentItemPreview/AssessmentItemPreview.vue
@@ -43,7 +43,7 @@
           </template>
 
           <template v-if="isMultipleSelection">
-            <Checkbox
+            <KCheckbox
               v-for="(answer, idx) in answers"
               :key="idx"
               v-model="correctAnswersIndices"
@@ -55,7 +55,7 @@
                   <MarkdownViewer :markdown="answer.answer" />
                 </div>
               </template>
-            </Checkbox>
+            </KCheckbox>
           </template>
 
           <VList v-if="isInputQuestion">
@@ -114,14 +114,12 @@
   import { getCorrectAnswersIndices } from '../../utils';
   import translator from '../../translator';
   import { AssessmentItemTypes } from 'shared/constants';
-  import Checkbox from 'shared/views/form/Checkbox';
   import MarkdownViewer from 'shared/views/MarkdownEditor/MarkdownViewer/MarkdownViewer.vue';
 
   export default {
     name: 'AssessmentItemPreview',
     components: {
-      MarkdownViewer,
-      Checkbox,
+      MarkdownViewer
     },
     props: {
       /**

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
@@ -9,7 +9,7 @@
     <template #header>
       <VListTile class="channel-tile py-2" inactive>
         <VListTileAction class="select-col">
-          <Checkbox
+          <KCheckbox
             ref="checkbox"
             class="ma-0 pa-0"
             :value="selected"
@@ -51,7 +51,6 @@
   import { mapGetters } from 'vuex';
   import clipboardMixin, { parentMixin } from './mixins';
   import ContentNode from './ContentNode';
-  import Checkbox from 'shared/views/form/Checkbox';
   import { SelectionFlags } from 'frontend/channelEdit/vuex/clipboard/constants';
   import LazyListGroup from 'shared/views/LazyListGroup';
 
@@ -59,7 +58,6 @@
     name: 'Channel',
     components: {
       ContentNode,
-      Checkbox,
       LazyListGroup,
     },
     mixins: [clipboardMixin, parentMixin],

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -32,7 +32,7 @@
               <VListTile class="grow">
                 <VSlideXTransition hide-on-leave>
                   <VListTileAction v-if="!initializing && channels.length && !previewSourceNode">
-                    <Checkbox
+                    <KCheckbox
                       ref="checkbox"
                       class="ma-0 pa-0"
                       :value="selected"
@@ -142,7 +142,6 @@
   import clipboardMixin from './mixins';
   import Channel from './Channel';
   import ResizableNavigationDrawer from 'shared/views/ResizableNavigationDrawer';
-  import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import ToolBar from 'shared/views/ToolBar';
   import LoadingText from 'shared/views/LoadingText';
@@ -158,7 +157,6 @@
       ResizableNavigationDrawer,
       ResourcePanel,
       Channel,
-      Checkbox,
       IconButton,
       ToolBar,
       LoadingText,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -37,8 +37,8 @@
             </transition>
           </VListTileAction>
           <VListTileAction class="mx-2 select-col" @click.stop>
-            <Checkbox
-              v-model="selected"
+            <KCheckbox
+              :checked="selected"
               :disabled="copying"
               class="mt-0 pt-0"
               @dblclick.stop
@@ -102,7 +102,6 @@
   import ContentNodeListItem from './ContentNodeListItem';
   import ContentNodeOptions from './ContentNodeOptions';
   import ContentNodeContextMenu from './ContentNodeContextMenu';
-  import Checkbox from 'shared/views/form/Checkbox';
   import IconButton from 'shared/views/IconButton';
   import DraggableItem from 'shared/views/draggable/DraggableItem';
   import { ContentNode } from 'shared/data/resources';
@@ -118,7 +117,6 @@
       ContentNodeListItem,
       ContentNodeOptions,
       ContentNodeContextMenu,
-      Checkbox,
       IconButton,
     },
     props: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -128,8 +128,8 @@
             class="my-3"
           >
             <VFlex>
-              <Checkbox
-                v-model="showAnswers"
+              <KCheckbox
+                :checked="showAnswers"
                 :label="$tr('showAnswers')"
                 class="ma-0"
               />
@@ -552,7 +552,6 @@
   import DetailsRow from 'shared/views/details/DetailsRow';
   import ExpandableList from 'shared/views/ExpandableList';
   import Licenses from 'shared/leUtils/Licenses';
-  import Checkbox from 'shared/views/form/Checkbox';
   import Banner from 'shared/views/Banner';
   import Tabs from 'shared/views/Tabs';
   import {
@@ -572,7 +571,6 @@
       FilePreview,
       ExpandableList,
       AssessmentItemPreview,
-      Checkbox,
       ContentNodeValidator,
       Banner,
       Tabs,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Migrated some of the used `Checkbox` components to use KDS's `KCheckbox` component 


### Manual verification steps performed

### Does this introduce any tech-debt items?
NA
___
## Reviewer guidance

### Are there any risky areas that deserve extra testing?
The UI of the changes and the indented functionality may require a careful review. 

## References
Fixes part of [this issue in KDS](https://github.com/learningequality/kolibri-design-system/issues/254)

### Contributor's Checklist
PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
