### PR TITLE
Fix dual scrollbars when using FullscreenModal 

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/FullscreenModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/FullscreenModal.vue
@@ -100,7 +100,7 @@
         this.hideHTMLScroll(!!val);
       },
     },
-    activated(){
+    activated() {
       this.hideHTMLScroll(true);
     },
     deactivated() {

--- a/contentcuration/contentcuration/frontend/shared/views/FullscreenModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/FullscreenModal.vue
@@ -100,11 +100,13 @@
         this.hideHTMLScroll(!!val);
       },
     },
-    beforeDestroy() {
+    activated(){
+      this.hideHTMLScroll(true);
+    },
+    deactivated() {
       this.hideHTMLScroll(false); // Ensure scroll is restored when the component is destroyed
     },
     mounted() {
-      this.hideHTMLScroll(true);
       this.$refs.dialog.initDetach();
     },
     methods: {


### PR DESCRIPTION

## Summary
### Description of the change(s) you made
changed lifecycle events in FullscreenModal for hideHTMLScroll logic
- The logic was handled by using the mount/destroy lifecycle events
- To account for all cases, replaced it with activation based lifecycle events
- Previous events led to sometimes having dual scrollbars"


### Screenshots 
![image](https://github.com/learningequality/studio/assets/98864225/ca4f8cfc-9cca-45cf-b06d-177f991840bc)
after closing these modals, the scrollbar behaves normally


## Reviewer guidance
### How can a reviewer test these changes?

This PR addresses #1978


## References
I have tested in Chrome 122.0.6261.131 (Windows)
tested in Brave 1.64.109 (Windows)
Firefox 20.04 (Ubuntu)

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
