### PR TITLE
Fixed the missing checkbox labels

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
@@ -83,6 +83,7 @@
         return this.getChannel(this.channelId);
       },
       channelColor() {
+        console.log(this.getChannelColor(this.channelId));
         return this.getChannelColor(this.channelId) || this.$vuetify.theme.channelHighlightDefault;
       },
       thumbnailSrc() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
@@ -83,7 +83,6 @@
         return this.getChannel(this.channelId);
       },
       channelColor() {
-        console.log(this.getChannelColor(this.channelId));
         return this.getChannelColor(this.channelId) || this.$vuetify.theme.channelHighlightDefault;
       },
       thumbnailSrc() {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
@@ -30,14 +30,14 @@
     </template>
     <template #item="{ item }">
       <Checkbox :key="item.id" :input-value="value" :value="item.id" class="mt-0">
-          <VTooltip bottom lazy>
-            <template #activator="{ on }">
-              <div class="text-truncate" style="width: 250px;" v-on="on">
-                {{ item.name }}
-              </div>
-            </template>
-            <span>{{ item.name }}</span>
-          </VTooltip>
+        <VTooltip bottom lazy>
+          <template #activator="{ on }">
+            <div class="text-truncate" style="width: 250px;" v-on="on">
+              {{ item.name }}
+            </div>
+          </template>
+          <span>{{ item.name }}</span>
+        </VTooltip>
       </Checkbox>
     </template>
   </VAutocomplete>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
@@ -30,7 +30,6 @@
     </template>
     <template #item="{ item }">
       <Checkbox :key="item.id" :input-value="value" :value="item.id" class="mt-0">
-        <template #label>
           <VTooltip bottom lazy>
             <template #activator="{ on }">
               <div class="text-truncate" style="width: 250px;" v-on="on">
@@ -39,7 +38,6 @@
             </template>
             <span>{{ item.name }}</span>
           </VTooltip>
-        </template>
       </Checkbox>
     </template>
   </VAutocomplete>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
@@ -93,7 +93,7 @@
     },
     methods: {
       languageSearchValue(item) {
-        return item.name;
+        return item.name + (item.related_names || []).join('') + item.id;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -20,7 +20,7 @@
             {{ getText(item) }}
           </VChip>
         </template>
-        <template #item="{ item, tile }">
+        <template #item="{ item }">
           <KCheckbox
             :checked="selections.includes(item)"
             :label="getText(item)"
@@ -43,7 +43,7 @@
 
   export default {
     name: 'MultiSelect',
-    components: { Checkbox, DropdownWrapper },
+    components: { DropdownWrapper },
     // $attrs are rebound to a descendent component
     inheritAttrs: false,
     props: {

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -27,6 +27,7 @@
             :value="item"
             :style="getEllipsisStyle()"
             :ripple="false"
+            :class="{ notranslate }"
           />
         </template>
       </VSelect>

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -21,11 +21,13 @@
           </VChip>
         </template>
         <template #item="{ item, tile }">
-          <Checkbox v-bind="tile.props" class="ma-0">
-              <span :class="{ notranslate }" :style="getEllipsisStyle()" dir="auto">
-                {{ getText(item) }}
-              </span>
-          </Checkbox>
+          <KCheckbox
+            :checked="selections.includes(item)"
+            :label="getText(item)"
+            :value="item"
+            :style="getEllipsisStyle()"
+            :ripple="false"
+          />
         </template>
       </VSelect>
     </template>

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -38,7 +38,6 @@
 
 <script>
 
-  import Checkbox from './Checkbox';
   import DropdownWrapper from './DropdownWrapper';
 
   export default {

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -22,11 +22,9 @@
         </template>
         <template #item="{ item, tile }">
           <Checkbox v-bind="tile.props" class="ma-0">
-            <template #label>
               <span :class="{ notranslate }" :style="getEllipsisStyle()" dir="auto">
                 {{ getText(item) }}
               </span>
-            </template>
           </Checkbox>
         </template>
       </VSelect>


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
I have fixed the missing checkout labels in the content library that were used for filtering out the content for the users to prevent confusion and possible unintended selections. Fixes the issue #4525 

### Manual verification steps performed
1. Step 1 ) Checked the working of the component by running the app locally

### Screenshots (if applicable)
[Screencast from 2024-04-20 13-49-01.webm](https://github.com/learningequality/studio/assets/117429248/b141351c-ea32-49ab-85af-336fae499be9)

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
