### PR TITLE
Properly format node_id+channel_id query parameter

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/clipboard/actions.js
@@ -193,7 +193,7 @@ export function addClipboardNodeFromListener(context, obj) {
     .then(() =>
       context.dispatch(
         'contentNode/loadContentNodes',
-        { '[node_id+channel_id]__in': [obj.source_node_id, obj.source_channel_id] },
+        { '[node_id+channel_id]__in': [[obj.source_node_id, obj.source_channel_id]] },
         { root }
       )
     )

--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/ContentNodeResource.spec.js
@@ -720,7 +720,7 @@ describe('ContentNode methods', () => {
       );
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(fetchCollection).toHaveBeenCalledWith({
-        _node_id_channel_id_: [node_id, channel_id],
+        '[node_id+channel_id]__in': [[node_id, channel_id]],
       });
     });
 
@@ -731,7 +731,7 @@ describe('ContentNode methods', () => {
       await expect(ContentNode.getByNodeIdChannelId(node_id, channel_id)).resolves.toBeFalsy();
       expect(table.get).toHaveBeenCalledWith({ '[node_id+channel_id]': [node_id, channel_id] });
       expect(fetchCollection).toHaveBeenCalledWith({
-        _node_id_channel_id_: [node_id, channel_id],
+        '[node_id+channel_id]__in': [[node_id, channel_id]],
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1644,7 +1644,9 @@ export const ContentNode = new TreeResource({
     const values = [nodeId, channelId];
     return this.table.get({ '[node_id+channel_id]': values }).then(node => {
       if (!node) {
-        return this.fetchCollection({ '[node_id+channel_id]__in': [values] }).then(nodes => nodes[0]);
+        return this.fetchCollection({ '[node_id+channel_id]__in': [values] }).then(
+          nodes => nodes[0]
+        );
       }
       return node;
     });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1644,7 +1644,7 @@ export const ContentNode = new TreeResource({
     const values = [nodeId, channelId];
     return this.table.get({ '[node_id+channel_id]': values }).then(node => {
       if (!node) {
-        return this.fetchCollection({ _node_id_channel_id_: values }).then(nodes => nodes[0]);
+        return this.fetchCollection({ '[node_id+channel_id]__in': [values] }).then(nodes => nodes[0]);
       }
       return node;
     });


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updates resource method `getByNodeIdChannelId` to use proper format for the query parameter
- Updates other potential issues related to `[node_id+channel_id]__in` filtering

### Manual verification steps performed
1. Create public channel with some nodes and publish it
2. Sign out
3. Sign into Studio
4. Create new channel (without opening the public channel)
5. Click <kbd>ADD</kbd> and select 'Import from channels'
6. Search for one of the public channel nodes
7. Click the clipboard icon on the node

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
Follow the above steps

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
I did update some clipboard actions that seemed to be passing a flattened array for `__in` query

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/4508

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [x] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
