### PR TITLE
Fix hover color for red delete account button

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -100,7 +100,13 @@
         :text="$tr('deleteAccountLabel')"
         :appearanceOverrides="{
           backgroundColor: $themeTokens.error,
-          color: $themeTokens.textInverted
+          color: $themeTokens.textInverted,
+          ':hover': {
+            // Vuetify generates this based on theme colors, but oddly it doesn't make it
+            // available in the theme tokens
+            // TODO: Replace with KDS lighten/darken utilities
+            backgroundColor: 'var(--v-error-darken1)',
+          },
         }"
         @click="showDeleteConfirmation = true"
       />


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Fixes the hover state for the account deletion CTA

### Manual verification steps performed
1. Logged in as `user@a.com` with password `a`
2. Deleted the account's sole channel
3. Navigated to Settings
4. Observed button's hovered state

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
[Screencast from 04-22-2024 02:36:16 PM.webm](https://github.com/learningequality/studio/assets/819838/938adfcc-22b7-45c7-ada4-7f5d1b7d2444)


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
Not directly. We can replace the CSS var that Vuetify generates based on the error color with darken utilities if/when KDS has them. Currently no red color darker than the error color exists.
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Closes https://github.com/learningequality/studio/issues/4529

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
