### PR TITLE
Post-rebranding update to Card hover styling

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/AdministrationIndex.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/AdministrationIndex.vue
@@ -161,7 +161,7 @@
 
     tr:hover td {
       /* stylelint-disable-next-line custom-property-pattern */
-      background-color: var(--v-greyBackground-base) !important;
+      background-color: var(--v-greyBackground-lighten1) !important;
     }
 
     /deep/ .v-table__overflow {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VCard @click="handleClick">
+  <VCard hover @click="handleClick">
     <VCardTitle>
       <VLayout row wrap>
         <VFlex class="pt-2 px-4 thumbnail-column">
@@ -229,11 +229,6 @@
 
   .v-card {
     cursor: pointer;
-
-    &:hover {
-      /* stylelint-disable-next-line custom-property-pattern */
-      background-color: var(--v-greyBackground-base);
-    }
   }
 
   h3 {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VCard :to="channelRoute">
+  <VCard hover :to="channelRoute">
     <VCardTitle>
       <VLayout row wrap>
         <VFlex lg2 md4 sm5 xs12 class="px-3">
@@ -113,11 +113,6 @@
 
   .v-card {
     cursor: pointer;
-
-    &:hover {
-      /* stylelint-disable-next-line custom-property-pattern */
-      background-color: var(--v-greyBackground-base);
-    }
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelItem.vue
@@ -3,7 +3,8 @@
   <div>
     <VCard
       class="channel my-3"
-      :class="{ hideHighlight, added }"
+      hover
+      :class="{ added }"
       data-test="channel-card"
       tabindex="0"
       :href="linkToChannelTree ? channelHref : null"
@@ -99,8 +100,6 @@
                 class="mr-1"
                 icon="info"
                 :text="$tr('details')"
-                @mouseenter.native="hideHighlight = true"
-                @mouseleave.native="hideHighlight = false"
               />
 
             </router-link>
@@ -112,16 +111,12 @@
               :text="$tr('copyToken')"
               data-test="token-button"
               @click.stop.prevent="tokenDialog = true"
-              @mouseenter.native="hideHighlight = true"
-              @mouseleave.native="hideHighlight = false"
             />
             <ChannelStar
               v-if="loggedIn"
               :channelId="channelId"
               :bookmark="channel.bookmark"
               class="mr-1"
-              @mouseenter.native="hideHighlight = true"
-              @mouseleave.native="hideHighlight = false"
             />
             <Menu v-if="showOptions">
               <template #activator="{ on }">
@@ -131,8 +126,6 @@
                   data-test="menu"
                   v-on="on"
                   @click.stop.prevent
-                  @mouseenter="hideHighlight = true"
-                  @mouseleave="hideHighlight = false"
                 >
                   <Icon>more_vert</Icon>
                 </VBtn>
@@ -152,7 +145,7 @@
                 <VListTile
                   v-if="allowEdit && channel.published"
                   data-test="token-listitem"
-                  @click="tokenDialog = true"
+                  @click.stop="tokenDialog = true"
                 >
                   <VListTileAction>
                     <Icon>content_copy</Icon>
@@ -264,7 +257,6 @@
       return {
         deleteDialog: false,
         tokenDialog: false,
-        hideHighlight: false,
         added: false,
       };
     },
@@ -356,17 +348,10 @@
           this.$store.dispatch('showSnackbarSimple', this.$tr('channelDeletedSnackbar'));
         });
       },
-      goToChannelRoute(e) {
-        // preventDefault whenever we have clicked a button
-        // that is a child of this card to avoid redirect
-        // overriding the action of the clicked button
-        if (this.hideHighlight) {
-          e.preventDefault();
-        } else {
-          this.linkToChannelTree
-            ? (window.location.href = this.channelHref)
-            : this.$router.push(this.channelDetailsLink).catch(() => {});
-        }
+      goToChannelRoute() {
+        this.linkToChannelTree
+          ? (window.location.href = this.channelHref)
+          : this.$router.push(this.channelDetailsLink).catch(() => {});
       },
       trackTokenCopy() {
         this.$analytics.trackAction('channel_list', 'Copy token', {
@@ -400,11 +385,6 @@
   .v-card {
     width: 100%;
     cursor: pointer;
-
-    &:hover:not(.hideHighlight) {
-      /* stylelint-disable-next-line custom-property-pattern */
-      background-color: var(--v-greyBackground-base);
-    }
 
     &.added {
       /* stylelint-disable-next-line custom-property-pattern */

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelStar.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelStar.vue
@@ -7,7 +7,7 @@
       :icon="bookmark ? 'star' : 'starBorder'"
       :text="starText"
       v-bind="$attrs"
-      @click="toggleStar"
+      @click.stop.prevent="toggleStar"
     />
   </div>
 

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -18,6 +18,7 @@
           v-for="channel in listChannels"
           :key="channel.id"
           flat
+          hover
           class="px-3"
         >
           <Checkbox
@@ -133,11 +134,6 @@
     /deep/ label,
     /deep/ .v-input__control {
       width: 100% !important;
-    }
-
-    &:hover {
-      /* stylelint-disable-next-line custom-property-pattern */
-      background-color: var(--v-channelHighlightDefault-base);
     }
   }
 

--- a/contentcuration/contentcuration/frontend/shared/app.js
+++ b/contentcuration/contentcuration/frontend/shared/app.js
@@ -113,7 +113,7 @@ import { theme, icons } from 'shared/vuetify';
 
 import { i18nSetup } from 'shared/i18n';
 
-import './styles/vuetify.css';
+import './styles/vuetify.scss';
 import 'shared/styles/main.less';
 import Base from 'shared/Base.vue';
 import urls from 'shared/urls';

--- a/contentcuration/contentcuration/frontend/shared/styles/vuetify.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/vuetify.scss
@@ -1,4 +1,5 @@
 /* stylelint-disable */
+@import '~kolibri-design-system/lib/styles/definitions';
 
 /* Need a ! so that the following comment won't get removed during build process */
 
@@ -4541,9 +4542,8 @@ p {
   border-color: #424242;
 }
 .v-card {
+  @extend %dropshadow-2dp;
   text-decoration: none;
-  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-    0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }
 .v-card > :first-child:not(.v-btn):not(.v-chip) {
   border-top-left-radius: inherit;
@@ -4562,8 +4562,10 @@ p {
   transition-property: box-shadow;
 }
 .v-card--hover:hover {
-  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14),
-    0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  @extend %dropshadow-4dp;
+}
+.v-card--hover.v-card--flat:hover {
+  @extend %dropshadow-2dp;
 }
 .v-card__title {
   display: flex;

--- a/jest_config/jest.conf.js
+++ b/jest_config/jest.conf.js
@@ -7,7 +7,7 @@ module.exports = {
   moduleFileExtensions: ['js', 'json', 'vue'],
   modulePaths: [frontendDir],
   moduleNameMapper: {
-    '\\.(css|less|styl)$': 'identity-obj-proxy',
+    '\\.(css|scss|less|styl)$': 'identity-obj-proxy',
     '^frontend/(.*)': '<rootDir>/contentcuration/contentcuration/frontend/$1',
     '^static/(.*)': '<rootDir>/contentcuration/contentcuration/static/$1',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': path.resolve(


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Aligns `VCard` hover styling with how `KCard` hover styling will be implemented
- Removes previous logic related to handling hover background with `VCard`s containing buttons
- Updates admin to reduce row hover darkness
- Adds `.scss` file handling alongside existing `less` and `styl` handling for Jest

### Manual verification steps performed
1. Created a new channel
2. Uploaded content to the channel
3. Marked the channel as public in the admin
4. Published the channel
5. Browsed the channel through 'Import from channels' modal
6. Browsed the channel through 'Content Library'

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
#### Previous
![Screenshot from 2024-05-01 11-47-35](https://github.com/learningequality/studio/assets/819838/e87460e3-2a4f-4343-b7ba-68f57901eb9d)

#### Updated
| Default | Hovered |
| --- | --- |
| ![Screenshot from 2024-05-02 08-00-18](https://github.com/learningequality/studio/assets/819838/567fa0d6-5114-496d-823a-bd7da793fdc5) | ![Screenshot from 2024-05-02 08-00-22](https://github.com/learningequality/studio/assets/819838/ca15b6df-cd2e-4ff7-a518-c9e15e7881d0) |
| ![Screenshot from 2024-05-02 08-14-41](https://github.com/learningequality/studio/assets/819838/0aafe731-86d1-4040-bc08-7290faa7219a) | ![Screenshot from 2024-05-02 08-14-44](https://github.com/learningequality/studio/assets/819838/3233f780-f4d5-4a4a-a0bd-71ade7d2949e) |
| ![Screenshot from 2024-05-02 08-15-33](https://github.com/learningequality/studio/assets/819838/08a5a95a-0c63-4acd-834e-be64e199b040) | ![Screenshot from 2024-05-02 08-15-35](https://github.com/learningequality/studio/assets/819838/2413f023-b2ea-4fda-bc45-90021c27355f) |
| ![Screenshot from 2024-05-02 07-59-57](https://github.com/learningequality/studio/assets/819838/b0daeebb-5cee-4cb1-b8a1-a85f06f278bd) | ![Screenshot from 2024-05-02 08-00-01](https://github.com/learningequality/studio/assets/819838/4bd40191-b04f-4cbf-8580-461256eb8691) |
| ![Screenshot from 2024-05-02 08-31-26](https://github.com/learningequality/studio/assets/819838/43acd3c8-851c-4b83-b163-03229e15d06d) | ![Screenshot from 2024-05-02 08-31-30](https://github.com/learningequality/studio/assets/819838/9248eb5d-0a3c-4970-9c6f-d4ffe9f91288) |



### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
Not necessarily. When we replace `VCard` with `KCard`, hopefully there will be little to no visual differences
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
See my testing steps

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
Clicking buttons on cards, ensuring that the default card action does not get triggered and the button's specific action is triggered instead.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/4547

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
