### PR TITLE
add spacing and hover state to channel list cards

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -19,7 +19,7 @@
           :key="channel.id"
           flat
           hover
-          class="px-3"
+          class="list-card-hover px-3"
         >
           <Checkbox
             v-model="selectedChannels"
@@ -135,6 +135,11 @@
     /deep/ .v-input__control {
       width: 100% !important;
     }
+  }
+
+  .list-card-hover {
+    margin: 16px;
+    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
   }
 
 </style>


### PR DESCRIPTION
Adds just a small quick-fix of margin and slightly darker drop shadow on hover so that the cards don't run into each other. 

More substantial fix to be addressed separately.