### PR TITLE
Update publish logic with edge case

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -193,8 +193,8 @@ class ReturnedChanges extends ChangeDispatcher {
         .and(node => {
           const unpublishedNodeIds = db[TABLE_NAMES.CHANGES_TABLE]
             .where({ table: TABLE_NAMES.CONTENTNODE })
-            .toArray()
-            .map(change => change.key);
+            .map(change => change.key)
+            .toArray();
           return !unpublishedNodeIds.includes(node.id);
         })
         .modify({ changed: false, published: true });

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -186,10 +186,17 @@ class ReturnedChanges extends ChangeDispatcher {
     }
 
     // Publish changes associate with the channel, but we open a transaction on contentnode
-    return transaction(change, TABLE_NAMES.CONTENTNODE, () => {
+    return transaction(change, TABLE_NAMES.CONTENTNODE, TABLE_NAMES.CHANGES_TABLE, () => {
       return db
         .table(TABLE_NAMES.CONTENTNODE)
         .where({ channel_id: change.channel_id })
+        .and(node => {
+          const unpublishedNodeIds = db[TABLE_NAMES.CHANGES_TABLE]
+            .where({ table: TABLE_NAMES.CONTENTNODE })
+            .toArray()
+            .map(change => change.obj.node_id);
+          return !unpublishedNodeIds.includes(node.node_id);
+        })
         .modify({ changed: false, published: true });
     });
   }

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -192,10 +192,10 @@ class ReturnedChanges extends ChangeDispatcher {
         .where({ channel_id: change.channel_id })
         .and(node => {
           const unpublishedNodeIds = db[TABLE_NAMES.CHANGES_TABLE]
-            .where({ table: TABLE_NAMES.CONTENTNODE })
-            .map(change => change.key)
+            .where({ table: TABLE_NAMES.CONTENTNODE, key: node.id })
+            .limit(1)
             .toArray();
-          return !unpublishedNodeIds.includes(node.id);
+          return unpublishedNodeIds.length === 0;
         })
         .modify({ changed: false, published: true });
     });

--- a/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
+++ b/contentcuration/contentcuration/frontend/shared/data/applyRemoteChanges.js
@@ -194,8 +194,8 @@ class ReturnedChanges extends ChangeDispatcher {
           const unpublishedNodeIds = db[TABLE_NAMES.CHANGES_TABLE]
             .where({ table: TABLE_NAMES.CONTENTNODE })
             .toArray()
-            .map(change => change.obj.node_id);
-          return !unpublishedNodeIds.includes(node.node_id);
+            .map(change => change.key);
+          return !unpublishedNodeIds.includes(node.id);
         })
         .modify({ changed: false, published: true });
     });


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This PR enhances the remote publish logic to safeguard against accidental overwrites of the `changes` and `published` statuses in IndexedDB, particularly in scenarios where multiple users are editing the same resource. It ensures that one user's publish action does not inadvertently overwrite another user's unpublished changes.


### Manual verification steps performed
1. Log in to Studio using two separate user sessions (e.g., one in incognito mode and the other in a normal browser).
2. Make changes to the same content in both user sessions.
3. Publish the changes in one session.
4. In the other session, monitor the syncing changes. To test this thoroughly, you can throttle the browsers connection to offline mode and then restore it to confirm that changes remain intact before and after connectivity is restored.
5. Inspect the `CONTENTNODE` and `CHANGES_TABLE` in IndexedDB to verify that the syncing has no effect on changes.

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- See manual verification steps above


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/4138

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md