### PR TITLE
Remove pinned covid channel collection

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilterBar.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilterBar.vue
@@ -19,68 +19,6 @@
         @click="clearFilters"
       />
     </div>
-    <div v-else>
-      <VLayout row wrap>
-        <VFlex
-          v-for="collection in collections"
-          :key="`public-collection-${collection.id}`"
-          xs12
-          class="py-2"
-        >
-          <VCard
-            tabindex="0"
-            class="pt-2"
-            data-test="collection"
-            @click="setCollection(collection.id)"
-            @keyup.enter="setCollection(collection.id)"
-          >
-            <VLayout>
-              <div class="px-2 text-xs-center">
-                <Icon style="font-size: 75px;">
-                  local_hospital
-                </Icon>
-              </div>
-              <VCardTitle primary-title class="pb-2 pt-2">
-
-                <!-- TODO: add 'notranslate' class once we figure out how to handle collections
-                          that have multiple channel languages inside -->
-                <h3 class="headline mb-0">
-                  {{ collection.name }}
-                </h3>
-                <p class="body-1 grey--text">
-                  {{ $tr('channelCount', { count: collection.count }) }}
-                </p>
-                <p v-if="collection.description">
-                  {{ collection.description }}
-                </p>
-              </VCardTitle>
-            </VLayout>
-            <VCardActions>
-              <VSpacer />
-              <IconButton
-                icon="copy"
-                :text="$tr('copyToken')"
-                @click.stop="displayToken = collection.token"
-              />
-            </VCardActions>
-          </VCard>
-        </VFlex>
-      </VLayout>
-
-      <KModal
-        v-if="displayToken"
-        :title="$tr('copyTitle')"
-        :text="$tr('copyTokenInstructions')"
-        :cancelText="$tr('close')"
-        @cancel="displayToken = null"
-      >
-        <div class="mb-3">
-          {{ $tr('copyTokenInstructions') }}
-        </div>
-        <CopyToken :token="displayToken" />
-      </KModal>
-
-    </div>
   </VContainer>
 
 </template>
@@ -90,10 +28,6 @@
   import flatten from 'lodash/flatten'; // Tests fail with native Array.flat() method
   import { catalogFilterMixin } from './mixins';
   import { constantsTranslationMixin } from 'shared/mixins';
-  import IconButton from 'shared/views/IconButton';
-  import CopyToken from 'shared/views/CopyToken';
-
-  const publicCollections = window.publicCollections || [];
 
   /*
     Returns the expected format for filters
@@ -108,16 +42,7 @@
 
   export default {
     name: 'CatalogFilterBar',
-    components: {
-      IconButton,
-      CopyToken,
-    },
     mixins: [constantsTranslationMixin, catalogFilterMixin],
-    data() {
-      return {
-        displayToken: null,
-      };
-    },
     computed: {
       currentFilters() {
         return flatten([
@@ -150,24 +75,10 @@
           createFilter(this.coach, this.$tr('coachContent'), this.resetCoach),
           createFilter(this.assessments, this.$tr('assessments'), this.resetAssessments),
           createFilter(this.subtitles, this.$tr('subtitles'), this.resetSubtitles),
-          createFilter(this.collection, this.getCollectionName(), this.resetCollection),
         ]).filter(Boolean);
-      },
-      collections() {
-        return publicCollections;
       },
     },
     methods: {
-      getCollectionName() {
-        const collection = this.collections.find(c => c.id === this.collection);
-        return collection && collection.name;
-      },
-      setCollection(collectionId) {
-        this.collection = collectionId;
-      },
-      resetCollection() {
-        this.setCollection(null);
-      },
       resetKeywords() {
         this.keywords = '';
       },
@@ -200,12 +111,6 @@
       subtitles: 'Subtitles',
       starred: 'Starred',
       clearAll: 'Clear all',
-      channelCount: '{count, plural,\n =1 {# channel}\n other {# channels}}',
-      copyToken: 'Copy collection token',
-      copyTitle: 'Copy collection token',
-      copyTokenInstructions:
-        'Paste this token into Kolibri to import the channels contained in this collection',
-      close: 'Close',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilterBar.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilterBar.spec.js
@@ -35,16 +35,6 @@ describe('catalogFilterBar', () => {
     wrapper = makeWrapper();
   });
 
-  describe('public collections', () => {
-    it('should list collections if no filters are selected', () => {
-      expect(wrapper.find('[data-test="collection"]').exists()).toBe(true);
-    });
-    it('should filter by collection if one on click', () => {
-      wrapper.find('[data-test="collection"]').trigger('click');
-      expect(wrapper.vm.collection).toBe(collection.id);
-    });
-  });
-
   describe('removing filters', () => {
     beforeEach(() => {
       Object.entries(query).forEach(([key, val]) => {
@@ -72,15 +62,6 @@ describe('catalogFilterBar', () => {
 
       // Make sure other queries weren't affected
       expect(wrapper.vm.$route.query.collection).toBeTruthy();
-      expect(wrapper.vm.$route.query.languages).toBeTruthy();
-      expect(wrapper.vm.$route.query.keywords).toBeTruthy();
-    });
-    it('removing collection filter should remove it from the query', () => {
-      wrapper.vm.resetCollection();
-      expect(wrapper.vm.$route.query.collection).toBeUndefined();
-
-      // Make sure other queries weren't affected
-      expect(wrapper.vm.$route.query.coach).toBeTruthy();
       expect(wrapper.vm.$route.query.languages).toBeTruthy();
       expect(wrapper.vm.$route.query.keywords).toBeTruthy();
     });

--- a/contentcuration/contentcuration/templates/channel_list.html
+++ b/contentcuration/contentcuration/templates/channel_list.html
@@ -31,7 +31,6 @@
 		var publicLanguages = JSON.parse({{ public_languages | safe }});
 		var publicLicenses = JSON.parse({{ public_licenses | safe }});
 		var publicKinds = JSON.parse({{ public_kinds | safe }});
-		var publicCollections = JSON.parse({{ public_collections | safe }});
 	</script>
 	{% render_bundle 'channel_list' 'js' %}
 

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -263,23 +263,6 @@ def channel_list(request):
         kinds = list(public_kind_query)
         cache.set(PUBLIC_CHANNELS_CACHE_KEYS["kinds"], json_for_parse_from_data(kinds), None)
 
-    # Get public channel sets
-    collections = cache.get(PUBLIC_CHANNELS_CACHE_KEYS["collections"])
-    if collections is None:
-        public_channelset_query = ChannelSet.objects.filter(public=True).annotate(
-            count=SQCountDistinct(
-                Channel.objects.filter(
-                    secret_tokens=OuterRef("secret_token"),
-                    public=True,
-                    main_tree__published=True,
-                    deleted=False,
-                ).values_list("id", flat=True),
-                field="id",
-            )
-        )
-        cache.set(PUBLIC_CHANNELS_CACHE_KEYS["collections"], json_for_parse_from_serializer(
-            PublicChannelSetSerializer(public_channelset_query, many=True)), None)
-
     return render(
         request,
         "channel_list.html",
@@ -291,7 +274,6 @@ def channel_list(request):
             "public_languages": languages,
             "public_kinds": kinds,
             "public_licenses": licenses,
-            "public_collections": collections,
         },
     )
 


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Removes pinned COVID card

### Manual verification steps performed
1. Ran devserver
2. Loaded the channel list page
3. Verified no related errors from its removal

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
https://learningequality.slack.com/archives/C0LKEH6NM/p1717091295577929

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
