### PR TITLE
Fix regression with publish task

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -2565,14 +2565,13 @@ class Change(models.Model):
 class CustomTaskMetadata(models.Model):
     # Task_id for reference
     task_id = models.CharField(
-        max_length=255,  # Adjust the max_length as needed
+        max_length=255,
         unique=True,
     )
-    # user shouldn't be null, but in order to append the field, this needs to be allowed
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="tasks", on_delete=models.CASCADE, null=True)
     channel_id = DjangoUUIDField(db_index=True, null=True, blank=True)
     progress = models.IntegerField(null=True, blank=True, validators=[MinValueValidator(0), MaxValueValidator(100)])
-    # a hash of the task name and kwargs for identifying repeat tasks
+    # A hash of the task name and kwargs for identifying repeat tasks
     signature = models.CharField(null=True, blank=False, max_length=32)
     date_created = models.DateTimeField(
         auto_now_add=True,
@@ -2582,7 +2581,6 @@ class CustomTaskMetadata(models.Model):
 
     class Meta:
         indexes = [
-            # add index that matches query usage for signature
             models.Index(
                 fields=['signature'],
                 name='task_result_signature',

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -1,13 +1,17 @@
 from __future__ import absolute_import
 
+import json
 import os
 import random
 import string
 import tempfile
+import uuid
 
 import pytest
+from celery import states
 from django.core.management import call_command
 from django.db import connections
+from django_celery_results.models import TaskResult
 from kolibri_content import models as kolibri_models
 from kolibri_content.router import cleanup_content_database_connection
 from kolibri_content.router import get_active_content_database
@@ -29,6 +33,8 @@ from .testdata import node as create_node
 from .testdata import slideshow
 from .testdata import thumbnail_bytes
 from contentcuration import models as cc
+from contentcuration.models import CustomTaskMetadata
+from contentcuration.utils.celery.tasks import generate_task_signature
 from contentcuration.utils.publish import ChannelIncompleteError
 from contentcuration.utils.publish import convert_channel_thumbnail
 from contentcuration.utils.publish import create_content_database
@@ -37,6 +43,7 @@ from contentcuration.utils.publish import fill_published_fields
 from contentcuration.utils.publish import map_prerequisites
 from contentcuration.utils.publish import MIN_SCHEMA_VERSION
 from contentcuration.utils.publish import set_channel_icon_encoding
+from contentcuration.viewsets.base import create_change_tracker
 
 pytestmark = pytest.mark.django_db
 
@@ -553,3 +560,43 @@ class ChannelExportPublishedData(StudioTestCase):
         self.assertTrue(channel.published_data)
         self.assertIsNotNone(channel.published_data.get(0))
         self.assertEqual(channel.published_data[0]['version_notes'], version_notes)
+
+
+class PublishFailCleansUpTaskObjects(StudioTestCase):
+    def setUp(self):
+        super(PublishFailCleansUpTaskObjects, self).setUpBase()
+
+    def test_failed_task_objects_cleaned_up_when_publishing(self):
+        channel_id = self.channel.id
+        task_name = 'export-channel'
+        task_id = uuid.uuid4().hex
+        pk = 'ab684452f2ad4ba6a1426d6410139f60'
+        table = 'channel'
+        task_kwargs = json.dumps({'pk': pk, 'table': table})
+        signature = generate_task_signature(task_name, task_kwargs=task_kwargs, channel_id=channel_id)
+
+        TaskResult.objects.create(
+            task_id=task_id,
+            status=states.FAILURE,
+            task_name=task_name,
+        )
+
+        CustomTaskMetadata.objects.create(
+            task_id=task_id,
+            channel_id=channel_id,
+            user=self.user,
+            signature=signature
+        )
+
+        assert TaskResult.objects.filter(task_id=task_id).exists()
+        assert CustomTaskMetadata.objects.filter(task_id=task_id).exists()
+
+        with create_change_tracker(pk, table, channel_id, self.user, task_name):
+            pass
+
+        assert not TaskResult.objects.filter(task_id=task_id).exists()
+        assert not CustomTaskMetadata.objects.filter(task_id=task_id).exists()
+
+        new_task_result = TaskResult.objects.get(task_name=task_name, status=states.STARTED)
+        new_custom_task_metadata = CustomTaskMetadata.objects.get(channel_id=channel_id, user=self.user, signature=signature)
+        assert new_custom_task_metadata.task_id == new_task_result.task_id

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -592,11 +592,8 @@ class PublishFailCleansUpTaskObjects(StudioTestCase):
         assert CustomTaskMetadata.objects.filter(task_id=task_id).exists()
 
         with create_change_tracker(pk, table, channel_id, self.user, task_name):
-            pass
-
-        assert not TaskResult.objects.filter(task_id=task_id).exists()
-        assert not CustomTaskMetadata.objects.filter(task_id=task_id).exists()
-
-        new_task_result = TaskResult.objects.get(task_name=task_name, status=states.STARTED)
-        new_custom_task_metadata = CustomTaskMetadata.objects.get(channel_id=channel_id, user=self.user, signature=signature)
-        assert new_custom_task_metadata.task_id == new_task_result.task_id
+            assert not TaskResult.objects.filter(task_id=task_id).exists()
+            assert not CustomTaskMetadata.objects.filter(task_id=task_id).exists()
+            new_task_result = TaskResult.objects.filter(task_name=task_name, status=states.STARTED).first()
+            new_custom_task_metadata = CustomTaskMetadata.objects.get(channel_id=channel_id, user=self.user, signature=signature)
+            assert new_custom_task_metadata.task_id == new_task_result.task_id


### PR DESCRIPTION
## Summary
Implement cleanup of CustomTaskMetadata and add deletion tests.

### Description of the change(s) you made
- Properly clean up unwanted CustomTaskMetada objects.
- Add tests to ensure proper deletion 


### Manual verification steps performed
1. Step 1
2. Step 2
3. ...

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
closes #4599 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
