### PR TITLE
Update account deletion string

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -197,7 +197,7 @@
       completelyDeleteAccountLabel: 'Completely remove your account from Kolibri Studio',
       unableToDeleteAdminAccount: 'Unable to delete an admin account',
       handleChannelsBeforeAccount:
-        'You must delete these channels manually or invite others to edit them before you can delete your account.',
+        'You cannot delete accounts that have channels. You must delete these channels manually before you can delete your account.',
 
       // API strings
       apiTokenHeading: 'API Token',


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Updates string to more accurately display the current (if not ideal) behavior for account deletion with shared channels.


### Manual verification steps performed
Create a brand new account
Create a channel and share it with someone so that they can edit it.
Go to Settings > Account and attempt to delete the account. See updated warning string. 

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/0c50cedf-c12f-4cc4-9be6-379fadc6b543)

### Does this introduce any tech-debt items?
No, but it doesn't resolve the underlying problem, either 
___
## Reviewer guidance
### How can a reviewer test these changes?
Reference manual verification steps above.


## References
Sort of fixes #4532 , at least as much as we can right now.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
