### PR TITLE
Fix mis-rendered external links on downloaded PDFs

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -262,7 +262,7 @@
             <VFlex class="source-thumbnail">
               <Thumbnail :src="channel.thumbnail" />
             </VFlex>
-            <VFlex v-if="libraryMode" class="font-weight-bold notranslate px-4 subheading">
+            <VFlex v-if="printing" class="font-weight-bold notranslate px-4 subheading">
               {{ channel.name }}
             </VFlex>
             <a
@@ -418,9 +418,6 @@
           });
         }
         return '';
-      },
-      libraryMode() {
-        return window.libraryMode;
       },
       sizeText() {
         const size = this._details.resource_size;


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Replaces use of `libraryMode` computed prop with `printing`, to prevent the improperly rendered external link icon on downloaded PDFs

### Screenshots (if applicable)
On studio (with link):
<img width="1439" alt="Screenshot 2024-07-17 at 11 19 38 AM" src="https://github.com/user-attachments/assets/38e1f5f2-c7c6-4a59-b564-4508562c9ea5">

Downloaded:
<img width="1055" alt="Screenshot 2024-07-17 at 11 19 45 AM" src="https://github.com/user-attachments/assets/4fb77b94-027d-476a-8d6b-c75d097bff9e">


## Reviewer guidance
### How can a reviewer test these changes?

Channel (that has imported at least one piece of content from another channel) > Channel Details Modal > Download Channel Summary


## References
Fixes #4094


## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
