### PR TITLE
Before entering Main, check for showPolicy query param to show policy

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -413,12 +413,11 @@
     },
     methods: {
       ...mapActions('account', ['register']),
-      ...mapActions('policies', ['openPolicy']),
       showTermsOfService() {
-        this.openPolicy(policies.TERMS_OF_SERVICE);
+        this.$router.push({ query: { showPolicy: policies.TERMS_OF_SERVICE } });
       },
       showPrivacyPolicy() {
-        this.openPolicy(policies.PRIVACY);
+        this.$router.push({ query: { showPolicy: policies.PRIVACY } });
       },
       showStorageField(id) {
         return id === uses.STORING && this.form.uses.includes(id);

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -153,6 +153,17 @@ import { availableLanguages, currentLanguage, sortLanguages } from '../../shared
         return params.get('next');
       },
     },
+    beforeRouteEnter(to, from, next) {
+      if (
+        get(to, 'query.showPolicy', false) &&
+        Object.values(policies).includes(to.query.showPolicy) &&
+        !from.name // Prevents the modal from showing when navigating back
+      ) {
+        next(vm => vm.openPolicy(to.query.showPolicy));
+      } else {
+        next();
+      }
+    },
     methods: {
       ...mapActions(['login']),
       ...mapActions('policies', ['openPolicy']),
@@ -188,23 +199,6 @@ import { availableLanguages, currentLanguage, sortLanguages } from '../../shared
         }
         return Promise.resolve();
       },
-    },
-    beforeRouteEnter(to, from, next) {
-      console.log(availableLanguages);
-      for(const policy of Object.values(policies)) {
-        for(const lang of Object.keys(availableLanguages)) {
-          console.log(`https://studio.learningequality.org/${lang}/accounts?showPolicy=${policy}`);
-        }
-      }
-      if(
-        get(to, 'query.showPolicy', false) &&
-        Object.values(policies).includes(to.query.showPolicy) &&
-        !from.name   // Prevents the modal from showing when navigating back
-      ) {
-        next(vm => vm.openPolicy(to.query.showPolicy));
-      } else {
-        next();
-      }
     },
     $trs: {
       kolibriStudio: 'Kolibri Studio',

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -187,6 +187,16 @@
         return Promise.resolve();
       },
     },
+      if(
+        to.query?.showPolicy &&
+        Object.values(policies).includes(to.query.showPolicy) &&
+        !from.name   // Prevents the modal from showing when navigating back
+      ) {
+        next(vm => vm.openPolicy(to.query.showPolicy));
+      } else {
+        next();
+      }
+    },
     $trs: {
       kolibriStudio: 'Kolibri Studio',
       passwordLabel: 'Password',

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -153,12 +153,11 @@
     },
     methods: {
       ...mapActions(['login']),
-      ...mapActions('policies', ['openPolicy']),
       showTermsOfService() {
-        this.openPolicy(policies.TERMS_OF_SERVICE);
+        this.$router.push({ query: { showPolicy: policies.TERMS_OF_SERVICE } });
       },
       showPrivacyPolicy() {
-        this.openPolicy(policies.PRIVACY);
+        this.$router.push({ query: { showPolicy: policies.PRIVACY } });
       },
       submit() {
         if (this.$refs.form.validate()) {

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -117,6 +117,8 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
+import { availableLanguages, currentLanguage, sortLanguages } from '../../shared/i18n';
+  import get from 'lodash/get';
   import EmailField from 'shared/views/form/EmailField';
   import PasswordField from 'shared/views/form/PasswordField';
   import Banner from 'shared/views/Banner';
@@ -187,8 +189,15 @@
         return Promise.resolve();
       },
     },
+    beforeRouteEnter(to, from, next) {
+      console.log(availableLanguages);
+      for(const policy of Object.values(policies)) {
+        for(const lang of Object.keys(availableLanguages)) {
+          console.log(`https://studio.learningequality.org/${lang}/accounts?showPolicy=${policy}`);
+        }
+      }
       if(
-        to.query?.showPolicy &&
+        get(to, 'query.showPolicy', false) &&
         Object.values(policies).includes(to.query.showPolicy) &&
         !from.name   // Prevents the modal from showing when navigating back
       ) {

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -117,7 +117,6 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
-  import get from 'lodash/get';
   import EmailField from 'shared/views/form/EmailField';
   import PasswordField from 'shared/views/form/PasswordField';
   import Banner from 'shared/views/Banner';
@@ -151,17 +150,6 @@
         const params = new URLSearchParams(window.location.search.substring(1));
         return params.get('next');
       },
-    },
-    beforeRouteEnter(to, from, next) {
-      if (
-        get(to, 'query.showPolicy', false) &&
-        Object.values(policies).includes(to.query.showPolicy) &&
-        !from.name // Prevents the modal from showing when navigating back
-      ) {
-        next(vm => vm.openPolicy(to.query.showPolicy));
-      } else {
-        next();
-      }
     },
     methods: {
       ...mapActions(['login']),

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -117,7 +117,6 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
-import { availableLanguages, currentLanguage, sortLanguages } from '../../shared/i18n';
   import get from 'lodash/get';
   import EmailField from 'shared/views/form/EmailField';
   import PasswordField from 'shared/views/form/PasswordField';

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -83,21 +83,19 @@
 
 <script>
 
-  import { mapActions } from 'vuex';
   import { policies } from 'shared/constants';
 
   export default {
     name: 'UsingStudio',
     methods: {
-      ...mapActions('policies', ['openPolicy']),
       showTermsOfService() {
-        this.openPolicy(policies.TERMS_OF_SERVICE);
+        this.$router.push({ query: { showPolicy: policies.TERMS_OF_SERVICE } });
       },
       showPrivacyPolicy() {
-        this.openPolicy(policies.PRIVACY);
+        this.$router.push({ query: { showPolicy: policies.PRIVACY } });
       },
       showCommunityStandards() {
-        this.openPolicy(policies.COMMUNITY_STANDARDS);
+        this.$router.push({ query: { showPolicy: policies.COMMUNITY_STANDARDS } });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/settings/pages/__tests__/usingStudio.spec.js
+++ b/contentcuration/contentcuration/frontend/settings/pages/__tests__/usingStudio.spec.js
@@ -1,11 +1,16 @@
 import Vuex, { Store } from 'vuex';
+import VueRouter from 'vue-router';
 import { mount, createLocalVue } from '@vue/test-utils';
+import router from '../../../accounts/router';
 
 import UsingStudio from '../UsingStudio/index';
 import { policies } from 'shared/constants';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+localVue.use(VueRouter);
+
+jest.spyOn(router, 'push');
 
 function makeWrapper({ methods = {} } = {}) {
   const store = new Store({
@@ -18,34 +23,35 @@ function makeWrapper({ methods = {} } = {}) {
       },
     },
   });
-
   return mount(UsingStudio, {
     localVue,
     store,
     methods,
+    router,
     stubs: ['PolicyModals'],
   });
 }
 
 describe('usingStudio tab', () => {
   let wrapper;
-  let openPolicy;
 
   beforeEach(() => {
-    openPolicy = jest.fn();
-    wrapper = makeWrapper({ methods: { openPolicy } });
+    wrapper = makeWrapper();
   });
 
   it('clicking privacy link should open policies modal', () => {
     wrapper.find('[data-test="policy-link"]').trigger('click');
-    expect(openPolicy).toHaveBeenCalledWith(policies.PRIVACY);
+    const query = { query: { showPolicy: policies.PRIVACY } };
+    expect(wrapper.vm.$router.push).toHaveBeenCalledWith(query);
   });
   it('clicking terms of service link should open tos modal', () => {
     wrapper.find('[data-test="tos-link"]').trigger('click');
-    expect(openPolicy).toHaveBeenCalledWith(policies.TERMS_OF_SERVICE);
+    const query = { query: { showPolicy: policies.TERMS_OF_SERVICE } };
+    expect(wrapper.vm.$router.push).toHaveBeenCalledWith(query);
   });
   it('clicking community standards link should open standards modal', () => {
     wrapper.find('[data-test="communitystandards-link"]').trigger('click');
-    expect(openPolicy).toHaveBeenCalledWith(policies.COMMUNITY_STANDARDS);
+    const query = { query: { showPolicy: policies.COMMUNITY_STANDARDS } };
+    expect(wrapper.vm.$router.push).toHaveBeenCalledWith(query);
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/policies/PolicyModals.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/PolicyModals.vue
@@ -4,21 +4,21 @@
     <TermsOfServiceModal
       v-if="showTermsOfService"
       :needsAcceptance="isPolicyUnaccepted(policies.TERMS_OF_SERVICE)"
-      @accept="acceptPolicy(getPolicyAcceptedData(policies.TERMS_OF_SERVICE))"
-      @close="closePolicy(policies.TERMS_OF_SERVICE)"
-      @open="policy => openPolicy(policy)"
+      @accept="handleAcceptPolicy"
+      @open="openPolicy"
+      @close="closePolicy"
     />
     <PrivacyPolicyModal
       v-if="showPrivacyPolicy"
       :needsAcceptance="isPolicyUnaccepted(policies.PRIVACY)"
-      @accept="acceptPolicy(getPolicyAcceptedData(policies.PRIVACY))"
-      @close="closePolicy(policies.PRIVACY)"
-      @open="policy => openPolicy(policy)"
+      @accept="handleAcceptPolicy"
+      @open="openPolicy"
+      @close="closePolicy"
     />
     <CommunityStandardsModal
       v-if="showCommunityStandards"
       :needsAcceptance="false"
-      @close="closePolicy(policies.COMMUNITY_STANDARDS)"
+      @close="closePolicy"
     />
   </div>
 
@@ -26,6 +26,7 @@
 
 <script>
 
+  import get from 'lodash/get';
   import { mapActions, mapGetters } from 'vuex';
   import PrivacyPolicyModal from './PrivacyPolicyModal';
   import TermsOfServiceModal from './TermsOfServiceModal';
@@ -40,13 +41,10 @@
       TermsOfServiceModal,
     },
     data() {
-      return {
-        policies,
-      };
+      return { policies };
     },
     computed: {
       ...mapGetters('policies', [
-        'selectedPolicy',
         'getPolicyAcceptedData',
         'isPolicyUnaccepted',
         'firstUnacceptedPolicy',
@@ -66,15 +64,24 @@
       showCommunityStandards() {
         return this.selectedPolicy === policies.COMMUNITY_STANDARDS;
       },
-    },
-    created() {
-      const { query } = this.$route;
-      if (query.showPolicy && Object.values(policies).includes(query.showPolicy)) {
-        this.openPolicy(query.showPolicy);
-      }
+      selectedPolicy() {
+        // Effectively results in watching the route query
+        return get(this, '$route.query.showPolicy', this.firstUnacceptedPolicy);
+      },
     },
     methods: {
-      ...mapActions('policies', ['acceptPolicy', 'openPolicy', 'closePolicy']),
+      ...mapActions('policies', ['acceptPolicy']),
+      openPolicy(policy) {
+        const toRoute = this.$route;
+        toRoute.query.showPolicy = policy;
+        this.$router.push(toRoute);
+      },
+      closePolicy() {
+        this.$router.push({ query: {} });
+      },
+      handleAcceptPolicy(policy) {
+        this.acceptPolicy(this.getPolicyAcceptedData(policy)).then(this.closePolicy);
+      },
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/views/policies/PolicyModals.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/PolicyModals.vue
@@ -67,6 +67,12 @@
         return this.selectedPolicy === policies.COMMUNITY_STANDARDS;
       },
     },
+    created() {
+      const { query } = this.$route;
+      if (query.showPolicy && Object.values(policies).includes(query.showPolicy)) {
+        this.openPolicy(query.showPolicy);
+      }
+    },
     methods: {
       ...mapActions('policies', ['acceptPolicy', 'openPolicy', 'closePolicy']),
     },

--- a/contentcuration/contentcuration/frontend/shared/views/policies/PrivacyPolicyModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/PrivacyPolicyModal.vue
@@ -16,7 +16,7 @@
         {{ $untranslated('introductionP1Part1') }}
         <ActionLink
           :text="$untranslated('introductionP1TC')"
-          @click="$emit('open', policies.TERMS_OF_SERVICE)"
+          @click="$router.push({ query: { showPolicy: policies.COMMUNITY_STANDARDS } })"
         />
         {{ $untranslated('introductionP1Part2') }}
         <b>{{ $untranslated('introductionP1TU') }}</b>
@@ -204,7 +204,7 @@
           {{ $untranslated('expectationOfPrivacyP1') }}
           <ActionLink
             :text="$untranslated('expectationOfPrivacyP1TC')"
-            @click="$emit('open', policies.TERMS_OF_SERVICE)"
+            @click="$router.push({ query: { showPolicy: policies.TERMS_OF_SERVICE } })"
           />
         </p>
       </div>

--- a/contentcuration/contentcuration/frontend/shared/views/policies/TermsOfServiceModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/TermsOfServiceModal.vue
@@ -186,7 +186,7 @@
         <p>
           <ActionLink
             :text="$tr('communityStandardsLink')"
-            @click="$emit('open', policies.COMMUNITY_STANDARDS)"
+            @click="$router.push({ query: { showPolicy: policies.COMMUNITY_STANDARDS } })"
           />
         </p>
       </div>
@@ -198,7 +198,7 @@
         <p>
           <ActionLink
             :text="$tr('yourPrivacyLink')"
-            @click="$emit('open', policies.PRIVACY)"
+            @click="$router.push({ query: { showPolicy: policies.PRIVACY } })"
           />
         </p>
       </div>

--- a/contentcuration/contentcuration/frontend/shared/vuex/policies/index.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/policies/index.js
@@ -62,9 +62,6 @@ export const getters = {
       return getters.nonAcceptedPolicies.includes(policy);
     };
   },
-  selectedPolicy(state) {
-    return state.selectedPolicy;
-  },
   /**
    * @returns There can be more unaccepted policies.
    * This getter returns the first of them when sorted
@@ -85,9 +82,6 @@ export const getters = {
 };
 
 export const mutations = {
-  SET_SELECTED_POLICY(state, policy) {
-    state.selectedPolicy = policy;
-  },
   SET_POLICIES(state, policies) {
     for (const policy in policies) {
       Vue.set(state.policies, policy, policies[policy]);
@@ -98,14 +92,6 @@ export const mutations = {
 export const actions = {
   setPolicies(context, policies) {
     context.commit('SET_POLICIES', policies);
-  },
-  openPolicy(context, policy) {
-    context.commit('SET_SELECTED_POLICY', policy);
-  },
-  closePolicy(context, policy) {
-    if (context.state.selectedPolicy === policy) {
-      context.commit('SET_SELECTED_POLICY', null);
-    }
   },
   /**
    * Accept a policy
@@ -118,11 +104,7 @@ export const actions = {
   acceptPolicy(context, policyAcceptedData) {
     return client
       .post(window.Urls.policy_update(), { policy: JSON.stringify(policyAcceptedData) })
-      .then(() => {
-        return context
-          .dispatch('setPolicies', policyAcceptedData)
-          .then(() => context.dispatch('closePolicy'));
-      });
+      .then(() => context.dispatch('setPolicies', policyAcceptedData));
   },
 };
 
@@ -131,7 +113,6 @@ export default {
   state() {
     return {
       policies: {},
-      selectedPolicy: null,
     };
   },
   getters,

--- a/contentcuration/contentcuration/frontend/shared/vuex/policies/index.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/vuex/policies/index.spec.js
@@ -138,9 +138,8 @@ describe('policies store', () => {
         const policyAcceptedData = { privacy_policy_2020_12_10: '12/05/2021 09:56' };
         await actions.acceptPolicy({ getters, dispatch }, policyAcceptedData);
 
-        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls.length).toBe(1);
         expect(dispatch.mock.calls[0]).toEqual(['setPolicies', policyAcceptedData]);
-        expect(dispatch.mock.calls[1]).toEqual(['closePolicy']);
       });
     });
   });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

In `beforeRouteEnter` in `Main.vue` we check the `to.query.showPolicy` - if it's a valid policy it'll be shown to the user. Includes a check to help be sure this is the first page load.

The URLs would be:

https://studio.learningequality.org/en/accounts?showPolicy=privacy_policy
https://studio.learningequality.org/ar/accounts?showPolicy=privacy_policy
https://studio.learningequality.org/es-es/accounts?showPolicy=privacy_policy
https://studio.learningequality.org/fr-fr/accounts?showPolicy=privacy_policy
https://studio.learningequality.org/pt-br/accounts?showPolicy=privacy_policy

https://studio.learningequality.org/en/accounts?showPolicy=terms_of_service
https://studio.learningequality.org/ar/accounts?showPolicy=terms_of_service
https://studio.learningequality.org/es-es/accounts?showPolicy=terms_of_service
https://studio.learningequality.org/fr-fr/accounts?showPolicy=terms_of_service
https://studio.learningequality.org/pt-br/accounts?showPolicy=terms_of_service

https://studio.learningequality.org/en/accounts?showPolicy=community_standards
https://studio.learningequality.org/ar/accounts?showPolicy=community_standards
https://studio.learningequality.org/es-es/accounts?showPolicy=community_standards
https://studio.learningequality.org/fr-fr/accounts?showPolicy=community_standards
https://studio.learningequality.org/pt-br/accounts?showPolicy=community_standards


## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->

Run the changes, then replace `studio.learningequality.org` in the URLs listed above with the one you use to access your testing instance and see that they work.


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->

Go back & forth. Sign in, out, etc. It should only show the policy if it is the initial load of the page.

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

Closes #4133

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
