### PR TITLE
Add test for StorageSettingsView

### DIFF
--- a/contentcuration/contentcuration/tests/views/test_settings.py
+++ b/contentcuration/contentcuration/tests/views/test_settings.py
@@ -1,0 +1,60 @@
+from mock import mock
+
+from django.template.loader import render_to_string
+from django.conf import settings as ccsettings
+
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.views.settings import StorageSettingsView
+from contentcuration.forms import StorageRequestForm
+
+class StorageSettingsViewTestCase(StudioAPITestCase):
+
+    def setUp(self):
+        super(StorageSettingsViewTestCase, self).setUp()
+        self.view = StorageSettingsView()
+        self.view.request = mock.Mock()
+        self.view.request.user = testdata.user(email="tester@tester.com")
+
+    def test_storage_request(self):
+        
+        with mock.patch("contentcuration.views.settings.send_mail") as send_mail:
+
+            data = dict(
+                storage="storage",
+                kind="kind",
+                resource_count="resource_count",
+                resource_size="resource_size",
+                creators="creators",
+                sample_link="sample_link",
+                license="license",
+                public="channel1, channel2",
+                audience="audience",
+                import_count="import_count",
+                location="location",
+                uploading_for="uploading_for",
+                organization_type="organization_type",
+                time_constraint="time_constraint",
+                message="message"
+            )
+            self.form = StorageRequestForm(data=data)     
+
+            self.assertTrue(self.form.is_valid())
+            self.view.form_valid(self.form)
+
+            message = render_to_string(
+                "settings/storage_request_email.txt",
+                {
+                    "data": self.form.cleaned_data,
+                    "user": self.view.request.user,
+                    "channels": ["channel1", "channel2"]
+                },
+            )
+
+            send_mail.assert_called_once()
+            send_mail.assert_called_with(
+                f"Kolibri Studio storage request from {self.view.request.user.email}",
+                message,
+                ccsettings.DEFAULT_FROM_EMAIL,
+                [ccsettings.SPACE_REQUEST_EMAIL, self.view.request.user.email],
+            )

--- a/contentcuration/contentcuration/views/settings.py
+++ b/contentcuration/contentcuration/views/settings.py
@@ -184,7 +184,7 @@ class StorageSettingsView(PostFormMixin, FormView):
         )
 
         send_mail(
-            f"Kolibri Studio storage request from {self.request.user}",
+            f"Kolibri Studio storage request from {self.request.user.email}",
             message,
             ccsettings.DEFAULT_FROM_EMAIL,
             [ccsettings.SPACE_REQUEST_EMAIL, self.request.user.email],


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
This PR adds a test case for the `StorageSettingsView` and changes the email subject line to explicitly use the user's email.

### Manual verification steps performed
1. Ran `python manage.py test contentcuration.tests.views.test_settings`

___

## References
Closes #4418.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
