### PR TITLE
Always require an actor_id to identify the user who caused a specific event in a channel's history.

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -716,6 +716,32 @@ class PermissionCTE(With):
         return Exists(self.queryset().filter(*filters).values("user_id"))
 
 
+class ChannelModelQuerySet(models.QuerySet):
+    def create(self, **kwargs):
+        """
+        Create a new object with the given kwargs, saving it to the database
+        and returning the created object.
+        Overriding the Django default here to allow passing through the actor_id
+        to register this event in the channel history.
+        """
+        # Either allow the actor_id to be passed in, or read from a special attribute
+        # on the queryset, this makes super calls to other methods easier to handle
+        # without having to reimplement the entire method.
+        actor_id = kwargs.pop("actor_id", getattr(self, "_actor_id", None))
+        obj = self.model(**kwargs)
+        self._for_write = True
+        obj.save(force_insert=True, using=self.db, actor_id=actor_id)
+        return obj
+
+    def get_or_create(self, defaults=None, **kwargs):
+        self._actor_id = kwargs.pop("actor_id", None)
+        return super().get_or_create(defaults, **kwargs)
+
+    def update_or_create(self, defaults=None, **kwargs):
+        self._actor_id = kwargs.pop("actor_id", None)
+        return super().update_or_create(defaults, **kwargs)
+
+
 class Channel(models.Model):
     """ Permissions come from association with organizations """
     id = UUIDField(primary_key=True, default=uuid.uuid4)
@@ -800,6 +826,8 @@ class Channel(models.Model):
         "version",
     ])
 
+    objects = ChannelModelQuerySet.as_manager()
+
     @classmethod
     def get_editable(cls, user, channel_id):
         return cls.filter_edit_queryset(cls.objects.all(), user).get(id=channel_id)
@@ -874,6 +902,10 @@ class Channel(models.Model):
         return files['resource_size'] or 0
 
     def on_create(self):
+        actor_id = getattr(self, "_actor_id", None)
+        if actor_id is None:
+            raise ValueError("No actor_id passed to save method")
+
         if not self.content_defaults:
             self.content_defaults = DEFAULT_CONTENT_DEFAULTS
 
@@ -905,7 +937,7 @@ class Channel(models.Model):
         if self.public and (self.main_tree and self.main_tree.published):
             delete_public_channel_cache_keys()
 
-    def on_update(self):
+    def on_update(self):  # noqa C901
         from contentcuration.utils.user import calculate_user_storage
         original_values = self._field_updates.changed()
 
@@ -929,14 +961,23 @@ class Channel(models.Model):
             for editor in self.editors.all():
                 calculate_user_storage(editor.pk)
 
-        # Delete db if channel has been deleted and mark as unpublished
         if "deleted" in original_values and not original_values["deleted"]:
             self.pending_editors.all().delete()
+            # Delete db if channel has been deleted and mark as unpublished
             export_db_storage_path = os.path.join(settings.DB_ROOT, "{channel_id}.sqlite3".format(channel_id=self.id))
             if default_storage.exists(export_db_storage_path):
                 default_storage.delete(export_db_storage_path)
                 if self.main_tree:
                     self.main_tree.published = False
+        # mark the instance as deleted or recovered, if requested
+        if "deleted" in original_values:
+            user_id = getattr(self, "_actor_id", None)
+            if user_id is None:
+                raise ValueError("No actor_id passed to save method")
+            if original_values["deleted"]:
+                self.history.create(actor_id=user_id, action=channel_history.RECOVERY)
+            else:
+                self.history.create(actor_id=user_id, action=channel_history.DELETION)
 
         if self.main_tree and self.main_tree._field_updates.changed():
             self.main_tree.save()
@@ -946,12 +987,19 @@ class Channel(models.Model):
             delete_public_channel_cache_keys()
 
     def save(self, *args, **kwargs):
-        if self._state.adding:
+        self._actor_id = kwargs.pop("actor_id", None)
+        creating = self._state.adding
+        if creating:
+            if self._actor_id is None:
+                raise ValueError("No actor_id passed to save method")
             self.on_create()
         else:
             self.on_update()
 
         super(Channel, self).save(*args, **kwargs)
+
+        if creating:
+            self.history.create(actor_id=self._actor_id, action=channel_history.CREATION)
 
     def get_thumbnail(self):
         return get_channel_thumbnail(self)
@@ -996,23 +1044,10 @@ class Channel(models.Model):
 
         return self
 
-    def mark_created(self, user):
-        self.history.create(actor_id=to_pk(user), action=channel_history.CREATION)
-
     def mark_publishing(self, user):
         self.history.create(actor_id=to_pk(user), action=channel_history.PUBLICATION)
         self.main_tree.publishing = True
         self.main_tree.save()
-
-    def mark_deleted(self, user):
-        self.history.create(actor_id=to_pk(user), action=channel_history.DELETION)
-        self.deleted = True
-        self.save()
-
-    def mark_recovered(self, user):
-        self.history.create(actor_id=to_pk(user), action=channel_history.RECOVERY)
-        self.deleted = False
-        self.save()
 
     @property
     def deletion_history(self):

--- a/contentcuration/contentcuration/tests/test_channel_model.py
+++ b/contentcuration/contentcuration/tests/test_channel_model.py
@@ -145,7 +145,7 @@ class ChannelGetDateModifiedTestCase(StudioTestCase):
         # add a new node
         node(
             parent=self.channel.main_tree,
-            data={"node_id": "nodez", "title": "new child", "kind_id": "video",},
+            data={"node_id": "nodez", "title": "new child", "kind_id": "video"},
         )
         # check that the returned date is newer
         assert self.channel.get_date_modified() > old_date
@@ -160,7 +160,7 @@ class GetAllChannelsTestCase(StudioTestCase):
         super(GetAllChannelsTestCase, self).setUp()
 
         # create 10 channels for comparison
-        self.channels = mixer.cycle(10).blend(Channel)
+        self.channels = [Channel.objects.create(actor_id=self.admin_user.id) for _ in range(10)]
 
     def test_returns_all_channels_in_the_db(self):
         """
@@ -179,9 +179,10 @@ class ChannelSetTestCase(BaseAPITestCase):
     def setUp(self):
         super(ChannelSetTestCase, self).setUp()
         self.channelset = mixer.blend(ChannelSet, editors=[self.user])
-        self.channels = mixer.cycle(10).blend(
-            Channel, secret_tokens=[self.channelset.secret_token], editors=[self.user]
-        )
+        self.channels = [Channel.objects.create(actor_id=self.user.id) for _ in range(10)]
+        for chann in self.channels:
+            chann.secret_tokens.add(self.channelset.secret_token)
+            chann.editors.add(self.user)
 
     def test_get_user_channel_sets(self):
         """ Make sure get_user_channel_sets returns the correct sets """
@@ -215,7 +216,7 @@ class ChannelSetTestCase(BaseAPITestCase):
     def test_save_channels_to_token(self):
         """ Check endpoint will assign token to channels """
         token = self.channelset.secret_token
-        channels = mixer.cycle(5).blend(Channel)
+        channels = [Channel.objects.create(actor_id=self.user.id) for _ in range(5)]
         channels = Channel.objects.filter(
             pk__in=[c.pk for c in channels]
         )  # Make this a queryset
@@ -274,7 +275,7 @@ class ChannelMetadataSaveTestCase(StudioTestCase):
 
     def setUp(self):
         super(ChannelMetadataSaveTestCase, self).setUp()
-        self.channels = mixer.cycle(5).blend(Channel)
+        self.channels = [Channel.objects.create(actor_id=self.admin_user.id) for _ in range(5)]
         for c in self.channels:
             c.main_tree.changed = False
             c.main_tree.save()

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -876,7 +876,7 @@ class SyncNodesOperationTestCase(StudioTestCase):
 
         # Setup derivative channel
         self.new_channel = Channel.objects.create(
-            name="derivative of teschannel", source_id="lkajs"
+            name="derivative of teschannel", source_id="lkajs", actor_id=self.admin_user.id
         )
         self.new_channel.save()
         self.new_channel.main_tree = self._create_empty_tree()

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -493,20 +493,21 @@ class ChannelExportUtilityFunctionTestCase(StudioTestCase):
         clear_tasks()
 
     def test_convert_channel_thumbnail_empty_thumbnail(self):
-        channel = cc.Channel.objects.create()
+        channel = cc.Channel.objects.create(actor_id=self.admin_user.id)
         self.assertEqual("", convert_channel_thumbnail(channel))
 
     def test_convert_channel_thumbnail_static_thumbnail(self):
-        channel = cc.Channel.objects.create(thumbnail="/static/kolibri_flapping_bird.png")
+        channel = cc.Channel.objects.create(thumbnail="/static/kolibri_flapping_bird.png", actor_id=self.admin_user.id)
         self.assertEqual("", convert_channel_thumbnail(channel))
 
     def test_convert_channel_thumbnail_encoding_valid(self):
-        channel = cc.Channel.objects.create(thumbnail="/content/kolibri_flapping_bird.png", thumbnail_encoding={"base64": "flappy_bird"})
+        channel = cc.Channel.objects.create(
+            thumbnail="/content/kolibri_flapping_bird.png", thumbnail_encoding={"base64": "flappy_bird"}, actor_id=self.admin_user.id)
         self.assertEqual("flappy_bird", convert_channel_thumbnail(channel))
 
     def test_convert_channel_thumbnail_encoding_invalid(self):
         with patch("contentcuration.utils.publish.get_thumbnail_encoding", return_value="this is a test"):
-            channel = cc.Channel.objects.create(thumbnail="/content/kolibri_flapping_bird.png", thumbnail_encoding={})
+            channel = cc.Channel.objects.create(thumbnail="/content/kolibri_flapping_bird.png", thumbnail_encoding={}, actor_id=self.admin_user.id)
             self.assertEqual("this is a test", convert_channel_thumbnail(channel))
 
     def test_create_slideshow_manifest(self):
@@ -543,7 +544,7 @@ class ChannelExportPrerequisiteTestCase(StudioTestCase):
             os.remove(self.output_db)
 
     def test_nonexistent_prerequisites(self):
-        channel = cc.Channel.objects.create()
+        channel = cc.Channel.objects.create(actor_id=self.admin_user.id)
         node1 = cc.ContentNode.objects.create(kind_id="exercise", parent_id=channel.main_tree.pk, complete=True)
         exercise = cc.ContentNode.objects.create(kind_id="exercise", complete=True)
 
@@ -554,7 +555,7 @@ class ChannelExportPrerequisiteTestCase(StudioTestCase):
 class ChannelExportPublishedData(StudioTestCase):
     def test_fill_published_fields(self):
         version_notes = description()
-        channel = cc.Channel.objects.create()
+        channel = cc.Channel.objects.create(actor_id=self.admin_user.id)
         channel.last_published
         fill_published_fields(channel, version_notes)
         self.assertTrue(channel.published_data)

--- a/contentcuration/contentcuration/tests/test_restore_channel.py
+++ b/contentcuration/contentcuration/tests/test_restore_channel.py
@@ -93,7 +93,7 @@ class ChannelRestoreUtilityFunctionTestCase(StudioTestCase):
             self.version,
             self.last_updated,
         )
-        self.channel, _ = create_channel(self.cursor_mock, self.id)
+        self.channel, _ = create_channel(self.cursor_mock, self.id, self.admin_user)
 
     def test_restore_channel_id(self):
         self.assertEqual(self.channel.id, self.id)

--- a/contentcuration/contentcuration/tests/test_serializers.py
+++ b/contentcuration/contentcuration/tests/test_serializers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.db.models.query import QuerySet
 from le_utils.constants import content_kinds
+from mock import Mock
 from rest_framework import serializers
 
 from .base import BaseAPITestCase
@@ -146,12 +147,15 @@ class ContentDefaultsSerializerUseTestCase(BaseAPITestCase):
             nested_writes = True
 
     def test_save__create(self):
+        request = Mock()
+        request.user = self.user
         s = self.ChannelSerializer(
             data=dict(
                 name="New test channel",
                 description="This is the best test channel",
                 content_defaults=dict(author="Buster"),
-            )
+            ),
+            context=dict(request=request),
         )
 
         self.assertTrue(s.is_valid())
@@ -167,7 +171,7 @@ class ContentDefaultsSerializerUseTestCase(BaseAPITestCase):
             description="This is the best test channel",
             content_defaults=dict(author="Buster"),
         )
-        c.save()
+        c.save(actor_id=self.user.id)
 
         s = self.ChannelSerializer(
             c, data=dict(content_defaults=dict(license="Special Permissions"))

--- a/contentcuration/contentcuration/tests/test_sync.py
+++ b/contentcuration/contentcuration/tests/test_sync.py
@@ -37,7 +37,7 @@ class SyncTestCase(StudioTestCase):
 
     def setUp(self):
         super(SyncTestCase, self).setUpBase()
-        self.derivative_channel = Channel.objects.create(name="testchannel")
+        self.derivative_channel = Channel.objects.create(name="testchannel", actor_id=self.admin_user.id)
         self.channel.main_tree.copy_to(self.derivative_channel.main_tree)
         self.derivative_channel.main_tree.refresh_from_db()
         self.derivative_channel.save()

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -211,7 +211,8 @@ def tree(parent=None):
 
 
 def channel(name="testchannel"):
-    channel = cc.Channel.objects.create(name=name)
+    channel_creator = user()
+    channel = cc.Channel.objects.create(name=name, actor_id=channel_creator.id)
     channel.save()
 
     channel.main_tree = tree()

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -486,7 +486,7 @@ class PublishEndpointTestCase(BaseAPITestCase):
                 del connections.databases[alias]
 
     def test_404_not_authorized(self):
-        new_channel = Channel.objects.create()
+        new_channel = Channel.objects.create(actor_id=self.user.id)
         response = self.post(
             reverse_lazy("api_publish_channel"), {"channel_id": new_channel.id}
         )
@@ -637,7 +637,7 @@ class APICommitChannelEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_404_no_permission(self):
-        new_channel = Channel.objects.create()
+        new_channel = Channel.objects.create(actor_id=self.user.id)
         response = self.post(
             reverse_lazy("api_finish_channel"), {"channel_id": new_channel.id}
         )
@@ -652,7 +652,7 @@ class CheckUserIsEditorEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_404_no_permission(self):
-        new_channel = Channel.objects.create()
+        new_channel = Channel.objects.create(actor_id=self.user.id)
         response = self.post(
             reverse_lazy("check_user_is_editor"), {"channel_id": new_channel.id}
         )
@@ -668,7 +668,7 @@ class GetTreeDataEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_404_no_permission(self):
-        new_channel = Channel.objects.create()
+        new_channel = Channel.objects.create(actor_id=self.user.id)
         response = self.post(
             reverse_lazy("get_tree_data"),
             {"channel_id": new_channel.id, "tree": "main"},
@@ -685,7 +685,7 @@ class GetNodeTreeDataEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_404_no_permission(self):
-        new_channel = Channel.objects.create()
+        new_channel = Channel.objects.create(actor_id=self.user.id)
         response = self.post(
             reverse_lazy("get_node_tree_data"),
             {"channel_id": new_channel.id, "tree": "main"},
@@ -701,7 +701,7 @@ class GetChannelStatusBulkEndpointTestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_404_no_permission(self):
-        new_channel = Channel.objects.create()
+        new_channel = Channel.objects.create(actor_id=self.user.id)
         response = self.post(
             reverse_lazy("get_channel_status_bulk"),
             {"channel_ids": [self.channel.id, new_channel.id]},

--- a/contentcuration/contentcuration/tests/viewsets/test_bookmark.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_bookmark.py
@@ -179,13 +179,7 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.post(
             reverse("bookmark-list"), bookmark, format="json",
         )
-        self.assertEqual(response.status_code, 201, response.content)
-        try:
-            models.Channel.bookmarked_by.through.objects.get(
-                user=self.user
-            )
-        except models.Channel.bookmarked_by.through.DoesNotExist:
-            self.fail("Bookmark was not created")
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_bookmark(self):
         bookmark = models.Channel.bookmarked_by.through.objects.create(
@@ -196,9 +190,4 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.delete(
             reverse("bookmark-detail", kwargs={"pk": bookmark.id})
         )
-        self.assertEqual(response.status_code, 204, response.content)
-        try:
-            models.Channel.bookmarked_by.through.objects.get(id=bookmark.id)
-            self.fail("Bookmark was not deleted")
-        except models.Channel.bookmarked_by.through.DoesNotExist:
-            pass
+        self.assertEqual(response.status_code, 405, response.content)

--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -441,7 +441,10 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.delete(
             reverse("channel-detail", kwargs={"pk": channel.id})
         )
-        self.assertEqual(response.status_code, 405, response.content)
+        self.assertEqual(response.status_code, 204, response.content)
+        channel = models.Channel.objects.get(id=channel.id)
+        self.assertTrue(channel.deleted)
+        self.assertEqual(1, channel.deletion_history.filter(actor=user).count())
 
     def test_admin_restore_channel(self):
         user = testdata.user()

--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -430,8 +430,7 @@ class CRUDTestCase(StudioAPITestCase):
             {"name": new_name},
             format="json",
         )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual(models.Channel.objects.get(id=channel.id).name, new_name)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_channel(self):
         user = testdata.user()
@@ -442,10 +441,7 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.delete(
             reverse("channel-detail", kwargs={"pk": channel.id})
         )
-        self.assertEqual(response.status_code, 204, response.content)
-        channel = models.Channel.objects.get(id=channel.id)
-        self.assertTrue(channel.deleted)
-        self.assertEqual(1, channel.deletion_history.filter(actor=user).count())
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_admin_restore_channel(self):
         user = testdata.user()

--- a/contentcuration/contentcuration/tests/viewsets/test_channelset.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channelset.py
@@ -334,36 +334,7 @@ class CRUDTestCase(StudioAPITestCase):
             {"channels": {self.channel.id: True}},
             format="json",
         )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertTrue(
-            models.ChannelSet.objects.get(id=channelset.id)
-            .secret_token.channels.filter(pk=self.channel.id)
-            .exists()
-        )
-
-    def test_update_channelset_empty(self):
-
-        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
-        channelset.editors.add(self.user)
-        self.client.force_authenticate(user=self.user)
-        response = self.client.patch(
-            reverse("channelset-detail", kwargs={"pk": channelset.id}),
-            {},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-
-    def test_update_channelset_unwriteable_fields(self):
-
-        channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
-        channelset.editors.add(self.user)
-        self.client.force_authenticate(user=self.user)
-        response = self.client.patch(
-            reverse("channelset-detail", kwargs={"pk": channelset.id}),
-            {"not_a_field": "not_a_value"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_channelset(self):
         channelset = models.ChannelSet.objects.create(**self.channelset_db_metadata)
@@ -373,9 +344,4 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.delete(
             reverse("channelset-detail", kwargs={"pk": channelset.id})
         )
-        self.assertEqual(response.status_code, 204, response.content)
-        try:
-            models.ChannelSet.objects.get(id=channelset.id)
-            self.fail("ChannelSet was not deleted")
-        except models.ChannelSet.DoesNotExist:
-            pass
+        self.assertEqual(response.status_code, 405, response.content)

--- a/contentcuration/contentcuration/tests/viewsets/test_clipboard.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_clipboard.py
@@ -263,11 +263,7 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.post(
             reverse("clipboard-list"), clipboard, format="json",
         )
-        self.assertEqual(response.status_code, 201, response.content)
-        try:
-            models.ContentNode.objects.get(id=clipboard["id"])
-        except models.ContentNode.DoesNotExist:
-            self.fail("ContentNode was not created")
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_clipboard(self):
         clipboard = models.ContentNode.objects.create(**self.clipboard_db_metadata)
@@ -276,9 +272,4 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.delete(
             reverse("clipboard-detail", kwargs={"pk": clipboard.id})
         )
-        self.assertEqual(response.status_code, 204, response.content)
-        try:
-            models.ContentNode.objects.get(id=clipboard.id)
-            self.fail("ContentNode was not deleted")
-        except models.ContentNode.DoesNotExist:
-            pass
+        self.assertEqual(response.status_code, 405, response.content)

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -1424,7 +1424,7 @@ class CRUDTestCase(StudioAPITestCase):
 
     def test_fetch_contentnode__by_parent(self):
 
-        channel = models.Channel.objects.create(name="Test channel")
+        channel = models.Channel.objects.create(actor_id=self.user.id, name="Test channel")
         channel.editors.add(self.user)
         channel.save()
 
@@ -1440,7 +1440,7 @@ class CRUDTestCase(StudioAPITestCase):
         self.assertEqual(response.data[0]["id"], contentnode.id)
 
     def test_fetch_contentnode__by_node_id_channel_id(self):
-        channel = models.Channel.objects.create(name="Test channel")
+        channel = models.Channel.objects.create(actor_id=self.user.id, name="Test channel")
         channel.editors.add(self.user)
         channel.save()
 

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -933,6 +933,25 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
             .exists()
         )
 
+    def test_update_contentnode_tag_greater_than_30_chars(self):
+
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+        tag = "kolibri studio, kolibri studio!"
+
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    contentnode.id, CONTENTNODE, {"tags.{}".format(tag): True}, channel_id=self.channel.id
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertFalse(
+            models.ContentNode.objects.get(id=contentnode.id)
+            .tags.filter(tag_name=tag)
+            .exists()
+        )
+
     def test_update_contentnode_suggested_duration(self):
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
         new_suggested_duration = 600
@@ -1500,42 +1519,7 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.post(
             reverse("contentnode-list"), contentnode, format="json",
         )
-        self.assertEqual(response.status_code, 201, response.content)
-        try:
-            models.ContentNode.objects.get(id=contentnode["id"])
-        except models.ContentNode.DoesNotExist:
-            self.fail("ContentNode was not created")
-
-    def test_create_contentnode_tag(self):
-        tag = "howzat!"
-
-        contentnode = self.contentnode_metadata
-        contentnode["tags"] = {
-            tag: True,
-        }
-        response = self.client.post(
-            reverse("contentnode-list"), contentnode, format="json",
-        )
-        self.assertEqual(response.status_code, 201, response.content)
-        self.assertTrue(
-            models.ContentNode.objects.get(id=contentnode["id"])
-            .tags.filter(tag_name=tag)
-            .exists()
-        )
-
-    def test_contentnode_tag_greater_than_30_chars(self):
-        tag = "kolibri studio, kolibri studio!"
-
-        contentnode = self.contentnode_metadata
-        contentnode["tags"] = {
-            tag: True,
-        }
-
-        response = self.client.post(
-            reverse("contentnode-list"), contentnode, format="json",
-        )
-
-        self.assertEqual(response.status_code, 400, response.content)
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_update_contentnode(self):
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
@@ -1546,96 +1530,7 @@ class CRUDTestCase(StudioAPITestCase):
             {"title": new_title},
             format="json",
         )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).title, new_title
-        )
-
-    def test_update_contentnode_tags(self):
-        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
-        tag = "howzat!"
-
-        response = self.client.patch(
-            reverse("contentnode-detail", kwargs={"pk": contentnode.id}),
-            {"tags.{}".format(tag): True},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertTrue(
-            models.ContentNode.objects.get(id=contentnode.id)
-            .tags.filter(tag_name=tag)
-            .exists()
-        )
-
-        other_tag = "LBW!"
-
-        response = self.client.patch(
-            reverse("contentnode-detail", kwargs={"pk": contentnode.id}),
-            {"tags.{}".format(other_tag): True},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertTrue(
-            models.ContentNode.objects.get(id=contentnode.id)
-            .tags.filter(tag_name=tag)
-            .exists()
-        )
-        self.assertTrue(
-            models.ContentNode.objects.get(id=contentnode.id)
-            .tags.filter(tag_name=other_tag)
-            .exists()
-        )
-
-        response = self.client.patch(
-            reverse("contentnode-detail", kwargs={"pk": contentnode.id}),
-            {"tags.{}".format(other_tag): None},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertTrue(
-            models.ContentNode.objects.get(id=contentnode.id)
-            .tags.filter(tag_name=tag)
-            .exists()
-        )
-        self.assertFalse(
-            models.ContentNode.objects.get(id=contentnode.id)
-            .tags.filter(tag_name=other_tag)
-            .exists()
-        )
-
-    def test_update_contentnode_suggested_duration(self):
-        user = testdata.user()
-        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
-        new_suggested_duration = 600
-
-        self.client.force_authenticate(user=user)
-        response = self.client.patch(
-            reverse("contentnode-detail", kwargs={"pk": contentnode.id}),
-            {"suggested_duration": new_suggested_duration},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertEqual(
-            models.ContentNode.objects.get(id=contentnode.id).suggested_duration, new_suggested_duration
-        )
-
-    def test_update_contentnode_tags_dont_duplicate(self):
-        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
-        tag = "howzat!"
-
-        old_tag = models.ContentTag.objects.create(tag_name=tag)
-
-        response = self.client.patch(
-            reverse("contentnode-detail", kwargs={"pk": contentnode.id}),
-            {"tags.{}".format(tag): True},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 200, response.content)
-        self.assertTrue(
-            models.ContentNode.objects.get(id=contentnode.id)
-            .tags.filter(id=old_tag.id)
-            .exists()
-        )
+        self.assertEqual(response.status_code, 405, response.content)
 
     def test_delete_contentnode(self):
         contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
@@ -1643,66 +1538,7 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.delete(
             reverse("contentnode-detail", kwargs={"pk": contentnode.id})
         )
-        self.assertEqual(response.status_code, 204, response.content)
-        try:
-            models.ContentNode.objects.get(id=contentnode.id)
-            self.fail("ContentNode was not deleted")
-        except models.ContentNode.DoesNotExist:
-            pass
-
-    def test_create_contentnode_moveable(self):
-        """
-        Regression test to ensure that nodes created here are able to be moved to
-        other MPTT trees without invalidating data.
-        """
-        contentnode = self.contentnode_metadata
-        response = self.client.post(
-            reverse("contentnode-list"), contentnode, format="json",
-        )
-        self.assertEqual(response.status_code, 201, response.content)
-        try:
-            new_node = models.ContentNode.objects.get(id=contentnode["id"])
-        except models.ContentNode.DoesNotExist:
-            self.fail("ContentNode was not created")
-
-        new_root = models.ContentNode.objects.create(
-            title="Aron's cool contentnode",
-            kind_id=content_kinds.VIDEO,
-            description="coolest contentnode this side of the Pacific",
-        )
-
-        new_node.move_to(new_root, "last-child")
-
-        try:
-            new_node.get_root()
-        except models.ContentNode.MultipleObjectsReturned:
-            self.fail("Moving caused a breakdown of the tree structure")
-
-    def test_update_orphanage_root(self):
-        new_title = "This is not the old title"
-
-        response = self.client.patch(
-            reverse("contentnode-detail", kwargs={"pk": settings.ORPHANAGE_ROOT_ID}),
-            {"title": new_title},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 404, response.content)
-        self.assertNotEqual(
-            models.ContentNode.objects.get(id=settings.ORPHANAGE_ROOT_ID).title,
-            new_title,
-        )
-
-    def test_delete_orphanage_root(self):
-        models.ContentNode.objects.create(**self.contentnode_db_metadata)
-
-        response = self.client.delete(
-            reverse("contentnode-detail", kwargs={"pk": settings.ORPHANAGE_ROOT_ID})
-        )
-        self.assertEqual(response.status_code, 404, response.content)
-        try:
-            models.ContentNode.objects.get(id=settings.ORPHANAGE_ROOT_ID)
-        except models.ContentNode.DoesNotExist:
-            self.fail("Orphanage root was deleted")
+        self.assertEqual(response.status_code, 405, response.content)
 
     @mock.patch("contentcuration.utils.nodes.STALE_MAX_CALCULATION_SIZE", 5000)
     def test_resource_size(self):

--- a/contentcuration/contentcuration/utils/db_tools.py
+++ b/contentcuration/contentcuration/utils/db_tools.py
@@ -67,7 +67,7 @@ def create_channel(
     domain = uuid.uuid5(uuid.NAMESPACE_DNS, name)
     node_id = uuid.uuid5(domain, name)
 
-    channel, _new = Channel.objects.get_or_create(pk=node_id.hex)
+    channel, _new = Channel.objects.get_or_create(actor_id=editors[0].id, pk=node_id.hex)
 
     channel.name = name
     channel.description = description
@@ -86,7 +86,6 @@ def create_channel(
         channel.viewers.add(v)
 
     channel.save()
-    channel.mark_created(editors[0])
     channel.main_tree.get_descendants().delete()
     channel.staging_tree and channel.staging_tree.get_descendants().delete()
     return channel

--- a/contentcuration/contentcuration/utils/import_tools.py
+++ b/contentcuration/contentcuration/utils/import_tools.py
@@ -99,10 +99,10 @@ def import_channel(source_id, target_id=None, download_url=None, editor=None, lo
 
         # Start by creating channel
         log.info("Creating channel...")
-        channel, root_pk = create_channel(conn, target_id)
-        if editor:
-            channel.editors.add(models.User.objects.get(email=editor))
-            channel.save()
+        editor = models.User.objects.get(email=editor)
+        channel, root_pk = create_channel(conn, target_id, editor)
+        channel.editors.add(editor)
+        channel.save()
 
         # Create root node
         root = models.ContentNode.objects.create(
@@ -140,7 +140,7 @@ def import_channel(source_id, target_id=None, download_url=None, editor=None, lo
     log.info("\n\n********** IMPORT COMPLETE **********\n\n")
 
 
-def create_channel(cursor, target_id):
+def create_channel(cursor, target_id, editor):
     """ create_channel: Create channel at target id
         Args:
             cursor (sqlite3.Connection): connection to export database
@@ -150,7 +150,7 @@ def create_channel(cursor, target_id):
     id, name, description, thumbnail, root_pk, version, last_updated = cursor.execute(
         'SELECT id, name, description, thumbnail, root_pk, version, last_updated FROM {table}'
         .format(table=CHANNEL_TABLE)).fetchone()
-    channel, is_new = models.Channel.objects.get_or_create(pk=target_id)
+    channel, is_new = models.Channel.objects.get_or_create(pk=target_id, actor_id=editor.id)
     channel.name = name
     channel.description = description
     channel.thumbnail = write_to_thumbnail_file(thumbnail)

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -130,7 +130,7 @@ def get_prober_channel(request):
 
     channel = Channel.objects.filter(editors=request.user).first()
     if not channel:
-        channel = Channel.objects.create(name="Prober channel", editors=[request.user])
+        channel = Channel.objects.create(actor_id=request.user.id, name="Prober channel", editors=[request.user])
 
     return Response(SimplifiedChannelProbeCheckSerializer(channel).data)
 

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -2,8 +2,8 @@ import json
 import logging
 from builtins import str
 from collections import namedtuple
-from distutils.version import LooseVersion
 
+from distutils.version import LooseVersion
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
 from django.core.exceptions import SuspiciousOperation
@@ -470,7 +470,7 @@ def get_status(channel_id):
 def create_channel(channel_data, user):
     """ Set up channel """
     # Set up initial channel
-    channel, isNew = Channel.objects.get_or_create(id=channel_data["id"])
+    channel, isNew = Channel.objects.get_or_create(id=channel_data["id"], actor_id=user.id)
 
     # Add user as editor if channel is new or channel has no editors
     # Otherwise, check if user is an editor
@@ -519,7 +519,6 @@ def create_channel(channel_data, user):
         map_files_to_node(user, channel.chef_tree, files)
     channel.chef_tree.save()
     channel.save()
-    channel.mark_created(user)
 
     # Delete chef tree if it already exists
     if old_chef_tree and old_chef_tree != channel.staging_tree:

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -705,6 +705,8 @@ class CreateModelMixin(object):
 
         return errors
 
+
+class RESTCreateModelMixin(CreateModelMixin):
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -726,11 +728,6 @@ class DestroyModelMixin(object):
     def _map_delete_change(self, change):
         return change["key"]
 
-    def destroy(self, request, *args, **kwargs):
-        instance = self.get_edit_object()
-        self.perform_destroy(instance)
-        return Response(status=HTTP_204_NO_CONTENT)
-
     def perform_destroy(self, instance):
         instance.delete()
 
@@ -751,6 +748,13 @@ class DestroyModelMixin(object):
                 change["errors"] = [str(e)]
                 errors.append(change)
         return errors
+
+
+class RESTDestroyModelMixin(DestroyModelMixin):
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_edit_object()
+        self.perform_destroy(instance)
+        return Response(status=HTTP_204_NO_CONTENT)
 
 
 class UpdateModelMixin(object):
@@ -790,6 +794,8 @@ class UpdateModelMixin(object):
                 errors.append(change)
         return errors
 
+
+class RESTUpdateModelMixin(UpdateModelMixin):
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
         instance = self.get_edit_object()

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -156,11 +156,10 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
                 raise ValueError("Many to many fields must be explicitly handled", attr)
             setattr(instance, attr, value)
 
-        if hasattr(instance, "on_update") and callable(instance.on_update):
-            instance.on_update()
-
         if not getattr(self, "parent"):
             instance.save()
+        elif hasattr(instance, "on_update") and callable(instance.on_update):
+            instance.on_update()
 
         return instance
 
@@ -191,11 +190,10 @@ class BulkModelSerializer(SimpleReprMixin, ModelSerializer):
 
         instance = ModelClass(**validated_data)
 
-        if hasattr(instance, "on_create") and callable(instance.on_create):
-            instance.on_create()
-
         if not getattr(self, "parent", False):
             instance.save()
+        elif hasattr(instance, "on_create") and callable(instance.on_create):
+            instance.on_create()
 
         return instance
 

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -26,6 +26,7 @@ from rest_framework.serializers import CharField
 from rest_framework.serializers import FloatField
 from rest_framework.serializers import IntegerField
 from rest_framework.status import HTTP_201_CREATED
+from rest_framework.status import HTTP_204_NO_CONTENT
 from search.models import ChannelFullTextSearch
 from search.models import ContentNodeFullTextSearch
 from search.utils import get_fts_search_query
@@ -426,6 +427,16 @@ class ChannelViewSet(ValuesViewset):
         instance = serializer.instance
         Change.create_change(generate_create_event(instance.id, CHANNEL, request.data, channel_id=instance.id), applied=True, created_by_id=request.user.id)
         return Response(self.serialize_object(pk=instance.pk), status=HTTP_201_CREATED)
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_edit_object()
+        self.perform_destroy(instance)
+        Change.create_change(
+            generate_update_event(
+                instance.id, CHANNEL, {"deleted": True}, channel_id=instance.id
+            ), applied=True, created_by_id=request.user.id
+        )
+        return Response(status=HTTP_204_NO_CONTENT)
 
     def perform_destroy(self, instance):
         instance.deleted = True

--- a/contentcuration/contentcuration/viewsets/channelset.py
+++ b/contentcuration/contentcuration/viewsets/channelset.py
@@ -11,6 +11,7 @@ from contentcuration.models import User
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import FilterSet
+from contentcuration.viewsets.base import RESTCreateModelMixin
 from contentcuration.viewsets.base import ValuesViewset
 from contentcuration.viewsets.common import NotNullMapArrayAgg
 from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
@@ -65,7 +66,7 @@ class ChannelSetFilter(FilterSet):
         fields = ("edit",)
 
 
-class ChannelSetViewSet(ValuesViewset):
+class ChannelSetViewSet(ValuesViewset, RESTCreateModelMixin):
     queryset = ChannelSet.objects.all()
     serializer_class = ChannelSetSerializer
     filter_class = ChannelSetFilter

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -29,7 +29,8 @@ from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ReadOnlyValuesViewset
 from contentcuration.viewsets.base import RequiredFilterSet
-from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.base import RESTDestroyModelMixin
+from contentcuration.viewsets.base import RESTUpdateModelMixin
 from contentcuration.viewsets.common import NotNullArrayAgg
 from contentcuration.viewsets.common import SQCount
 from contentcuration.viewsets.common import UUIDFilter
@@ -346,7 +347,7 @@ class AdminUserSerializer(UserSerializer):
         list_serializer_class = BulkListSerializer
 
 
-class AdminUserViewSet(ValuesViewset):
+class AdminUserViewSet(ReadOnlyValuesViewset, RESTUpdateModelMixin, RESTDestroyModelMixin):
     pagination_class = UserListPagination
     permission_classes = [IsAdminUser]
     serializer_class = AdminUserSerializer

--- a/contentcuration/kolibri_public/tests/test_mapper.py
+++ b/contentcuration/kolibri_public/tests/test_mapper.py
@@ -14,6 +14,7 @@ from kolibri_public.utils.mapper import ChannelMapper
 from le_utils.constants import content_kinds
 
 from contentcuration.models import Channel
+from contentcuration.tests.testdata import user
 
 
 class ChannelMapperTest(TestCase):
@@ -35,6 +36,7 @@ class ChannelMapperTest(TestCase):
         super(ChannelMapperTest, cls).setUpClass()
         call_command("loadconstants")
         _, cls.tempdb = tempfile.mkstemp(suffix=".sqlite3")
+        admin_user = user()
 
         with using_content_database(cls.tempdb):
             call_command("migrate", "content", database=get_active_content_database(), no_input=True)
@@ -45,7 +47,7 @@ class ChannelMapperTest(TestCase):
             builder.insert_into_default_db()
             cls.source_root = kolibri_content_models.ContentNode.objects.get(id=builder.root_node["id"])
             cls.channel = kolibri_content_models.ChannelMetadata.objects.get(id=builder.channel["id"])
-            contentcuration_channel = Channel.objects.create(id=cls.channel.id, name=cls.channel.name, public=True)
+            contentcuration_channel = Channel.objects.create(actor_id=admin_user.id, id=cls.channel.id, name=cls.channel.name, public=True)
             contentcuration_channel.main_tree.published = True
             contentcuration_channel.main_tree.save()
             cls.mapper = ChannelMapper(cls.channel)

--- a/contentcuration/search/tests/test_search.py
+++ b/contentcuration/search/tests/test_search.py
@@ -51,7 +51,7 @@ class SearchViewsetTestCase(StudioAPITestCase):
             user = testdata.user(email="a{}@a.com".format(i))
             users.append(user)
 
-            channel = Channel.objects.create(name="user_a{}_channel".format(i))
+            channel = Channel.objects.create(actor_id=user.id, name="user_a{}_channel".format(i))
             channel.save()
             channels.append(channel)
             channel.editors.add(user)


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Requires any edits to a channel that changed its soft deletion status or creation of a channel to pass the user_id for the user to whom that change should be attributed.
Consolidates all channel history creation and management onto the Channel model.
Adds and updates tests for the channel history.
Updates every instance in the code base that requires the new actor_id parameter.

This does not ensure history is created by queryset updates, or bulk model creation. Neither are used in our backend for channels, and it would be considerably involved to implement.

Locks down all API endpoints to by default only support GET methods (detail and list). Add specific behaviour for those that need to use the REST API for specific actions, and ensure that relevant change events are created.

Updates all tests to reflect this change in the API.

### Manual verification steps performed
Tests written to ensure behaviour.

## Reviewer guidance
### How can a reviewer test these changes?
If the tests pass this should be good to go - I've left it as a draft for now in case I missed anything.

See issue below.

## References
Fixes #4148

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
