### PR TITLE
Paginate topics

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -172,7 +172,11 @@
             @deselect="selected = selected.filter(id => id !== $event)"
             @scroll="scroll"
             @editTitleDescription="showTitleDescriptionModal"
-          />
+          >
+            <template #pagination>
+              <slot name="pagination"></slot>
+            </template>
+          </NodePanel>
         </DraggableRegion>
       </VFadeTransition>
       <ResourceDrawer

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -45,6 +45,7 @@
         />
       </template>
     </VList>
+    <slot name="pagination"></slot>
   </div>
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.spec.js
@@ -22,7 +22,7 @@ const GETTERS = {
     canManage: jest.fn(() => true),
   },
   contentNode: {
-    getContentNodeChildren: () => jest.fn(() => []),
+    getContentNodeChildren: () => jest.fn(() => ({ results: [], more: null })),
     getContentNodeAncestors: () => jest.fn(() => []),
     getContentNode: () => jest.fn(() => ({})),
     getTopicAndResourceCounts: () => jest.fn(() => ({ topicCount: 0, resourceCount: 0 })),
@@ -35,7 +35,7 @@ const ACTIONS = {
     loadContentNode: jest.fn(),
     headContentNode: () => jest.fn(),
     loadContentNodes: jest.fn(),
-    loadChildren: jest.fn(),
+    loadChildren: jest.fn(() => ({ results: [], more: null })),
   },
 };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -19,9 +19,10 @@ import * as publicApi from 'shared/data/public';
 import db from 'shared/data/db';
 
 export function loadContentNodes(context, params = {}) {
-  return ContentNode.where(params).then(contentNodes => {
+  return ContentNode.where(params).then(response => {
+    const contentNodes = response.results ? response.results : response;
     context.commit('ADD_CONTENTNODES', contentNodes);
-    return contentNodes;
+    return response;
   });
 }
 
@@ -70,7 +71,7 @@ export function loadContentNodeByNodeId(context, nodeId) {
 }
 
 export function loadChildren(context, { parent, published = null, complete = null }) {
-  const params = { parent };
+  const params = { parent, max_results: 25 };
   if (published !== null) {
     params.published = published;
   }

--- a/contentcuration/contentcuration/frontend/shared/data/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/data/constants.js
@@ -29,6 +29,7 @@ export const CHANGE_TYPES_LOOKUP = invert(CHANGE_TYPES);
 
 // Tables
 export const CHANGES_TABLE = 'changesForSyncing';
+export const PAGINATION_TABLE = 'pagination';
 
 export const TABLE_NAMES = {
   SESSION: 'session',

--- a/contentcuration/contentcuration/frontend/shared/data/index.js
+++ b/contentcuration/contentcuration/frontend/shared/data/index.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/vue';
 import mapValues from 'lodash/mapValues';
-import { CHANGES_TABLE, TABLE_NAMES } from './constants';
+import { CHANGES_TABLE, PAGINATION_TABLE, TABLE_NAMES } from './constants';
 import db from './db';
 import { INDEXEDDB_RESOURCES } from './registry';
 import { startSyncing, stopSyncing, syncOnChanges } from './serverSync';
@@ -14,7 +14,10 @@ export function setupSchema() {
   if (!Object.keys(resources).length) {
     console.warn('No resources defined!'); // eslint-disable-line no-console
   }
-  // Version incremented to 3 to add new index on CHANGES_TABLE.
+  // Version incremented to 2 to add Bookmark table and new index on CHANGES_TABLE.
+  // Version incremented to 3 to add:
+  //   new index on CHANGES_TABLE.
+  //   PAGINATION_TABLE.
   db.version(3).stores({
     // A special table for logging unsynced changes
     // Dexie.js appears to have a table for this,
@@ -22,6 +25,7 @@ export function setupSchema() {
     // that I do not currently understand, so we engage
     // in somewhat duplicative behaviour instead.
     [CHANGES_TABLE]: 'rev++,[table+key],server_rev,type',
+    [PAGINATION_TABLE]: '[table+queryString]',
     ...mapValues(INDEXEDDB_RESOURCES, value => value.schema),
   });
 }

--- a/contentcuration/contentcuration/utils/pagination.py
+++ b/contentcuration/contentcuration/utils/pagination.py
@@ -153,13 +153,13 @@ class ValuesViewsetCursorPagination(CursorPagination):
             *ordering
         )
 
-    def get_more(self):  # noqa C901
+    def _get_more_position_offset(self):
         """
         Vendored and modified from
         https://github.com/encode/django-rest-framework/blob/6ea95b6ad1bc0d4a4234a267b1ba32701878c6bb/rest_framework/pagination.py#L694
         """
         if not self.has_next:
-            return None
+            return None, None
 
         if (
             self.page
@@ -211,6 +211,13 @@ class ValuesViewsetCursorPagination(CursorPagination):
 
         if not self.page:
             position = self.next_position
+
+        return position, offset
+
+    def get_more(self):
+        position, offset = self._get_more_position_offset()
+        if position is None and offset is None:
+            return None
 
         tokens = {}
         if offset != 0:


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds simple lft__gt based pagination to contentnode endpoint, only really usable when filtering by parent or tree_id
* Deletes unused pagination from the resource layer, and adds support for simple single value incrementing (e.g. lft) pagination to it
* Updates the UI to handle this

### Manual verification steps performed
Make a topic with more than 50 children.
Check basic pagination works.
Clear cache and all indexedDB.
Load one additional page (so there should still be one more).
Reload the page.
Turn off the network connection in the network tab of the browser.
Press show more.
See that the additional page loads from indexedDB, and that even though there are no more nodes in IndexedDB, the cached pagination result allows 'show more' to still be shown.
Turn the network back on and press show more to see the remainder.

## Screenshot
![Screenshot from 2024-07-23 09-30-00](https://github.com/user-attachments/assets/f7adefbc-8102-4c23-8cd4-9ed18e6f1be9)


## References
Fixes #1280

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
