### PR TITLE
Fix incomplete resource importable

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -155,7 +155,9 @@
     },
     mounted() {
       this.loading = true;
-      let params = {};
+      let params = {
+        complete: true,
+      };
       const channelListType = this.$route.query.channel_list || ChannelListTypes.PUBLIC;
       if (channelListType === ChannelListTypes.PUBLIC) {
         // TODO: load from public API instead

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -148,6 +148,7 @@
         this.loading = true;
         return this.loadChildren({
           parent,
+          complete: true,
         }).then(() => {
           this.loading = false;
         });
@@ -155,14 +156,14 @@
     },
     mounted() {
       this.loading = true;
-      let params = {
+      const params = {
         complete: true,
       };
       const channelListType = this.$route.query.channel_list || ChannelListTypes.PUBLIC;
       if (channelListType === ChannelListTypes.PUBLIC) {
         // TODO: load from public API instead
         // TODO: challenging because of node_id->id and root_id->channel_id
-        params = { published: true };
+        params.published = true;
       }
 
       return Promise.all([

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -69,10 +69,13 @@ export function loadContentNodeByNodeId(context, nodeId) {
     });
 }
 
-export function loadChildren(context, { parent, published = null }) {
+export function loadChildren(context, { parent, published = null, complete = null }) {
   const params = { parent };
   if (published !== null) {
     params.published = published;
+  }
+  if (complete !== null) {
+    params.complete = complete;
   }
   return loadContentNodes(context, params);
 }

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -18,6 +18,7 @@ from django.utils.timezone import now
 from django_cte import CTEQuerySet
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import UUIDFilter
+from django_filters.rest_framework import BooleanFilter
 from le_utils.constants import completion_criteria
 from le_utils.constants import content_kinds
 from le_utils.constants import roles
@@ -86,6 +87,7 @@ class ContentNodeFilter(RequiredFilterSet):
     ancestors_of = UUIDFilter(method="filter_ancestors_of")
     parent__in = UUIDInFilter(field_name="parent")
     _node_id_channel_id___in = CharFilter(method="filter__node_id_channel_id")
+    complete = BooleanFilter(field_name="complete")
 
     class Meta:
         model = ContentNode


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Avoid listing incomplete resources in "import from channels" view.

### Manual verification steps performed
1. Tried loading incomplete resources that were already loaded in indexedDB.
2. Tried loading incomplete resources that havent been loaded before.
3. Verfied that the rest of valid resources/folders appear in the search.

### Screenshots (if applicable)
Given this incomplete resource:
![image](https://github.com/user-attachments/assets/763033b8-321a-4557-9424-59e05ddc6add)

Before:

![image](https://github.com/user-attachments/assets/329aed51-2690-4e8e-a7f2-3bbd4336a044)


After:

![image](https://github.com/user-attachments/assets/1b7389e2-8b41-4aca-b016-30da60eb7907)


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
1. Create incomplete resources in a given channel.
2. Publish the channel
3. Go to another channel and click on Add > Import from channels
4. Look for the incomplete resource, it should not appear.


## References
Closes #4088

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
