### PR TITLE
Fix undo remove last child

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -157,6 +157,7 @@ export class ChangeTracker {
       if (change.type === CHANGE_TYPES.MOVED && change.oldObj) {
         const { parent } = change.oldObj;
         siblings = await resource.where({ parent }, false);
+        siblings = siblings.filter(sibling => sibling.id !== change.key);
       }
 
       return resource.transaction({}, CHANGES_TABLE, () => {

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -140,7 +140,7 @@ export class ChangeTracker {
     // We'll go through each change one by one and revert each.
     //
     // R. Tibbles: I think this could be done in two queries (TODO)
-    return promiseChunk(this._changes.reverse(), 1, ([change]) => {
+    return promiseChunk(this._changes.reverse(), 1, async ([change]) => {
       const resource = INDEXEDDB_RESOURCES[change.table];
       if (!resource) {
         if (process.env.NODE_ENV !== 'production') {
@@ -150,6 +150,15 @@ export class ChangeTracker {
         }
         return Promise.resolve();
       }
+
+      // Query siblings before starting the transaction
+      // to avoid any potential API call inside the transaction
+      let siblings;
+      if (change.type === CHANGE_TYPES.MOVED && change.oldObj) {
+        const { parent } = change.oldObj;
+        siblings = await resource.where({ parent }, false);
+      }
+
       return resource.transaction({}, CHANGES_TABLE, () => {
         // If we had created something, we'll delete it
         // Special MOVED case here comes from the operation of COPY then MOVE for duplicating
@@ -170,17 +179,15 @@ export class ChangeTracker {
           const { parent, lft } = change.oldObj;
 
           // Collect the affected node's siblings prior to the change
-          return resource.where({ parent }, false).then(siblings => {
-            // Search the siblings ordered by `lft` to find the first a sibling
-            // where we should move the node, positioned before that sibling
-            const relativeSibling = sortBy(siblings, 'lft').find(sibling => sibling.lft >= lft);
-            if (relativeSibling) {
-              return resource.move(change.key, relativeSibling.id, RELATIVE_TREE_POSITIONS.LEFT);
-            }
+          // Search the siblings ordered by `lft` to find the first a sibling
+          // where we should move the node, positioned before that sibling
+          const relativeSibling = sortBy(siblings, 'lft').find(sibling => sibling.lft >= lft);
+          if (relativeSibling) {
+            return resource.move(change.key, relativeSibling.id, RELATIVE_TREE_POSITIONS.LEFT);
+          }
 
-            // this handles if there were no siblings OR if the deleted node was at the end
-            return resource.move(change.key, parent, RELATIVE_TREE_POSITIONS.LAST_CHILD);
-          });
+          // this handles if there were no siblings OR if the deleted node was at the end
+          return resource.move(change.key, parent, RELATIVE_TREE_POSITIONS.LAST_CHILD);
         } else {
           if (process.env.NODE_ENV !== 'production') {
             /* eslint-disable no-console */

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1363,6 +1363,7 @@ export const ContentNode = new TreeResource({
         return Promise.all([getNode, this.where({ parent: parent.id }, false)]).then(
           ([node, siblings]) => {
             let lft = 1;
+            siblings = siblings.filter(s => s.id !== id);
             if (siblings.length) {
               // If we're creating, we don't need to worry about passing the ID
               lft = this.getNewSortOrder(isCreate ? null : id, target, position, siblings);


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

When removing the last child of a folder, the folder was left without nodes, and within the undo transaction there was a resource.where() filter to find the siblings of the recovered node, but as it did not find siblings, it was making an API call, which caused the transaction to end before the api call returned, while there were still operations to be done within the transaction.

This PR just relocates the siblings query so that it is done before the transaction.

### Manual verification steps performed
1. verified that removing the last child and then redoing it now worked correctly.
2. verified that the redo of the rest of the operations keep working correctly.

### Screenshots (if applicable)

https://github.com/user-attachments/assets/c5cbbc1f-19b9-413d-9881-f0f8aaf33a18

___
## Reviewer guidance
### How can a reviewer test these changes?
1. Remove the last node of a channel/folder
2. Wait a couple of seconds for the change to be replicated in IndexedDB
3. Redo de operation

## References
Closes #4468


----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
