### PR TITLE
Fix to issue #4606 : Links leading outside Studio need to have a pop out icon

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -47,18 +47,6 @@
     </h2>
     <p>
       {{ $tr('apiTokenMessage') }}
-      <!-- <KExternalLink
-        href="https://ricecooker.readthedocs.io/en/latest/index.html"
-        target="_blank"
-        rel="noopener noreferrer"
-      > 
-        {{ $tr('apiDocumentation') }}
-        <KIconButton
-          :disabled="true"
-          icon="openNewTab"
-          class="inline-icon"
-        />
-      </KExternalLink> -->
       <ActionLink
         class="inline-icon"
         :text="$tr('apiDocumentation')"
@@ -248,7 +236,7 @@
 }
 .inline-icon {
   margin-bottom: 4px !important;
-  vertical-align: middle; /* Align icon with text */
+
 }
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -47,12 +47,12 @@
     </h2>
     <p>
       {{ $tr('apiTokenMessage') }}
-      <ActionLink
-        class="inline-icon"
-        :text="$tr('apiDocumentation')"
+      <KExternalLink
+        class="kexternal-redirect"
         href="https://ricecooker.readthedocs.io/en/latest/index.html"
-        target="_blank"
-        :tabindex="handleclickTab"
+        openInNewTab="true"
+        :text="$tr('apiDocumentation')"
+        rel="noopener noreferrer"
       />
     </p>
     <CopyToken
@@ -198,7 +198,7 @@
       completelyDeleteAccountLabel: 'Completely remove your account from Kolibri Studio',
       unableToDeleteAdminAccount: 'Unable to delete an admin account',
       handleChannelsBeforeAccount:
-        'You must delete these channels manually or invite others to edit them before you can delete your account.',
+        'You cannot delete accounts that have channels. You must delete these channels manually before you can delete your account.',
 
       // API strings
       apiTokenHeading: 'API Token',
@@ -234,9 +234,9 @@
 .row {
   padding: 8px 0;
 }
-.inline-icon {
-  margin-bottom: 4px !important;
-
-}
+.kexternal-redirect{
+    margin-left: -8px;
+    display: inline !important;
+  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -47,11 +47,24 @@
     </h2>
     <p>
       {{ $tr('apiTokenMessage') }}
-      <KExternalLink
+      <!-- <KExternalLink
         href="https://ricecooker.readthedocs.io/en/latest/index.html"
         target="_blank"
-        :text="$tr('apiDocumentation')"
         rel="noopener noreferrer"
+      > 
+        {{ $tr('apiDocumentation') }}
+        <KIconButton
+          :disabled="true"
+          icon="openNewTab"
+          class="inline-icon"
+        />
+      </KExternalLink> -->
+      <ActionLink
+        class="inline-icon"
+        :text="$tr('apiDocumentation')"
+        href="https://learningequality.org/"
+        target="_blank"
+        :tabindex="handleclickTab"
       />
     </p>
     <CopyToken
@@ -232,6 +245,10 @@
 
 .row {
   padding: 8px 0;
+}
+.inline-icon {
+  margin-bottom: 4px !important;
+  vertical-align: middle; /* Align icon with text */
 }
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -48,7 +48,6 @@
     <p>
       {{ $tr('apiTokenMessage') }}
       <KExternalLink
-        class="kexternal-redirect"
         href="https://ricecooker.readthedocs.io/en/latest/index.html"
         openInNewTab
         :text="$tr('apiDocumentation')"
@@ -234,7 +233,4 @@
 .row {
   padding: 8px 0;
 }
-.kexternal-redirect{
-    margin-left: -8px;
-  }
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -50,7 +50,7 @@
       <ActionLink
         class="inline-icon"
         :text="$tr('apiDocumentation')"
-        href="https://learningequality.org/"
+        href="https://ricecooker.readthedocs.io/en/latest/index.html"
         target="_blank"
         :tabindex="handleclickTab"
       />

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -198,7 +198,7 @@
       completelyDeleteAccountLabel: 'Completely remove your account from Kolibri Studio',
       unableToDeleteAdminAccount: 'Unable to delete an admin account',
       handleChannelsBeforeAccount:
-        'You cannot delete accounts that have channels. You must delete these channels manually before you can delete your account.',
+        'You must delete these channels manually or invite others to edit them before you can delete your account.',
 
       // API strings
       apiTokenHeading: 'API Token',
@@ -238,5 +238,4 @@
     margin-left: -8px;
     display: inline !important;
   }
-
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/index.vue
@@ -50,7 +50,7 @@
       <KExternalLink
         class="kexternal-redirect"
         href="https://ricecooker.readthedocs.io/en/latest/index.html"
-        openInNewTab="true"
+        openInNewTab
         :text="$tr('apiDocumentation')"
         rel="noopener noreferrer"
       />
@@ -236,6 +236,5 @@
 }
 .kexternal-redirect{
     margin-left: -8px;
-    display: inline !important;
   }
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -39,7 +39,7 @@
 
     <p>
 
-      <span>{{ $tr('requestMoreSpaceMessage') }}</span>
+      <span>{{ $tr('requestMoreSpaceMessage') + " " }}</span>
 
       <KExternalLink
         class="kexternal-redirect"

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -45,7 +45,7 @@
         class="kexternal-redirect"
         :text="$tr('learnMoreAboutImportingContentFromChannels')"
         href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
-        openInNewTab="true"
+        openInNewTab
       />
 
     </p>
@@ -162,6 +162,5 @@
   }
   .kexternal-redirect{
     margin-left: -8px;
-    display: inline !important;
   }
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -42,7 +42,6 @@
       <span>{{ $tr('requestMoreSpaceMessage') + " " }}</span>
 
       <KExternalLink
-        class="kexternal-redirect"
         :text="$tr('learnMoreAboutImportingContentFromChannels')"
         href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
         openInNewTab
@@ -159,8 +158,5 @@
     /deep/.is-determinate {
       height: 8px !important;
     }
-  }
-  .kexternal-redirect{
-    margin-left: -8px;
   }
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -40,12 +40,12 @@
     <p>
 
       <span>{{ $tr('requestMoreSpaceMessage') }}</span>
-      <ActionLink
-        class="inline-icon"
+
+      <KExternalLink
+        class="kexternal-redirect"
         :text="$tr('learnMoreAboutImportingContentFromChannels')"
         href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
-        target="_blank"
-        :tabindex="handleclickTab"
+        openInNewTab="true"
       />
 
     </p>
@@ -160,9 +160,9 @@
       height: 8px !important;
     }
   }
-  .inline-icon {
-  margin-bottom: 4px !important;
-}
-
+  .kexternal-redirect{
+    margin-left: -8px;
+    display: inline !important;
+  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -164,5 +164,4 @@
     margin-left: -8px;
     display: inline !important;
   }
-
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -159,4 +159,5 @@
       height: 8px !important;
     }
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -41,7 +41,7 @@
 
       <span>{{ $tr('requestMoreSpaceMessage') }}</span>
 
-      <KExternalLink
+      <!-- <KExternalLink
         style="display: inline;"
         href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
         target="_blank"
@@ -53,7 +53,14 @@
           class="inline-icon"
         />
       
-      </KExternalLink>
+      </KExternalLink> -->
+      <ActionLink
+        class="inline-icon"
+        :text="$tr('learnMoreAboutImportingContentFromChannels')"
+        href="https://learningequality.org/"
+        target="_blank"
+        :tabindex="handleclickTab"
+      />
 
     </p>
 
@@ -168,10 +175,8 @@
     }
   }
   .inline-icon {
-  display: inline;
-  margin-left: -8px;
-  vertical-align: middle; /* Align icon with text */
-  transform: scale(0.7);
+  margin-bottom: 4px !important;
 }
+
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -40,24 +40,10 @@
     <p>
 
       <span>{{ $tr('requestMoreSpaceMessage') }}</span>
-
-      <!-- <KExternalLink
-        style="display: inline;"
-        href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
-        target="_blank"
-      >
-        {{ $tr('learnMoreAboutImportingContentFromChannels') }}
-        <KIconButton
-          :disabled="true"
-          icon="openNewTab"
-          class="inline-icon"
-        />
-      
-      </KExternalLink> -->
       <ActionLink
         class="inline-icon"
         :text="$tr('learnMoreAboutImportingContentFromChannels')"
-        href="https://learningequality.org/"
+        href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
         target="_blank"
         :tabindex="handleclickTab"
       />

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -43,10 +43,17 @@
 
       <KExternalLink
         style="display: inline;"
-        :text="$tr('learnMoreAboutImportingContentFromChannels')"
         href="https://kolibri-studio.readthedocs.io/en/latest/add_content.html#import-content-from-other-channels"
         target="_blank"
-      />
+      >
+        {{ $tr('learnMoreAboutImportingContentFromChannels') }}
+        <KIconButton
+          :disabled="true"
+          icon="openNewTab"
+          class="inline-icon"
+        />
+      
+      </KExternalLink>
 
     </p>
 
@@ -160,5 +167,11 @@
       height: 8px !important;
     }
   }
+  .inline-icon {
+  display: inline;
+  margin-left: -8px;
+  vertical-align: middle; /* Align icon with text */
+  transform: scale(0.7);
+}
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -28,12 +28,12 @@
       />
     </p>
     <p>
-      <ActionLink
-        class="inline-icon"
-        :text="$tr('userDocsLink')"
+      <KExternalLink
+        class="kexternal-redirect"
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
-        target="_blank"
-        :tabindex="handleclickTab"
+        openInNewTab="true"
+        :text="$tr('userDocsLink')"
+        rel="noopener noreferrer"
       />
     </p>
 
@@ -50,14 +50,13 @@
         <li>{{ $tr('bestPractice3') }}</li>
         <li>{{ $tr('bestPractice5') }}</li>
         <li>
-          <ActionLink
-            class="inline-icon"
-            :text="$tr('bestPractice6')"
+          <KExternalLink
+            class="kexternal-redirect"
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
-            target="_blank"
-            :tabindex="handleclickTab"
+            :text="$tr('bestPractice6')"
+            openInNewTab="true"
+            rel="noopener noreferrer"
           />
-
         </li>
         <li>{{ $tr('bestPractice7') }}</li>
         <li>{{ $tr('bestPractice9') }}</li>
@@ -66,20 +65,20 @@
 
     <!-- Issues -->
     <h2>{{ $tr('notableIssues') }}</h2>
-    <ActionLink
-      class="inline-icon"
-      :text="$tr('issueLink1')"
+    <KExternalLink
+      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues/3992"
-      target="_blank"
-      :tabindex="handleclickTab"
+      :text="$tr('issueLink1')"
+      openInNewTab="true"
+      rel="noopener noreferrer"
     />
     <p>{{ $tr('issue1') }}</p>
-    <ActionLink
-      class="inline-icon"
-      :text="$tr('issuesPageLink')"
+    <KExternalLink
+      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues"
-      target="_blank"
-      :tabindex="handleclickTab"
+      :text="$tr('issuesPageLink')"
+      openInNewTab="true"
+      rel="noopener noreferrer"
     />
   </div>
 
@@ -146,9 +145,7 @@
   h2 {
     margin-top: 32px;
   }
-
-  .inline-icon {
-  margin-bottom: 4px !important;
-}
-
+  .kexternal-redirect{
+    margin-left: -8px;
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -31,7 +31,7 @@
       <KExternalLink
         class="kexternal-redirect"
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
-        openInNewTab="true"
+        openInNewTab
         :text="$tr('userDocsLink')"
         rel="noopener noreferrer"
       />
@@ -54,7 +54,7 @@
             class="kexternal-redirect"
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
             :text="$tr('bestPractice6')"
-            openInNewTab="true"
+            openInNewTab
             rel="noopener noreferrer"
           />
         </li>
@@ -69,7 +69,7 @@
       class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues/3992"
       :text="$tr('issueLink1')"
-      openInNewTab="true"
+      openInNewTab
       rel="noopener noreferrer"
     />
     <p>{{ $tr('issue1') }}</p>
@@ -77,7 +77,7 @@
       class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues"
       :text="$tr('issuesPageLink')"
-      openInNewTab="true"
+      openInNewTab
       rel="noopener noreferrer"
     />
   </div>

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -29,7 +29,6 @@
     </p>
     <p>
       <KExternalLink
-        class="kexternal-redirect"
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
         openInNewTab
         :text="$tr('userDocsLink')"
@@ -51,7 +50,6 @@
         <li>{{ $tr('bestPractice5') }}</li>
         <li>
           <KExternalLink
-            class="kexternal-redirect"
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
             :text="$tr('bestPractice6')"
             openInNewTab
@@ -66,7 +64,6 @@
     <!-- Issues -->
     <h2>{{ $tr('notableIssues') }}</h2>
     <KExternalLink
-      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues/3992"
       :text="$tr('issueLink1')"
       openInNewTab
@@ -74,7 +71,6 @@
     />
     <p>{{ $tr('issue1') }}</p>
     <KExternalLink
-      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues"
       :text="$tr('issuesPageLink')"
       openInNewTab
@@ -144,8 +140,5 @@
 <style scoped>
   h2 {
     margin-top: 32px;
-  }
-  .kexternal-redirect{
-    margin-left: -8px;
   }
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -31,9 +31,15 @@
       <KExternalLink
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
         target="_blank"
-        :text="$tr('userDocsLink')"
         rel="noopener noreferrer"
-      />
+      >
+        {{ $tr('userDocsLink') }}             
+        <KIconButton
+          :disabled="true"
+          icon="openNewTab"
+          class="inline-icon"
+        />
+      </KExternalLink>
     </p>
 
     <!-- About Studio -->
@@ -51,10 +57,18 @@
         <li>
           <KExternalLink
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
-            :text="$tr('bestPractice6')"
             target="_blank"
             rel="noopener noreferrer"
-          />
+          >
+            {{ $tr('bestPractice6') }}
+            <KIconButton
+              :disabled="true"
+              icon="openNewTab"
+              class="inline-icon"
+            />
+          </KExternalLink>
+          
+
         </li>
         <li>{{ $tr('bestPractice7') }}</li>
         <li>{{ $tr('bestPractice9') }}</li>
@@ -65,17 +79,29 @@
     <h2>{{ $tr('notableIssues') }}</h2>
     <KExternalLink
       href="https://github.com/learningequality/studio/issues/3992"
-      :text="$tr('issueLink1')"
       target="_blank"
       rel="noopener noreferrer"
-    />
+    >
+      {{ $tr('issueLink1') }}
+      <KIconButton
+        :disabled="true"
+        icon="openNewTab"
+        class="inline-icon"
+      />
+    </KExternalLink>
     <p>{{ $tr('issue1') }}</p>
     <KExternalLink
       href="https://github.com/learningequality/studio/issues"
-      :text="$tr('issuesPageLink')"
       target="_blank"
       rel="noopener noreferrer"
-    />
+    >
+      {{ $tr('issuesPageLink') }}
+      <KIconButton
+        :disabled="true"
+        icon="openNewTab"
+        class="inline-icon"
+      />
+    </KExternalLink>
   </div>
 
 </template>
@@ -141,4 +167,13 @@
   h2 {
     margin-top: 32px;
   }
+
+  .inline-icon {
+  display: inline;
+  margin-left: -8px;
+  vertical-align: middle; 
+  transform: scale(0.7);
+}
+  .external-link {
+}
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -28,22 +28,10 @@
       />
     </p>
     <p>
-      <!-- <KExternalLink
-        href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {{ $tr('userDocsLink') }}             
-        <KIconButton
-          :disabled="true"
-          icon="openNewTab"
-          class="inline-icon"
-        />
-      </KExternalLink> -->
       <ActionLink
         class="inline-icon"
         :text="$tr('userDocsLink')"
-        href="https://learningequality.org/"
+        href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
         target="_blank"
         :tabindex="handleclickTab"
       />
@@ -62,22 +50,10 @@
         <li>{{ $tr('bestPractice3') }}</li>
         <li>{{ $tr('bestPractice5') }}</li>
         <li>
-          <!-- <KExternalLink
-            href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{ $tr('bestPractice6') }}
-            <KIconButton
-              :disabled="true"
-              icon="openNewTab"
-              class="inline-icon"
-            />
-          </KExternalLink> -->
           <ActionLink
             class="inline-icon"
             :text="$tr('bestPractice6')"
-            href="https://learningequality.org/"
+            href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
             target="_blank"
             :tabindex="handleclickTab"
           />
@@ -90,42 +66,18 @@
 
     <!-- Issues -->
     <h2>{{ $tr('notableIssues') }}</h2>
-    <!-- <KExternalLink
-      href="https://github.com/learningequality/studio/issues/3992"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {{ $tr('issueLink1') }}
-      <KIconButton
-        :disabled="true"
-        icon="openNewTab"
-        class="inline-icon"
-      />
-    </KExternalLink> -->
     <ActionLink
       class="inline-icon"
       :text="$tr('issueLink1')"
-      href="https://learningequality.org/"
+      href="https://github.com/learningequality/studio/issues/3992"
       target="_blank"
       :tabindex="handleclickTab"
     />
     <p>{{ $tr('issue1') }}</p>
-    <!-- <KExternalLink
-      href="https://github.com/learningequality/studio/issues"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {{ $tr('issuesPageLink') }}
-      <KIconButton
-        :disabled="true"
-        icon="openNewTab"
-        class="inline-icon"
-      />
-    </KExternalLink> -->
     <ActionLink
       class="inline-icon"
       :text="$tr('issuesPageLink')"
-      href="https://learningequality.org/"
+      href="https://github.com/learningequality/studio/issues"
       target="_blank"
       :tabindex="handleclickTab"
     />

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -28,7 +28,7 @@
       />
     </p>
     <p>
-      <KExternalLink
+      <!-- <KExternalLink
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
         target="_blank"
         rel="noopener noreferrer"
@@ -39,7 +39,14 @@
           icon="openNewTab"
           class="inline-icon"
         />
-      </KExternalLink>
+      </KExternalLink> -->
+      <ActionLink
+        class="inline-icon"
+        :text="$tr('userDocsLink')"
+        href="https://learningequality.org/"
+        target="_blank"
+        :tabindex="handleclickTab"
+      />
     </p>
 
     <!-- About Studio -->
@@ -55,7 +62,7 @@
         <li>{{ $tr('bestPractice3') }}</li>
         <li>{{ $tr('bestPractice5') }}</li>
         <li>
-          <KExternalLink
+          <!-- <KExternalLink
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
             target="_blank"
             rel="noopener noreferrer"
@@ -66,8 +73,14 @@
               icon="openNewTab"
               class="inline-icon"
             />
-          </KExternalLink>
-          
+          </KExternalLink> -->
+          <ActionLink
+            class="inline-icon"
+            :text="$tr('bestPractice6')"
+            href="https://learningequality.org/"
+            target="_blank"
+            :tabindex="handleclickTab"
+          />
 
         </li>
         <li>{{ $tr('bestPractice7') }}</li>
@@ -77,7 +90,7 @@
 
     <!-- Issues -->
     <h2>{{ $tr('notableIssues') }}</h2>
-    <KExternalLink
+    <!-- <KExternalLink
       href="https://github.com/learningequality/studio/issues/3992"
       target="_blank"
       rel="noopener noreferrer"
@@ -88,9 +101,16 @@
         icon="openNewTab"
         class="inline-icon"
       />
-    </KExternalLink>
+    </KExternalLink> -->
+    <ActionLink
+      class="inline-icon"
+      :text="$tr('issueLink1')"
+      href="https://learningequality.org/"
+      target="_blank"
+      :tabindex="handleclickTab"
+    />
     <p>{{ $tr('issue1') }}</p>
-    <KExternalLink
+    <!-- <KExternalLink
       href="https://github.com/learningequality/studio/issues"
       target="_blank"
       rel="noopener noreferrer"
@@ -101,7 +121,14 @@
         icon="openNewTab"
         class="inline-icon"
       />
-    </KExternalLink>
+    </KExternalLink> -->
+    <ActionLink
+      class="inline-icon"
+      :text="$tr('issuesPageLink')"
+      href="https://learningequality.org/"
+      target="_blank"
+      :tabindex="handleclickTab"
+    />
   </div>
 
 </template>
@@ -169,11 +196,7 @@
   }
 
   .inline-icon {
-  display: inline;
-  margin-left: -8px;
-  vertical-align: middle; 
-  transform: scale(0.7);
+  margin-bottom: 4px !important;
 }
-  .external-link {
-}
+
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -29,6 +29,7 @@
     </p>
     <p>
       <KExternalLink
+        class="kexternal-redirect"
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
         openInNewTab
         :text="$tr('userDocsLink')"
@@ -50,6 +51,7 @@
         <li>{{ $tr('bestPractice5') }}</li>
         <li>
           <KExternalLink
+            class="kexternal-redirect"
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
             :text="$tr('bestPractice6')"
             openInNewTab
@@ -64,6 +66,7 @@
     <!-- Issues -->
     <h2>{{ $tr('notableIssues') }}</h2>
     <KExternalLink
+      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues/3992"
       :text="$tr('issueLink1')"
       openInNewTab
@@ -71,6 +74,7 @@
     />
     <p>{{ $tr('issue1') }}</p>
     <KExternalLink
+      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues"
       :text="$tr('issuesPageLink')"
       openInNewTab
@@ -140,5 +144,8 @@
 <style scoped>
   h2 {
     margin-top: 32px;
+  }
+  .kexternal-redirect{
+    margin-left: -8px;
   }
 </style>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,31 @@
-version: '3.4'
+version: "3.4"
 
-x-studio-environment:
-  &studio-environment
-    MPLBACKEND: ps
-    SHELL: /bin/bash
-    AWS_S3_ENDPOINT_URL: http://minio:9000
-    DATA_DB_HOST: postgres
-    DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
-    RUN_MODE: docker-compose
-    CELERY_TIMEZONE: America/Los_Angeles
-    CELERY_REDIS_DB: 0
-    CELERY_BROKER_ENDPOINT: redis
-    CELERY_RESULT_BACKEND_ENDPOINT: redis
-    CELERY_REDIS_PASSWORD: ""
-    PROBER_STUDIO_BASE_URL: http://studio-app:8080/{path}
+x-studio-environment: &studio-environment
+  MPLBACKEND: ps
+  SHELL: /bin/bash
+  AWS_S3_ENDPOINT_URL: http://minio:9000
+  DATA_DB_HOST: postgres
+  DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
+  RUN_MODE: docker-compose
+  CELERY_TIMEZONE: America/Los_Angeles
+  CELERY_REDIS_DB: 0
+  CELERY_BROKER_ENDPOINT: redis
+  CELERY_RESULT_BACKEND_ENDPOINT: redis
+  CELERY_REDIS_PASSWORD: ""
+  PROBER_STUDIO_BASE_URL: http://studio-app:8080/{path}
 
-x-studio-worker:
-  &studio-worker
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.dev
-    image: learningequality/studio-app-dev
-    depends_on:
-      - minio
-      - postgres
-      - redis
-    volumes:
-      - .:/src
-    environment: *studio-environment
+x-studio-worker: &studio-worker
+  build:
+    context: .
+    dockerfile: docker/Dockerfile.dev
+  image: learningequality/studio-app-dev
+  depends_on:
+    - minio
+    - postgres
+    - redis
+  volumes:
+    - .:/src
+  environment: *studio-environment
 
 services:
   studio-nginx:
@@ -59,7 +57,7 @@ services:
     environment:
       MINIO_ACCESS_KEY: development
       MINIO_SECRET_KEY: development
-      MINIO_API_CORS_ALLOW_ORIGIN: 'http://localhost:8080,http://127.0.0.1:8080'
+      MINIO_API_CORS_ALLOW_ORIGIN: "http://localhost:8080,http://127.0.0.1:8080"
     volumes:
       - .docker/minio:/data
 
@@ -90,7 +88,6 @@ services:
     depends_on:
       - studio-app
       - celery-worker
-
 
 volumes:
   minio_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,33 @@
-version: "3.4"
+version: '3.4'
 
-x-studio-environment: &studio-environment
-  MPLBACKEND: ps
-  SHELL: /bin/bash
-  AWS_S3_ENDPOINT_URL: http://minio:9000
-  DATA_DB_HOST: postgres
-  DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
-  RUN_MODE: docker-compose
-  CELERY_TIMEZONE: America/Los_Angeles
-  CELERY_REDIS_DB: 0
-  CELERY_BROKER_ENDPOINT: redis
-  CELERY_RESULT_BACKEND_ENDPOINT: redis
-  CELERY_REDIS_PASSWORD: ""
-  PROBER_STUDIO_BASE_URL: http://studio-app:8080/{path}
+x-studio-environment:
+  &studio-environment
+    MPLBACKEND: ps
+    SHELL: /bin/bash
+    AWS_S3_ENDPOINT_URL: http://minio:9000
+    DATA_DB_HOST: postgres
+    DJANGO_SETTINGS_MODULE: contentcuration.dev_settings
+    RUN_MODE: docker-compose
+    CELERY_TIMEZONE: America/Los_Angeles
+    CELERY_REDIS_DB: 0
+    CELERY_BROKER_ENDPOINT: redis
+    CELERY_RESULT_BACKEND_ENDPOINT: redis
+    CELERY_REDIS_PASSWORD: ""
+    PROBER_STUDIO_BASE_URL: http://studio-app:8080/{path}
 
-x-studio-worker: &studio-worker
-  build:
-    context: .
-    dockerfile: docker/Dockerfile.dev
-  image: learningequality/studio-app-dev
-  depends_on:
-    - minio
-    - postgres
-    - redis
-  volumes:
-    - .:/src
-  environment: *studio-environment
+x-studio-worker:
+  &studio-worker
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.dev
+    image: learningequality/studio-app-dev
+    depends_on:
+      - minio
+      - postgres
+      - redis
+    volumes:
+      - .:/src
+    environment: *studio-environment
 
 services:
   studio-nginx:
@@ -57,7 +59,7 @@ services:
     environment:
       MINIO_ACCESS_KEY: development
       MINIO_SECRET_KEY: development
-      MINIO_API_CORS_ALLOW_ORIGIN: "http://localhost:8080,http://127.0.0.1:8080"
+      MINIO_API_CORS_ALLOW_ORIGIN: 'http://localhost:8080,http://127.0.0.1:8080'
     volumes:
       - .docker/minio:/data
 
@@ -88,6 +90,7 @@ services:
     depends_on:
       - studio-app
       - celery-worker
+
 
 volumes:
   minio_data:


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This merge request addresses the issue where external links in Studio did not have a visual indicator to distinguish them from internal links. The affected links also did not open in a new tab by default. To resolve this, the **KExternalLink** component has been replaced with the **ActionLink** component, and a CSS class **inline-icon** has been added to provide the necessary visual indication.

### Manual verification steps performed
1. Step 1 : Replaced instances of `KExternalLink` with `ActionLink` to ensure consistent behavior and appearance across the application.
2. Step 2 : Added the `inline-icon` CSS class to the ActionLink component to display a pop-out icon for adjusting the position.
3. ...

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

https://github.com/user-attachments/assets/4db79b12-d93c-40a7-a540-77411d438270



## Affected Areas

- **In Settings -> page -> Account -> Index.vue : ** Updated the "API documentation" link to use the `ActionLink` component with the `inline-icon` class.
- **In Settings -> page -> UsingStudio -> index.vue :** Updated the "User Guide", "bestPractice6", "issueLink1", "issuesPageLink" link to use the `ActionLink` component replacing **KExternalLink**  component and  adding the `inline-icon` class rep.

## Reviewer guidance
### How can a reviewer test these changes?

1. Go to Studio then Settings.
2. Check all the links leading outside the studio have pop-out icon (open in new tab) in all three tabs.

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
