### PR TITLE
Ensure that complete is not incorrectly set via the API

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1846,6 +1846,13 @@ class ContentNode(MPTTModel, models.Model):
                         completion_criteria.validate(criterion, kind=content_kinds.EXERCISE)
                     except completion_criteria.ValidationError:
                         errors.append("Mastery criterion is defined but is invalid")
+            else:
+                criterion = self.extra_fields.get("options", {}).get("completion_criteria", {})
+                if criterion:
+                    try:
+                        completion_criteria.validate(criterion, kind=self.kind_id)
+                    except completion_criteria.ValidationError:
+                        errors.append("Completion criterion is defined but is invalid")
         self.complete = not errors
         return errors
 

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -1040,6 +1040,33 @@ class NodeCompletionTestCase(StudioTestCase):
         new_obj.mark_complete()
         self.assertFalse(new_obj.complete)
 
+    def test_create_video_invalid_completion_criterion(self):
+        licenses = list(License.objects.filter(copyright_holder_required=False, is_custom=False).values_list("pk", flat=True))
+        channel = testdata.channel()
+        new_obj = ContentNode(
+            title="yes",
+            kind_id=content_kinds.VIDEO,
+            parent=channel.main_tree,
+            license_id=licenses[0],
+            copyright_holder="Some person",
+            extra_fields={
+                "randomize": False,
+                "options": {
+                    "completion_criteria": {
+                        "threshold": {
+                            "mastery_model": exercises.M_OF_N,
+                            "n": 5,
+                        },
+                        "model": completion_criteria.MASTERY,
+                    }
+                }
+            },
+        )
+        new_obj.save()
+        File.objects.create(contentnode=new_obj, preset_id=format_presets.VIDEO_HIGH_RES, checksum=uuid.uuid4().hex)
+        new_obj.mark_complete()
+        self.assertFalse(new_obj.complete)
+
     def test_create_exercise_no_assessment_items(self):
         licenses = list(License.objects.filter(copyright_holder_required=False, is_custom=False).values_list("pk", flat=True))
         channel = testdata.channel()

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -854,7 +854,7 @@ class ApiAddRemoteNodesToTreeTestCase(StudioTestCase):
             "license_description": "This is a fake license",
             "copyright_holder": random_data.copyright_holder,
             "questions": [],
-            "extra_fields": "{}",
+            "extra_fields": {},
             "role": "learner",
         }
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Update mark_complete to handle completion criteria for non-exercises.
Use the updated function to add verification when a contentnode is marked complete via the API.

### Manual verification steps performed
Added regression tests for new mark_complete behaviour, and for an API call setting a node as complete when it is not.

Fixes #4173