### PR TITLE
Fix clipboard moveModal incorrect resource count

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/Channel.vue
@@ -12,9 +12,9 @@
           <Checkbox
             ref="checkbox"
             class="ma-0 pa-0"
-            :value="selected"
+            :inputValue="selected"
             :indeterminate="indeterminate"
-            @click.stop.prevent="goNextSelectionState"
+            @input="goNextSelectionState"
           />
         </VListTileAction>
         <div class="mr-2">

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -34,7 +34,7 @@
                         class="mt-0 pt-0"
                         :inputValue="selected"
                         :indeterminate="indeterminate"
-                        @click.stop.prevent="goNextSelectionState"
+                        @input="goNextSelectionState"
                       />
                     </VListTileAction>
                     <div

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNode.vue
@@ -55,7 +55,7 @@
                       </VListTileContent>
                       <VListTileAction style="min-width: unset;" class="pl-3 pr-1">
                         <div class="badge caption font-weight-bold">
-                          {{ contentNode.resource_count }}
+                          {{ contentNodeResourceCount }}
                         </div>
                       </VListTileAction>
                       <!-- Custom placement of dropdown indicator -->
@@ -117,7 +117,7 @@
 </template>
 <script>
 
-  import { mapActions, mapGetters } from 'vuex';
+  import { mapActions, mapGetters, mapState } from 'vuex';
   import clipboardMixin, { parentMixin } from './mixins';
   import ContentNodeOptions from './ContentNodeOptions';
   import Checkbox from 'shared/views/form/Checkbox';
@@ -150,6 +150,7 @@
       };
     },
     computed: {
+      ...mapState('clipboard', ['clipboardNodesMap']),
       ...mapGetters('clipboard', ['isPreloading', 'isLoaded']),
       thumbnailAttrs() {
         if (this.contentNode) {
@@ -180,6 +181,10 @@
         // See CurrentTopicView.handleDragDrop
         const contentNode = this.contentNode || {};
         return { ...contentNode, clipboardNodeId: this.nodeId };
+      },
+      contentNodeResourceCount() {
+        return Object.values(this.clipboardNodesMap).filter(node => node.parent === this.nodeId)
+          .length;
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -9,7 +9,7 @@
     </VListTile>
     <VListTile v-if="allowMove" @click.stop="calculateMoveNodes">
       <VListTileTitle>{{ $tr('moveTo') }}</VListTileTitle>
-      <MoveModal v-if="moveModalOpen" ref="moveModal" v-model="moveModalOpen" @target="moveNodes" />
+      <MoveModal v-if="moveModalOpen" ref="moveModal" v-model="moveModalOpen" @target="moveNodes"  :moveNodeIds="[contentNode.id]"/>
     </VListTile>
     <VListTile @click="removeNode()">
       <VListTileTitle>{{ $tr('remove') }}</VListTileTitle>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -9,7 +9,13 @@
     </VListTile>
     <VListTile v-if="allowMove" @click.stop="calculateMoveNodes">
       <VListTileTitle>{{ $tr('moveTo') }}</VListTileTitle>
-      <MoveModal v-if="moveModalOpen" ref="moveModal" v-model="moveModalOpen" @target="moveNodes"  :moveNodeIds="[contentNode.id]"/>
+      <MoveModal 
+        v-if="moveModalOpen" 
+        ref="moveModal" 
+        v-model="moveModalOpen" 
+        :moveNodeIds="[contentNode.id]" 
+        @target="moveNodes" 
+      />
     </VListTile>
     <VListTile @click="removeNode()">
       <VListTileTitle>{{ $tr('remove') }}</VListTileTitle>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -13,7 +13,7 @@
         v-if="moveModalOpen" 
         ref="moveModal" 
         v-model="moveModalOpen" 
-        :moveNodeIds="[contentNode.id]" 
+        :clipboardTopicResourceCount="topicAndResourceCount"
         @target="moveNodes" 
       />
     </VListTile>
@@ -26,7 +26,7 @@
 
 <script>
 
-  import { mapActions, mapGetters } from 'vuex';
+  import { mapActions, mapGetters, mapState } from 'vuex';
   import { RouteNames } from '../../constants';
   import MoveModal from '../move/MoveModal';
   import clipboardMixin from './mixins';
@@ -46,6 +46,7 @@
       };
     },
     computed: {
+      ...mapState('clipboard', ['clipboardNodesMap']),
       ...mapGetters('clipboard', ['getMoveTrees', 'isLegacyNode']),
       isLegacy() {
         return this.isLegacyNode(this.nodeId);
@@ -65,6 +66,19 @@
           },
         });
         return `${channelURI}${sourceNode.href}`;
+      },
+      topicAndResourceCount() {
+        let topicCount = 0;
+        let resourceCount = 0;
+        if (this.contentNode.kind === 'topic') {
+          topicCount = 1;
+          resourceCount = Object.values(this.clipboardNodesMap).filter(
+            node => node.parent === this.nodeId
+          ).length;
+        } else {
+          resourceCount = 1;
+        }
+        return { topicCount: topicCount, resourceCount: resourceCount };
       },
     },
     methods: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -71,7 +71,8 @@
                         v-if="allowMove && moveModalOpen"
                         ref="moveModal"
                         v-model="moveModalOpen"
-                        :moveNodeIds="selectedSourceNodeIds"
+                        :moveNodeIds="selectedNodeIds"
+                        :clipboardTopicResourceCount="topicAndResourceCount"
                         @target="moveNodes"
                       />
                       <IconButton
@@ -200,7 +201,7 @@
     },
     computed: {
       ...mapGetters(['clipboardRootId']),
-      ...mapState('clipboard', ['initializing']),
+      ...mapState('clipboard', ['initializing', 'clipboardNodesMap']),
       ...mapGetters('clipboard', [
         'channels',
         'selectedNodeIds',
@@ -208,7 +209,6 @@
         'getMoveTrees',
         'legacyNodesSelected',
         'previewSourceNode',
-        'getContentNodeForRender',
       ]),
       ...mapGetters('contentNode', {
         getRealContentNodes: 'getContentNodes',
@@ -245,8 +245,20 @@
           ? DropEffect.COPY
           : DropEffect.NONE;
       },
-      selectedSourceNodeIds() {
-        return this.selectedNodeIds.map(this.getContentNodeForRender).map(n => n.id);
+      topicAndResourceCount() {
+        let topicCount = 0;
+        let resourceCount = 0;
+        this.selectedNodeIds.forEach(id => {
+          const kind = this.clipboardNodesMap[id]?.kind;
+          if (kind === 'topic' || !kind) {
+            // Increment topicCount if kind is "topic" or not set
+            topicCount++;
+          } else {
+            // Increment resourceCount for any other kind
+            resourceCount++;
+          }
+        });
+        return { topicCount: topicCount, resourceCount: resourceCount };
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -70,6 +70,7 @@
                       <MoveModal
                         v-if="allowMove && moveModalOpen"
                         ref="moveModal"
+                        :moveNodeIds="selectedSourceNodeIds"
                         v-model="moveModalOpen"
                         @target="moveNodes"
                       />
@@ -207,6 +208,7 @@
         'getMoveTrees',
         'legacyNodesSelected',
         'previewSourceNode',
+        'getContentNodeForRender',
       ]),
       ...mapGetters('contentNode', {
         getRealContentNodes: 'getContentNodes',
@@ -242,6 +244,9 @@
         return this.activeDraggableId !== DraggableRegions.CLIPBOARD
           ? DropEffect.COPY
           : DropEffect.NONE;
+      },
+      selectedSourceNodeIds(){
+        return this.selectedNodeIds.map(this.getContentNodeForRender).map(n => n.id)
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -70,8 +70,8 @@
                       <MoveModal
                         v-if="allowMove && moveModalOpen"
                         ref="moveModal"
-                        :moveNodeIds="selectedSourceNodeIds"
                         v-model="moveModalOpen"
+                        :moveNodeIds="selectedSourceNodeIds"
                         @target="moveNodes"
                       />
                       <IconButton
@@ -245,8 +245,8 @@
           ? DropEffect.COPY
           : DropEffect.NONE;
       },
-      selectedSourceNodeIds(){
-        return this.selectedNodeIds.map(this.getContentNodeForRender).map(n => n.id)
+      selectedSourceNodeIds() {
+        return this.selectedNodeIds.map(this.getContentNodeForRender).map(n => n.id);
       },
     },
     watch: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -35,10 +35,10 @@
                     <Checkbox
                       ref="checkbox"
                       class="ma-0 pa-0"
-                      :value="selected"
+                      :inputValue="selected"
                       :label="selectionState ? '' : $tr('selectAll')"
                       :indeterminate="indeterminate"
-                      @click.stop.prevent="goNextSelectionState"
+                      @input="goNextSelectionState"
                     />
                   </VListTileAction>
                 </VSlideXTransition>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -173,6 +173,10 @@
         type: Boolean,
         default: false,
       },
+      clipboardTopicResourceCount: {
+        type: Object,
+        default: () => ({}),
+      },
     },
     data() {
       return {
@@ -200,7 +204,10 @@
         },
       },
       moveHeader() {
-        return this.$tr('moveItems', this.getTopicAndResourceCounts(this.moveNodeIds));
+        const resourceCounts = Object.keys(this.clipboardTopicResourceCount).length
+          ? this.clipboardTopicResourceCount
+          : this.getTopicAndResourceCounts(this.moveNodeIds);
+        return this.$tr('moveItems', resourceCounts);
       },
       moveHereButtonDisabled() {
         if (this.moveNodesInProgress) {

--- a/contentcuration/contentcuration/frontend/shared/views/form/Checkbox.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/Checkbox.vue
@@ -127,7 +127,8 @@
       },
     },
     methods: {
-      handleChange(checked) {
+      handleChange(checked, e) {
+        e.stopPropagation();
         this.isChecked = checked;
       },
       updateInputValue(newValue) {


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pull request fixes the incorrect folder and resource count displayed when opening the `moveModal` from the `Clipboard` component. This pull request also fixes a selection issue in the `Clipboard`.

### Manual verification steps performed
1. Select folder/resource in the clipboard
2. Click on the Move button
3. Observe the title with the correct count when the `moveModal` opens

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
Before:
![incorrectResourceTopicCount](https://github.com/user-attachments/assets/ba5f0b77-b43d-4138-ab88-6e2144380883)


After:

https://github.com/user-attachments/assets/99851e4b-444e-4b9c-8f4d-30091dc062cf




## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #3744 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
