### PR TITLE
Add validation for threshold none invalid cases

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -851,7 +851,6 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
                     )
                 ],
         )
-
         self.assertEqual(len(response.data["errors"]), 0)
         updated_contentnode = models.ContentNode.objects.get(id=contentnode.id)
         self.assertEqual(updated_contentnode.extra_fields["options"]["completion_criteria"]["model"], completion_criteria.DETERMINED_BY_RESOURCE)

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -455,11 +455,9 @@ def migrate_extra_fields(extra_fields):
     return extra_fields
 
 
-def validate_and_conform_to_schema_threshold_none(validated_options):
-    completion_criteria_validated = validated_options.get("completion_criteria", {})
+def validate_and_conform_to_schema_threshold_none(completion_criteria_validated):
     model = completion_criteria_validated.get("model", {})
     if model in ["reference", "determined_by_resource"]:
         if "threshold" not in completion_criteria_validated or completion_criteria_validated["threshold"] is not None:
             completion_criteria_validated["threshold"] = None
-    validated_options["completion_criteria"] = completion_criteria_validated
-    return validated_options
+    return completion_criteria_validated

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -453,3 +453,13 @@ def migrate_extra_fields(extra_fields):
             "model": completion_criteria.MASTERY,
         }
     return extra_fields
+
+
+def validate_and_conform_to_schema_threshold_none(validated_options):
+    completion_criteria_validated = validated_options.get("completion_criteria", {})
+    model = completion_criteria_validated.get("model", {})
+    if model in ["reference", "determined_by_resource"]:
+        if "threshold" not in completion_criteria_validated or completion_criteria_validated["threshold"] is not None:
+            completion_criteria_validated["threshold"] = None
+    validated_options["completion_criteria"] = completion_criteria_validated
+    return validated_options

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -282,14 +282,14 @@ class CompletionCriteriaSerializer(JSONFieldDictSerializer):
     model = CharField()
     learner_managed = BooleanField(required=False, allow_null=True)
 
+    def update(self, instance, validated_data):
+        validated_data = validate_and_conform_to_schema_threshold_none(validated_data)
+        return super(CompletionCriteriaSerializer, self).update(instance, validated_data)
+
 
 class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
     modality = ChoiceField(choices=(("QUIZ", "Quiz"),), allow_null=True, required=False)
     completion_criteria = CompletionCriteriaSerializer(required=False)
-
-    def update(self, instance, validated_data):
-        validated_data = validate_and_conform_to_schema_threshold_none(validated_data)
-        return super(ExtraFieldsOptionsSerializer, self).update(instance, validated_data)
 
 
 class ExtraFieldsSerializer(JSONFieldDictSerializer):

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -58,6 +58,7 @@ from contentcuration.tasks import calculate_resource_size_task
 from contentcuration.utils.nodes import calculate_resource_size
 from contentcuration.utils.nodes import migrate_extra_fields
 from contentcuration.utils.pagination import ValuesViewsetCursorPagination
+from contentcuration.utils.nodes import validate_and_conform_to_schema_threshold_none
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import BulkUpdateMixin
@@ -285,6 +286,10 @@ class CompletionCriteriaSerializer(JSONFieldDictSerializer):
 class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
     modality = ChoiceField(choices=(("QUIZ", "Quiz"),), allow_null=True, required=False)
     completion_criteria = CompletionCriteriaSerializer(required=False)
+
+    def update(self, instance, validated_data):
+        validated_data = validate_and_conform_to_schema_threshold_none(validated_data)
+        return super(ExtraFieldsOptionsSerializer, self).update(instance, validated_data)
 
 
 class ExtraFieldsSerializer(JSONFieldDictSerializer):


### PR DESCRIPTION
## Summary
Add validation to automatically resolve cases where allowed none value of threshold was causing validation error. 

### Description of the change(s) you made
- Implement logic to resolve edge case with completion criteria objects.
- Add test to confirm the edge case.


### Manual verification steps performed
1. Open studio in two different browsers.
2.  Login with admin user and userC.
3. Simultaneously open same ContentNode with content kind html5 in both tabs.
4. First change the completion criteria to reference model.
5. In one tab change to approx time model.
6. Simultaneously on other tab change the model to determined by resources.
7. Validation error does not arise.

### Does this introduce any tech-debt items?
Validation error would still come up for the cases where the changes just has a threshold field in it without the model information and may contradict with models that want it to be None. We would handle this in the frontend by reverting the optimistic changes. 

## References
closes #3879 


### Contributor's Checklist
PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
