### PR TITLE
Fix save edit completion modal on exercise resources

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCompletionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCompletionModal.vue
@@ -67,6 +67,13 @@
         },
       },
     },
+    watch: {
+      completionObject() {
+        this.$nextTick(() => {
+          this.validate();
+        });
+      },
+    },
     mounted() {
       const { suggested_duration, extra_fields = {} } = this.contentNode;
       const { suggested_duration_type, options } = extra_fields || {};

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -48,9 +48,9 @@
         v-model="mOfN"
         :showMofN="showMofN"
         :mPlaceholder="getPlaceholder('mOfN.m')"
-        :mRequired="isUnique(mOfN.m)"
+        :mRequired="showMofN && isUnique(mOfN.m)"
         :nPlaceholder="getPlaceholder('mOfN.n')"
-        :nRequired="isUnique(mOfN.n)"
+        :nRequired="showMofN && isUnique(mOfN.n)"
         @mFocus="trackClick('Mastery m value')"
         @nFocus="trackClick('Mastery n value')"
       />


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Fix save edit completion modal on exercise resources. MasteryCriteriaMofNFields was being validated even if we didnt need them.

### Manual verification steps performed
1. Verified that edit completion modal was working with all completion types.
2. Verified that edit all details moadl was still working fine.

### Screenshots (if applicable)

https://github.com/user-attachments/assets/2bc0c699-8fad-4175-9cf0-667f499988d2

___
## Reviewer guidance
### How can a reviewer test these changes?
Follow instructions in #4648.


### Are there any risky areas that deserve extra testing?
Test that edit all details doesnt break.


## References
Closes #4648.

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [x] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
