### PR TITLE
Add MVP modal for applying inheritable metadata

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -102,6 +102,7 @@
             </VContent>
           </template>
         </Uploader>
+
       </VCard>
       <BottomBar v-if="!loading && !loadError && !showFileUploadDefault">
         <VLayout row align-center fill-height class="px-2">
@@ -123,6 +124,9 @@
       </BottomBar>
       <AboutLicensesModal
         v-if="isAboutLicensesModalOpen"
+      />
+      <InheritAncestorMetadataModal
+        :inheritableMetadataItems="dummyAncestorMetadata"
       />
     </VDialog>
 
@@ -185,6 +189,7 @@
   import SavingIndicator from './SavingIndicator';
   import EditView from './EditView';
   import EditList from './EditList';
+  import InheritAncestorMetadataModal from './InheritAncestorMetadataModal.vue';
   import { ContentKindLearningActivityDefaults } from 'shared/leUtils/ContentKinds';
   import { fileSizeMixin, routerMixin } from 'shared/mixins';
   import FileStorage from 'shared/views/files/FileStorage';
@@ -203,6 +208,18 @@
 
   const CHECK_STORAGE_INTERVAL = 10000;
 
+  const dummyAncestorMetadata = {
+    categories: {
+      // PbGoe2MV
+      EHcbjuKq: '4f9be4145e7946438af6f28d225c3cb0',
+      HGIc9sZq: '4f9be4145e7946438af6f28d225c3cb0',
+    },
+    levels: {
+      BkGYi3lD: '4f9be4145e7946438af6f28d225c3cb0',
+    },
+    language: 'en',
+  };
+
   export default {
     name: 'EditModal',
     components: {
@@ -210,6 +227,7 @@
       EditView,
       ResizableNavigationDrawer,
       Uploader,
+      InheritAncestorMetadataModal,
       FileStorage,
       FileUploadDefault,
       LoadingText,
@@ -309,6 +327,9 @@
       },
       invalidNodes() {
         return this.nodeIds.filter(id => !this.getContentNodeIsValid(id));
+      },
+      dummyAncestorMetadata() {
+        return dummyAncestorMetadata;
       },
     },
     beforeRouteEnter(to, from, next) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -127,6 +127,7 @@
       />
       <InheritAncestorMetadataModal
         :contentNode="createMode ? { parent: $route.params.nodeId } : null"
+        @inherit="indicateInheritableMetadata"
       />
     </VDialog>
 
@@ -255,6 +256,7 @@
         promptFailed: false,
         listElevated: false,
         storagePoll: null,
+        parentNodeMetadataToInherit: {},
       };
     },
     computed: {
@@ -429,6 +431,9 @@
       scroll(e) {
         this.listElevated = e.target.scrollTop > 0;
       },
+      indicateInheritableMetadata(args) {
+        this.parentNodeMetadataToInherit = args;
+      },
 
       /* Button actions */
       handleClose() {
@@ -475,6 +480,10 @@
           payload.learning_activities = {
             [ContentKindLearningActivityDefaults[kind]]: true,
           };
+        }
+        if (Object.keys(this.parentNodeMetadataToInherit).length) {
+          console.log('Inheriting metadata', this.parentNodeMetadataToInherit);
+          payload = { ...this.parentNodeMetadataToInherit };
         }
         return this.createContentNode({
           kind,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -126,7 +126,7 @@
         v-if="isAboutLicensesModalOpen"
       />
       <InheritAncestorMetadataModal
-        :inheritableMetadataItems="dummyAncestorMetadata"
+        :contentNode="createMode ? { parent: $route.params.nodeId } : null"
       />
     </VDialog>
 
@@ -208,18 +208,6 @@
 
   const CHECK_STORAGE_INTERVAL = 10000;
 
-  const dummyAncestorMetadata = {
-    categories: {
-      // PbGoe2MV
-      EHcbjuKq: '4f9be4145e7946438af6f28d225c3cb0',
-      HGIc9sZq: '4f9be4145e7946438af6f28d225c3cb0',
-    },
-    levels: {
-      BkGYi3lD: '4f9be4145e7946438af6f28d225c3cb0',
-    },
-    language: 'en',
-  };
-
   export default {
     name: 'EditModal',
     components: {
@@ -288,11 +276,12 @@
       uploadMode() {
         return this.$route.name === RouteNames.UPLOAD_FILES;
       },
-      /* eslint-disable kolibri/vue-no-unused-properties */
       createExerciseMode() {
         return this.$route.name === RouteNames.ADD_EXERCISE;
       },
-      /* eslint-enable */
+      createMode() {
+        return this.addTopicsMode || this.uploadMode || this.createExerciseMode;
+      },
       editMode() {
         return this.$route.name === RouteNames.CONTENTNODE_DETAILS;
       },
@@ -327,9 +316,6 @@
       },
       invalidNodes() {
         return this.nodeIds.filter(id => !this.getContentNodeIsValid(id));
-      },
-      dummyAncestorMetadata() {
-        return dummyAncestorMetadata;
       },
     },
     beforeRouteEnter(to, from, next) {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -170,8 +170,11 @@
     },
     watch: {
       parent(newParent, oldParent) {
-        console.log(newParent, oldParent);
-        if ((!oldParent && newParent) || oldParent.id !== newParent.id) {
+        if (
+          (!oldParent && newParent) ||
+          (oldParent && !newParent) ||
+          oldParent.id !== newParent.id
+        ) {
           this.resetData();
         }
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -1,0 +1,74 @@
+<template>
+
+  <KModal
+    data-test="inheritable-metadata-dialog"
+    :title="$tr('applyResourceDetailsTitle')"
+    :submitText="$tr('continueAction')"
+    :cancelText="$tr('cancelAction')"
+    @submit="handleContinue"
+    @cancel="close"
+  >
+    <div class="inherit-metadata-dialog">
+      <p class="inherit-metadata-dialog__description">
+        {{ $tr('inheritMetadataDescription') }}
+      </p>
+      <div class="inherit-metadata-dialog-checkboxes">
+        <KCheckbox
+          v-for="item in inheritableMetadataItems"
+          :key="item.value"
+          :label="generateLabel(item)"
+        />
+      </div>
+      <div class="divider"></div>
+      <KCheckbox
+        :label="$tr('doNotShowThisAgain')"
+      />
+      <p>{{ $tr('doNotShowAgainDescription') }}</p>
+    </div>
+  </KModal>
+
+</template>
+
+<script>
+
+  export default {
+    name: 'InheritAncestorMetadataModal',
+    props: {
+      inheritableMetadataItems: {
+        type: Object,
+        required: true,
+      },
+    },
+    methods: {
+      handleContinue() {
+        // TO DO apply metadata to the selected resources, or alternatively, just emit with event
+        this.$emit('handleContinue');
+      },
+      generateLabel(item) {
+        // TO DO generate label with all of the metadata le-consts, etc.
+        return `${item}`;
+      },
+      close() {
+        this.$emit('close');
+      },
+    },
+    $trs: {
+      applyResourceDetailsTitle: 'Apply resource details',
+      /* eslint-disable kolibri/vue-no-unused-translations */
+      applyResourceDetailsDescriptionUpload:
+        'The folder `{folder}` has the following details. Select the details you want to apply to your upload.',
+      applyResourceDetailsDescriptionImport:
+        'The folder `{folder}` has the following details. Select the details you want to apply to the {resource, plural, one {resource}, other {resources}} you are importing.',
+      applyResourceDetailsDescriptionMoving:
+        'The folder `{folder}` has the following details. Select the details you want to apply to the {resource, plural, one {resource}, other {resources}} you are moving.',
+      /* eslint-enable kolibri/vue-no-unused-translations */
+      continueAction: 'Continue',
+      cancelAction: 'Cancel',
+      inheritMetadataDescription: 'Inherit metadata from the folder above',
+      doNotShowThisAgain: "Don't ask me about this folder again",
+      doNotShowAgainDescription:
+        'All future additions to this folder will have the selected information by default',
+    },
+  };
+
+</script>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -86,7 +86,8 @@
           this.contentNode !== null &&
           this.contentNode.parent &&
           !this.allFieldsDesignatedByParent &&
-          !this.closed
+          !this.closed &&
+          this.parentHasInheritableMetadata
         );
       },
       inheritableMetadataItems() {
@@ -135,6 +136,9 @@
       },
       fieldsToInherit() {
         return Object.keys(this.inheritableMetadataItems).filter(field => this.checks[field]);
+      },
+      parentHasInheritableMetadata() {
+        return this.inheritableMetadataItems && !isEmpty(this.inheritableMetadataItems);
       },
     },
     created() {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -28,7 +28,9 @@
         :checked="dontShowAgain"
         @change="dontShowAgain = !dontShowAgain"
       />
-      <p>{{ $tr('doNotShowAgainDescription') }}</p>
+      <p class="helper-text">
+        {{ $tr('doNotShowAgainDescription') }}
+      </p>
     </div>
   </KModal>
 
@@ -259,3 +261,19 @@
   };
 
 </script>
+
+
+<style lang="less" scoped>
+
+  .divider {
+    margin: 16px 0;
+    border-bottom: 1px solid #e6e6e6;
+  }
+
+  .helper-text {
+    margin: -8px 32px;
+    font-size: 12px;
+    color: #9e9e9e;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -3,7 +3,7 @@
   <KModal
     v-if="active"
     data-test="inheritable-metadata-dialog"
-    :title="$tr('applyResourceDetailsTitle')"
+    :title="$tr('applyResourceDetailsTitle', { folder: parent.title })"
     :submitText="$tr('continueAction')"
     :cancelText="$tr('cancelAction')"
     @submit="handleContinue"
@@ -285,22 +285,15 @@
       },
     },
     $trs: {
-      applyResourceDetailsTitle: 'Apply resource details',
+      applyResourceDetailsTitle: "Apply details from the folder '{folder}'",
       /* eslint-disable kolibri/vue-no-unused-translations */
-      applyResourceDetailsDescriptionUpload:
-        'The folder `{folder}` has the following details. Select the details you want to apply to your upload. You can add edit these details and add additional resource information later.',
-      applyResourceDetailsDescriptionImport:
-        'The folder `{folder}` has the following details. Select the details you want to apply to the {resource, plural, one {resource}, other {resources}} you are importing.',
-      applyResourceDetailsDescriptionMoving:
-        'The folder `{folder}` has the following details. Select the details you want to apply to the {resource, plural, one {resource}, other {resources}} you are moving.',
-      /* eslint-enable kolibri/vue-no-unused-translations */
       continueAction: 'Continue',
       cancelAction: 'Cancel',
-      inheritMetadataDescription: 'Add metadata from the folder above',
-      updateLanguage: 'Update language to match the folder above',
+      inheritMetadataDescription: 'Select details to add:',
+      updateLanguage: 'Update language:',
       doNotShowThisAgain: "Don't ask me about this folder again",
       doNotShowAgainDescription:
-        'All future additions to this folder will have the selected information by default',
+        'All future additions to this folder will have the selected details by default',
       language: 'Language: {language}',
       categories: 'Categories: {categories}',
       learnerNeeds: 'Learner needs: {learnerNeeds}',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -135,7 +135,7 @@
 </template>
 <script>
 
-  import { mapGetters, mapActions } from 'vuex';
+  import { mapGetters, mapActions, mapMutations } from 'vuex';
   import ResourceDrawer from '../ResourceDrawer';
   import { RouteNames } from '../../constants';
   import NewTopicModal from './NewTopicModal';
@@ -248,6 +248,7 @@
     },
     methods: {
       ...mapActions('contentNode', ['createContentNode', 'loadChildren']),
+      ...mapMutations('contentNode', ['ADD_INHERITING_NODE']),
       isDisabled(node) {
         return this.moveNodeIds.includes(node.id);
       },
@@ -300,6 +301,9 @@
           actionText: this.$tr('goToLocationButton'),
           actionCallback: this.goToLocation,
         });
+        for (const nodeId of this.moveNodeIds) {
+          this.ADD_INHERITING_NODE(this.getContentNode(nodeId));
+        }
         this.moveNodesInProgress = false;
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -596,6 +596,7 @@
         'copyContentNode',
         'waitForCopyingStatus',
         'setQuickEditModal',
+        'updateContentNode',
       ]),
       ...mapMutations('contentNode', ['ADD_INHERITING_NODE', 'CLEAR_INHERITING_NODES']),
       ...mapActions('clipboard', ['copyAll']),

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -538,6 +538,7 @@ export function copyContentNode(
   // with a `source_id` of the source node then create the content node copies
   return ContentNode.copy(id, target, position, excluded_descendants, sourceNode).then(node => {
     context.commit('ADD_CONTENTNODE', node);
+    context.commit('ADD_INHERITING_NODE', node);
     return node;
   });
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -322,6 +322,9 @@ function generateContentNodeData({
     if (extra_fields.suggested_duration_type) {
       contentNodeData.extra_fields.suggested_duration_type = extra_fields.suggested_duration_type;
     }
+    if (extra_fields.inherit_metadata) {
+      contentNodeData.extra_fields.inherit_metadata = extra_fields.inherit_metadata;
+    }
   }
   if (prerequisite !== NOVALUE) {
     contentNodeData.prerequisite = prerequisite;
@@ -354,6 +357,14 @@ export function updateContentNode(context, { id, ...payload } = {}) {
         ...(extraFields.options || {}),
         ...contentNodeData.extra_fields.options,
       };
+    }
+
+    if (contentNodeData.extra_fields.inherit_metadata) {
+      // Don't set inherit_metadata on non-topic nodes
+      // as they cannot have children to bequeath metadata to
+      if (node.kind !== ContentKindsNames.TOPIC) {
+        delete contentNodeData.extra_fields.inherit_metadata;
+      }
     }
 
     contentNodeData = {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/index.js
@@ -35,6 +35,13 @@ export default {
       */
       moveNodes: [],
 
+      /*
+        Adding this to the vuex store to only need to manage ancestor inheritance
+        in the edit modal, and in the topic view. This state is only used for topic view handling,
+        so that node moving, and copying both trigger in the inheritance logic,
+        via the multiple means that these can all be triggered.
+      */
+      inheritingNodes: null,
       /**
        * Here we denormalize our prerequisite data in order to
        * allow simple forwards/backwards lookups in our graph

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
@@ -78,6 +78,18 @@ export function SET_MOVE_NODES(state, ids) {
   state.moveNodes = ids;
 }
 
+export function ADD_INHERITING_NODE(state, node) {
+  state.inheritingNodes = (state.inheritingNodes || []).concat(node);
+}
+
+export function CLEAR_INHERITING_NODES(state, ids) {
+  if (!state.inheritingNodes) {
+    return;
+  }
+  const nodes = state.inheritingNodes.filter(n => !ids.includes(n.id));
+  state.inheritingNodes = nodes.length ? nodes : null;
+}
+
 export function SET_QUICK_EDIT_MODAL(state, quickEditModalOpen) {
   state.quickEditModalOpen = quickEditModalOpen;
 }

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -2,6 +2,7 @@ import invert from 'lodash/invert';
 import Subjects from 'kolibri-constants/labels/Subjects';
 import CompletionCriteria from 'kolibri-constants/CompletionCriteria';
 import ContentLevels from 'kolibri-constants/labels/Levels';
+import ResourcesNeededTypes from 'kolibri-constants/labels/Needs';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import featureFlagsSchema from 'static/feature_flags.json';
 
@@ -15,6 +16,7 @@ export { default as ResourcesNeededTypes } from 'kolibri-constants/labels/Needs'
 export const CategoriesLookup = invert(Subjects);
 export const CompletionCriteriaLookup = invert(CompletionCriteria);
 export const LevelsLookup = invert(ContentLevels);
+export const NeedsLookup = invert(ResourcesNeededTypes);
 
 export const ContentDefaults = {
   author: 'author',

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -1,3 +1,4 @@
+import camelCase from 'lodash/camelCase';
 import isEqual from 'lodash/isEqual';
 import transform from 'lodash/transform';
 import uniq from 'lodash/uniq';
@@ -704,8 +705,16 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
 export const metadataTranslationMixin = {
   methods: {
     translateMetadataString(key) {
+      const camelKey = camelCase(key);
       if (nonconformingKeys[key]) {
-        return metadataStrings.$tr(nonconformingKeys[key]);
+        key = nonconformingKeys[key];
+      } else if (nonconformingKeys[camelKey]) {
+        key = nonconformingKeys[camelKey];
+      } else if (
+        !metadataStrings.defaultMessages[key] &&
+        metadataStrings.defaultMessages[camelKey]
+      ) {
+        key = camelKey;
       }
       return metadataStrings.$tr(key);
     },
@@ -733,6 +742,8 @@ const nonconformingKeys = {
   foundations: 'basicSkills',
   OTHER_SUPPLIES: 'needsMaterials',
   SPECIAL_SOFTWARE: 'softwareTools',
+  PROFESSIONAL: 'specializedProfessionalTraining',
+  WORK_SKILLS: 'allLevelsWorkSkills',
 };
 
 /**

--- a/contentcuration/contentcuration/tests/test_exportchannel.py
+++ b/contentcuration/contentcuration/tests/test_exportchannel.py
@@ -69,6 +69,10 @@ class ExportChannelTestCase(StudioTestCase):
         super(ExportChannelTestCase, self).setUp()
         self.content_channel = channel()
 
+        # Make a ricecooker channel to test inheritance behaviour
+        self.content_channel.ricecooker_version = "0.7.1"
+        self.content_channel.save()
+
         # Add some incomplete nodes to ensure they don't get published.
         new_node = create_node({'kind_id': 'topic', 'title': 'Incomplete topic', 'children': []})
         new_node.complete = False

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -28,8 +28,8 @@ from contentcuration.tests.viewsets.base import generate_copy_event
 from contentcuration.tests.viewsets.base import generate_create_event
 from contentcuration.tests.viewsets.base import generate_delete_event
 from contentcuration.tests.viewsets.base import generate_publish_channel_event
-from contentcuration.tests.viewsets.base import generate_update_event
 from contentcuration.tests.viewsets.base import generate_update_descendants_event
+from contentcuration.tests.viewsets.base import generate_update_event
 from contentcuration.tests.viewsets.base import SyncTestMixin
 from contentcuration.utils.db_tools import TreeBuilder
 from contentcuration.viewsets.channel import _unpublished_changes_query
@@ -584,7 +584,7 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         descendants.exclude(kind_id=content_kinds.TOPIC).update(extra_fields={})
 
         new_language = "es"
-        
+
         response = self.sync_changes(
             [generate_update_descendants_event(root_node.id, {"language": new_language}, channel_id=self.channel.id)],
         )
@@ -595,12 +595,12 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
             language = models.ContentNode.objects.get(id=descendant.id).language
             language = str(language)
             self.assertEqual(language, new_language)
-    
+
     def test_cannot_update_descendants_when_updating_non_topic_node(self):
         root_node = testdata.tree()
         video_node = root_node.get_descendants().filter(kind_id=content_kinds.VIDEO).first()
         new_language = "pt"
-        
+
         response = self.sync_changes(
             [generate_update_descendants_event(video_node.id, {"language": new_language}, channel_id=self.channel.id)],
         )
@@ -609,7 +609,7 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         self.assertNotEqual(
             models.ContentNode.objects.get(id=video_node.id).language, new_language
         )
-    
+
     def test_update_contentnode_exercise_mastery_model(self):
         metadata = self.contentnode_db_metadata
         metadata["kind_id"] = content_kinds.EXERCISE
@@ -1058,6 +1058,17 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(
             models.ContentNode.objects.get(id=contentnode.id).suggested_duration, new_suggested_duration
+        )
+
+    def test_update_contentnode_extra_fields_inherited_metadata(self):
+        contentnode = models.ContentNode.objects.create(**self.contentnode_db_metadata)
+
+        response = self.sync_changes(
+            [generate_update_event(contentnode.id, CONTENTNODE, {"extra_fields.inherited_metadata.categories": True}, channel_id=self.channel.id)],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertTrue(
+            models.ContentNode.objects.get(id=contentnode.id).extra_fields["inherited_metadata"]["categories"]
         )
 
     def test_update_contentnode_tags_dont_duplicate(self):

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -57,8 +57,8 @@ from contentcuration.models import UUIDField
 from contentcuration.tasks import calculate_resource_size_task
 from contentcuration.utils.nodes import calculate_resource_size
 from contentcuration.utils.nodes import migrate_extra_fields
-from contentcuration.utils.pagination import ValuesViewsetCursorPagination
 from contentcuration.utils.nodes import validate_and_conform_to_schema_threshold_none
+from contentcuration.utils.pagination import ValuesViewsetCursorPagination
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import BulkUpdateMixin
@@ -292,10 +292,18 @@ class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
     completion_criteria = CompletionCriteriaSerializer(required=False)
 
 
+class InheritedMetadataSerializer(JSONFieldDictSerializer):
+    categories = BooleanField(required=False)
+    language = BooleanField(required=False)
+    grade_levels = BooleanField(required=False)
+    learner_needs = BooleanField(required=False)
+
+
 class ExtraFieldsSerializer(JSONFieldDictSerializer):
     randomize = BooleanField()
     options = ExtraFieldsOptionsSerializer(required=False)
     suggested_duration_type = ChoiceField(choices=[completion_criteria.TIME, completion_criteria.APPROX_TIME], allow_null=True, required=False)
+    inherited_metadata = InheritedMetadataSerializer(required=False)
 
     def update(self, instance, validated_data):
         instance = migrate_extra_fields(instance)
@@ -1073,9 +1081,10 @@ class ContentNodeViewSet(BulkUpdateMixin, ValuesViewset):
 
         descendantsIds = root.get_descendants(include_self=True).values_list("id", flat=True)
 
-        changes = [{ "key": descendantId, "mods": mods } for descendantId in descendantsIds]
+        changes = [{"key": descendantId, "mods": mods} for descendantId in descendantsIds]
 
-        return self.update_from_changes(changes) # Bulk update
+        # Bulk update
+        return self.update_from_changes(changes)
 
     def update_descendants_from_changes(self, changes):
         errors = []


### PR DESCRIPTION
This PR adds additional functionality so that when a user uploads, imports, or moves a resource to a folder (moving can be with the "move" button, drag and drop, or copying via the clipboard) that has "bulk edit-able" metadata, they are prompted to select any options they would like that resource to inherit. 

<img width="885" alt="Screenshot 2024-08-29 at 2 58 51 PM" src="https://github.com/user-attachments/assets/123192fb-f2f4-4876-b5fe-abbcff8c28c6">

Steps for manual QA: 

1. Create a folder and add language, categories, level, and/or requirements (learner needs) to the folder. 
2. Create a second folder and do the same, but with different metadata 
3. Upload some resources into one of the folders, you should see the modal appear 
4. Move a resource into the second folder. you should be prompted to add the second folder's metadata 
5. import a resource to either folder
6. copy a resource to clipboard, and copy it into a new folder 
7. create a new folder with no metadata. move/import a resource into it. you should not see the modal appear
8. create a folder that has a language tagged but no additional details. you should not see the "Select details to add" text or any checkboxes
9. 8. create a folder that has categories (etc_ tagged but no additional langauge. you should see the "Select details to add" text but not "update language" or any checkboxes