### PR TITLE
(Change|Reset)Password components apply length validation

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/resetPassword.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/resetPassword.spec.js
@@ -39,8 +39,10 @@ describe('resetPassword', () => {
   });
   it('should call setPassword on submit if password data is valid', () => {
     wrapper.setData({ new_password1: 'pass', new_password2: 'pass' });
-    wrapper.find({ ref: 'form' }).trigger('submit');
-    expect(setPassword).toHaveBeenCalled();
+    wrapper.vm.$nextTick(() => {
+      wrapper.find({ ref: 'form' }).trigger('submit');
+      expect(setPassword).toHaveBeenCalled();
+    });
   });
   it('should retain data from query params so reset credentials are preserved', () => {
     router.replace({
@@ -50,7 +52,9 @@ describe('resetPassword', () => {
       },
     });
     wrapper.setData({ new_password1: 'pass', new_password2: 'pass' });
-    wrapper.find({ ref: 'form' }).trigger('submit');
-    expect(setPassword.mock.calls[0][0].test).toBe('testing');
+    wrapper.vm.$nextTick(() => {
+      wrapper.find({ ref: 'form' }).trigger('submit');
+      expect(setPassword.mock.calls[0][0].test).toBe('testing');
+    });
   });
 });

--- a/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ResetPassword.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ResetPassword.vue
@@ -9,6 +9,7 @@
       <PasswordField
         v-model="new_password1"
         :label="$tr('passwordLabel')"
+        :additionalRules="passwordValidationRules"
         autofocus
       />
       <PasswordField
@@ -52,6 +53,9 @@
       passwordConfirmRules() {
         return [value => (this.new_password1 === value ? true : this.$tr('passwordMatchMessage'))];
       },
+      passwordValidationRules() {
+        return [value => (value.length >= 8 ? true : this.$tr('passwordValidationMessage'))];
+      },
     },
     methods: {
       ...mapActions('account', ['setPassword']),
@@ -80,6 +84,7 @@
       resetPasswordPrompt: 'Enter and confirm your new password',
       passwordLabel: 'New password',
       passwordConfirmLabel: 'Confirm password',
+      passwordValidationMessage: 'Password should be at least 8 characters long',
       passwordMatchMessage: "Passwords don't match",
       submitButton: 'Submit',
       resetPasswordFailed: 'Failed to reset password. Please try again.',

--- a/contentcuration/contentcuration/frontend/settings/pages/Account/ChangePasswordForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/ChangePasswordForm.vue
@@ -8,9 +8,11 @@
     @submit="submitPassword"
     @cancel="dialog = false"
   >
-    <VForm ref="form">
+    <!-- inline style here avoids scrollbar on validations -->
+    <VForm ref="form" style="height: 196px">
       <PasswordField
         v-model="password"
+        :additionalRules="passwordValidationRules"
         :label="$tr('newPasswordLabel')"
       />
       <PasswordField
@@ -52,6 +54,9 @@
           this.$emit('input', value);
         },
       },
+      passwordValidationRules() {
+        return [value => (value.length >= 8 ? true : this.$tr('passwordValidationMessage'))];
+      },
       passwordConfirmRules() {
         return [value => (this.password === value ? true : this.$tr('formInvalidText'))];
       },
@@ -86,6 +91,7 @@
       newPasswordLabel: 'New password',
       confirmNewPasswordLabel: 'Confirm new password',
       formInvalidText: "Passwords don't match",
+      passwordValidationMessage: 'Password should be at least 8 characters long',
       cancelAction: 'Cancel',
       saveChangesAction: 'Save changes',
       paswordChangeSuccess: 'Password updated',


### PR DESCRIPTION
## Summary

### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->

- Copies the string definitions for the password length validation to other places where passwords are updated (Reset password, Change password from user account page)
- Copies the validator functions over to the same components
- Ensures length > 8
- Adds a bit of height to the container of the KModal for the "Change password" because it would show a scroll bar whenever the errors were visible

### Manual verification steps performed (Also Reviewer Guidance)

1. Create an account
2. Change your password from your account page
3. Log out
4. Click "Reset password" on the login page
5. If you're running this locally, look at your server logs for the URL to reset your password otherwise check your email
6. Click the reset password link

- In all cases, if you put a password < 8 characters in length, you should see the appropriate error message.
- You should also be able to actually update / reset your password 😄 


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

I do hate the hard-coded style there... and I feel like we've somehow fixed this another better way... but I could not think of it. 

Is this something that is no longer a problem in upcoming KDS versions?


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

Fixes: #4646 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
