### PR TITLE
Update snackbar

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
@@ -54,6 +54,7 @@
   import { ResourcesNeededTypes } from 'shared/constants';
   import { constantsTranslationMixin } from 'shared/mixins';
   import { hasMultipleFieldValues } from 'shared/utils/helpers';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditAudienceModal',
@@ -137,10 +138,8 @@
             });
           })
         );
-        this.$store.dispatch(
-          'showSnackbarSimple',
-          this.$tr('editedAudience', { count: this.nodes.length })
-        );
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
         this.close();
       },
     },
@@ -148,8 +147,6 @@
       editAudienceTitle: 'Edit Audience',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      editedAudience:
-        'Edited audience for {count, number, integer} {count, plural, one {resource} other {resources}}',
       resourcesSelected:
         '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
       forBeginnersCheckbox: 'For beginners',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCategoriesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCategoriesModal.vue
@@ -5,7 +5,7 @@
     isDescendantsUpdatable
     :title="$tr('editCategories')"
     :nodeIds="nodeIds"
-    :confirmationMessage="$tr('editedCategories', { count: nodeIds.length })"
+    :confirmationMessage="changesSaved"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -26,6 +26,7 @@
 
   import EditBooleanMapModal from './EditBooleanMapModal.vue';
   import CategoryOptions from 'shared/views/contentNodeFields/CategoryOptions';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditCategoriesModal',
@@ -39,10 +40,14 @@
         required: true,
       },
     },
+    computed: {
+      changesSaved() {
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        return commonStrings.$tr('changesSaved');
+      },
+    },
     $trs: {
       editCategories: 'Edit Categories',
-      editedCategories:
-        'Edited categories for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCompletionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCompletionModal.vue
@@ -26,6 +26,7 @@
   import { mapGetters, mapActions } from 'vuex';
   import { getFileDuration } from 'shared/utils/helpers';
   import CompletionOptions from 'shared/views/contentNodeFields/CompletionOptions';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditCompletionModal',
@@ -120,8 +121,8 @@
         };
 
         this.updateContentNode({ id: this.nodeId, ...payload });
-
-        this.$store.dispatch('showSnackbarSimple', this.$tr('editedCompletion', { count: 1 }));
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
         this.close();
       },
       close() {
@@ -132,8 +133,6 @@
       editCompletion: 'Edit Completion',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      editedCompletion:
-        'Edited completion for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -60,6 +60,7 @@
   import { mapGetters, mapActions } from 'vuex';
   import { LanguagesList } from 'shared/leUtils/Languages';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditLanguageModal',
@@ -144,11 +145,8 @@
             });
           })
         );
-
-        this.$store.dispatch(
-          'showSnackbarSimple',
-          this.$tr('editedLanguage', { count: this.nodes.length })
-        );
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
         this.close();
       },
     },
@@ -157,8 +155,6 @@
       languageItemText: '{language} ({code})',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      editedLanguage:
-        'Edited language for {count, number, integer} {count, plural, one {resource} other {resources}}',
       selectLanguage: 'Select / Type Language',
       resourcesSelected:
         '{count, number, integer} {count, plural, one {resource} other {resources}} selected',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLearningActivitiesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLearningActivitiesModal.vue
@@ -6,7 +6,7 @@
     :title="$tr('editLearningActivitiesTitle')"
     :nodeIds="nodeIds"
     :validators="learningActivityValidators"
-    :confirmationMessage="$tr('editedLearningActivities', { count: nodeIds.length })"
+    :confirmationMessage="changesSaved"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -28,6 +28,7 @@
   import EditBooleanMapModal from './EditBooleanMapModal';
   import { getLearningActivityValidators } from 'shared/utils/validation';
   import LearningActivityOptions from 'shared/views/contentNodeFields/LearningActivityOptions';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditLearningActivitiesModal',
@@ -45,11 +46,13 @@
       learningActivityValidators() {
         return getLearningActivityValidators();
       },
+      changesSaved() {
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        return commonStrings.$tr('changesSaved');
+      },
     },
     $trs: {
       editLearningActivitiesTitle: 'Edit Learning Activities',
-      editedLearningActivities:
-        'Edited learning activities for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLevelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLevelsModal.vue
@@ -5,7 +5,7 @@
     isDescendantsUpdatable
     :title="$tr('editLevelsTitle')"
     :nodeIds="nodeIds"
-    :confirmationMessage="$tr('editedLevels', { count: nodeIds.length })"
+    :confirmationMessage="changesSaved"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -26,6 +26,7 @@
 
   import EditBooleanMapModal from './EditBooleanMapModal';
   import LevelsOptions from 'shared/views/contentNodeFields/LevelsOptions';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditLevelsModal',
@@ -39,10 +40,14 @@
         required: true,
       },
     },
+    computed: {
+      changesSaved() {
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        return commonStrings.$tr('changesSaved');
+      },
+    },
     $trs: {
       editLevelsTitle: 'What Levels',
-      editedLevels:
-        'Edited levels for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -5,7 +5,7 @@
     isDescendantsUpdatable
     :title="$tr('editResourcesNeededTitle')"
     :nodeIds="nodeIds"
-    :confirmationMessage="$tr('editedResourcesNeeded', { count: nodeIds.length })"
+    :confirmationMessage="changesSaved"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -26,6 +26,7 @@
 
   import EditBooleanMapModal from './EditBooleanMapModal';
   import ResourcesNeededOptions from 'shared/views/contentNodeFields/ResourcesNeededOptions';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditResourcesNeededModal',
@@ -39,10 +40,14 @@
         required: true,
       },
     },
+    computed: {
+      changesSaved() {
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        return commonStrings.$tr('changesSaved');
+      },
+    },
     $trs: {
       editResourcesNeededTitle: 'What will you need?',
-      editedResourcesNeeded:
-        "Edited 'what will you need' for {count, number, integer} {count, plural, one {resource} other {resources}}",
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -103,6 +103,7 @@
   import HelpTooltip from 'shared/views/HelpTooltip';
   import LicenseDropdown from 'shared/views/LicenseDropdown';
   import { getCopyrightHolderValidators, getInvalidText } from 'shared/utils/validation';
+  import commonStrings from 'shared/translator';
 
   function generateGetterSetter(key) {
     return {
@@ -256,11 +257,8 @@
             return this.updateContentNode(payload);
           })
         );
-
-        this.$store.dispatch(
-          'showSnackbarSimple',
-          this.$tr('editedAttribution', { count: nodesToEdit.length })
-        );
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
         this.close();
       },
     },
@@ -281,8 +279,6 @@
       mixed: 'Mixed',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      editedAttribution:
-        'Edited attribution for {count, number, integer} {count, plural, one {resource} other {resources}}',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
@@ -39,6 +39,7 @@
 
   import { mapActions, mapGetters } from 'vuex';
   import { getTitleValidators, getInvalidText } from 'shared/utils/validation';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditTitleDescriptionModal',
@@ -85,8 +86,8 @@
           title: title.trim(),
           description: description.trim(),
         });
-
-        this.$store.dispatch('showSnackbarSimple', this.$tr('editedTitleDescription'));
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
         this.close();
       },
     },
@@ -96,7 +97,6 @@
       descriptionLabel: 'Description',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      editedTitleDescription: 'Edited title and description',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/translator.js
+++ b/contentcuration/contentcuration/frontend/shared/translator.js
@@ -25,6 +25,7 @@ const MESSAGES = {
   longActivityLteOneTwenty: 'Value must be equal or less than 120',
   activityDurationTooLongWarning:
     'This value is very high. Please make sure this is how long learners should work on the resource for, in order to complete it.',
+  changesSaved: 'Changes saved',
 };
 
 export default createTranslator('sharedVue', MESSAGES);


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
Fixes #4654 

Adds a "changes saved" string to the shared translator.js file.

### Manual verification steps performed
Made one edit for each possible bulk editing modal, and confirmed that the "Changes saved" string was displayed instead of the more specific string, [per QA team idea](https://github.com/learningequality/studio/issues/4654#issuecomment-2302374718)

### Screenshots (if applicable)

<img width="1440" alt="Screenshot 2024-08-22 at 2 38 12 PM" src="https://github.com/user-attachments/assets/4c056997-70fc-4619-a1c3-62cad5b8eef8">

### Does this introduce any tech-debt items?
I don't think so but the string linting disabling seems not ideal for common strings, but kind of out of scope
___
## Reviewer guidance
### How can a reviewer test these changes?
Edit each metadata option


