### PR TITLE
Move pagination into NodePanel where the contents of the topic are actually loaded and displayed.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -172,11 +172,7 @@
             @deselect="selected = selected.filter(id => id !== $event)"
             @scroll="scroll"
             @editTitleDescription="showTitleDescriptionModal"
-          >
-            <template #pagination>
-              <slot name="pagination"></slot>
-            </template>
-          </NodePanel>
+          />
         </DraggableRegion>
       </VFadeTransition>
       <ResourceDrawer

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -45,7 +45,11 @@
         />
       </template>
     </VList>
-    <slot name="pagination"></slot>
+    <div class="pagination-container">
+      <KButton v-if="more" :disabled="moreLoading" @click="loadMore">
+        {{ $tr('showMore') }}
+      </KButton>
+    </div>
   </div>
 
 </template>
@@ -80,6 +84,8 @@
     data() {
       return {
         loading: false,
+        more: null,
+        moreLoading: false,
       };
     },
     computed: {
@@ -102,12 +108,13 @@
     },
     created() {
       this.loading = true;
-      this.loadChildren({ parent: this.parentId }).then(() => {
+      this.loadChildren({ parent: this.parentId }).then(childrenResponse => {
         this.loading = false;
+        this.more = childrenResponse.more || null;
       });
     },
     methods: {
-      ...mapActions('contentNode', ['loadChildren']),
+      ...mapActions('contentNode', ['loadChildren', 'loadContentNodes']),
       goToNodeDetail(nodeId) {
         if (
           this.$route.params.nodeId === this.parentId &&
@@ -151,12 +158,22 @@
           }
         }
       },
+      loadMore() {
+        if (this.more && !this.moreLoading) {
+          this.moreLoading = true;
+          this.loadContentNodes(this.more).then(response => {
+            this.more = response.more || null;
+            this.moreLoading = false;
+          });
+        }
+      },
     },
     $trs: {
       emptyViewOnlyChannelText: 'Nothing in this channel yet',
       emptyTopicText: 'Nothing in this folder yet',
       emptyChannelText: 'Click "ADD" to start building your channel',
       emptyChannelSubText: 'Create, upload, or import resources from other channels',
+      showMore: 'Show more',
     },
   };
 
@@ -172,6 +189,12 @@
     padding-bottom: 88px;
     /* stylelint-disable-next-line custom-property-pattern */
     background-color: var(--v-backgroundColor-base);
+  }
+
+  .pagination-container {
+    display: flex;
+    justify-content: flex-start;
+    margin: 4px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -128,13 +128,6 @@
             />
           </div>
         </template>
-        <template #pagination>
-          <div class="pagination-container">
-            <KButton v-if="more" :disabled="moreLoading" @click="loadMore">
-              {{ $tr('showMore') }}
-            </KButton>
-          </div>
-        </template>
       </CurrentTopicView>
     </VContent>
   </TreeViewBase>
@@ -199,8 +192,6 @@
         },
         loading: true,
         listElevated: false,
-        more: null,
-        moreLoading: false,
       };
     },
     computed: {
@@ -308,16 +299,7 @@
         collapseAll: 'COLLAPSE_ALL_EXPANDED',
         setExpanded: 'SET_EXPANSION',
       }),
-      ...mapActions('contentNode', ['loadAncestors', 'loadChildren', 'loadContentNodes']),
-      loadMore() {
-        if (this.more && !this.moreLoading) {
-          this.moreLoading = true;
-          this.loadContentNodes(this.more).then(response => {
-            this.more = response.more || null;
-            this.moreLoading = false;
-          });
-        }
-      },
+      ...mapActions('contentNode', ['loadAncestors', 'loadChildren']),
       verifyContentNodeId(id) {
         this.nodeNotFound = false;
         return this.$store.dispatch('contentNode/headContentNode', id).catch(() => {
@@ -414,7 +396,6 @@
       openCurrentLocationButton: 'Expand to current folder location',
       updatedResourcesReadyForReview: 'Updated resources are ready for review',
       closeDrawer: 'Close',
-      showMore: 'Show more',
     },
   };
 
@@ -460,12 +441,6 @@
       /* stylelint-disable-next-line custom-property-pattern */
       background-color: var(--v-draggableDropZone-base);
     }
-  }
-
-  .pagination-container {
-    display: flex;
-    justify-content: flex-start;
-    margin: 4px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -753,12 +753,10 @@ class Resource extends mix(APIResource, IndexedDBResource) {
   }
 
   savePagination(queryString, more) {
-    if (more) {
-      return this.transaction({ mode: 'rw' }, PAGINATION_TABLE, () => {
-        return db[PAGINATION_TABLE].put({ table: this.tableName, queryString, more });
-      });
-    }
-    return Promise.resolve();
+    return this.transaction({ mode: 'rw' }, PAGINATION_TABLE, () => {
+      // Always save the pagination even if null, so we know we have fetched it
+      return db[PAGINATION_TABLE].put({ table: this.tableName, queryString, more });
+    });
   }
 
   loadPagination(queryString) {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Always save the pagination result, so we invalidate the cache if needed.
* Move pagination into NodePanel where the contents of the topic are actually loaded and displayed.
* Fixes issue with pagination whereby pagination at the parent folder will erroneously paginate for the node panel display


### Manual verification steps performed
* Add > 25 resources to the root folder of a channel
* Add a folder, navigate into it, see that Show more is not displayed in the child folder, but is in the parent

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
