### PR TITLE
Fixes UI glitch on cards in collections

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelItem.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelItem.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <VLayout v-if="channel" align-center wrap class="pa-2">
+  <VLayout v-if="channel" align-center wrap class="pa-2" @click="handleClick">
     <VFlex class="pa-2" xs12 sm4 md3 lg2>
       <Thumbnail :src="channel.thumbnail_url" />
     </VFlex>
@@ -45,6 +45,11 @@
       ...mapGetters('channel', ['getChannel']),
       channel() {
         return this.getChannel(this.channelId);
+      },
+    },
+    methods: {
+      handleClick() {
+        this.$emit('click', this.channelId);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -121,7 +121,6 @@
         this.selectedChannels = this.selectedChannels.includes(channelId)
           ? this.selectedChannels.filter(id => id !== channelId)
           : [...this.selectedChannels, channelId];
-        console.log('clicked');
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -21,15 +21,20 @@
           hover
           class="list-card-hover px-3"
         >
-          <Checkbox
-            v-model="selectedChannels"
-            color="primary"
-            :data-test="`checkbox-${channel.id}`"
-            :value="channel.id"
-            class="channel ma-0"
-          >
-            <ChannelItem :channelId="channel.id" />
-          </Checkbox>
+          <VLayout align-center row>
+            <Checkbox
+              v-model="selectedChannels"
+              color="primary"
+              :data-test="`checkbox-${channel.id}`"
+              :value="channel.id"
+              class="channel ma-0"
+            />
+            <ChannelItem
+              :channelId="channel.id"
+              :data-test="`channel-item-${channel.id}`"
+              @click="handleSelectChannel"
+            />
+          </VLayout>
         </VCard>
       </template>
     </template>
@@ -112,6 +117,12 @@
     },
     methods: {
       ...mapActions('channel', ['loadChannelList']),
+      handleSelectChannel(channelId) {
+        this.selectedChannels = this.selectedChannels.includes(channelId)
+          ? this.selectedChannels.filter(id => id !== channelId)
+          : [...this.selectedChannels, channelId];
+        console.log('clicked');
+      },
     },
     $trs: {
       searchText: 'Search for a channel',

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import Vuex from 'vuex';
 import ChannelSelectionList from '../ChannelSelectionList';
 import { ChannelListTypes } from 'shared/constants';
 
@@ -25,6 +26,25 @@ const publicChannel = {
   published: true,
 };
 
+const getters = {
+  channels: jest.fn(() => [editChannel, editChannel2, publicChannel]),
+  getChannel: jest.fn(() => () => editChannel),
+};
+
+const actions = {
+  loadChannelList: jest.fn(() => Promise.resolve()),
+};
+
+const store = new Vuex.Store({
+  modules: {
+    channel: {
+      namespaced: true,
+      getters,
+      actions,
+    },
+  },
+});
+
 function makeWrapper() {
   return mount(ChannelSelectionList, {
     sync: false,
@@ -41,9 +61,7 @@ function makeWrapper() {
         return Promise.resolve();
       },
     },
-    stubs: {
-      ChannelItem: true,
-    },
+    store,
   });
 }
 
@@ -76,5 +94,19 @@ describe('channelSelectionList', () => {
     wrapper.setData({ loading: false, search: searchWord });
     expect(wrapper.vm.listChannels.find(c => c.id === editChannel.id)).toBeTruthy();
     expect(wrapper.vm.listChannels.find(c => c.id === editChannel2.id)).toBeFalsy();
+  });
+
+  it('should select channels when the channel card has been clicked', () => {
+    wrapper.setData({ loading: false });
+    wrapper.find(`[data-test="channel-item-${editChannel.id}"]`).trigger('click');
+    expect(wrapper.emitted('input')[0][0]).toEqual([editChannel.id]);
+  });
+  it('should deselect channels when the channel card has been clicked', () => {
+    wrapper.setData({ loading: false });
+    wrapper.find(`[data-test="channel-item-${editChannel.id}"]`).element.click(); // Check the channel
+    wrapper.find(`[data-test="channel-item-${editChannel.id}"]`).element.click(); // Uncheck the channel
+
+    expect(wrapper.emitted('input')[0].length).toEqual(1); // Only one event should be emitted (corresponding to the initial check)
+    expect(wrapper.emitted('input')[0][0]).toEqual([editChannel.id]); // The initial check event should be emitted
   });
 });

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
@@ -95,7 +95,6 @@ describe('channelSelectionList', () => {
     expect(wrapper.vm.listChannels.find(c => c.id === editChannel.id)).toBeTruthy();
     expect(wrapper.vm.listChannels.find(c => c.id === editChannel2.id)).toBeFalsy();
   });
-
   it('should select channels when the channel card has been clicked', () => {
     wrapper.setData({ loading: false });
     wrapper.find(`[data-test="channel-item-${editChannel.id}"]`).trigger('click');


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the UI glitch on card thumbnails experienced while creating collections. 


### Manual verification steps performed
1. Click on the collections tab
2. Click on the "New Collection" button
3. Click "Select channels"
4. Navigate between "Content Channels" and "My Channes" while observing the channel cards.
5. Try to remove the description from one a channel and view it again
6. Also, try to select the channel by clicking on both the checkbox or anywhere on the card

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
![image](https://github.com/user-attachments/assets/ceb32c6c-6779-44d4-9ee4-5d070b70e4d4)

![image](https://github.com/user-attachments/assets/c19b1edc-191c-44e9-b6c1-5c62b454a889)


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
See manual verificatiion


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4656

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
