### PR TITLE
Consolidate selection text formatting.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
@@ -8,8 +8,8 @@
     @submit="handleSave"
     @cancel="close"
   >
-    <p v-if="nodeIds.length > 1" data-test="resources-selected-message">
-      {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+    <p v-if="resourcesSelectedText.length > 0" data-test="resources-selected-message">
+      {{ resourcesSelectedText }}
     </p>
     <template v-if="isMultipleAudience">
       <p data-test="multiple-audience-message">
@@ -63,6 +63,10 @@
       nodeIds: {
         type: Array,
         required: true,
+      },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
       },
     },
     data() {
@@ -147,8 +151,6 @@
       editAudienceTitle: 'Edit Audience',
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      resourcesSelected:
-        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
       forBeginnersCheckbox: 'For beginners',
       visibleTo: 'Visible to:',
       visibleToAnyone: 'Resources are visible to anyone',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -8,8 +8,8 @@
     @submit="handleSave"
     @cancel="close"
   >
-    <p v-if="nodeIds.length > 1" data-test="resources-selected-message">
-      {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+    <p v-if="resourcesSelectedText.length > 0" data-test="resources-selected-message">
+      {{ resourcesSelectedText }}
     </p>
     <template v-if="isDescendantsUpdatable && isTopicSelected">
       <KCheckbox
@@ -71,6 +71,10 @@
       validators: {
         type: Array,
         default: () => [],
+      },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
       },
     },
     data() {
@@ -165,8 +169,6 @@
     $trs: {
       saveAction: 'Save',
       cancelAction: 'Cancel',
-      resourcesSelected:
-        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
       updateDescendantsCheckbox:
         'Apply to all resources and folders nested within the selected folders',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCategoriesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCategoriesModal.vue
@@ -6,6 +6,7 @@
     :title="$tr('editCategories')"
     :nodeIds="nodeIds"
     :confirmationMessage="changesSaved"
+    :resourcesSelectedText="resourcesSelectedText"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -38,6 +39,10 @@
       nodeIds: {
         type: Array,
         required: true,
+      },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
       },
     },
     computed: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -9,8 +9,8 @@
     @submit="handleSave"
     @cancel="close"
   >
-    <p v-if="nodeIds.length > 1" data-test="resources-selected-message">
-      {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+    <p v-if="resourcesSelectedText.length > 0" data-test="resources-selected-message">
+      {{ resourcesSelectedText }}
     </p>
     <p v-if="isMultipleNodeLanguages" data-test="different-languages-message">
       {{ $tr('differentLanguages') }}
@@ -68,6 +68,10 @@
       nodeIds: {
         type: Array,
         required: true,
+      },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
       },
     },
     data() {
@@ -156,8 +160,6 @@
       saveAction: 'Save',
       cancelAction: 'Cancel',
       selectLanguage: 'Select / Type Language',
-      resourcesSelected:
-        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
       differentLanguages:
         'The selected resources have different languages set. Choosing an option below will apply the language to all the selected resources',
       updateDescendantsCheckbox:

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLearningActivitiesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLearningActivitiesModal.vue
@@ -7,6 +7,7 @@
     :nodeIds="nodeIds"
     :validators="learningActivityValidators"
     :confirmationMessage="changesSaved"
+    :resourcesSelectedText="resourcesSelectedText"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -40,6 +41,10 @@
       nodeIds: {
         type: Array,
         required: true,
+      },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
       },
     },
     computed: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLevelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLevelsModal.vue
@@ -6,6 +6,7 @@
     :title="$tr('editLevelsTitle')"
     :nodeIds="nodeIds"
     :confirmationMessage="changesSaved"
+    :resourcesSelectedText="resourcesSelectedText"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -39,6 +40,10 @@
         type: Array,
         required: true,
       },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
+      },
     },
     computed: {
       changesSaved() {
@@ -47,7 +52,7 @@
       },
     },
     $trs: {
-      editLevelsTitle: 'What Levels',
+      editLevelsTitle: 'Edit Levels',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -6,6 +6,7 @@
     :title="$tr('editResourcesNeededTitle')"
     :nodeIds="nodeIds"
     :confirmationMessage="changesSaved"
+    :resourcesSelectedText="resourcesSelectedText"
     @close="() => $emit('close')"
   >
     <template #input="{ value, inputHandler }">
@@ -38,6 +39,10 @@
       nodeIds: {
         type: Array,
         required: true,
+      },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
       },
     },
     computed: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -10,8 +10,8 @@
       @submit="handleSave"
       @cancel="close"
     >
-      <p v-if="nodeIds.length > 1" data-test="resources-selected-message" style="margin-top: 8px;">
-        {{ $tr('resourcesSelected', { count: nodeIds.length }) }}
+      <p v-if="resourcesSelectedText.length > 0" data-test="resources-selected-message">
+        {{ resourcesSelectedText }}
       </p>
       <div class="form-item">
         <div class="input-container">
@@ -146,6 +146,10 @@
         type: Array,
         required: true,
       },
+      resourcesSelectedText: {
+        type: String,
+        default: '',
+      },
     },
     data() {
       /* eslint-disable  kolibri/vue-no-unused-properties */
@@ -271,8 +275,6 @@
       aggregatorLabel: 'Aggregator',
       aggregatorToolTip:
         'Website or org hosting the content collection but not necessarily the creator or copyright holder',
-      resourcesSelected:
-        '{count, number, integer} {count, plural, one {resource} other {resources}} selected',
       copyrightHolderLabel: 'Copyright holder',
       cannotEditPublic: 'Cannot edit for public channel resources',
       editOnlyLocal: 'Edits will be reflected only for local resources',

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditAudienceModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditAudienceModal.spec.js
@@ -38,6 +38,7 @@ const makeWrapper = nodeIds => {
     store,
     propsData: {
       nodeIds,
+      resourcesSelectedText: '2 resources',
     },
   });
 };

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditBooleanMapModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditBooleanMapModal.spec.js
@@ -69,6 +69,7 @@ const makeWrapper = ({ nodeIds, field = 'categories', ...restOptions }) => {
       field,
       autocompleteLabel: 'Select option',
       confirmationMessage: 'edited',
+      resourcesSelectedText: '2 resources',
       ...restOptions,
     },
     scopedSlots: {
@@ -217,7 +218,7 @@ describe('EditBooleanMapModal', () => {
 
     const resourcesCounter = wrapper.find('[data-test="resources-selected-message"]');
     expect(resourcesCounter.exists()).toBeTruthy();
-    expect(resourcesCounter.text()).toContain('4');
+    expect(resourcesCounter.text()).toContain('2 resources');
   });
 
   describe('Submit', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditLanguageModal.spec.js
@@ -20,6 +20,7 @@ const makeWrapper = nodeIds => {
     store,
     propsData: {
       nodeIds,
+      resourcesSelectedText: '2 resources',
     },
   });
 };
@@ -101,7 +102,7 @@ describe('EditLanguageModal', () => {
 
     const resourcesCounter = wrapper.find('[data-test="resources-selected-message"]');
     expect(resourcesCounter.exists()).toBeTruthy();
-    expect(resourcesCounter.text()).toContain('4');
+    expect(resourcesCounter.text()).toContain('2 resources');
   });
 
   test('should filter languages options based on search query', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditSourceModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditSourceModal.spec.js
@@ -41,6 +41,7 @@ const makeWrapper = nodeIds => {
     store,
     propsData: {
       nodeIds,
+      resourcesSelectedText: '2 resources',
     },
   });
 };

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/index.vue
@@ -9,36 +9,43 @@
     <EditLanguageModal
       v-if="isLanguageOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditResourcesNeededModal
       v-if="isResourcesNeededOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditCategoriesModal
       v-if="isCategoriesOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditLevelsModal
       v-if="isLevelsOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditLearningActivitiesModal
       v-if="isLearningActivitiesOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditSourceModal
       v-if="isEditSourceOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditAudienceModal
       v-if="isAudienceOpen"
       :nodeIds="nodeIds"
+      :resourcesSelectedText="displayedResourceSelectedText"
       @close="close"
     />
     <EditCompletionModal
@@ -55,6 +62,7 @@
 
   import { mapGetters, mapActions } from 'vuex';
   import { QuickEditModals } from '../../constants';
+  import messages from '../../translator';
   import EditSourceModal from './EditSourceModal';
   import EditLevelsModal from './EditLevelsModal';
   import EditLanguageModal from './EditLanguageModal';
@@ -79,7 +87,10 @@
       EditLearningActivitiesModal,
     },
     computed: {
-      ...mapGetters('contentNode', ['getQuickEditModalOpen']),
+      ...mapGetters('contentNode', [
+        'getQuickEditModalOpen',
+        'getSelectedTopicAndResourceCountText',
+      ]),
       openedModal() {
         const quickEditModal = this.getQuickEditModalOpen();
         if (!quickEditModal) {
@@ -93,6 +104,19 @@
           return [];
         }
         return quickEditModal.nodeIds;
+      },
+      resourcesSelectedText() {
+        return this.getSelectedTopicAndResourceCountText(this.nodeIds);
+      },
+      singleResourceSelected() {
+        return (
+          this.resourcesSelectedText ===
+          // eslint-disable-next-line kolibri/vue-no-undefined-string-uses
+          messages.$tr('selectionCount', { topicCount: 0, resourceCount: 1 })
+        );
+      },
+      displayedResourceSelectedText() {
+        return this.singleResourceSelected ? '' : this.resourcesSelectedText;
       },
       isTitleDescriptionOpen() {
         return this.openedModal === QuickEditModals.TITLE_DESCRIPTION;
@@ -134,5 +158,5 @@
 
 
 <style lang="scss" scoped>
-  
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/translator.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/translator.js
@@ -14,6 +14,8 @@ const MESSAGES = {
   errorMissingAnswer: 'Choose a correct answer',
   errorChooseAtLeastOneCorrectAnswer: 'Choose at least one correct answer',
   errorProvideAtLeastOneCorrectAnswer: 'Provide at least one correct answer',
+  selectionCount:
+    '{topicCount, plural, =0 {} one {# folder, } other {# folders, }}{resourceCount, plural, one {# resource} other {# resources}}',
 };
 
 export default createTranslator(NAMESPACE, MESSAGES);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -60,16 +60,9 @@
           v-if="node && node.total_count"
           v-model="selectAll"
           :indeterminate="selected.length > 0 && !selectAll"
-          :label="selected.length ? '' : $tr('selectAllLabel')"
+          :label="selected.length ? selectionText : $tr('selectAllLabel')"
           style="font-size: 16px;"
         />
-      </div>
-      <div
-        v-show="selected.length"
-        v-if="$vuetify.breakpoint.mdAndUp"
-        class="no-shrink px-1"
-      >
-        {{ selectionText }}
       </div>
       <div v-if="selected.length" class="command-palette-wrapper">
         <KListWithOverflow
@@ -308,7 +301,7 @@
         'getContentNode',
         'getContentNodes',
         'getContentNodeAncestors',
-        'getTopicAndResourceCounts',
+        'getSelectedTopicAndResourceCountText',
         'getContentNodeChildren',
         'isNodeInCopyingState',
       ]),
@@ -502,7 +495,7 @@
         };
       },
       selectionText() {
-        return this.$tr('selectionCount', this.getTopicAndResourceCounts(this.selected));
+        return this.getSelectedTopicAndResourceCountText(this.selected);
       },
       draggableId() {
         return DraggableRegions.TOPIC_VIEW;
@@ -927,8 +920,6 @@
       moveSelectedButton: 'Move',
       duplicateSelectedButton: 'Make a copy',
       deleteSelectedButton: 'Delete',
-      selectionCount:
-        '{topicCount, plural,\n =1 {# folder}\n other {# folders}}, {resourceCount, plural,\n =1 {# resource}\n other {# resources}}',
       undo: 'Undo',
       creatingCopies: 'Copying...',
       copiedItems: 'Copy operation complete',

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -78,7 +78,7 @@
     </VContent>
     <template #bottom>
       <span v-if="selected.length" class="mr-4 subheading">
-        {{ $tr('selectedCountText', counts) }}
+        {{ getSelectedTopicAndResourceCountText(selected) }}
       </span>
       <VSpacer />
       <VBtn
@@ -167,7 +167,11 @@
     },
     computed: {
       ...mapGetters('currentChannel', ['currentChannel', 'trashId', 'rootId']),
-      ...mapGetters('contentNode', ['getContentNodeChildren', 'getTopicAndResourceCounts']),
+      ...mapGetters('contentNode', [
+        'getContentNodeChildren',
+        'getTopicAndResourceCounts',
+        'getSelectedTopicAndResourceCountText',
+      ]),
       headers() {
         return [
           {
@@ -261,8 +265,6 @@
       trashEmptySubtext: 'Resources removed from this channel will appear here',
       selectAllHeader: 'Select all',
       deletedHeader: 'Removed',
-      selectedCountText:
-        '{topicCount, plural,\n =1 {# folder}\n other {# folders}}, {resourceCount, plural,\n =1 {# resource}\n other {# resources}}',
       deleteButton: 'Delete',
       restoreButton: 'Restore',
       deleteConfirmationHeader:

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -3,6 +3,7 @@ import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
 
+import messages from '../../translator';
 import { parseNode } from './utils';
 import { getNodeDetailsErrors, getNodeFilesErrors } from 'shared/utils/validation';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
@@ -101,6 +102,13 @@ export function getTopicAndResourceCounts(state, getters) {
       },
       { topicCount: 0, resourceCount: 0 }
     );
+  };
+}
+
+export function getSelectedTopicAndResourceCountText(state, getters) {
+  return function(contentNodeIds) {
+    const { topicCount, resourceCount } = getters.getTopicAndResourceCounts(contentNodeIds);
+    return messages.$tr('selectionCount', { topicCount, resourceCount });
   };
 }
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Elide folders from text when 0 folders selected
* Update all usage of selection text to use common source.
* Update selection text to appear as text box label to maintain text formatting
* Flyby fix of string 'What Levels' to 'Edit Levels'

### Manual verification steps performed
1. Selected a single resource
2. Confirmed that `1 resource` is displayed only for the selection text.
3. Confirmed that no text displays in the quick edit modals.
4. Select multiple resources or a folder, confirm that appropriate messages display.

### Screenshots (if applicable)
![Screenshot from 2024-08-23 14-32-20](https://github.com/user-attachments/assets/d6e1ae1c-45a6-4a6f-9bd0-796be6c17bce)
![Screenshot from 2024-08-23 14-32-14](https://github.com/user-attachments/assets/dab6faab-5263-44f5-941e-c0830b1aea79)
![Screenshot from 2024-08-23 14-31-29](https://github.com/user-attachments/assets/9ee68926-fedb-4447-a894-c7e1a428c2f4)
![Screenshot from 2024-08-23 14-31-21](https://github.com/user-attachments/assets/01828b1b-0dcf-432a-8586-21632c7638d1)


## References
Fixes #4650

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
