### PR TITLE
Correct topic count when node kind is not found in clipboardNodesMap

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -202,6 +202,7 @@
     computed: {
       ...mapGetters(['clipboardRootId']),
       ...mapState('clipboard', ['initializing', 'clipboardNodesMap']),
+      ...mapState('contentNode', ['contentNodesMap']),
       ...mapGetters('clipboard', [
         'channels',
         'selectedNodeIds',
@@ -248,16 +249,22 @@
       topicAndResourceCount() {
         let topicCount = 0;
         let resourceCount = 0;
+        const contentNodesValues = Object.values(this.contentNodesMap);
         this.selectedNodeIds.forEach(id => {
-          const kind = this.clipboardNodesMap[id]?.kind;
-          if (kind === 'topic' || !kind) {
-            // Increment topicCount if kind is "topic" or not set
-            topicCount++;
-          } else {
-            // Increment resourceCount for any other kind
-            resourceCount++;
-          }
-        });
+            let node = this.clipboardNodesMap[id];
+            let kind = node?.kind;
+            // Check contentNodesMap for node kind if missing in clipboardNodesMap
+            if (!kind && node?.source_node_id) {
+              const contentNode = contentNodesValues.find(n => n.node_id === node.source_node_id);
+              kind = contentNode?.kind;
+            }
+
+            if (kind === 'topic') {
+              topicCount++;
+            } else {
+              resourceCount++;
+            }
+          });
         return { topicCount: topicCount, resourceCount: resourceCount };
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -251,20 +251,20 @@
         let resourceCount = 0;
         const contentNodesValues = Object.values(this.contentNodesMap);
         this.selectedNodeIds.forEach(id => {
-            let node = this.clipboardNodesMap[id];
-            let kind = node?.kind;
-            // Check contentNodesMap for node kind if missing in clipboardNodesMap
-            if (!kind && node?.source_node_id) {
-              const contentNode = contentNodesValues.find(n => n.node_id === node.source_node_id);
-              kind = contentNode?.kind;
-            }
+          const node = this.clipboardNodesMap[id];
+          let kind = node?.kind;
+          // Check contentNodesMap for node kind if missing in clipboardNodesMap
+          if (!kind && node?.source_node_id) {
+            const contentNode = contentNodesValues.find(n => n.node_id === node.source_node_id);
+            kind = contentNode?.kind;
+          }
 
-            if (kind === 'topic') {
-              topicCount++;
-            } else {
-              resourceCount++;
-            }
-          });
+          if (kind === 'topic') {
+            topicCount++;
+          } else {
+            resourceCount++;
+          }
+        });
         return { topicCount: topicCount, resourceCount: resourceCount };
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/index.vue
@@ -252,17 +252,19 @@
         const contentNodesValues = Object.values(this.contentNodesMap);
         this.selectedNodeIds.forEach(id => {
           const node = this.clipboardNodesMap[id];
-          let kind = node?.kind;
+          let kind = node.kind;
           // Check contentNodesMap for node kind if missing in clipboardNodesMap
-          if (!kind && node?.source_node_id) {
+          if (!kind && node.source_node_id) {
             const contentNode = contentNodesValues.find(n => n.node_id === node.source_node_id);
-            kind = contentNode?.kind;
+            kind = contentNode.kind;
           }
 
           if (kind === 'topic') {
             topicCount++;
-          } else {
+          } else if (kind) {
             resourceCount++;
+          } else {
+            console.error('`kind` missing from content.');
           }
         });
         return { topicCount: topicCount, resourceCount: resourceCount };


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pull request modifies the computed property `topicAndResourceCount()` to address instances where items in the `clipboardNodesMap` may be missing the node `kind`. It introduces the use of `contentNodesMap` to retrieve the `kind` when it is not present in the `clipboardNodesMap`.

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
1. Select folder/resource in the clipboard
2. Click on the Move button
3. Observe the title with the correct count when the moveModal opens


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #3744 
## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
