### PR TITLE
Analytics for quick edit modals, relative to legacy edit modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
@@ -125,10 +125,20 @@
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
-      close() {
-        this.$emit('close');
+      close(changed = false) {
+        this.$emit('close', {
+          changed,
+        });
       },
       async handleSave() {
+        const changed = this.nodes.some(node => {
+          return (
+            node.role_visibility !== this.selectedRol ||
+            (node.learner_needs &&
+              node.learner_needs[ResourcesNeededTypes.FOR_BEGINNERS] !== this.forBeginners)
+          );
+        });
+
         await Promise.all(
           this.nodes.map(node => {
             const learnerNeeds = {
@@ -144,7 +154,7 @@
         );
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close();
+        this.close(changed);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCategoriesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCategoriesModal.vue
@@ -7,7 +7,7 @@
     :nodeIds="nodeIds"
     :confirmationMessage="changesSaved"
     :resourcesSelectedText="resourcesSelectedText"
-    @close="() => $emit('close')"
+    v-on="$listeners"
   >
     <template #input="{ value, inputHandler }">
       <CategoryOptions

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCompletionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditCompletionModal.vue
@@ -23,6 +23,7 @@
 
 <script>
 
+  import isEqual from 'lodash/isEqual';
   import { mapGetters, mapActions } from 'vuex';
   import { getFileDuration } from 'shared/utils/helpers';
   import CompletionOptions from 'shared/views/contentNodeFields/CompletionOptions';
@@ -42,6 +43,8 @@
     data() {
       return {
         completionObject: {},
+        hasError: false,
+        changed: false,
       };
     },
     computed: {
@@ -61,10 +64,12 @@
           return this.completionObject;
         },
         set({ completion_criteria, ...value }) {
-          this.completionObject = {
+          const newValue = {
             ...value,
             ...(completion_criteria || {}),
           };
+          this.changed = this.changed || !isEqual(this.completionObject, newValue);
+          this.completionObject = newValue;
         },
       },
     },
@@ -90,7 +95,8 @@
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
       validate() {
-        return this.$refs.completionOptions.validate();
+        this.hasError = this.$refs.completionOptions.validate();
+        return this.hasError;
       },
       handleSave() {
         const error = this.validate();
@@ -123,10 +129,12 @@
         this.updateContentNode({ id: this.nodeId, ...payload });
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close();
+        this.close(this.changed);
       },
-      close() {
-        this.$emit('close');
+      close(changed = false) {
+        this.$emit('close', {
+          changed: this.hasError ? false : changed,
+        });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -79,6 +79,7 @@
         selectedLanguage: '',
         searchQuery: '',
         updateDescendants: false,
+        isMultipleNodeLanguages: false,
       };
     },
     computed: {
@@ -127,14 +128,18 @@
           code: langObject.id,
         });
       },
-      close() {
-        this.$emit('close');
+      close(changed = false) {
+        this.$emit('close', {
+          changed,
+          updateDescendants: this.updateDescendants,
+        });
       },
       async handleSave() {
         if (!this.selectedLanguage) {
           return;
         }
 
+        const changed = this.nodes.some(node => node.language !== this.selectedLanguage);
         await Promise.all(
           this.nodes.map(node => {
             if (this.updateDescendants && node.kind === ContentKindsNames.TOPIC) {
@@ -151,7 +156,7 @@
         );
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close();
+        this.close(changed);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -80,6 +80,7 @@
         searchQuery: '',
         updateDescendants: false,
         isMultipleNodeLanguages: false,
+        changed: false,
       };
     },
     computed: {
@@ -101,12 +102,21 @@
         );
       },
     },
+    watch: {
+      selectedLanguage(newLanguage, oldLanguage) {
+        this.changed = this.changed || newLanguage !== oldLanguage;
+      },
+    },
     created() {
       const languages = [...new Set(this.nodes.map(node => node.language))];
       if (languages.length === 1) {
         this.selectedLanguage = languages[0] || '';
       }
       this.isMultipleNodeLanguages = languages.length > 1;
+      // Reset the changed flag after the initial value is set
+      this.$nextTick(() => {
+        this.changed = false;
+      });
     },
     mounted() {
       if (this.selectedLanguage) {
@@ -139,7 +149,6 @@
           return;
         }
 
-        const changed = this.nodes.some(node => node.language !== this.selectedLanguage);
         await Promise.all(
           this.nodes.map(node => {
             if (this.updateDescendants && node.kind === ContentKindsNames.TOPIC) {
@@ -156,7 +165,7 @@
         );
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close(changed);
+        this.close(this.changed);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLearningActivitiesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLearningActivitiesModal.vue
@@ -8,7 +8,7 @@
     :validators="learningActivityValidators"
     :confirmationMessage="changesSaved"
     :resourcesSelectedText="resourcesSelectedText"
-    @close="() => $emit('close')"
+    v-on="$listeners"
   >
     <template #input="{ value, inputHandler }">
       <LearningActivityOptions

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLevelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLevelsModal.vue
@@ -7,7 +7,7 @@
     :nodeIds="nodeIds"
     :confirmationMessage="changesSaved"
     :resourcesSelectedText="resourcesSelectedText"
-    @close="() => $emit('close')"
+    v-on="$listeners"
   >
     <template #input="{ value, inputHandler }">
       <LevelsOptions

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditResourcesNeededModal.vue
@@ -7,7 +7,7 @@
     :nodeIds="nodeIds"
     :confirmationMessage="changesSaved"
     :resourcesSelectedText="resourcesSelectedText"
-    @close="() => $emit('close')"
+    v-on="$listeners"
   >
     <template #input="{ value, inputHandler }">
       <ResourcesNeededOptions

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -135,6 +135,10 @@
     'copyright_holder',
   ];
 
+  const hasChanged = function(newValue, oldValue) {
+    this.changed = newValue !== oldValue;
+  };
+
   export default {
     name: 'EditSourceModal',
     components: {
@@ -161,6 +165,7 @@
         license_description: '',
         copyright_holder: '',
         copyrightHolderError: '',
+        changed: false,
       };
       /* eslint-enable  kolibri/vue-no-unused-properties */
     },
@@ -203,6 +208,14 @@
         return '';
       },
     },
+    watch: {
+      author: hasChanged,
+      provider: hasChanged,
+      aggregator: hasChanged,
+      license: hasChanged,
+      license_description: hasChanged,
+      copyright_holder: hasChanged,
+    },
     created() {
       const values = {};
       this.nodes.forEach(node => {
@@ -219,11 +232,17 @@
       sourceKeys.forEach(prop => {
         this[prop] = values[prop] || '';
       });
+      // reset changed flag
+      this.$nextTick(() => {
+        this.changed = false;
+      });
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
-      close() {
-        this.$emit('close');
+      close(changed = false) {
+        this.$emit('close', {
+          changed: this.hasError ? false : changed,
+        });
       },
       validateCopyrightHolder() {
         if (this.copyright_holder === nonUniqueValue) {
@@ -263,7 +282,7 @@
         );
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close();
+        this.close(this.changed);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
@@ -54,6 +54,7 @@
         title: '',
         description: '',
         titleError: '',
+        changed: false,
       };
     },
     computed: {
@@ -62,9 +63,19 @@
         return this.getContentNode(this.nodeId);
       },
     },
+    watch: {
+      title(newTitle, oldTitle) {
+        this.changed = this.changed || newTitle !== oldTitle;
+      },
+      description(newDescription, oldDescription) {
+        this.changed = this.changed || newDescription !== oldDescription;
+      },
+    },
     created() {
       this.title = this.contentNode.title || '';
       this.description = this.contentNode.description || '';
+      // Reset changed flag after the component is created
+      this.$nextTick(() => (this.changed = false));
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
@@ -83,10 +94,6 @@
         }
 
         const { nodeId, title, description } = this;
-        const changed =
-          this.contentNode.title !== title.trim() ||
-          this.contentNode.description !== description.trim();
-
         await this.updateContentNode({
           id: nodeId,
           title: title.trim(),
@@ -94,7 +101,7 @@
         });
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close(changed);
+        this.close(this.changed);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditTitleDescriptionModal.vue
@@ -71,8 +71,10 @@
       validateTitle() {
         this.titleError = getInvalidText(getTitleValidators(), this.title);
       },
-      close() {
-        this.$emit('close');
+      close(changed = false) {
+        this.$emit('close', {
+          changed: this.titleError ? false : changed,
+        });
       },
       async handleSave() {
         this.validateTitle();
@@ -81,6 +83,10 @@
         }
 
         const { nodeId, title, description } = this;
+        const changed =
+          this.contentNode.title !== title.trim() ||
+          this.contentNode.description !== description.trim();
+
         await this.updateContentNode({
           id: nodeId,
           title: title.trim(),
@@ -88,7 +94,7 @@
         });
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
         this.$store.dispatch('showSnackbarSimple', commonStrings.$tr('changesSaved'));
-        this.close();
+        this.close(changed);
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -546,6 +546,7 @@
         tagText: null,
         valid: true,
         diffTracker: {},
+        changed: false,
       };
     },
     computed: {
@@ -774,17 +775,21 @@
       ),
       saveFromDiffTracker(id) {
         if (this.diffTracker[id]) {
+          this.changed = true;
           return this.updateContentNode({ id, ...this.diffTracker[id] }).then(() => {
             delete this.diffTracker[id];
+            return this.changed;
           });
         }
-        return Promise.resolve();
+        return Promise.resolve(this.changed);
       },
       /*
        * @public
        */
       immediateSaveAll() {
-        return Promise.all(Object.keys(this.diffTracker).map(this.saveFromDiffTracker));
+        return Promise.all(Object.keys(this.diffTracker).map(this.saveFromDiffTracker)).then(
+          results => this.changed || results.some(Boolean)
+        );
       },
       update(payload) {
         this.nodeIds.forEach(id => {


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Adds analytics event tracking to quick edit modals
- Adds analytics event tracking to legacy edit modal

### Manual verification steps performed
1. Use quick edit modals
2. Confirm the analytics data in the console-- that it's accurate and representative of the changes
3. Use legacy edit modal
4. Confirm the analytics data in the console-- that it's accurate and representative of the changes

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Events and data should support the desired tracking defined in Confirm the analytics data in the console-- that it's accurate and representative of the changes

Notion doc for reference: https://www.notion.so/learningequality/Use-Studio-tag-manager-to-track-the-bulk-editing-feature-update-a225bb594ddf4571aa02d4ad349a92be?pvs=4

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [X] Code is clean and well-commented
- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
