### PR TITLE
Fix saved search endpoint and add regression tests.

### DIFF
--- a/contentcuration/search/tests/test_savesearch.py
+++ b/contentcuration/search/tests/test_savesearch.py
@@ -1,0 +1,124 @@
+import uuid
+
+from django.urls import reverse
+from search.models import SavedSearch
+
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.tests.viewsets.base import generate_create_event
+from contentcuration.tests.viewsets.base import generate_delete_event
+from contentcuration.tests.viewsets.base import SyncTestMixin
+from contentcuration.viewsets.sync.constants import SAVEDSEARCH
+
+
+class SavedSearchViewsetTestCase(SyncTestMixin, StudioAPITestCase):
+
+    @property
+    def savedsearch_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "name": "test",
+            "params": {"lang": "en", "keyword": "test"},
+        }
+
+    @property
+    def savedsearch_db_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "name": "test",
+            "params": {"lang": "en", "keyword": "test"},
+            "saved_by": self.user,
+        }
+
+    def setUp(self):
+        super(SavedSearchViewsetTestCase, self).setUp()
+        self.user = testdata.user()
+        self.client.force_authenticate(user=self.user)
+
+    def test_create_savedsearch(self):
+        savedsearch = self.savedsearch_metadata
+        response = self.sync_changes(
+            [generate_create_event(savedsearch["id"], SAVEDSEARCH, savedsearch, user_id=self.user.id)],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            SavedSearch.objects.get(id=uuid.UUID(savedsearch["id"]))
+        except SavedSearch.DoesNotExist:
+            self.fail("SavedSearch was not created")
+
+    def test_create_savedsearchs(self):
+        savedsearch1 = self.savedsearch_metadata
+        savedsearch2 = self.savedsearch_metadata
+        response = self.sync_changes(
+            [
+                generate_create_event(savedsearch1["id"], SAVEDSEARCH, savedsearch1, user_id=self.user.id),
+                generate_create_event(savedsearch2["id"], SAVEDSEARCH, savedsearch2, user_id=self.user.id),
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            SavedSearch.objects.get(id=uuid.UUID(savedsearch1["id"]))
+        except SavedSearch.DoesNotExist:
+            self.fail("SavedSearch 1 was not created")
+
+        try:
+            SavedSearch.objects.get(id=uuid.UUID(savedsearch2["id"]))
+        except SavedSearch.DoesNotExist:
+            self.fail("SavedSearch 2 was not created")
+
+    def test_delete_savedsearch(self):
+
+        savedsearch = SavedSearch.objects.create(**self.savedsearch_db_metadata)
+
+        response = self.sync_changes(
+            [generate_delete_event(savedsearch.id, SAVEDSEARCH, user_id=self.user.id)],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            SavedSearch.objects.get(id=uuid.UUID(savedsearch.id))
+            self.fail("SavedSearch was not deleted")
+        except SavedSearch.DoesNotExist:
+            pass
+
+    def test_delete_savedsearchs(self):
+        savedsearch1 = SavedSearch.objects.create(**self.savedsearch_db_metadata)
+
+        savedsearch2 = SavedSearch.objects.create(**self.savedsearch_db_metadata)
+
+        response = self.sync_changes(
+            [
+                generate_delete_event(savedsearch1.id, SAVEDSEARCH, user_id=self.user.id),
+                generate_delete_event(savedsearch2.id, SAVEDSEARCH, user_id=self.user.id),
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            SavedSearch.objects.get(id=uuid.UUID(savedsearch1.id))
+            self.fail("SavedSearch 1 was not deleted")
+        except SavedSearch.DoesNotExist:
+            pass
+
+        try:
+            SavedSearch.objects.get(id=uuid.UUID(savedsearch2.id))
+            self.fail("SavedSearch 2 was not deleted")
+        except SavedSearch.DoesNotExist:
+            pass
+
+    def test_retrieve_savedsearch(self):
+        savedsearch = SavedSearch.objects.create(**self.savedsearch_db_metadata)
+
+        response = self.client.get(reverse("savedsearch-detail", kwargs={"pk": savedsearch.id}))
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(response.data["id"], savedsearch.id)
+
+    def test_list_savedsearch(self):
+        savedsearch1 = SavedSearch.objects.create(**self.savedsearch_db_metadata)
+        savedsearch2 = SavedSearch.objects.create(**self.savedsearch_db_metadata)
+
+        response = self.client.get(reverse("savedsearch-list"))
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(len(response.data), 2)
+        sorted_response_data = sorted(response.data, key=lambda x: x["id"])
+        sorted_expected_data = sorted([savedsearch1, savedsearch2], key=lambda x: x.id)
+        self.assertEqual(sorted_response_data[0]["id"], sorted_expected_data[0].id)
+        self.assertEqual(sorted_response_data[1]["id"], sorted_expected_data[1].id)

--- a/contentcuration/search/viewsets/savedsearch.py
+++ b/contentcuration/search/viewsets/savedsearch.py
@@ -1,15 +1,13 @@
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.serializers import PrimaryKeyRelatedField
+from rest_framework.serializers import UUIDField
 from search.models import SavedSearch
 
-from contentcuration.models import User
-from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
 
 
 class SavedSearchSerializer(BulkModelSerializer):
-    saved_by = PrimaryKeyRelatedField(queryset=User.objects.all())
+    id = UUIDField(format="hex")
 
     def create(self, validated_data):
         if "request" in self.context:
@@ -23,12 +21,8 @@ class SavedSearchSerializer(BulkModelSerializer):
         fields = (
             "id",
             "name",
-            "created",
-            "modified",
             "params",
-            "saved_by",
         )
-        list_serializer_class = BulkListSerializer
 
 
 class SavedSearchViewSet(ValuesViewset):
@@ -45,7 +39,7 @@ class SavedSearchViewSet(ValuesViewset):
     )
 
     field_map = {
-        "id": lambda x: x["id"].replace("-", ""),
+        "id": lambda x: x["id"].hex,
     }
 
     def get_queryset(self):


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Fixes regression in savedsearch endpoint
* Adds regression tests for minimal guarantees of behaviour
* Removes serializer fields for things set automatically in the backend

## References
Fixes #4700

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
