### PR TITLE
Fixed field is required' validation

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -2,7 +2,7 @@
 
   <KModal
     :title="title"
-    :submitText="$tr('saveAction')"
+    :submitText="error ? null : $tr('saveAction')"
     :cancelText="$tr('cancelAction')"
     data-test="edit-booleanMap-modal"
     @submit="handleSave"
@@ -26,9 +26,9 @@
       :inputHandler="(value) => { selectedValues = value }"
     ></slot>
 
-    <span v-if="error" class="red--text">
+    <!-- <span v-if="error" class="red--text">
       {{ error }}
-    </span>
+    </span> -->
   </KModal>
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -31,9 +31,6 @@
       :inputHandler="(value) => { selectedValues = value }"
     ></slot>
 
-    <!-- <span v-if="error" class="red--text">
-      {{ error }}
-    </span> -->
   </KModal>
 
 </template>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable kolibri/vue-no-undefined-string-uses -->
 <template>
 
   <KModal
@@ -12,19 +13,16 @@
     <p v-if="resourcesSelectedText.length > 0" data-test="resources-selected-message">
       {{ resourcesSelectedText }}
     </p>
-
-    <!-- Display helper text if categories are mixed -->
-    <p v-if="hasMixedCategories" data-test="additional-categories-description">
-      {{ $tr('addAdditionalCategoriesDescription') }}
+    <p v-if="hasMixedCategories" data-test="mixed-categories-message">
+      {{ hasMixedCategoriesMessage }}
     </p>
-
     <template v-if="isDescendantsUpdatable && isTopicSelected">
       <KCheckbox
         :checked="updateDescendants"
         data-test="update-descendants-checkbox"
         :label="$tr('updateDescendantCheckbox')"
         @change="(value) => { updateDescendants = value }"
-        />
+      />
       <Divider />
     </template>
     <slot
@@ -51,6 +49,7 @@
   import { mapGetters, mapActions } from 'vuex';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import { getInvalidText } from 'shared/utils/validation';
+  import commonStrings from 'shared/translator';
 
   export default {
     name: 'EditBooleanMapModal',
@@ -110,10 +109,16 @@
         return Object.values(this.selectedValues).some(value => value.length > 0);
       },
       hasMixedCategories() {
-      const selectedNodes = this.nodes.filter(node => this.selectedValues[node.id]);
-      const categories = selectedNodes.map(node => node.categories || []);
-      return selectedNodes.length > 0 && new Set(categories.flat()).size > 1;
-     },
+        const categories = this.nodes.map(node =>
+          Object.keys(node[this.field] || {}).filter(key => node[this.field][key])
+        );
+        const uniqueCategories = [...new Set(categories.flat())];
+        return uniqueCategories.length > 1;
+      },
+      hasMixedCategoriesMessage() {
+        // eslint-disable-next-line kolibri/vue-no-undefined-string-uses
+        return commonStrings.$tr('addAdditionalCatgoriesDescription');
+      },
     },
     watch: {
       selectedValues() {
@@ -181,8 +186,6 @@
       cancelAction: 'Cancel',
       updateDescendantCheckbox:
         'Apply to all resources, folders, and subfolders contained within the selected folders.',
-      addAdditionalCategoriesDescription:
-        'You selected resources that have different categories. The categories you choose below will be added to all selected resources. This will not remove existing categories.',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -162,13 +162,15 @@
       },
       async handleSave() {
         await Promise.all(
-          this.nodes.map(node => {
+          this.nodes.map(async node => {
             const fieldValue = {};
             const currentNode = this.getContentNode(node.id);
+
             Object.entries(this.selectedValues).forEach(([key, value]) => {
-              const existingValue = currentNode[this.field][key] || false;
+              const existingValue = currentNode[this.field]?.[key] || false;
               fieldValue[key] = existingValue || value.includes(node.id);
             });
+
             if (this.updateDescendants && node.kind === ContentKindsNames.TOPIC) {
               return this.updateContentNodeDescendants({
                 id: node.id,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -2,7 +2,8 @@
 
   <KModal
     :title="title"
-    :submitText="canSave ? $tr('saveAction') : null"
+    :submitText="$tr('saveAction')"
+    :submitDisabled="!canSave"
     :cancelText="$tr('cancelAction')"
     data-test="edit-booleanMap-modal"
     @submit="handleSave"
@@ -11,13 +12,19 @@
     <p v-if="resourcesSelectedText.length > 0" data-test="resources-selected-message">
       {{ resourcesSelectedText }}
     </p>
+
+    <!-- Display helper text if categories are mixed -->
+    <p v-if="hasMixedCategories" data-test="additional-categories-description">
+      {{ $tr('addAdditionalCategoriesDescription') }}
+    </p>
+
     <template v-if="isDescendantsUpdatable && isTopicSelected">
       <KCheckbox
         :checked="updateDescendants"
         data-test="update-descendants-checkbox"
         :label="$tr('updateDescendantCheckbox')"
         @change="(value) => { updateDescendants = value }"
-      />
+        />
       <Divider />
     </template>
     <slot
@@ -102,6 +109,11 @@
       canSave() {
         return Object.values(this.selectedValues).some(value => value.length > 0);
       },
+      hasMixedCategories() {
+      const selectedNodes = this.nodes.filter(node => this.selectedValues[node.id]);
+      const categories = selectedNodes.map(node => node.categories || []);
+      return selectedNodes.length > 0 && new Set(categories.flat()).size > 1;
+     },
     },
     watch: {
       selectedValues() {
@@ -169,6 +181,8 @@
       cancelAction: 'Cancel',
       updateDescendantCheckbox:
         'Apply to all resources, folders, and subfolders contained within the selected folders.',
+      addAdditionalCategoriesDescription:
+        'You selected resources that have different categories. The categories you choose below will be added to all selected resources. This will not remove existing categories.',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -2,7 +2,7 @@
 
   <KModal
     :title="title"
-    :submitText="error ? null : $tr('saveAction')"
+    :submitText="canSave ? $tr('saveAction') : null"
     :cancelText="$tr('cancelAction')"
     data-test="edit-booleanMap-modal"
     @submit="handleSave"
@@ -99,6 +99,9 @@
       isTopicSelected() {
         return this.nodes.some(node => node.kind === ContentKindsNames.TOPIC);
       },
+      canSave() {
+        return Object.values(this.selectedValues).some(value => value.length > 0);
+      },
     },
     watch: {
       selectedValues() {
@@ -137,11 +140,6 @@
         }
       },
       async handleSave() {
-        this.validate();
-        if (this.error) {
-          return;
-        }
-
         await Promise.all(
           this.nodes.map(node => {
             const fieldValue = {};

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditBooleanMapModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditBooleanMapModal.spec.js
@@ -16,7 +16,6 @@ let generalActions;
 const CheckboxValue = {
   UNCHECKED: 'UNCHECKED',
   CHECKED: 'CHECKED',
-  INDETERMINATE: 'INDETERMINATE',
 };
 
 const { translateMetadataString } = metadataTranslationMixin.methods;
@@ -31,11 +30,9 @@ const getOptionsValues = wrapper => {
   const categories = {};
   const checkboxes = wrapper.findAll('[data-test="option-checkbox"]');
   checkboxes.wrappers.forEach(checkbox => {
-    const { label, checked, indeterminate } = checkbox.vm.$props || {};
+    const { label, checked } = checkbox.vm.$props || {};
     let value;
-    if (indeterminate) {
-      value = CheckboxValue.INDETERMINATE;
-    } else if (checked) {
+    if (checked) {
       value = CheckboxValue.CHECKED;
     } else {
       value = CheckboxValue.UNCHECKED;
@@ -181,26 +178,6 @@ describe('EditBooleanMapModal', () => {
         } = optionsValues;
         expect(dailyLifeValue).toBe(CheckboxValue.CHECKED);
         expect(foundationsValue).toBe(CheckboxValue.CHECKED);
-      });
-
-      test('checkbox option should be indeterminate if not all nodes have the same options set', () => {
-        nodes['node1'].categories = {
-          [Categories.DAILY_LIFE]: true,
-          [Categories.FOUNDATIONS]: true,
-        };
-        nodes['node2'].categories = {
-          [Categories.DAILY_LIFE]: true,
-        };
-
-        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
-
-        const optionsValues = getOptionsValues(wrapper);
-        const {
-          [Categories.DAILY_LIFE]: dailyLifeValue,
-          [Categories.FOUNDATIONS]: foundationsValue,
-        } = optionsValues;
-        expect(dailyLifeValue).toBe(CheckboxValue.CHECKED);
-        expect(foundationsValue).toBe(CheckboxValue.INDETERMINATE);
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CategoryOptions.vue
@@ -157,14 +157,6 @@
       },
       autocompleteOptions() {
         const options = [...this.categoriesList];
-        if (this.expanded) {
-          // Just boolean maps can have indeterminate values
-          options.push({
-            value: MIXED,
-            text: this.$tr('mixedLabel'),
-            undeletable: true,
-          });
-        }
         return options;
       },
       autocompleteValues() {
@@ -216,9 +208,6 @@
         this.selected = {};
       },
       tooltipText(optionId) {
-        if (optionId === MIXED) {
-          return this.$tr('mixedLabel');
-        }
         const option = this.categoriesList.find(option => option.value === optionId);
         if (!option) {
           return '';
@@ -301,7 +290,6 @@
     },
     $trs: {
       noCategoryFoundText: 'Category not found',
-      mixedLabel: 'Mixed',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CategoryOptions.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CategoryOptions.vue
@@ -24,6 +24,10 @@
           :attach="attach"
           @click:clear="$nextTick(() => removeAll())"
         >
+          <!-- Display helper text if categories are mixed -->
+          <p v-if="hasMixedCategories" data-test="additional-categories-description">
+            {{ $tr('addAdditionalCategoriesDescription') }}
+          </p>
           <template #selection="data">
             <VTooltip bottom lazy>
               <template #activator="{ on, attrs }">
@@ -183,6 +187,22 @@
           option.text.toLowerCase().includes(searchQuery)
         );
       },
+      hasMixedCategories() {
+        // Fetch the selected categories for the given nodeIds
+        const selectedNodes = this.nodeIds.map(nodeId => {
+          // Find the category ID in the selected values
+          const categoryForNode = Object.entries(this.selected).find(([nodes]) =>
+            nodes.includes(nodeId)
+          );
+          return categoryForNode ? categoryForNode[0] : null; // Return the categoryId or null
+        });
+
+        const uniqueCategories = new Set(selectedNodes);
+        console.log('Selected Nodes:', selectedNodes); // Log selected nodes
+        console.log('Unique Categories:', uniqueCategories); // Log unique categories
+
+        return uniqueCategories.size > 1;
+      },
     },
     methods: {
       treeItemStyle(item) {
@@ -290,6 +310,8 @@
     },
     $trs: {
       noCategoryFoundText: 'Category not found',
+      addAdditionalCategoriesDescription:
+        'You selected resources that have different categories. The categories you choose below will be added to all selected resources. This will not remove existing categories.',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/views/form/ExpandableSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/ExpandableSelect.vue
@@ -50,7 +50,6 @@
           :key="option.value"
           :label="option.text"
           :checked="isSelected(option.value)"
-          :indeterminate="isIndeterminate(option.value)"
           data-test="option-checkbox"
           @change="value => setOption(option.value, value)"
         />
@@ -187,12 +186,6 @@
           return false;
         }
         return this.valueModel[value].length === this.availableItems.length;
-      },
-      isIndeterminate(value) {
-        if (!this.valueModel[value]) {
-          return false;
-        }
-        return this.valueModel[value].length < this.availableItems.length;
       },
       setOption(optionId, value) {
         if (value) {


### PR DESCRIPTION


## Summary
This pull request addresses the issue where the text 'This field is required' is displayed when bulk editing learning activities.
Fixes https://github.com/learningequality/studio/issues/4651


## Reviewer guidance
### How can a reviewer test these changes?
1. Select multiple resources with different categories.
2. Verify that the "mixed" tag is not displayed as a category.
3. Verify that indeterminate state checkboxes are not displayed.
4. Verify that the helper text is displayed: "You selected resources that have different categories. The categories you choose below will be added to all selected resources. This will not remove existing categories."
5. Verify that the "save" button is enabled only if one or more boxes are checked.
6. Verify that no validation is required, and no error message is displayed.


## References
https://github.com/learningequality/studio/issues/4651



### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
