### PR TITLE
Run migrations to fix incorrect source fields of contentnodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ migrate:
 # 4) Remove the management command from this `deploy-migrate` recipe
 # 5) Repeat!
 deploy-migrate:
-	echo "Nothing to do here!"
+	python contentcuration/manage.py rectify_incorrect_contentnode_source_fields
 
 contentnodegc:
 	python contentcuration/manage.py garbage_collect

--- a/contentcuration/contentcuration/tests/test_rectify_source_field_migraiton_command.py
+++ b/contentcuration/contentcuration/tests/test_rectify_source_field_migraiton_command.py
@@ -2,14 +2,8 @@
 import datetime
 import uuid
 
-from django.db.models import Exists
-from django.db.models import F
-from django.db.models import OuterRef
-from django.db.models import Q
-from django.db.models import Value
-from django.db.models.functions import Coalesce
+from django.core.management import call_command
 from django.utils import timezone
-from django_cte import With
 from le_utils.constants import content_kinds
 
 from contentcuration.models import Channel
@@ -40,143 +34,97 @@ class TestRectifyMigrationCommand(StudioAPITestCase):
             license=self.license_original,
             original_channel_id=None,
             source_channel_id=None,
-            author="old author hehehe"
+            author="old author"
         )
         self.user = testdata.user()
         self.original_channel.editors.add(self.user)
         self.client.force_authenticate(user=self.user)
 
-    def run_migrations(self):
-        filter_date = datetime.datetime(2023, 7, 9, tzinfo=timezone.utc)
-        main_trees_cte = With(
-            (
-                Channel.objects.filter(
-                     main_tree__isnull=False
-                )
-                .annotate(channel_id=F("id"))
-                .values("channel_id", "deleted", tree_id=F("main_tree__tree_id"))
-            ),
-            name="main_trees",
-        )
-
-        nodes = main_trees_cte.join(
-            ContentNode.objects.all(),
-            tree_id=main_trees_cte.col.tree_id,
-        ).annotate(channel_id=main_trees_cte.col.channel_id, deleted=main_trees_cte.col.deleted)
-
-        original_source_nodes = (
-            nodes.with_cte(main_trees_cte)
-            .filter(
-                node_id=OuterRef("original_source_node_id"),
-            )
-            .exclude(
-                tree_id=OuterRef("tree_id"),
-            )
-            .annotate(
-                coalesced_provider=Coalesce("provider", Value("")),
-                coalesced_author=Coalesce("author", Value("")),
-                coalesced_aggregator=Coalesce("aggregator", Value("")),
-                coalesced_license_id=Coalesce("license_id", -1),
-            )
-        )
-        # We filter out according to last_modified date before this PR
-        # https://github.com/learningequality/studio/pull/4189
-        # As we want to lossen up the public=True Filter and open the
-        # migration for all the nodes even if they are not published
-        diff = (
-            nodes.with_cte(main_trees_cte).filter(
-                deleted=False,  # we dont want the channel to be deleted or else we are fixing ghost nodes
-                source_node_id__isnull=False,
-                original_source_node_id__isnull=False,
-                modified__lt=filter_date
-                # published=True,
-            )
-        ).annotate(
-            coalesced_provider=Coalesce("provider", Value("")),
-            coalesced_author=Coalesce("author", Value("")),
-            coalesced_aggregator=Coalesce("aggregator", Value("")),
-            coalesced_license_id=Coalesce("license_id", -1),
-        )
-
-        print(diff)
-
-        diff_combined = diff.annotate(
-            original_source_node_f_changed=Exists(
-                original_source_nodes.filter(
-                    ~Q(coalesced_provider=OuterRef("coalesced_provider"))
-                    | ~Q(coalesced_author=OuterRef("coalesced_author"))
-                    | ~Q(coalesced_aggregator=OuterRef("coalesced_aggregator"))
-                    | ~Q(coalesced_license_id=OuterRef("coalesced_license_id"))
-                )
-            )
-        ).filter(original_source_node_f_changed=True)
-        final_nodes = diff_combined.values(
-            "id",
-            "channel_id",
-            "original_channel_id",
-            "original_source_node_id",
-            "coalesced_provider",
-            "coalesced_author",
-            "coalesced_aggregator",
-            "coalesced_license_id",
-            "original_source_node_f_changed",
-        ).order_by()
-
-        for item in final_nodes:
-            base_node = ContentNode.objects.get(pk=item["id"])
-            original_source_channel_id = item["original_channel_id"]
-            original_source_node_id = item["original_source_node_id"]
-            tree_id = (
-                Channel.objects.filter(pk=original_source_channel_id)
-                .values_list("main_tree__tree_id", flat=True)
-                .get()
-            )
-            original_source_node = ContentNode.objects.filter(
-                tree_id=tree_id, node_id=original_source_node_id
-            )
-
-            base_channel = Channel.objects.get(pk=item['channel_id'])
-            to_be_republished = not (base_channel.main_tree.get_family().filter(changed=True).exists())
-            print("value of to be repblushied", to_be_republished)
-            if original_source_channel_id is not None and original_source_node.exists():
-                # original source node exists and its source fields dont match
-                # update the base node
-                if base_node.author != original_source_node[0].author:
-                    base_node.author = original_source_node[0].author
-                if base_node.provider != original_source_node[0].provider:
-                    base_node.provider = original_source_node[0].provider
-                if base_node.aggregator != original_source_node[0].aggregator:
-                    base_node.aggregator = original_source_node[0].aggregator
-                if base_node.license != original_source_node[0].license:
-                    base_node.license = original_source_node[0].license
-
-                base_node.save()
-                if to_be_republished and base_channel.public:
-                    # we would repbulish the channel
-                    print("publishingg the channel!!")
-                    publish_channel(self.user.id, base_channel.id)
-            else:
-                continue
-
-    def test_two_node_case(self):
+    def create_base_channel_and_contentnode(self, source_contentnode, source_channel):
         base_channel = testdata.channel()
         base_channel.public = True
         base_channel.save()
-        license_changed = License.objects.all()[1]
+        license_changed = License.objects.all()[2]
         base_node = ContentNode.objects.create(
             id=uuid.uuid4().hex,
             title="base contentnode",
             parent=base_channel.main_tree,
+            kind_id=content_kinds.VIDEO,
+            original_channel_id=self.original_channel.id,
+            original_source_node_id=self.original_contentnode.node_id,
+            source_channel_id=source_channel.id,
+            source_node_id=source_contentnode.node_id,
+            author="source author",
+            license=license_changed,
+        )
+        return base_node, base_channel
+
+    def create_source_channel_and_contentnode(self):
+        source_channel = testdata.channel()
+        source_channel.public = True
+        source_channel.save()
+        license_changed = License.objects.all()[1]
+        source_node = ContentNode.objects.create(
+            id=uuid.uuid4().hex,
+            title="base contentnode",
+            parent=source_channel.main_tree,
             kind_id=content_kinds.VIDEO,
             license=license_changed,
             original_channel_id=self.original_channel.id,
             source_channel_id=self.original_channel.id,
             source_node_id=self.original_contentnode.node_id,
             original_source_node_id=self.original_contentnode.node_id,
-            author="new herhe"
+            author="source author",
         )
-        # publish_channel(self.user.id, Channel.objects.get(pk=base_channel.pk).id)
+
+        return source_node, source_channel
+
+    def run_migrations(self):
+        call_command('rectify_incorrect_contentnode_source_fields', user_id=self.user.id, is_test=True)
+
+    def test_two_node_case(self):
+        base_node, base_channel = self.create_base_channel_and_contentnode(self.original_contentnode, self.original_channel)
+
+        publish_channel(self.user.id, Channel.objects.get(pk=base_channel.pk).id)
+
+        # main_tree node still has changed=true even after the publish
         for node in Channel.objects.get(pk=base_channel.pk).main_tree.get_family().filter(changed=True):
+            print(node.id)
+            print(node.id == base_channel.main_tree.id)
+            print("checking if the node is complete or not ", node.complete)
+            node.changed = False
+            # This should probably again change the changed=true but suprisingly it doesnot
+            # Meaning the changed boolean doesnot change for the main_tree no matter what we do
+            # through ContentNode model methods like save.
+            node.save()
+
+        ContentNode.objects.filter(pk=base_node.pk).update(
+        modified=datetime.datetime(2023, 7, 5, tzinfo=timezone.utc)
+        )
+
+        self.run_migrations()
+        updated_base_node = ContentNode.objects.get(pk=base_node.pk)
+        self.assertEqual(updated_base_node.license, self.original_contentnode.license)
+        self.assertEqual(updated_base_node.author, self.original_contentnode.author)
+        self.assertEqual(Channel.objects.get(pk=base_channel.id).main_tree.get_family().filter(changed=True).exists(), False)
+
+    def test_three_node_case_implicit(self):
+        source_node, source_channel = self.create_source_channel_and_contentnode()
+        base_node, base_channel = self.create_base_channel_and_contentnode(source_node, source_channel)
+        source_node.aggregator = "Nami"
+        source_node.save()
+        # Implicit case
+        base_node.author = source_node.author
+        base_node.license = source_node.license
+        base_node.aggregator = source_node.aggregator
+        base_node.save()
+
+        publish_channel(self.user.id, Channel.objects.get(pk=base_channel.pk).id)
+
+        for node in Channel.objects.get(pk=base_channel.pk).main_tree.get_family().filter(changed=True):
+            print(node.id)
+            print(node.id == base_channel.main_tree.id)
+            print("checking if the node is complete or not ", node.complete)
             node.changed = False
             node.save()
 
@@ -184,12 +132,51 @@ class TestRectifyMigrationCommand(StudioAPITestCase):
         modified=datetime.datetime(2023, 7, 5, tzinfo=timezone.utc)
         )
 
-        # base_channel.refresh_from_db()
-        # print(base_channel.main_tree.get_family().filter(changed=True))
+        ContentNode.objects.filter(pk=source_node.pk).update(
+            modified=datetime.datetime(2023, 3, 5, tzinfo=timezone.utc)
+        )
 
         self.run_migrations()
         updated_base_node = ContentNode.objects.get(pk=base_node.pk)
+        updated_source_node = ContentNode.objects.get(pk=source_node.pk)
         self.assertEqual(updated_base_node.license, self.original_contentnode.license)
         self.assertEqual(updated_base_node.author, self.original_contentnode.author)
+        self.assertEqual(updated_source_node.license, self.original_contentnode.license)
+        self.assertEqual(updated_source_node.author, self.original_contentnode.author)
+        self.assertEqual(updated_source_node.aggregator, self.original_contentnode.aggregator)
         self.assertEqual(Channel.objects.get(pk=base_channel.id).main_tree.get_family().filter(changed=True).exists(), False)
-        # assert(3==2)
+
+    def test_three_node_case_explicit(self):
+        source_node, source_channel = self.create_source_channel_and_contentnode()
+        base_node, base_channel = self.create_base_channel_and_contentnode(source_node, source_channel)
+        source_node.provider = "luffy"
+        base_node.provider = "zoro"
+        base_node.save()
+        source_node.save()
+        publish_channel(self.user.id, Channel.objects.get(pk=base_channel.pk).id)
+
+        for node in Channel.objects.get(pk=base_channel.pk).main_tree.get_family().filter(changed=True):
+            print(node.id)
+            print(node.id == base_channel.main_tree.id)
+            print("checking if the node is complete or not ", node.complete)
+            node.changed = False
+            node.save()
+
+        ContentNode.objects.filter(pk=base_node.pk).update(
+        modified=datetime.datetime(2023, 7, 5, tzinfo=timezone.utc)
+        )
+
+        ContentNode.objects.filter(pk=source_node.pk).update(
+            modified=datetime.datetime(2023, 3, 5, tzinfo=timezone.utc)
+        )
+
+        self.run_migrations()
+        updated_base_node = ContentNode.objects.get(pk=base_node.pk)
+        updated_source_node = ContentNode.objects.get(pk=source_node.pk)
+        self.assertEqual(updated_base_node.license, self.original_contentnode.license)
+        self.assertEqual(updated_base_node.author, self.original_contentnode.author)
+        self.assertEqual(updated_base_node.provider, self.original_contentnode.provider)
+        self.assertEqual(updated_source_node.license, self.original_contentnode.license)
+        self.assertEqual(updated_source_node.author, self.original_contentnode.author)
+        self.assertEqual(updated_source_node.provider, self.original_contentnode.provider)
+        self.assertEqual(Channel.objects.get(pk=base_channel.id).main_tree.get_family().filter(changed=True).exists(), False)

--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -116,6 +116,8 @@ class Command(BaseCommand):
             "original_source_node_f_changed",
         ).order_by()
 
+        channel_ids_to_republish = set()
+
         for item in final_nodes:
             base_node = ContentNode.objects.get(pk=item["id"])
 
@@ -146,12 +148,14 @@ class Command(BaseCommand):
                 if base_node.license != original_source_node[0].license:
                     base_node.license = original_source_node[0].license
                 base_node.save()
+
                 if to_be_republished and base_channel.last_published is not None:
-                    # we would repbulish the channel
-                    # Adding for testing
-                    if is_test:
-                        publish_channel(user_id, base_channel.id)
-                    else:
-                        publish_channel("SOME ID", base_channel.id, base_channel.id)
+                    channel_ids_to_republish.add(base_channel.id)
+
+        # we would repbulish the channel
+        # Adding for testing
+        for channel_id in channel_ids_to_republish:
+            if is_test:
+                publish_channel(user_id, channel_id)
             else:
-                continue
+                publish_channel("SOME ID", channel_id, channel_id)

--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -128,8 +128,7 @@ class Command(BaseCommand):
                 if base_node.license != original_source_node[0].license:
                     base_node.license = original_source_node[0].license
                 base_node.save()
-
-                if to_be_republished and base_channel.published:
+                if to_be_republished and base_channel.public:
                     # we would repbulish the channel
                     publish_channel("some_id", base_channel.id)
             else:

--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -13,6 +13,7 @@ from django_cte import With
 
 from contentcuration.models import Channel
 from contentcuration.models import ContentNode
+from contentcuration.models import User
 from contentcuration.utils.publish import publish_channel
 
 logger = logging.getLogger(__file__)
@@ -43,6 +44,9 @@ class Command(BaseCommand):
 
         is_test = options['is_test']
         user_id = options['user_id']
+
+        if not is_test:
+            user_id = User.objects.filter(email='channeladmin@learningequality.org').values('pk')
 
         filter_date = datetime.datetime(2023, 7, 9, tzinfo=timezone.utc)
         main_trees_cte = With(
@@ -155,7 +159,4 @@ class Command(BaseCommand):
         # we would repbulish the channel
         # Adding for testing
         for channel_id in channel_ids_to_republish:
-            if is_test:
-                publish_channel(user_id, channel_id)
-            else:
-                publish_channel("SOME ID", channel_id, channel_id)
+            publish_channel(user_id, channel_id)

--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         user_id = options['user_id']
 
         if not is_test:
-            user_id = User.objects.filter(email='channeladmin@learningequality.org').values('pk')
+            user_id = User.objects.get(email='channeladmin@learningequality.org').pk
 
         filter_date = datetime.datetime(2023, 7, 9, tzinfo=timezone.utc)
         main_trees_cte = With(
@@ -157,6 +157,5 @@ class Command(BaseCommand):
                     channel_ids_to_republish.add(base_channel.id)
 
         # we would repbulish the channel
-        # Adding for testing
         for channel_id in channel_ids_to_republish:
             publish_channel(user_id, channel_id)

--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -1,0 +1,163 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models import Exists
+from django.db.models import F
+from django.db.models import OuterRef
+from django.db.models import Q
+from django.db.models import Value
+from django.db.models.functions import Coalesce
+from django_cte import With
+
+from contentcuration.models import Channel
+from contentcuration.models import ContentNode
+
+logger = logging.getLogger(__file__)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        main_trees_cte = With(
+            (
+                Channel.objects.filter(
+                    deleted=False, last_published__isnull=False, main_tree__isnull=False
+                )
+                .annotate(channel_id=F("id"))
+                .values("channel_id", tree_id=F("main_tree__tree_id"))
+            ),
+            name="main_trees",
+        )
+
+        source_original_node_cte = With(
+            (
+                Channel.objects.filter(main_tree__isnull=False)
+                .annotate(channel_id=F("id"))
+                .values("channel_id", tree_id=F("main_tree__tree_id"))
+            ),
+            name="source_original_nodes",
+        )
+
+        nodes = main_trees_cte.join(
+            ContentNode.objects.filter(published=True),
+            tree_id=main_trees_cte.col.tree_id,
+        ).annotate(channel_id=main_trees_cte.col.channel_id)
+
+        parent_nodes = source_original_node_cte.join(
+            ContentNode.objects.all(), tree_id=source_original_node_cte.col.tree_id
+        ).annotate(channel_id=source_original_node_cte.col.channel_id)
+
+        original_source_nodes = (
+            parent_nodes.with_cte(source_original_node_cte)
+            .filter(
+                node_id=OuterRef("original_source_node_id"),
+            )
+            .exclude(
+                tree_id=OuterRef("tree_id"),
+            )
+            .annotate(
+                coalesced_provider=Coalesce("provider", Value("")),
+                coalesced_author=Coalesce("author", Value("")),
+                coalesced_aggregator=Coalesce("aggregator", Value("")),
+                coalesced_license_id=Coalesce("license_id", -1),
+            )
+        )
+
+        diff = (
+            nodes.with_cte(main_trees_cte).filter(
+                source_node_id__isnull=False,
+                original_source_node_id__isnull=False,
+                published=True,
+            )
+        ).annotate(
+            coalesced_provider=Coalesce("provider", Value("")),
+            coalesced_author=Coalesce("author", Value("")),
+            coalesced_aggregator=Coalesce("aggregator", Value("")),
+            coalesced_license_id=Coalesce("license_id", -1),
+        )
+
+        diff_combined = diff.annotate(
+            original_source_node_f_changed=Exists(
+                original_source_nodes.filter(
+                    ~Q(coalesced_provider=OuterRef("coalesced_provider"))
+                    | ~Q(coalesced_author=OuterRef("coalesced_author"))
+                    | ~Q(coalesced_aggregator=OuterRef("coalesced_aggregator"))
+                    | ~Q(coalesced_license_id=OuterRef("coalesced_license_id"))
+                )
+            )
+        ).filter(original_source_node_f_changed=True)
+
+        final_nodes = diff_combined.values(
+            "id",
+            "original_channel_id",
+            "original_source_node_id",
+            "coalesced_provider",
+            "coalesced_author",
+            "coalesced_aggregator",
+            "coalesced_license_id",
+            "original_source_node_f_changed",
+        ).order_by()
+
+        # diff_provider = diff.annotate(coalesced_provider=Coalesce('provider', Value(''))).annotate(
+        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_provider=Coalesce('provider', Value(''))).exclude(coalesced_provider=OuterRef('coalesced_provider')))
+        # ).filter(
+        #     original_source_node_f_changed=True
+        # )
+
+        # diff_author = diff.annotate(coalesced_author=Coalesce('author', Value(''))).annotate(
+        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_author=Coalesce('author', Value(''))).exclude(coalesced_author=OuterRef('coalesced_author')))
+        # ).filter(
+        #     original_source_node_f_changed=True
+        # )
+
+        # diff_aggregator = diff.annotate(coalesced_aggregator=Coalesce('aggregator', Value(''))).annotate(
+        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_aggregator=Coalesce('aggregator', Value(''))).exclude(coalesced_aggregator=OuterRef('coalesced_aggregator')))
+        # ).filter(
+        #     original_source_node_f_changed=True
+        #  )
+
+        # diff_lic = diff.annotate(coalesced_license_id=Coalesce('license_id', -1)).annotate(
+        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_license_id=Coalesce('license_id', -1)).exclude(coalesced_license_id=OuterRef('coalesced_license_id')))
+        # ).filter(
+        #     original_source_node_f_changed=True
+        # )
+
+        # final_nodes_author = diff_author.values('id', 'original_channel_id', 'original_source_node_id', 'source_node_f_changed', 'original_source_node_f_changed').order_by()
+
+        # final_nodes_provider = diff_provider.values('id', 'original_channel_id', 'original_source_node_id', 'source_node_f_changed', 'original_source_node_f_changed').order_by()
+
+        # final_nodes_aggregator = diff_aggregator.values('id', 'original_channel_id', 'original_source_node_id',  'coalesced_aggregator','source_node_f_changed', 'original_source_node_f_changed').order_by()
+
+        # final_nodes_license = diff_lic.values('id', 'original_channel_id', 'original_source_node_id',  'coalesced_license_id','source_node_f_changed', 'original_source_node_f_changed').order_by()
+
+        # final_nodes = final_nodes_provider + final_nodes_aggregator + final_nodes_license + final_nodes_author
+
+        for item in final_nodes:
+            base_node = ContentNode.objects.filter(pk=item["id"])
+
+            original_source_channel_id = item["original_channel_id"]
+            original_source_node_id = item["original_source_node_id"]
+            tree_id = (
+                Channel.objects.filter(pk=original_source_channel_id)
+                .values_list("main_tree__tree_id", flat=True)
+                .get()
+            )
+            original_source_node = ContentNode.objects.filter(
+                tree_id=tree_id, node_id=original_source_node_id
+            )
+
+            if original_source_channel_id is not None and original_source_node.exists():
+                ## original source node exists and its source fields dont match
+                ## update the base node
+                if base_node[0].author != original_source_node[0].author:
+                    base_node[0].author = original_source_node[0].author
+                if base_node[0].provider != original_source_node[0].provider:
+                    base_node[0].provider = original_source_node[0].provider
+                if base_node[0].aggregator != original_source_node[0].aggregator:
+                    base_node[0].aggregator = original_source_node[0].aggregator
+                if base_node[0].license != original_source_node[0].license:
+                    base_node[0].license = original_source_node[0].license
+
+                base_node[0].save()
+
+            else:
+                continue

--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -97,42 +97,8 @@ class Command(BaseCommand):
             "original_source_node_f_changed",
         ).order_by()
 
-        # diff_provider = diff.annotate(coalesced_provider=Coalesce('provider', Value(''))).annotate(
-        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_provider=Coalesce('provider', Value(''))).exclude(coalesced_provider=OuterRef('coalesced_provider')))
-        # ).filter(
-        #     original_source_node_f_changed=True
-        # )
-
-        # diff_author = diff.annotate(coalesced_author=Coalesce('author', Value(''))).annotate(
-        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_author=Coalesce('author', Value(''))).exclude(coalesced_author=OuterRef('coalesced_author')))
-        # ).filter(
-        #     original_source_node_f_changed=True
-        # )
-
-        # diff_aggregator = diff.annotate(coalesced_aggregator=Coalesce('aggregator', Value(''))).annotate(
-        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_aggregator=Coalesce('aggregator', Value(''))).exclude(coalesced_aggregator=OuterRef('coalesced_aggregator')))
-        # ).filter(
-        #     original_source_node_f_changed=True
-        #  )
-
-        # diff_lic = diff.annotate(coalesced_license_id=Coalesce('license_id', -1)).annotate(
-        #     original_source_node_f_changed=Exists(original_source_nodes.annotate(coalesced_license_id=Coalesce('license_id', -1)).exclude(coalesced_license_id=OuterRef('coalesced_license_id')))
-        # ).filter(
-        #     original_source_node_f_changed=True
-        # )
-
-        # final_nodes_author = diff_author.values('id', 'original_channel_id', 'original_source_node_id', 'source_node_f_changed', 'original_source_node_f_changed').order_by()
-
-        # final_nodes_provider = diff_provider.values('id', 'original_channel_id', 'original_source_node_id', 'source_node_f_changed', 'original_source_node_f_changed').order_by()
-
-        # final_nodes_aggregator = diff_aggregator.values('id', 'original_channel_id', 'original_source_node_id',  'coalesced_aggregator','source_node_f_changed', 'original_source_node_f_changed').order_by()
-
-        # final_nodes_license = diff_lic.values('id', 'original_channel_id', 'original_source_node_id',  'coalesced_license_id','source_node_f_changed', 'original_source_node_f_changed').order_by()
-
-        # final_nodes = final_nodes_provider + final_nodes_aggregator + final_nodes_license + final_nodes_author
-
         for item in final_nodes:
-            base_node = ContentNode.objects.filter(pk=item["id"])
+            base_node = ContentNode.objects.get(pk=item["id"])
 
             original_source_channel_id = item["original_channel_id"]
             original_source_node_id = item["original_source_node_id"]
@@ -146,8 +112,8 @@ class Command(BaseCommand):
             )
 
             if original_source_channel_id is not None and original_source_node.exists():
-                ## original source node exists and its source fields dont match
-                ## update the base node
+                # original source node exists and its source fields dont match
+                # update the base node
                 if base_node[0].author != original_source_node[0].author:
                     base_node[0].author = original_source_node[0].author
                 if base_node[0].provider != original_source_node[0].provider:


### PR DESCRIPTION
## Summary
We filter out all the contentnodes whose source fields have been changed after being imported and reset them to their original values.

### Manual verification steps performed
1. Ran the query in hotfixes 
2. Verified the returned nodes conform to expected disparities. 

## Reviewer guidance
### How can a reviewer test these changes?
Recommended to run the query in hotfixes and verify the returned nodes. some of the fields to look at would be 
last date of modification and verifying what source_node_fields have been changed. 

### Are there any risky areas that deserve extra testing?
If there is something that is missed migrations may be incorrect and may effect large number of nodes. 

## References
closes #4190 

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
