### PR TITLE
Incorrect view only channel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -467,12 +467,19 @@
     },
     watch: {
       rootId: {
-        handler: 'reloadChannel',
+        handler(id) {
+          if (!id) {
+            this.loadChannel().catch(() => {
+              this.$store.dispatch('showSnackbarSimple', 'Failed to load channel');
+            });
+          }
+        },
         immediate: true,
       },
     },
     methods: {
       ...mapActions('channel', ['deleteChannel']),
+      ...mapActions('currentChannel', ['loadChannel']),
       handleDelete() {
         this.deleteChannel(this.currentChannel.id).then(() => {
           localStorage.snackbar = this.$tr('channelDeletedSnackbar');
@@ -496,13 +503,6 @@
       },
       trackClickEvent(eventLabel) {
         this.$analytics.trackClick('channel_editor_toolbar', eventLabel);
-      },
-      reloadChannel(id) {
-        if (!id) {
-          this.$store.dispatch('currentChannel/loadChannel').catch(error => {
-            throw new Error(error);
-          });
-        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -465,6 +465,12 @@
         return DropEffect.COPY;
       },
     },
+    watch: {
+      rootId: {
+        handler: 'reloadChannel',
+        immediate: true,
+      },
+    },
     methods: {
       ...mapActions('channel', ['deleteChannel']),
       handleDelete() {
@@ -490,6 +496,13 @@
       },
       trackClickEvent(eventLabel) {
         this.$analytics.trackClick('channel_editor_toolbar', eventLabel);
+      },
+      reloadChannel(id) {
+        if (!id) {
+          this.$store.dispatch('currentChannel/loadChannel').catch(error => {
+            throw new Error(error);
+          });
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -89,7 +89,7 @@
         <div class="mt-5 pl-3">
           <LoadingText v-if="loading" />
           <StudioTree
-            v-else
+            v-else-if="rootId"
             :treeId="rootId"
             :nodeId="rootId"
             :selectedNodeId="nodeId"


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
This pull request resolves the issue where a channel containing imported resources transitions to the 'Unpublished View-only' display after opening a new tab and selecting a different channel. 
This pull request also fixes the console error `Invalid prop: type check failed for prop "nodeId". Expected String, got Undefined` which occurred when `rootId`/`nodeId` was undefined within `StudioTree.vue`.

- Edits `TreeViewBase.vue` with `rootId` watcher that triggers an API call if rootId is undefined, allowing the accurate view status of the channel to stay displayed.
- Extends the `v-else` `to v-else-if=“rootId”` to avoid rendering `StudioTree` when `rootId` is undefined, preventing the invalid prop error from appearing.

### Manual verification steps performed
1. Created a new channel and imported resources from an existing channel
2. Opened both channels in 2 separate browser tabs and observed the behavior

### Screenshots (if applicable)

https://github.com/user-attachments/assets/161c3a4f-d3db-4630-9ba2-7c201310d1ef

___
## Reviewer guidance
### How can a reviewer test these changes?
1. Create a new channel and import some resources from one of your existing channels
2. Open both channels in 2 separate browser tabs and observe the correct behavior

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4647

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
