### PR TITLE
Reset scroll on blur for multiselects and language filter

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/components/LanguageFilter.vue
@@ -15,6 +15,7 @@
     :search-input.sync="languageInput"
     v-bind="$attrs"
     @change="languageInput = ''"
+    @blur="resetScroll"
   >
     <template #selection="{ item }">
       <VTooltip bottom lazy>
@@ -31,9 +32,10 @@
     <template #item="{ item }">
       <Checkbox
         :key="item.id"
+        :ref="'checkbox-' + item.id"
         v-model="languages"
         :value="item.id"
-        class="mb-0 mt-1"
+        class="mb-0 mt-1 scroll-margin"
       >
         <VTooltip bottom lazy>
           <template #activator="{ on }">
@@ -100,6 +102,17 @@
       languageSearchValue(item) {
         return item.name + (item.related_names || []).join('') + item.id;
       },
+      resetScroll() {
+        const [{ id: firstLangId } = {}] = publicLanguages;
+        if (!firstLangId) {
+          return;
+        }
+        const firstItem = this.$refs[`checkbox-${firstLangId}`];
+        if (!firstItem) {
+          return;
+        }
+        firstItem.$el.scrollIntoView();
+      },
     },
     $trs: {
       languageLabel: 'Languages',
@@ -121,6 +134,11 @@
   /deep/ .v-chip__content,
   .text-truncate {
     max-width: 100%;
+  }
+
+  .scroll-margin {
+    /* Fixes scroll position on reset scroll */
+    scroll-margin: 16px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/MultiSelect.vue
@@ -14,6 +14,7 @@
         :attach="attach"
         v-bind="$attrs"
         @click.stop.prevent
+        @blur="resetScroll"
       >
         <template #selection="{ item }">
           <VChip :class="{ notranslate }">
@@ -21,7 +22,12 @@
           </VChip>
         </template>
         <template #item="{ item }">
-          <Checkbox v-model="selections" :value="item.value">
+          <Checkbox
+            :ref="'checkbox-' + item.value"
+            v-model="selections"
+            :value="item.value"
+            class="scroll-margin"
+          >
             <span :class="{ notranslate }" :style="getEllipsisStyle()" dir="auto">
               {{ getText(item) }}
             </span>
@@ -107,6 +113,17 @@
         }
         return item.text || item;
       },
+      resetScroll() {
+        const [{ value: firstItemValue } = {}] = this.items || [];
+        if (!firstItemValue) {
+          return;
+        }
+        const firstItem = this.$refs[`checkbox-${firstItemValue}`];
+        if (!firstItem) {
+          return;
+        }
+        firstItem.$el.scrollIntoView();
+      },
     },
     $trs: {
       noItemsFound: 'No items found',
@@ -132,6 +149,11 @@
     max-width: 100%;
     overflow: hidden;
     white-space: nowrap;
+  }
+
+  .scroll-margin {
+    /* Fixes scroll position on reset scroll */
+    scroll-margin: 16px;
   }
 
 </style>


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Reset scroll on blur for multiselects and language filter components.

### Manual verification steps performed
1. Simulated lot of language items in language filter and verified that the scroll was being reset on blur.
2. Simulated lot of license items in language filter and verified that the scroll was being reset on blur.

### Screenshots (if applicable)

https://github.com/user-attachments/assets/61bbce68-d698-409e-a26d-2b68a4ec975a


### Does this introduce any tech-debt items?
no
___
## Reviewer guidance
### How can a reviewer test these changes?
Replicate #4721.



## References
Closes #4721

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
