### PR TITLE
Move helpText to LicenseDropdown component

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditSourceModal.vue
@@ -62,11 +62,9 @@
             box
             :required="isEditable"
             :disabled="!isEditable"
+            :helpText="helpText"
           />
         </div>
-        <p v-if="helpText" class="help" style="margin-bottom: 8px">
-          {{ helpText }}
-        </p>
       </div>
       <div class="form-item">
         <div class="input-container">

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -271,7 +271,7 @@
               </template>
             </VCombobox>
             <p v-if="disableSourceEdits" class="help">
-              {{  helpTextString.$tr('cannotEditPublic') }}
+              {{ helpTextString.$tr('cannotEditPublic') }}
             </p>
 
             <!-- Provider -->
@@ -324,9 +324,9 @@
               :disabled="disableSourceEdits"
               :placeholder="getPlaceholder('license')"
               :descriptionPlaceholder="getPlaceholder('license_description')"
+              :helpText="disableSourceEdits ? helpTextString.$tr('cannotEditPublic') : ''"
               @focus="trackClick('License')"
               @descriptionFocus="trackClick('License description')"
-              :helpText="disableSourceEdits ? helpTextString.$tr('cannotEditPublic') : ''"
             />
 
             <!-- Copyright Holder -->
@@ -349,7 +349,7 @@
               @focus="trackClick('Copyright holder')"
             />
             <p v-if="disableSourceEdits" class="help">
-              {{  helpTextString.$tr('cannotEditPublic') }}
+              {{ helpTextString.$tr('cannotEditPublic') }}
             </p>
           </VFlex>
         </template>
@@ -391,6 +391,7 @@
   import FileUpload from '../../views/files/FileUpload';
   import SubtitlesList from '../../views/files/supplementaryLists/SubtitlesList';
   import { isImportedContent, isDisableSourceEdits, importedChannelLink } from '../../utils';
+  import EditSourceModal from '../QuickEditModal/EditSourceModal.vue';
   import AccessibilityOptions from './AccessibilityOptions.vue';
   import LevelsOptions from 'shared/views/contentNodeFields/LevelsOptions';
   import CategoryOptions from 'shared/views/contentNodeFields/CategoryOptions';
@@ -417,7 +418,6 @@
   } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
   import { crossComponentTranslator } from 'shared/i18n';
-  import EditSourceModal from '../QuickEditModal/EditSourceModal.vue';
 
   function getValueFromResults(results) {
     if (results.length === 0) {
@@ -1001,7 +1001,7 @@
     }
   }
 
-  // Positions help text underneath 
+  // Positions help text underneath
   p.help {
     position: relative;
     top: -20px;
@@ -1010,4 +1010,5 @@
     font-size: 12px;
     color: var(--v-text-lighten4);
   }
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -270,6 +270,9 @@
                 <HelpTooltip :text="$tr('authorToolTip')" top :small="false" />
               </template>
             </VCombobox>
+            <p v-if="disableSourceEdits" class="help">
+              {{  helpTextString.$tr('cannotEditPublic') }}
+            </p>
 
             <!-- Provider -->
             <VCombobox
@@ -323,6 +326,7 @@
               :descriptionPlaceholder="getPlaceholder('license_description')"
               @focus="trackClick('License')"
               @descriptionFocus="trackClick('License description')"
+              :helpText="disableSourceEdits ? helpTextString.$tr('cannotEditPublic') : ''"
             />
 
             <!-- Copyright Holder -->
@@ -344,6 +348,9 @@
               @input="copyright_holder = $event"
               @focus="trackClick('Copyright holder')"
             />
+            <p v-if="disableSourceEdits" class="help">
+              {{  helpTextString.$tr('cannotEditPublic') }}
+            </p>
           </VFlex>
         </template>
       </VLayout>
@@ -409,6 +416,8 @@
     nonUniqueValue,
   } from 'shared/constants';
   import { constantsTranslationMixin, metadataTranslationMixin } from 'shared/mixins';
+  import { crossComponentTranslator } from 'shared/i18n';
+  import EditSourceModal from '../QuickEditModal/EditSourceModal.vue';
 
   function getValueFromResults(results) {
     if (results.length === 0) {
@@ -547,6 +556,7 @@
         valid: true,
         diffTracker: {},
         changed: false,
+        helpTextString: crossComponentTranslator(EditSourceModal),
       };
     },
     computed: {
@@ -991,4 +1001,13 @@
     }
   }
 
+  // Positions help text underneath 
+  p.help {
+    position: relative;
+    top: -20px;
+    left: 10px;
+    margin-bottom: 14px;
+    font-size: 12px;
+    color: var(--v-text-lighten4);
+  }
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -26,7 +26,10 @@
         />
       </template>
     </DropdownWrapper>
-    <p>
+    <p v-if="helpText" class="help">
+      {{ helpText }}
+    </p>
+    <p style="position: relative; top: -15px">
       <KButton
         class="info-link"
         appearance="basic-link"
@@ -36,7 +39,7 @@
       />
     </p>
     <div 
-      v-for="(licenseItem, index) in licences" 
+      v-for="(licenseItem, index) in licencesList" 
       v-show="showAboutLicense" 
       :key="index" 
       class="mb-4 mt-3"
@@ -135,6 +138,10 @@
         type: Boolean,
         default: false,
       },
+      helpText: {
+        type: String,
+        default: '',
+      },
     },
     data() {
       return {
@@ -206,7 +213,7 @@
           ? getLicenseDescriptionValidators().map(translateValidator)
           : [];
       },
-      licences() {
+      licencesList() {
         return LicensesList.filter(license => license.id).map(license => ({
           ...license,
           name: this.translateConstant(license.license_name),
@@ -275,6 +282,15 @@
         border-color: rgba(0, 0, 0, 0.3) !important;
       }
     }
+  }
+
+  .help {
+    position: relative;
+    top: -25px;
+    left: 10px;
+    margin-bottom: 0;
+    font-size: 12px;
+    color: var(--v-text-lighten4);
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LicenseDropdown.vue
@@ -284,6 +284,7 @@
     }
   }
 
+  // Positions help text beneath the license dropdown
   .help {
     position: relative;
     top: -25px;


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pull request addresses the issue of the overlapping "About Licenses" dropdown button with the text `Cannot edit for public channel resources` by moving the `helpText` to the `LicenseDropdown` component as a new parameter.

### Screenshots (if applicable)

| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/user-attachments/assets/627615a3-ea31-48af-a68e-efbff2d4e27b)  | ![after](https://github.com/user-attachments/assets/623fcbd5-d144-4b3a-a484-06d520d6f1bf)  |


___
## Reviewer guidance
### How can a reviewer test these changes?
1. Open a channel and import a resource from another channel
2. Open the Edit source modal for that resource


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4736 

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
