### PR TITLE
Add regression test and fix for invitation not being marked as accepted.

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -286,10 +286,11 @@ class CRUDTestCase(StudioAPITestCase):
         response = self.client.post(reverse("invitation-accept", kwargs={"pk": invitation.id}))
         self.assertEqual(response.status_code, 200, response.content)
         try:
-            models.Invitation.objects.get(id=invitation.id)
+            invitation = models.Invitation.objects.get(id=invitation.id)
         except models.Invitation.DoesNotExist:
             self.fail("Invitation was deleted")
 
+        self.assertTrue(invitation.accepted)
         self.assertTrue(self.channel.editors.filter(pk=self.invited_user.id).exists())
         self.assertTrue(
             models.Invitation.objects.filter(

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -141,6 +141,8 @@ class InvitationViewSet(ValuesViewset):
     def accept(self, request, pk=None):
         invitation = self.get_object()
         invitation.accept()
+        invitation.accepted = True
+        invitation.save()
         Change.create_change(
             generate_update_event(
                 invitation.id, INVITATION, {"accepted": True}, channel_id=invitation.channel_id


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Moving acceptance to a dedicated endpoint omitted to update the `accepted` property of the invitation object.
* This fixes that oversight.

### Manual verification steps performed
1. Accept an invitation
2. Reload the page
3. See the invitation does not reappar

## References
Fixes [#4698](https://github.com/learningequality/studio/issues/4698)

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
