### PR TITLE
Pagination follow ups

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.spec.js
@@ -36,6 +36,11 @@ function mountComponent(opts = {}) {
           namespaced: true,
           getters: {
             isNodeInCopyingState: () => jest.fn(),
+            getContentNodesCount: () =>
+              jest.fn().mockReturnValue({
+                resource_count: TOPIC_NODE.resource_count,
+                assessment_item_count: EXERCISE_NODE.assessment_item_count,
+              }),
           },
         },
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -258,7 +258,11 @@
       };
     },
     computed: {
-      ...mapGetters('contentNode', ['isNodeInCopyingState', 'hasNodeCopyingErrored']),
+      ...mapGetters('contentNode', [
+        'isNodeInCopyingState',
+        'hasNodeCopyingErrored',
+        'getContentNodesCount',
+      ]),
       isCompact() {
         return this.compact || !this.$vuetify.breakpoint.mdAndUp;
       },
@@ -273,14 +277,15 @@
         return { title, kind, src, encoding };
       },
       subtitle() {
+        const count = this.getContentNodesCount(this.node.id);
         switch (this.node.kind) {
           case ContentKindsNames.TOPIC:
             return this.$tr('resources', {
-              value: this.node.resource_count || 0,
+              value: count.resource_count || 0,
             });
           case ContentKindsNames.EXERCISE:
             return this.$tr('questions', {
-              value: this.node.assessment_item_count || 0,
+              value: count.assessment_item_count || 0,
             });
         }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -281,11 +281,11 @@
         switch (this.node.kind) {
           case ContentKindsNames.TOPIC:
             return this.$tr('resources', {
-              value: count.resource_count || 0,
+              value: count?.resource_count || 0,
             });
           case ContentKindsNames.EXERCISE:
             return this.$tr('questions', {
-              value: count.assessment_item_count || 0,
+              value: count?.assessment_item_count || 0,
             });
         }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -432,7 +432,10 @@
         this.hideHTMLScroll(false);
         this.$router.push({
           name: RouteNames.TREE_VIEW,
-          params: { nodeId: this.$route.params.nodeId },
+          params: {
+            nodeId: this.$route.params.nodeId,
+            addedCount: this.nodeIds.length,
+          },
         });
       },
       hideHTMLScroll(hidden) {

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -33,6 +33,7 @@ const GETTERS = {
     getContentNodeAncestors: () => jest.fn(),
     getContentNode: () => jest.fn(),
     isNodeInCopyingState: () => jest.fn(),
+    getContentNodesCount: () => jest.fn(),
   },
 };
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -111,15 +111,24 @@
     },
     created() {
       this.loading = true;
-      this.loadChildren({ parent: this.parentId }).then(childrenResponse => {
-        this.loading = false;
-        this.more = childrenResponse.more || null;
-        const children = childrenResponse?.results || [];
-        this.setContentNodesCount(children);
+      this.clearContentNodes().then(success => {
+        if (success) {
+          this.loadChildren({ parent: this.parentId }).then(childrenResponse => {
+            this.loading = false;
+            this.more = childrenResponse.more || null;
+            const children = childrenResponse?.results || [];
+            this.setContentNodesCount(children);
+          });
+        }
       });
     },
     methods: {
-      ...mapActions('contentNode', ['loadChildren', 'loadContentNodes', 'setContentNodesCount']),
+      ...mapActions('contentNode', [
+        'loadChildren',
+        'loadContentNodes',
+        'setContentNodesCount',
+        'clearContentNodes',
+      ]),
       goToNodeDetail(nodeId) {
         if (
           this.$route.params.nodeId === this.parentId &&

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -111,10 +111,12 @@
       this.loadChildren({ parent: this.parentId }).then(childrenResponse => {
         this.loading = false;
         this.more = childrenResponse.more || null;
+        const children = childrenResponse?.results || [];
+        this.setContentNodesCount(children);
       });
     },
     methods: {
-      ...mapActions('contentNode', ['loadChildren', 'loadContentNodes']),
+      ...mapActions('contentNode', ['loadChildren', 'loadContentNodes', 'setContentNodesCount']),
       goToNodeDetail(nodeId) {
         if (
           this.$route.params.nodeId === this.parentId &&

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -47,7 +47,7 @@
     </VList>
     <div class="pagination-container">
       <KButton v-if="displayShowMoreButton" :disabled="moreLoading" @click="loadMore">
-        {{ toggleTextStrings.$tr('more') }}
+        {{ $tr('showMore') }}
       </KButton>
     </div>
   </div>
@@ -62,8 +62,6 @@
   import { RouteNames } from '../constants';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import LoadingText from 'shared/views/LoadingText';
-  import ToggleText from 'shared/views/ToggleText';
-  import { crossComponentTranslator } from 'shared/i18n';
 
   export default {
     name: 'NodePanel',
@@ -88,7 +86,6 @@
         loading: false,
         more: null,
         moreLoading: false,
-        toggleTextStrings: crossComponentTranslator(ToggleText),
       };
     },
     computed: {
@@ -199,7 +196,6 @@
       emptyTopicText: 'Nothing in this folder yet',
       emptyChannelText: 'Click "ADD" to start building your channel',
       emptyChannelSubText: 'Create, upload, or import resources from other channels',
-      /* eslint-disable kolibri/vue-no-unused-translations */
       showMore: 'Show more',
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -193,8 +193,8 @@
 
   .pagination-container {
     display: flex;
-    justify-content: flex-start;
-    margin: 4px;
+    justify-content: space-evenly;
+    margin: 32px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -46,7 +46,7 @@
       </template>
     </VList>
     <div class="pagination-container">
-      <KButton v-if="more" :disabled="moreLoading" @click="loadMore">
+      <KButton v-if="displayShowMoreButton" :disabled="moreLoading" @click="loadMore">
         {{ toggleTextStrings.$tr('more') }}
       </KButton>
     </div>
@@ -107,6 +107,16 @@
       },
       isRoot() {
         return this.rootId === this.parentId;
+      },
+      addedCount() {
+        return this.$route.params.addedCount;
+      },
+      displayShowMoreButton() {
+        // Handle inconsistency with this.more that causes double click on "Show more" to load
+        // more nodes when new nodes(exercises, folders or file uploads) are added to the channel.
+        // If the addedCount is equal to the children length, force hide the "Show more" button.
+        const moreAdditions = this.addedCount !== this.children.length ? this.more : null;
+        return this.addedCount ? moreAdditions : this.more;
       },
     },
     created() {
@@ -178,6 +188,8 @@
           this.loadContentNodes(this.more).then(response => {
             this.more = response.more || null;
             this.moreLoading = false;
+            const children = response?.results || [];
+            this.setContentNodesCount(children);
           });
         }
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/NodePanel.vue
@@ -47,7 +47,7 @@
     </VList>
     <div class="pagination-container">
       <KButton v-if="more" :disabled="moreLoading" @click="loadMore">
-        {{ $tr('showMore') }}
+        {{ toggleTextStrings.$tr('more') }}
       </KButton>
     </div>
   </div>
@@ -62,6 +62,8 @@
   import { RouteNames } from '../constants';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
   import LoadingText from 'shared/views/LoadingText';
+  import ToggleText from 'shared/views/ToggleText';
+  import { crossComponentTranslator } from 'shared/i18n';
 
   export default {
     name: 'NodePanel',
@@ -86,6 +88,7 @@
         loading: false,
         more: null,
         moreLoading: false,
+        toggleTextStrings: crossComponentTranslator(ToggleText),
       };
     },
     computed: {
@@ -175,6 +178,7 @@
       emptyTopicText: 'Nothing in this folder yet',
       emptyChannelText: 'Click "ADD" to start building your channel',
       emptyChannelSubText: 'Create, upload, or import resources from other channels',
+      /* eslint-disable kolibri/vue-no-unused-translations */
       showMore: 'Show more',
     },
   };

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -617,3 +617,10 @@ export function setContentNodesCount(context, nodes) {
     context.commit('SET_CONTENTNODES_COUNT', { id, resource_count, assessment_item_count });
   }
 }
+
+export function clearContentNodes(context) {
+  return new Promise(resolve => {
+    context.commit('CLEAR_CONTENTNODES');
+    resolve(true);
+  });
+}

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -610,3 +610,10 @@ export async function checkSavingProgress(
 export function setQuickEditModal(context, open) {
   context.commit('SET_QUICK_EDIT_MODAL', open);
 }
+
+export function setContentNodesCount(context, nodes) {
+  for (const node of nodes) {
+    const { id, assessment_item_count, resource_count } = node;
+    context.commit('SET_CONTENTNODES_COUNT', { id, resource_count, assessment_item_count });
+  }
+}

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/getters.js
@@ -365,3 +365,9 @@ export function getQuickEditModalOpen(state) {
     return state.quickEditModalOpen;
   };
 }
+
+export function getContentNodesCount(state) {
+  return function(nodeId) {
+    return state.contentNodesCountMap[nodeId];
+  };
+}

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/index.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/index.js
@@ -75,6 +75,17 @@ export default {
        * }
        */
       previousStepsMap: {},
+
+      /**
+       * A map of node ids to their respective resource or assessment item nodes counts.
+       *
+       * For example,
+       * {
+       *   '<content_node_id_1>': { 'resourceCount': 2  }
+       *   '<content_node_id_2>': { 'assessmentItemCount': 1  }
+       * }
+       */
+      contentNodesCountMap: {},
     };
   },
   getters,

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
@@ -139,6 +139,22 @@ export function SAVE_NEXT_STEPS(state, { mappings = [] } = {}) {
   }
 }
 
+/**
+ * Saves the content node count to vuex state.
+ * @param state - The vuex state
+ * @param id - The content node id
+ * @param assessment_item_count - The count of assessment items
+ * @param resource_count - The count of resources
+ */
 export function SET_CONTENTNODES_COUNT(state, { id, assessment_item_count, resource_count }) {
   Vue.set(state.contentNodesCountMap, id, { resource_count, assessment_item_count });
+}
+
+/**
+ * Clears all content node data (nodes and associated counts) from the vuex state.
+ * @param state - The vuex state
+ */
+export function CLEAR_CONTENTNODES(state) {
+  state.contentNodesMap = {};
+  state.contentNodesCountMap = {};
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/mutations.js
@@ -138,3 +138,7 @@ export function SAVE_NEXT_STEPS(state, { mappings = [] } = {}) {
     ADD_PREVIOUS_STEP(state, mapping);
   }
 }
+
+export function SET_CONTENTNODES_COUNT(state, { id, assessment_item_count, resource_count }) {
+  Vue.set(state.contentNodesCountMap, id, { resource_count, assessment_item_count });
+}


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr does the following;
1. Adds padding around the "Show more" pagination button
2. Streamlines the number of resources show in a particular folder
3.  Makes the "Show more" pagination button responsive when more than 25 resources have been uploaded.

### Manual verification steps performed
1. Login to studio
2. Navigate to a channel or its folder that has more than 25 resources and observe the behavior
3. Observe that the resource and question count correspond to what is in the folder and exercise respectively
3. Also, upload over 25 resources into a folder and try to use the "Show more" button

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->
**Padding**
![image](https://github.com/user-attachments/assets/a245b276-d44e-4a61-ba3b-a5ee2c2c24a1)

**Resource counts**

https://github.com/user-attachments/assets/a503baa6-0519-4184-90c7-72dcaeb50ec7

**Uploading >25 resources**

https://github.com/user-attachments/assets/c463ab37-2269-4152-91d6-73cccba130af


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
- No

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- See manual verification above

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
- The pagination feature
- Critical workflows


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4715
Fixes #4727

## Comments
<!-- Additional comments may be added here -->
- There appears to be an existing issue with pagination when importing from channels. After the import process, resources are added in 'copying' state, and this process takes time to complete. When the number of resources exceeds 25, all of them are displayed simultaneously, causing inconsistencies with the display of the 'Show more' button, rendering it non-operational in some cases. The expected behavior for this scenario needs to be clarified and addressed in a separate issue. cc @rtibbles @marcellamaki 

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
