### PR TITLE
Fix save quick edit modals

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -107,7 +107,9 @@
       },
       canSave() {
         if (this.hasMixedCategories) {
-          return Object.values(this.selectedValues).some(value => value.length === this.nodes.length);
+          return Object.values(this.selectedValues).some(
+            value => value.length === this.nodes.length
+          );
         }
         return !this.error;
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -107,7 +107,7 @@
       },
       canSave() {
         if (this.hasMixedCategories) {
-          return Object.values(this.selectedValues).some(value => value.length > 0);
+          return Object.values(this.selectedValues).some(value => value.length === this.nodes.length);
         }
         return !this.error;
       },
@@ -174,7 +174,7 @@
               Object.assign(fieldValue, currentNode[this.field] || {});
             }
             Object.entries(this.selectedValues)
-              .filter(([value]) => value.length === this.nodeIds.length)
+              .filter(entry => entry[1].length === this.nodeIds.length)
               .forEach(([key]) => {
                 fieldValue[key] = true;
               });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditBooleanMapModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditBooleanMapModal.spec.js
@@ -78,6 +78,11 @@ const makeWrapper = ({ nodeIds, field = 'categories', ...restOptions }) => {
             hideLabel: true,
             nodeIds,
           },
+          on: {
+            input(value) {
+              props.inputHandler(value);
+            },
+          },
         });
       },
     },
@@ -107,6 +112,7 @@ describe('EditBooleanMapModal', () => {
           actions: contentNodeActions,
           getters: {
             getContentNodes: () => ids => ids.map(id => nodes[id]),
+            getContentNode: () => id => nodes[id],
           },
         },
       },
@@ -199,7 +205,7 @@ describe('EditBooleanMapModal', () => {
   });
 
   describe('Submit', () => {
-    test('should call updateContentNode with the right options on success submit - categories', () => {
+    test('should call updateContentNode with the selected options on an empty boolean map when success submit', async () => {
       const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
 
       const schoolCheckbox = findOptionCheckbox(wrapper, Categories.SCHOOL);
@@ -207,58 +213,43 @@ describe('EditBooleanMapModal', () => {
       const sociologyCheckbox = findOptionCheckbox(wrapper, Categories.SOCIOLOGY);
       sociologyCheckbox.element.click();
 
-      const animationFrameId = requestAnimationFrame(() => {
-        wrapper.find('[data-test="edit-booleanMap-modal"]').vm.$emit('submit');
-        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
-          id: 'node1',
-          categories: {
-            [Categories.SCHOOL]: true,
-            [Categories.SOCIOLOGY]: true,
-          },
-        });
-        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
-          id: 'node2',
-          categories: {
-            [Categories.SCHOOL]: true,
-            [Categories.SOCIOLOGY]: true,
-          },
-        });
-        cancelAnimationFrame(animationFrameId);
+      await wrapper.vm.handleSave();
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'node1',
+        categories: {
+          [Categories.SCHOOL]: true,
+          [Categories.SOCIOLOGY]: true,
+        },
+      });
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'node2',
+        categories: {
+          [Categories.SCHOOL]: true,
+          [Categories.SOCIOLOGY]: true,
+        },
       });
     });
 
-    test('should emit close event on success submit', () => {
+    test('should emit close event on success submit', async () => {
       const wrapper = makeWrapper({ nodeIds: ['node1'] });
 
-      wrapper.find('[data-test="edit-booleanMap-modal"]').vm.$emit('submit');
-
-      const animationFrameId = requestAnimationFrame(() => {
-        expect(wrapper.emitted('close')).toBeTruthy();
-        cancelAnimationFrame(animationFrameId);
-      });
+      await wrapper.vm.handleSave();
+      expect(wrapper.emitted('close')).toBeTruthy();
     });
 
-    test('should show a confirmation snackbar on success submit', () => {
+    test('should show a confirmation snackbar on success submit', async () => {
       const wrapper = makeWrapper({ nodeIds: ['node1'] });
 
-      wrapper.find('[data-test="edit-booleanMap-modal"]').vm.$emit('submit');
-
-      const animationFrameId = requestAnimationFrame(() => {
-        expect(generalActions.showSnackbarSimple).toHaveBeenCalled();
-        cancelAnimationFrame(animationFrameId);
-      });
+      await wrapper.vm.handleSave();
+      expect(generalActions.showSnackbarSimple).toHaveBeenCalled();
     });
   });
 
   test('should emit close event on cancel', () => {
     const wrapper = makeWrapper({ nodeIds: ['node1'] });
 
-    wrapper.find('[data-test="edit-booleanMap-modal"]').vm.$emit('cancel');
-
-    const animationFrameId = requestAnimationFrame(() => {
-      expect(wrapper.emitted('close')).toBeTruthy();
-      cancelAnimationFrame(animationFrameId);
-    });
+    wrapper.vm.close();
+    expect(wrapper.emitted('close')).toBeTruthy();
   });
 
   describe('topic nodes present', () => {
@@ -284,39 +275,262 @@ describe('EditBooleanMapModal', () => {
       expect(wrapper.find('[data-test="update-descendants-checkbox"]').exists()).toBeFalsy();
     });
 
-    test('should call updateContentNode on success submit if the user does not check the update descendants checkbox', () => {
+    test('should call updateContentNode on success submit if the user does not check the update descendants checkbox', async () => {
       nodes['node1'].kind = ContentKindsNames.TOPIC;
 
       const wrapper = makeWrapper({ nodeIds: ['node1'], isDescendantsUpdatable: true });
+      await wrapper.vm.handleSave();
 
-      wrapper.find('[data-test="edit-booleanMap-modal"]').vm.$emit('submit');
-
-      const animationFrameId = requestAnimationFrame(() => {
-        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
-          id: 'node1',
-          categories: {},
-        });
-        cancelAnimationFrame(animationFrameId);
+      expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+        id: 'node1',
+        categories: {},
       });
     });
 
-    test('should call updateContentNodeDescendants on success submit if the user checks the descendants checkbox', () => {
+    test('should call updateContentNodeDescendants on success submit if the user checks the descendants checkbox', async () => {
       nodes['node1'].kind = ContentKindsNames.TOPIC;
 
       const wrapper = makeWrapper({ nodeIds: ['node1'], isDescendantsUpdatable: true });
+      wrapper.find('[data-test="update-descendants-checkbox"]').element.click();
+      await wrapper.vm.handleSave();
 
-      wrapper.find('[data-test="update-descendants-checkbox"] input').setChecked(true);
-      wrapper.find('[data-test="edit-booleanMap-modal"]').vm.$emit('submit');
+      expect(contentNodeActions.updateContentNodeDescendants).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          id: 'node1',
+          categories: {},
+        }
+      );
+    });
+  });
 
-      const animationFrameId = requestAnimationFrame(() => {
-        expect(contentNodeActions.updateContentNodeDescendants).toHaveBeenCalledWith(
-          expect.anything(),
-          {
-            id: 'node1',
-            categories: {},
-          }
-        );
-        cancelAnimationFrame(animationFrameId);
+  describe('mixed options that are not selected across all nodes', () => {
+    describe('render mixed options message', () => {
+      test('should not render mixed options message if there are not mixed options across selected nodes', () => {
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        expect(wrapper.find('[data-test="mixed-categories-message"]').exists()).toBeFalsy();
+      });
+
+      test('should not render mixed options message if there are not mixed options across selected nodes - 2', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        expect(wrapper.find('[data-test="mixed-categories-message"]').exists()).toBeFalsy();
+      });
+
+      test('should render mixed options message if there are mixed options across selected nodes', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+        nodes['node2'].categories = {};
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        expect(wrapper.find('[data-test="mixed-categories-message"]').exists()).toBeTruthy();
+      });
+
+      test('should render mixed options message if there are mixed options across selected nodes - 2', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        expect(wrapper.find('[data-test="mixed-categories-message"]').exists()).toBeTruthy();
+      });
+    });
+    describe('on submit', () => {
+      test('should add new selected options on submit even if there are not common selected options', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.FOUNDATIONS]: true,
+        };
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        const schoolCheckbox = findOptionCheckbox(wrapper, Categories.SCHOOL);
+        schoolCheckbox.element.click();
+
+        wrapper.vm.handleSave();
+
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node1',
+          categories: {
+            // already daily_life category selected plus new school category selected
+            [Categories.SCHOOL]: true,
+            [Categories.DAILY_LIFE]: true,
+          },
+        });
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node2',
+          categories: {
+            // already foundations category selected plus new school category selected
+            [Categories.SCHOOL]: true,
+            [Categories.FOUNDATIONS]: true,
+          },
+        });
+      });
+
+      test('should add new selected options on submit even if there are common selected options', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.FOUNDATIONS]: true,
+        };
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        const schoolCheckbox = findOptionCheckbox(wrapper, Categories.SCHOOL);
+        schoolCheckbox.element.click();
+
+        wrapper.vm.handleSave();
+
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node1',
+          categories: {
+            // already daily_life and foundation category selected plus new school category selected
+            [Categories.SCHOOL]: true,
+            [Categories.DAILY_LIFE]: true,
+            [Categories.FOUNDATIONS]: true,
+          },
+        });
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node2',
+          categories: {
+            // already foundations category selected plus new school category selected
+            [Categories.SCHOOL]: true,
+            [Categories.FOUNDATIONS]: true,
+          },
+        });
+      });
+
+      test('should not remove common selected options even if they are unchecked', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        const dailyLifeCheckbox = findOptionCheckbox(wrapper, Categories.DAILY_LIFE);
+        dailyLifeCheckbox.element.click(); // uncheck daily lifye
+
+        const schoolCheckbox = findOptionCheckbox(wrapper, Categories.SCHOOL);
+        schoolCheckbox.element.click(); // check school
+
+        wrapper.vm.handleSave();
+
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node1',
+          categories: {
+            // already daily_life and foundation category selected plus new school category selected
+            [Categories.DAILY_LIFE]: true,
+            [Categories.FOUNDATIONS]: true,
+            [Categories.SCHOOL]: true,
+          },
+        });
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node2',
+          categories: {
+            // already daily life category selected plus new school category selected
+            [Categories.DAILY_LIFE]: true,
+            [Categories.SCHOOL]: true,
+          },
+        });
+      });
+
+      test('should not remove common selected options even if they are unchecked and no new options are checked', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+          [Categories.SCHOOL]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        const dailyLifeCheckbox = findOptionCheckbox(wrapper, Categories.DAILY_LIFE);
+        dailyLifeCheckbox.element.click(); // uncheck daily lifye
+
+        wrapper.vm.handleSave();
+
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node1',
+          categories: {
+            // already selected options
+            [Categories.DAILY_LIFE]: true,
+            [Categories.FOUNDATIONS]: true,
+            [Categories.SCHOOL]: true,
+          },
+        });
+        expect(contentNodeActions.updateContentNode).toHaveBeenCalledWith(expect.anything(), {
+          id: 'node2',
+          categories: {
+            // already selected options
+            [Categories.DAILY_LIFE]: true,
+            [Categories.FOUNDATIONS]: true,
+          },
+        });
+      });
+    });
+    describe('can save method', () => {
+      test('should not can save if there are mixed categories and no options selected', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.FOUNDATIONS]: true,
+        };
+
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        expect(wrapper.vm.canSave).toBeFalsy();
+      });
+
+      test('should can save if there are mixed categories but new options are selected', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.FOUNDATIONS]: true,
+        };
+
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        const schoolCheckbox = findOptionCheckbox(wrapper, Categories.SCHOOL);
+        schoolCheckbox.element.click();
+
+        expect(wrapper.vm.canSave).toBeTruthy();
+      });
+
+      test('should can save if there are mixed categories but at least one common option across all nodes', () => {
+        nodes['node1'].categories = {
+          [Categories.DAILY_LIFE]: true,
+          [Categories.FOUNDATIONS]: true,
+        };
+        nodes['node2'].categories = {
+          [Categories.DAILY_LIFE]: true,
+        };
+
+        const wrapper = makeWrapper({ nodeIds: ['node1', 'node2'] });
+
+        expect(wrapper.vm.canSave).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Fix save edit boolean map modals. This PR fixes two things:
* When saving we do a filter of the current selected node, so we need to filter the values of `this.selectedValues` that have all nodes inside, but we have
```javascript
            Object.entries(this.selectedValues)
              .filter(([value]) => value.length === this.nodeIds.length)
```
which is an error as the value is the second element of the entries, not the first.
* Fix can save method, as we need to allow can save if there is at least one option selected, so we need to look for `.some(value => value.length === this.nodes.length)`, but we have `.some(value => value.length > 0)` and this is an error as this condition is true for values that arent selected across all nodes.


### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
