### PR TITLE
Follow up inheritable modal fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -282,9 +282,11 @@
         });
       },
       moveNode(target) {
-        return this.moveContentNodes({ id__in: [this.nodeId], parent: target }).then(
-          this.$refs.moveModal.moveComplete
-        );
+        return this.moveContentNodes({
+          id__in: [this.nodeId],
+          parent: target,
+          inherit: this.node.parent !== target,
+        }).then(this.$refs.moveModal.moveComplete);
       },
       getRemoveNodeRedirect() {
         // Returns a callback to do appropriate post-removal navigation
@@ -322,7 +324,7 @@
       removeNode: withChangeTracker(function(id__in, changeTracker) {
         this.trackAction('Delete');
         const redirect = this.getRemoveNodeRedirect();
-        return this.moveContentNodes({ id__in, parent: this.trashId }).then(() => {
+        return this.moveContentNodes({ id__in, parent: this.trashId, inherit: false }).then(() => {
           redirect();
           this.showSnackbar({
             text: this.$tr('removedItems'),

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -10,10 +10,10 @@
     @cancel="closed = true"
   >
     <div>
-      <p v-if="parentHasInheritableMetadata">
-        {{ $tr('inheritMetadataDescription') }}
-      </p>
       <div>
+        <p v-if="parentHasNonLanguageMetadata">
+          {{ $tr('inheritMetadataDescription') }}
+        </p>
         <KCheckbox
           v-if="!!inheritableMetadataItems.categories"
           key="categories"
@@ -140,6 +140,11 @@
       },
       fieldsToInherit() {
         return Object.keys(this.inheritableMetadataItems).filter(field => this.checks[field]);
+      },
+      parentHasNonLanguageMetadata() {
+        return (
+          !isEmpty(this.categories) || !isEmpty(this.grade_levels) || !isEmpty(this.learner_needs)
+        );
       },
       parentHasInheritableMetadata() {
         return !isEmpty(this.inheritableMetadataItems);

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -104,9 +104,9 @@
         // as to be inherited or not by a previous interaction with the modal.
         return Boolean(
           this.parent &&
-            this.parent?.extra_fields?.inherit_metadata &&
+            this.parent?.extra_fields?.inherited_metadata &&
             Object.keys(this.inheritableMetadataItems).every(
-              field => !isUndefined(this.parent.extra_fields.inherit_metadata[field])
+              field => !isUndefined(this.parent.extra_fields.inherited_metadata[field])
             )
         );
       },
@@ -203,10 +203,10 @@
           ContentNode.getAncestors(this.parent.id).then(ancestors => {
             for (const field of inheritableFields) {
               if (
-                this.parent.extra_fields.inherit_metadata &&
-                this.parent.extra_fields.inherit_metadata[field]
+                this.parent.extra_fields.inherited_metadata &&
+                this.parent.extra_fields.inherited_metadata[field]
               ) {
-                this.checks[field] = this.parent.extra_fields.inherit_metadata[field];
+                this.checks[field] = this.parent.extra_fields.inherited_metadata[field];
               }
             }
             this.categories = ancestors.reduce((acc, ancestor) => {
@@ -258,19 +258,19 @@
           // but just in case, return
           return;
         }
-        const inherit_metadata = {
-          ...(this.parent?.extra_fields.inherit_metadata || {}),
+        const inherited_metadata = {
+          ...(this.parent?.extra_fields.inherited_metadata || {}),
         };
         for (const field of inheritableFields) {
           if (this.inheritableMetadataItems[field]) {
             // Only store preferences for fields that have been shown to the user as inheritable
-            inherit_metadata[field] = this.checks[field];
+            inherited_metadata[field] = this.checks[field];
           }
         }
         this.updateContentNode({
           id: this.parent.id,
           extra_fields: {
-            inherit_metadata,
+            inherited_metadata,
           },
         });
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -135,7 +135,7 @@
 </template>
 <script>
 
-  import { mapGetters, mapActions, mapMutations } from 'vuex';
+  import { mapGetters, mapActions } from 'vuex';
   import ResourceDrawer from '../ResourceDrawer';
   import { RouteNames } from '../../constants';
   import NewTopicModal from './NewTopicModal';
@@ -248,7 +248,6 @@
     },
     methods: {
       ...mapActions('contentNode', ['createContentNode', 'loadChildren']),
-      ...mapMutations('contentNode', ['ADD_INHERITING_NODE']),
       isDisabled(node) {
         return this.moveNodeIds.includes(node.id);
       },
@@ -301,9 +300,6 @@
           actionText: this.$tr('goToLocationButton'),
           actionCallback: this.goToLocation,
         });
-        for (const nodeId of this.moveNodeIds) {
-          this.ADD_INHERITING_NODE(this.getContentNode(nodeId));
-        }
         this.moveNodesInProgress = false;
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -214,6 +214,7 @@
       </ResourceDrawer>
     </VLayout>
     <InheritAncestorMetadataModal
+      ref="inheritModal"
       :parent="inheritanceParent"
       @inherit="inheritMetadata"
     />
@@ -928,6 +929,12 @@
           this.updateContentNode({ id: nodeId, ...metadata, mergeMapFields: true });
         }
         this.CLEAR_INHERITING_NODES(nodeIds);
+        this.$nextTick(() => {
+          // Once the inheritance is complete, reset the modal closed state.
+          if (this.inheritingNodes.length === 0) {
+            this.$refs.inheritModal?.resetClosed();
+          }
+        });
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -588,7 +588,7 @@
         'setQuickEditModal',
         'updateContentNode',
       ]),
-      ...mapMutations('contentNode', ['ADD_INHERITING_NODE', 'CLEAR_INHERITING_NODES']),
+      ...mapMutations('contentNode', ['CLEAR_INHERITING_NODES']),
       ...mapActions('clipboard', ['copyAll']),
       clearSelections() {
         this.selected = [];
@@ -614,6 +614,7 @@
           id__in: nodeIdsToMove,
           target: targetNode,
           position: targetPosition,
+          inherit: false,
         });
       },
 
@@ -786,14 +787,7 @@
           return this.moveContentNodes({
             ...payload,
             id__in: data.sources.map(s => s.metadata.id),
-          }).then(ids => {
-            if (this.topicId !== payload.target) {
-              // If we are not moving within the same parent
-              // trigger the node inheritance behaviour.
-              for (const id of ids) {
-                this.ADD_INHERITING_NODE(this.getContentNode(id));
-              }
-            }
+            inherit: !data.sources.some(s => s.metadata.parent === payload.target),
           });
         }
       },
@@ -808,10 +802,13 @@
           : RELATIVE_TREE_POSITIONS.RIGHT;
       },
       moveNodes(target) {
-        return this.moveContentNodes({ id__in: this.selected, parent: target }).then(() => {
-          this.clearSelections();
-          this.$refs.moveModal.moveComplete();
-        });
+        // Always inherit here, as the move modal doesn't allow moving to the same parent.
+        return this.moveContentNodes({ id__in: this.selected, parent: target, inherit: true }).then(
+          () => {
+            this.clearSelections();
+            this.$refs.moveModal.moveComplete();
+          }
+        );
       },
       removeNodes: withChangeTracker(function(id__in, changeTracker) {
         this.trackClickEvent('Delete');
@@ -820,7 +817,7 @@
         if (id__in.includes(this.$route.params.detailNodeId)) {
           nextRoute = { params: { detailNodeId: null } };
         }
-        return this.moveContentNodes({ id__in, parent: this.trashId }).then(() => {
+        return this.moveContentNodes({ id__in, parent: this.trashId, inherit: false }).then(() => {
           this.clearSelections();
           if (nextRoute) {
             this.$router.replace(nextRoute);
@@ -931,7 +928,7 @@
         this.CLEAR_INHERITING_NODES(nodeIds);
         this.$nextTick(() => {
           // Once the inheritance is complete, reset the modal closed state.
-          if (this.inheritingNodes.length === 0) {
+          if (!this.inheritingNodes || this.inheritingNodes.length === 0) {
             this.$refs.inheritModal?.resetClosed();
           }
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -235,7 +235,11 @@
         'loadAncestors',
       ]),
       moveNodes(target) {
-        return this.moveContentNodes({ id__in: this.selected, parent: target }).then(() => {
+        return this.moveContentNodes({
+          id__in: this.selected,
+          parent: target,
+          inherit: false,
+        }).then(() => {
           this.reset();
           this.$refs.moveModal && this.$refs.moveModal.moveComplete();
         });

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -322,8 +322,8 @@ function generateContentNodeData({
     if (extra_fields.suggested_duration_type) {
       contentNodeData.extra_fields.suggested_duration_type = extra_fields.suggested_duration_type;
     }
-    if (extra_fields.inherit_metadata) {
-      contentNodeData.extra_fields.inherit_metadata = extra_fields.inherit_metadata;
+    if (extra_fields.inherited_metadata) {
+      contentNodeData.extra_fields.inherited_metadata = { ...extra_fields.inherited_metadata };
     }
   }
   if (prerequisite !== NOVALUE) {
@@ -369,11 +369,11 @@ export function updateContentNode(context, { id, mergeMapFields, ...payload } = 
       };
     }
 
-    if (contentNodeData.extra_fields.inherit_metadata) {
-      // Don't set inherit_metadata on non-topic nodes
+    if (contentNodeData.extra_fields.inherited_metadata) {
+      // Don't set inherited_metadata on non-topic nodes
       // as they cannot have children to bequeath metadata to
       if (node.kind !== ContentKindsNames.TOPIC) {
-        delete contentNodeData.extra_fields.inherit_metadata;
+        delete contentNodeData.extra_fields.inherited_metadata;
       }
     }
 

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -561,7 +561,7 @@ export function copyContentNodes(
 const PARENT_POSITIONS = [RELATIVE_TREE_POSITIONS.FIRST_CHILD, RELATIVE_TREE_POSITIONS.LAST_CHILD];
 export function moveContentNodes(
   context,
-  { id__in, parent, target = null, position = RELATIVE_TREE_POSITIONS.LAST_CHILD }
+  { id__in, parent, target = null, position = RELATIVE_TREE_POSITIONS.LAST_CHILD, inherit = true }
 ) {
   // Make sure use of parent vs target matches position param
   if (parent && !(PARENT_POSITIONS.indexOf(position) >= 0)) {
@@ -576,6 +576,9 @@ export function moveContentNodes(
     id__in.map(id => {
       return ContentNode.move(id, target, position).then(node => {
         context.commit('ADD_CONTENTNODE', node);
+        if (inherit) {
+          context.commit('ADD_INHERITING_NODE', node);
+        }
         return id;
       });
     })


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Conditionalize helper text in modal to not display general inheritable metadata title when only language is inheritable
* Ensure that the InheritMetadataModal in the CurrentTreeView can be used again after it has completed handling inheritance for moved nodes
* Make the frontend extra field name match the backend `inherited_metadata` to ensure that preferences for users to 'don't display this modal again' are persisted

### Manual verification steps performed
Create a new resource in a folder that only has language metadata set - confirm the non language related messaging in the modal doesn't display.
Move a resource into a folder that has inheritable metadata applied, apply the metadata. Move another resource into the same folder, confirm the modal shows again.
Upload a resource into a folder that has inheritable metadata applied, choose the 'don't show this modal again' option. Upload another resource into the same folder, and ensure that the metadata labels are also applied to this one, but that no modal displays.

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
Fixes #4699

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
