### PR TITLE
Fixes decline invitation

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -93,11 +93,10 @@ describe('invitation actions', () => {
       store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);
     });
     it('should call client.delete', () => {
-      const updateSpy = jest.spyOn(Invitation, 'accept');
+      const updateSpy = jest.spyOn(Invitation, 'decline');
       return store.dispatch('channelList/declineInvitation', id).then(() => {
         expect(updateSpy).toHaveBeenCalled();
         expect(updateSpy.mock.calls[0][0]).toBe(id);
-        expect(updateSpy.mock.calls[0][1]).toEqual({ declined: true });
         updateSpy.mockRestore();
       });
     });

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -53,41 +53,40 @@ describe('invitation actions', () => {
       });
     });
   });
-  // TODO: Figure out why client isn't getting mocked then uncomment this
-  // describe('acceptInvitation action', () => {
-  //   const channel = { id: channel_id, name: 'test', deleted: false, edit: true };
-  //   beforeEach(() => {
-  //     store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);
-  //     return Channel.add(channel);
-  //   });
-  //   afterEach(() => {
-  //     return Channel.table.toCollection().delete();
-  //   });
-  //   it('should call accept', () => {
-  //     const updateSpy = jest.spyOn(Invitation, 'accept');
-  //     return store.dispatch('channelList/acceptInvitation', id).then(() => {
-  //       expect(updateSpy).toHaveBeenCalled();
-  //       expect(updateSpy.mock.calls[0][0]).toBe(id);
-  //       updateSpy.mockRestore();
-  //     });
-  //   });
-  //   it('should load and set the invited channel', () => {
-  //     return store.dispatch('channelList/acceptInvitation', id).then(() => {
-  //       expect(store.getters['channel/getChannel'](channel_id).id).toBeTruthy();
-  //     });
-  //   });
-  //   it('should  remove the invitation from the list', () => {
-  //     return store.dispatch('channelList/acceptInvitation', id).then(() => {
-  //       expect(store.getters['channelList/getInvitation'](id)).toBeFalsy();
-  //     });
-  //   });
-  //   it('should set the correct permission on the accepted invite', () => {
-  //     return store.dispatch('channelList/acceptInvitation', id).then(() => {
-  //       expect(store.getters['channel/getChannel'](channel_id).view).toBe(true);
-  //       expect(store.getters['channel/getChannel'](channel_id).edit).toBe(false);
-  //     });
-  //   });
-  // });
+  describe('acceptInvitation action', () => {
+    const channel = { id: channel_id, name: 'test', deleted: false, edit: true };
+    beforeEach(() => {
+      store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);
+      return Channel.add(channel);
+    });
+    afterEach(() => {
+      return Channel.table.toCollection().delete();
+    });
+    it('should call accept', () => {
+      const acceptSpy = jest.spyOn(Invitation, 'accept');
+      return store.dispatch('channelList/acceptInvitation', id).then(() => {
+        expect(acceptSpy).toHaveBeenCalled();
+        expect(acceptSpy.mock.calls[0][0]).toBe(id);
+        acceptSpy.mockRestore();
+      });
+    });
+    it('should load and set the invited channel', () => {
+      return store.dispatch('channelList/acceptInvitation', id).then(() => {
+        expect(store.getters['channel/getChannel'](channel_id).id).toBeTruthy();
+      });
+    });
+    it('should  remove the invitation from the list', () => {
+      return store.dispatch('channelList/acceptInvitation', id).then(() => {
+        expect(store.getters['channelList/getInvitation'](id)).toBeFalsy();
+      });
+    });
+    it('should set the correct permission on the accepted invite', () => {
+      return store.dispatch('channelList/acceptInvitation', id).then(() => {
+        expect(store.getters['channel/getChannel'](channel_id).view).toBe(true);
+        expect(store.getters['channel/getChannel'](channel_id).edit).toBe(false);
+      });
+    });
+  });
   describe('declineInvitation action', () => {
     beforeEach(() => {
       store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -93,7 +93,7 @@ describe('invitation actions', () => {
       store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);
     });
     it('should call client.delete', () => {
-      const updateSpy = jest.spyOn(Invitation, 'update');
+      const updateSpy = jest.spyOn(Invitation, 'accept');
       return store.dispatch('channelList/declineInvitation', id).then(() => {
         expect(updateSpy).toHaveBeenCalled();
         expect(updateSpy.mock.calls[0][0]).toBe(id);

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/__tests__/module.spec.js
@@ -93,11 +93,11 @@ describe('invitation actions', () => {
       store.commit('channelList/SET_INVITATION_LIST', [{ id, ...invitation }]);
     });
     it('should call client.delete', () => {
-      const updateSpy = jest.spyOn(Invitation, 'decline');
+      const declineSpy = jest.spyOn(Invitation, 'decline');
       return store.dispatch('channelList/declineInvitation', id).then(() => {
-        expect(updateSpy).toHaveBeenCalled();
-        expect(updateSpy.mock.calls[0][0]).toBe(id);
-        updateSpy.mockRestore();
+        expect(declineSpy).toHaveBeenCalled();
+        expect(declineSpy.mock.calls[0][0]).toBe(id);
+        declineSpy.mockRestore();
       });
     });
     it('should not load and set the invited channel', () => {

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
@@ -56,7 +56,7 @@ export function loadInvitationList(context) {
 
 export function acceptInvitation(context, invitationId) {
   const invitation = context.getters.getInvitation(invitationId);
-  return Invitation.accept(invitationId, { accepted: true })
+  return Invitation.accept(invitationId)
     .then(() => {
       return context
         .dispatch('channel/loadChannel', invitation.channel, { root: true })
@@ -76,7 +76,7 @@ export function acceptInvitation(context, invitationId) {
 }
 
 export function declineInvitation(context, invitationId) {
-  return Invitation.accept(invitationId, { declined: true }).then(() => {
+  return Invitation.decline(invitationId).then(() => {
     return context.commit('REMOVE_INVITATION', invitationId);
   });
 }

--- a/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
+++ b/contentcuration/contentcuration/frontend/channelList/vuex/channelList/actions.js
@@ -56,7 +56,7 @@ export function loadInvitationList(context) {
 
 export function acceptInvitation(context, invitationId) {
   const invitation = context.getters.getInvitation(invitationId);
-  return Invitation.accept(invitationId)
+  return Invitation.accept(invitationId, { accepted: true })
     .then(() => {
       return context
         .dispatch('channel/loadChannel', invitation.channel, { root: true })
@@ -76,7 +76,7 @@ export function acceptInvitation(context, invitationId) {
 }
 
 export function declineInvitation(context, invitationId) {
-  return Invitation.update(invitationId, { declined: true }).then(() => {
+  return Invitation.accept(invitationId, { declined: true }).then(() => {
     return context.commit('REMOVE_INVITATION', invitationId);
   });
 }

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1930,8 +1930,16 @@ export const Invitation = new Resource({
   urlName: 'invitation',
   indexFields: ['channel'],
 
-  accept(id, changes) {
-    return client.post(window.Urls.invitationAccept(id), changes).then(() => {
+  accept(id) {
+    const changes = { accepted: true };
+    return this._handleInvitation(id, window.Urls.invitationAccept(id), changes);
+  },
+  decline(id) {
+    const changes = { declined: true };
+    return this._handleInvitation(id, window.Urls.invitationDecline(id), changes);
+  },
+  _handleInvitation(id, url, changes) {
+    return client.post(url).then(() => {
       return this.transaction({ mode: 'rw' }, () => {
         return this.table.update(id, changes);
       });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1939,7 +1939,7 @@ export const Invitation = new Resource({
     return this._handleInvitation(id, window.Urls.invitationDecline(id), changes);
   },
   _handleInvitation(id, url, changes) {
-    return client.post(url, changes).then(() => {
+    return client.post(url).then(() => {
       return this.transaction({ mode: 'rw' }, () => {
         return this.table.update(id, changes);
       });

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1930,8 +1930,7 @@ export const Invitation = new Resource({
   urlName: 'invitation',
   indexFields: ['channel'],
 
-  accept(id) {
-    const changes = { accepted: true };
+  accept(id, changes) {
     return client.post(window.Urls.invitationAccept(id), changes).then(() => {
       return this.transaction({ mode: 'rw' }, () => {
         return this.table.update(id, changes);

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1939,7 +1939,7 @@ export const Invitation = new Resource({
     return this._handleInvitation(id, window.Urls.invitationDecline(id), changes);
   },
   _handleInvitation(id, url, changes) {
-    return client.post(url).then(() => {
+    return client.post(url, changes).then(() => {
       return this.transaction({ mode: 'rw' }, () => {
         return this.table.update(id, changes);
       });

--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -322,3 +322,26 @@ class CRUDTestCase(StudioAPITestCase):
             reverse("invitation-detail", kwargs={"pk": invitation.id})
         )
         self.assertEqual(response.status_code, 405, response.content)
+
+    def test_update_invitation_decline(self):
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.client.post(
+            reverse("invitation-accept", kwargs={"pk": invitation.id}),
+            {"declined": True},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            invitation = models.Invitation.objects.get(id=invitation.id)
+        except models.Invitation.DoesNotExist:
+            self.fail("Invitation was deleted")
+
+        self.assertTrue(invitation.declined)
+        self.assertFalse(self.channel.editors.filter(pk=self.invited_user.id).exists())
+        self.assertTrue(
+            models.Invitation.objects.filter(
+                email=self.invited_user.email, channel=self.channel
+            ).exists()
+        )
+        self.assertTrue(models.Change.objects.filter(channel=self.channel).exists())

--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -283,7 +283,10 @@ class CRUDTestCase(StudioAPITestCase):
         invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
 
         self.client.force_authenticate(user=self.invited_user)
-        response = self.client.post(reverse("invitation-accept", kwargs={"pk": invitation.id}))
+        response = self.client.post(
+            reverse("invitation-accept", kwargs={"pk": invitation.id}),
+            {"accepted": True},
+        )
         self.assertEqual(response.status_code, 200, response.content)
         try:
             invitation = models.Invitation.objects.get(id=invitation.id)

--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -283,10 +283,7 @@ class CRUDTestCase(StudioAPITestCase):
         invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
 
         self.client.force_authenticate(user=self.invited_user)
-        response = self.client.post(
-            reverse("invitation-accept", kwargs={"pk": invitation.id}),
-            {"accepted": True},
-        )
+        response = self.client.post(reverse("invitation-accept", kwargs={"pk": invitation.id}))
         self.assertEqual(response.status_code, 200, response.content)
         try:
             invitation = models.Invitation.objects.get(id=invitation.id)
@@ -327,10 +324,7 @@ class CRUDTestCase(StudioAPITestCase):
         invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
 
         self.client.force_authenticate(user=self.invited_user)
-        response = self.client.post(
-            reverse("invitation-accept", kwargs={"pk": invitation.id}),
-            {"declined": True},
-        )
+        response = self.client.post(reverse("invitation-decline", kwargs={"pk": invitation.id}))
         self.assertEqual(response.status_code, 200, response.content)
         try:
             invitation = models.Invitation.objects.get(id=invitation.id)

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -143,7 +143,6 @@ class InvitationViewSet(ValuesViewset):
         invitation.accept()
         invitation.accepted = True
         invitation.save()
-
         Change.create_change(
             generate_update_event(
                 invitation.id, INVITATION, {"accepted": True}, channel_id=invitation.channel_id
@@ -156,7 +155,6 @@ class InvitationViewSet(ValuesViewset):
         invitation = self.get_object()
         invitation.declined = True
         invitation.save()
-
         Change.create_change(
             generate_update_event(
                 invitation.id, INVITATION, {"declined": True}, channel_id=invitation.channel_id

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -137,13 +137,6 @@ class InvitationViewSet(ValuesViewset):
         instance = serializer.save()
         instance.save()
 
-    def create_invitation_change(self, invitation, changes, user_id):
-        Change.create_change(
-            generate_update_event(
-                invitation.id, INVITATION, changes, channel_id=invitation.channel_id
-            ), applied=True, created_by_id=user_id
-        )
-
     @action(detail=True, methods=["post"])
     def accept(self, request, pk=None):
         invitation = self.get_object()


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the issue with a declined invitation popping up again. This fix updates the accept endpoint to allow for declining of invitations.


### Manual verification steps performed
1. Go to https://unstable.studio.learningequality.org/en/accounts/#/ and sign in as user A
2. Open a channel and select the 'Share channel' option
3. Share the channel with user B by either selecting the 'Can view' or 'Can edit' option
4. Sign in as user B and decline the invitation
5. Refresh the 'My channels' page and observe that the invitation message has reappeared

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

https://github.com/user-attachments/assets/c5caa6f8-76c2-418a-a100-6411d84bff4c


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
- No

## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- See **Manual verification steps performed** 


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
- Because the fix updates the accept invitation endpoint, it would be great to do some extra testing to verify that the accept invitation is working correctly.


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

Fixes #4743

Fixes #4744

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
