### PR TITLE
Fix bulk descendants boolean maps

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -349,6 +349,44 @@ const mapFields = [
   'tags',
 ];
 
+function getMergedMapFields(node, contentNodeData) {
+  const mergedMapFields = {};
+  for (const mapField of mapFields) {
+    if (contentNodeData[mapField]) {
+      if (mapField === 'categories') {
+        // Reduce categories to the minimal set
+        const existingCategories = Object.keys(node.categories || {});
+        const newCategories = Object.keys(contentNodeData.categories);
+        const newMap = {};
+        for (const category of existingCategories) {
+          // If any of the new categories are more specific than the existing category,
+          // omit this.
+          if (!newCategories.some(newCategory => newCategory.startsWith(category))) {
+            newMap[category] = true;
+          }
+        }
+        for (const category of newCategories) {
+          if (
+            !existingCategories.some(
+              existingCategory =>
+                existingCategory.startsWith(category) && category !== existingCategory
+            )
+          ) {
+            newMap[category] = true;
+          }
+        }
+        mergedMapFields[mapField] = newMap;
+      } else {
+        mergedMapFields[mapField] = {
+          ...node[mapField],
+          ...contentNodeData[mapField],
+        };
+      }
+    }
+  }
+  return mergedMapFields;
+}
+
 export function updateContentNode(context, { id, mergeMapFields, ...payload } = {}) {
   if (!id) {
     throw ReferenceError('id must be defined to update a contentNode');
@@ -387,38 +425,11 @@ export function updateContentNode(context, { id, mergeMapFields, ...payload } = 
   }
 
   if (mergeMapFields) {
-    for (const mapField of mapFields) {
-      if (contentNodeData[mapField]) {
-        if (mapField === 'categories') {
-          // Reduce categories to the minimal set
-          const existingCategories = Object.keys(node.categories || {});
-          const newCategories = Object.keys(contentNodeData.categories);
-          const newMap = {};
-          for (const category of existingCategories) {
-            // If any of the new categories are more specific than the existing category,
-            // omit this.
-            if (!newCategories.some(newCategory => newCategory.startsWith(category))) {
-              newMap[category] = true;
-            }
-          }
-          for (const category of newCategories) {
-            if (
-              !existingCategories.some(
-                existingCategory =>
-                  existingCategory.startsWith(category) && category !== existingCategory
-              )
-            ) {
-              newMap[category] = true;
-            }
-          }
-        } else {
-          contentNodeData[mapField] = {
-            ...node[mapField],
-            ...contentNodeData[mapField],
-          };
-        }
-      }
-    }
+    contentNodeData = {
+      ...contentNodeData,
+      ...getMergedMapFields(node, contentNodeData),
+    };
+    console.log('contentNodeData', contentNodeData);
   }
 
   const newNode = {
@@ -463,11 +474,11 @@ export function updateContentNodeDescendants(context, { id, ...payload } = {}) {
   const contentNodeData = generateContentNodeData(payload);
 
   const descendants = context.getters.getContentNodeDescendants(id);
-  const contentNodeIds = [id, ...descendants.map(node => node.id)];
+  const contentNodes = [node, ...descendants];
 
-  const contentNodesData = contentNodeIds.map(contentNodeId => ({
-    id: contentNodeId,
-    ...contentNodeData,
+  const contentNodesData = contentNodes.map(contentNode => ({
+    id: contentNode.id,
+    ...getMergedMapFields(contentNode, contentNodeData),
   }));
 
   context.commit('ADD_CONTENTNODES', contentNodesData);

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -21,12 +21,6 @@ import {
   COPYING_STATUS,
   TASK_ID,
 } from 'shared/data/constants';
-import {
-  Categories,
-  ContentLevels,
-  ResourcesNeededTypes,
-  ResourcesNeededOptions,
-} from 'shared/constants';
 import { INDEXEDDB_RESOURCES } from 'shared/data/registry';
 
 /**
@@ -489,36 +483,11 @@ export class UpdatedDescendantsChange extends Change {
     this.validateObj(changes, 'changes');
     changes = omitIgnoredSubFields(changes);
     this.mods = changes;
-    this.setModsDeletedProperties();
     this.setChannelAndUserId(oldObj);
   }
 
   get changed() {
     return !isEmpty(this.mods);
-  }
-
-  /**
-   * To ensure that the mods properties that are multi valued have set
-   * to true just the options that are present in the mods object. All
-   * other options are set to null.
-   */
-  setModsDeletedProperties() {
-    if (!this.mods) return;
-
-    const multiValueProperties = {
-      categories: Object.values(Categories),
-      learner_needs: ResourcesNeededOptions.map(option => ResourcesNeededTypes[option]),
-      grade_levels: Object.values(ContentLevels),
-    };
-    Object.entries(multiValueProperties).forEach(([key, values]) => {
-      if (this.mods[key]) {
-        values.forEach(value => {
-          if (!this.mods[key][value]) {
-            this.mods[key][value] = null;
-          }
-        });
-      }
-    });
   }
 
   saveChange() {

--- a/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_contentnode.py
@@ -580,8 +580,6 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         root_node = testdata.tree(parent=self.channel.main_tree)
 
         descendants = root_node.get_descendants(include_self=True)
-        # Fix undefined extra_fields
-        descendants.exclude(kind_id=content_kinds.TOPIC).update(extra_fields={})
 
         new_language = "es"
 


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

1. This PR changes the behaviour when we update boolean map fields when updating all descendants of a folder. This will now just add all new options in boolean maps to descendants instead of replacing them with the current ones.

2. This PR also fixes a bug that removed all current categories and just added new ones when we inherited categories from the parent folder.


### Manual verification steps performed
1. Tested bulk descendants changes with boolean maps fields, and verified that the described behaviour was being stored in the backend, in vuex, and in indexedDB.

### Screenshots (if applicable)



### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
