### PR TITLE
Fix incorrectly marked "incomplete" exercises on exercise copy

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeEditListItem.vue
@@ -258,6 +258,7 @@
       retryFailedCopy: withChangeTracker(function(changeTracker) {
         this.updateContentNode({
           id: this.nodeId,
+          checkComplete: true,
           [COPYING_STATUS]: COPYING_STATUS_VALUES.COPYING,
         });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -786,10 +786,12 @@
       saveFromDiffTracker(id) {
         if (this.diffTracker[id]) {
           this.changed = true;
-          return this.updateContentNode({ id, ...this.diffTracker[id] }).then(() => {
-            delete this.diffTracker[id];
-            return this.changed;
-          });
+          return this.updateContentNode({ id, checkComplete: true, ...this.diffTracker[id] }).then(
+            () => {
+              delete this.diffTracker[id];
+              return this.changed;
+            }
+          );
         }
         return Promise.resolve(this.changed);
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -399,7 +399,11 @@
 
                 if (completeCheck !== node.complete) {
                   validationPromises.push(
-                    vm.updateContentNode({ id: nodeId, complete: completeCheck })
+                    vm.updateContentNode({
+                      id: nodeId,
+                      complete: completeCheck,
+                      checkComplete: true,
+                    })
                   );
                 }
               });
@@ -578,7 +582,12 @@
       inheritMetadata(metadata) {
         const setMetadata = () => {
           for (const nodeId of this.newNodeIds) {
-            this.updateContentNode({ id: nodeId, ...metadata, mergeMapFields: true });
+            this.updateContentNode({
+              id: nodeId,
+              ...metadata,
+              mergeMapFields: true,
+              checkComplete: true,
+            });
           }
           this.newNodeIds = [];
         };

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/__tests__/actions.spec.js
@@ -111,7 +111,7 @@ describe('contentNode actions', () => {
     });
   });
   describe('updateContentNode action for an existing contentNode', () => {
-    it('should call ContentNode.update', () => {
+    it('should call ContentNode.update without complete if completeCheck is false', () => {
       store.commit('contentNode/ADD_CONTENTNODE', {
         id,
         title: 'test',
@@ -124,6 +124,32 @@ describe('contentNode actions', () => {
           description: 'very',
           language: 'no',
           learning_activities: { test: true },
+        })
+        .then(() => {
+          expect(updateSpy).toHaveBeenCalledWith(id, {
+            title: 'notatest',
+            description: 'very',
+            language: 'no',
+            changed: true,
+            learning_activities: { test: true },
+          });
+          updateSpy.mockRestore();
+        });
+    });
+    it('should call ContentNode.update with complete false if completeCheck is true', () => {
+      store.commit('contentNode/ADD_CONTENTNODE', {
+        id,
+        title: 'test',
+      });
+      const updateSpy = jest.spyOn(ContentNode, 'update');
+      return store
+        .dispatch('contentNode/updateContentNode', {
+          id,
+          title: 'notatest',
+          description: 'very',
+          language: 'no',
+          learning_activities: { test: true },
+          checkComplete: true,
         })
         .then(() => {
           expect(updateSpy).toHaveBeenCalledWith(id, {

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -1,5 +1,6 @@
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
+import isEmpty from 'lodash/isEmpty';
 import { NEW_OBJECT, NOVALUE, DescendantsUpdatableFields } from 'shared/constants';
 import client from 'shared/client';
 import {
@@ -349,9 +350,15 @@ const mapFields = [
   'tags',
 ];
 
-export function updateContentNode(context, { id, mergeMapFields, ...payload } = {}) {
+export function updateContentNode(
+  context,
+  { id, mergeMapFields, checkComplete = false, ...payload } = {}
+) {
   if (!id) {
     throw ReferenceError('id must be defined to update a contentNode');
+  }
+  if (isEmpty(payload)) {
+    return Promise.resolve();
   }
   let contentNodeData = generateContentNodeData(payload);
 
@@ -425,11 +432,15 @@ export function updateContentNode(context, { id, mergeMapFields, ...payload } = 
     ...node,
     ...contentNodeData,
   };
-  const complete = isNodeComplete({
-    nodeDetails: newNode,
-    assessmentItems: context.rootGetters['assessmentItem/getAssessmentItems'](id),
-    files: context.rootGetters['file/getContentNodeFiles'](id),
-  });
+  let complete = true;
+  if (checkComplete) {
+    complete = isNodeComplete({
+      nodeDetails: newNode,
+      assessmentItems: context.rootGetters['assessmentItem/getAssessmentItems'](id),
+      files: context.rootGetters['file/getContentNodeFiles'](id),
+    });
+  }
+
   contentNodeData = {
     ...contentNodeData,
     complete,

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -428,23 +428,21 @@ export function updateContentNode(
     }
   }
 
-  const newNode = {
-    ...node,
-    ...contentNodeData,
-  };
-  let complete = true;
   if (checkComplete) {
-    complete = isNodeComplete({
+    const newNode = {
+      ...node,
+      ...contentNodeData,
+    };
+    const complete = isNodeComplete({
       nodeDetails: newNode,
       assessmentItems: context.rootGetters['assessmentItem/getAssessmentItems'](id),
       files: context.rootGetters['file/getContentNodeFiles'](id),
     });
+    contentNodeData = {
+      ...contentNodeData,
+      complete,
+    };
   }
-
-  contentNodeData = {
-    ...contentNodeData,
-    complete,
-  };
 
   context.commit('ADD_CONTENTNODE', { id, ...contentNodeData });
   return ContentNode.update(id, contentNodeData);


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
adds a flag to the updateContentNode action to determine whether or not we need to check for completion - required within the EditModal for validations to work properly, but not in other quick edit options. Previously, this check was setting `complete` to false incorrectly due to assessmentItems validation failing in situations where we hadn't loaded that assessment data (i.e. not EditModal). 

### Manual verification steps performed
1. Copy a complete exercise from within the tree view (i.e. "make a copy") and confirm no false "incomplete"
2. Copy a complete exercise to the clipboard, and then move it to a new location, and confirm no  false "incomplete"
Regression testing: 
1. Create a complete exercise in the edit modal. After successfully passing validations/checks within the modal, after saving and closing, it should not update to now be marked as incomplete in the tree view
2. Create a complete exercise. After doing so, open a quick edit modal within the tree view and add some additional metadata. 

### Does this introduce any tech-debt items?
Well, there probably needs to be some general cleanup of a lot of how these validations are working.... and this feels pretty brittle.

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4747

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
