### PR TITLE
Fixes count of resources/questions on copy

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -375,7 +375,6 @@
               actionText: this.$tr('undo'),
               actionCallback: () => changeTracker.revert(),
             }).then(() => changeTracker.cleanUp());
-            this.setContentNodesCount([copiedContentNode]);
           })
           .catch(() => {
             this.clearSnackbar();

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -240,7 +240,6 @@
         'copyContentNode',
         'waitForCopyingStatus',
         'setQuickEditModal',
-        'setContentNodesCount',
       ]),
       ...mapActions('clipboard', ['copy']),
       async focusFirstOption() {
@@ -363,7 +362,6 @@
           target: this.nodeId,
           position: RELATIVE_TREE_POSITIONS.RIGHT,
         });
-        this.setContentNodesCount([copiedContentNode]);
 
         this.waitForCopyingStatus({
           contentNodeId: copiedContentNode.id,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeOptions.vue
@@ -240,6 +240,7 @@
         'copyContentNode',
         'waitForCopyingStatus',
         'setQuickEditModal',
+        'setContentNodesCount',
       ]),
       ...mapActions('clipboard', ['copy']),
       async focusFirstOption() {
@@ -362,6 +363,7 @@
           target: this.nodeId,
           position: RELATIVE_TREE_POSITIONS.RIGHT,
         });
+        this.setContentNodesCount([copiedContentNode]);
 
         this.waitForCopyingStatus({
           contentNodeId: copiedContentNode.id,
@@ -373,6 +375,7 @@
               actionText: this.$tr('undo'),
               actionCallback: () => changeTracker.revert(),
             }).then(() => changeTracker.cleanUp());
+            this.setContentNodesCount([copiedContentNode]);
           })
           .catch(() => {
             this.clearSnackbar();

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -548,6 +548,7 @@ export function copyContentNode(
   return ContentNode.copy(id, target, position, excluded_descendants, sourceNode).then(node => {
     context.commit('ADD_CONTENTNODE', node);
     context.commit('ADD_INHERITING_NODE', node);
+    setContentNodesCount(context, [node]);
     return node;
   });
 }


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
This pr fixes the count of resources/questions when copying resources that was inconsistent with the count of the originally copied resources.

### Manual verification steps performed
1. Copy a resource with some resources or exercise with some questions
2. Observe the count of resources/questions after the copying is completed.

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

https://github.com/user-attachments/assets/3db7d750-8139-49c6-9fdc-515195124972

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
See manual verification steps above

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
NA

## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes #4765

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
