### PR TITLE
Properly handle metadata inheritance for non uploaded nodes in edit modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -534,11 +534,17 @@
           return newNodeId;
         });
       },
+      resetInheritMetadataModal() {
+        this.$refs.inheritModal?.checkInheritance();
+      },
       createTopic() {
         this.createNode('topic', {
           title: '',
         }).then(newNodeId => {
           this.selected = [newNodeId];
+          this.$nextTick(() => {
+            this.resetInheritMetadataModal();
+          });
         });
       },
       async createNodesFromUploads(fileUploads) {
@@ -569,7 +575,7 @@
           })
         );
         this.creatingNodes = false;
-        this.$refs.inheritModal?.resetClosed();
+        this.resetInheritMetadataModal();
       },
       updateTitleForPage() {
         this.updateTabTitle(this.$store.getters.appendChannelName(this.modalTitle));
@@ -580,8 +586,13 @@
         });
       },
       inheritMetadata(metadata) {
+        if (!this.createMode) {
+          // This shouldn't happen, but prevent this just in case.
+          return;
+        }
         const setMetadata = () => {
-          for (const nodeId of this.newNodeIds) {
+          const nodeIds = this.uploadMode ? this.newNodeIds : this.selected;
+          for (const nodeId of nodeIds) {
             this.updateContentNode({
               id: nodeId,
               ...metadata,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -129,7 +129,7 @@
       </BottomBar>
       <InheritAncestorMetadataModal
         ref="inheritModal"
-        :parent="createMode ? parent : null"
+        :parent="(createMode && detailNodeIds.length) ? parent : null"
         @inherit="inheritMetadata"
         @updateActive="active => isInheritModalOpen = active"
       />
@@ -549,6 +549,7 @@
       },
       async createNodesFromUploads(fileUploads) {
         this.creatingNodes = true;
+        const parentPropDefinedForInheritModal = Boolean(this.$refs.inheritModal?.parent);
         this.newNodeIds = await Promise.all(
           fileUploads.map(async (file, index) => {
             let title;
@@ -575,7 +576,11 @@
           })
         );
         this.creatingNodes = false;
-        this.resetInheritMetadataModal();
+        if (parentPropDefinedForInheritModal) {
+          // Only call this if the parent prop was previously defined, otherwise,
+          // rely on the parent prop watcher to trigger the inherit event.
+          this.resetInheritMetadataModal();
+        }
       },
       updateTitleForPage() {
         this.updateTabTitle(this.$store.getters.appendChannelName(this.modalTitle));

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -129,7 +129,7 @@
       </BottomBar>
       <InheritAncestorMetadataModal
         ref="inheritModal"
-        :parent="(createMode && detailNodeIds.length) ? parent : null"
+        :parent="createMode ? parent : null"
         @inherit="inheritMetadata"
         @updateActive="active => isInheritModalOpen = active"
       />

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -111,12 +111,7 @@
         );
       },
       active() {
-        return (
-          this.parent !== null &&
-          !this.allFieldsDesignatedByParent &&
-          !this.closed &&
-          this.parentHasInheritableMetadata
-        );
+        return this.parent !== null && !this.closed;
       },
       inheritableMetadataItems() {
         const returnValue = {};
@@ -304,12 +299,6 @@
       handleCancel() {
         this.closed = true;
         this.$emit('inherit', {});
-      },
-      /**
-       * @public
-       */
-      resetClosed() {
-        this.closed = false;
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/InheritAncestorMetadataModal.vue
@@ -192,6 +192,19 @@
     },
     methods: {
       ...mapActions('contentNode', ['updateContentNode']),
+      /**
+       * @public
+       */
+      checkInheritance() {
+        if (this.allFieldsDesignatedByParent || !this.parentHasInheritableMetadata) {
+          // If all fields have been designated by the parent, or there is nothing to inherit,
+          // automatically continue
+          this.handleContinue();
+        } else {
+          // Wait for the data to be updated before showing the dialog
+          this.closed = false;
+        }
+      },
       resetData() {
         if (this.parent) {
           this.dontShowAgain = false;
@@ -242,14 +255,7 @@
               };
             }, {});
             this.$nextTick(() => {
-              if (this.allFieldsDesignatedByParent || !this.parentHasInheritableMetadata) {
-                // If all fields have been designated by the parent, or there is nothing to inherit,
-                // automatically continue
-                this.handleContinue();
-              } else {
-                // Wait for the data to be updated before showing the dialog
-                this.closed = false;
-              }
+              this.checkInheritance();
             });
           });
         }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -931,12 +931,6 @@
           this.updateContentNode({ id: nodeId, ...metadata, mergeMapFields: true });
         }
         this.CLEAR_INHERITING_NODES(nodeIds);
-        this.$nextTick(() => {
-          // Once the inheritance is complete, reset the modal closed state.
-          if (!this.inheritingNodes || this.inheritingNodes.length === 0) {
-            this.$refs.inheritModal?.resetClosed();
-          }
-        });
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Use selected for node ids for inheritance when not uploading
* Ensure that we properly retrigger the inheritance modal checks when something new is added in the same edit modal lifecycle


### Manual verification steps performed
1. Create a new folder, ensure that the modal triggers and applies
2. Within the same edit modal session click "add new folder" and ensure the same behaviour happens
3. Repeat with "don't show this again" behaviour
4. Create a new exercise, ensure that the modal triggers and applies
5. Repeat with "Don't show this again" behaviour

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
Fixes [#4762](https://github.com/learningequality/studio/issues/4762)

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
