### PR TITLE
Make user_id required false for migration

### DIFF
--- a/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
+++ b/contentcuration/kolibri_public/management/commands/rectify_incorrect_contentnode_source_fields.py
@@ -33,7 +33,6 @@ class Command(BaseCommand):
             '--user_id',
             type=int,
             help="User ID for the operation",
-            required=True
         )
 
     def handle(self, *args, **options):


### PR DESCRIPTION
user_id was required for the ContentNode migration which caused the run to fail. 