### PR TITLE
Ensure actor_id gets passed in case channel creation API endpoint ends up in undeleting channel

### DIFF
--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -777,6 +777,23 @@ class CreateChannelTestCase(StudioTestCase):
         except Channel.DoesNotExist:
             self.fail("Channel was not created")
 
+    def test_updates_already_created_channel(self):
+        """
+        Test that it creates a channel with the given id
+        """
+        deleted_channel = channel()
+        deleted_channel.deleted = True
+        deleted_channel.save(actor_id=self.user.id)
+        self.channel_data.update({"name": "Updated name", "id": deleted_channel.id})
+        self.admin_client().post(
+            reverse_lazy("api_create_channel"), data={"channel_data": self.channel_data}, format="json"
+        )
+        try:
+            c = Channel.objects.get(id=self.channel_data["id"])
+            self.assertEqual(c.name, "Updated name")
+        except Channel.DoesNotExist:
+            self.fail("Channel was not created")
+
     def test_creates_cheftree(self):
         """
         Test that it creates a channel with the given id

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -519,7 +519,9 @@ def create_channel(channel_data, user):
     if files:
         map_files_to_node(user, channel.chef_tree, files)
     channel.chef_tree.save()
-    channel.save()
+    # If the channel was previously deleted, this save will undelete it
+    # so will require the actor_id to be set
+    channel.save(actor_id=user.id)
 
     # Delete chef tree if it already exists
     if old_chef_tree and old_chef_tree != channel.staging_tree:


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
When trying to chef a previously deleted channel, the API endpoint would return a 500 because the actor_id argument was not being passed to the save method.
This is required, as the channel would be undeleted by this operation, so this is needed for the channel history tracking.

### Manual verification steps performed
1. Wrote a regression test, saw that it failed.
2. Fixed the issue.
3. Saw that it passed!

## References
Fixes #4783

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
