### PR TITLE
Validate UUID Format in Public API Requests to Prevent 500 Errors

### DIFF
--- a/contentcuration/kolibri_public/import_metadata_view.py
+++ b/contentcuration/kolibri_public/import_metadata_view.py
@@ -14,6 +14,7 @@ from kolibri_content.constants.schema_versions import CONTENT_SCHEMA_VERSION  # 
 from kolibri_content.constants.schema_versions import MIN_CONTENT_SCHEMA_VERSION  # Use kolibri_content
 from kolibri_public import models  # Use kolibri_public models
 from kolibri_public.views import metadata_cache
+from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -68,6 +69,14 @@ class ImportMetadataViewset(GenericViewSet):
         :param pk: id parent node
         :return: an object with keys for each content metadata table and a schema_version key
         """
+
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         content_schema = request.query_params.get(
             "schema_version", self.default_content_schema

--- a/contentcuration/kolibri_public/tests/test_content_app.py
+++ b/contentcuration/kolibri_public/tests/test_content_app.py
@@ -236,6 +236,17 @@ class ContentNodeAPIBase(object):
                 )
         return recursion_depth if not recursion_depths else max(recursion_depths)
 
+    def test_contentnode_tree_invalid_uuid(self):
+        invalid_uuid = "8f0a5b9d89795"
+
+        response = self._get(
+            reverse("publiccontentnode_tree-detail", kwargs={"pk": invalid_uuid})
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(response.data["error"], "Invalid UUID format.")
+
     def test_contentnode_tree(self):
         response = self._get(
             reverse("publiccontentnode_tree-detail", kwargs={"pk": self.root.id})

--- a/contentcuration/kolibri_public/tests/test_importmetadata_api.py
+++ b/contentcuration/kolibri_public/tests/test_importmetadata_api.py
@@ -85,6 +85,17 @@ class ImportMetadataTestCase(APITestCase):
     def test_import_metadata_tags(self):
         self._assert_data(public.ContentTag, content.ContentTag, self.tags)
 
+    def test_import_metadata_invalid_uuid(self):
+        invalid_uuid = "8f0a5b9d89795"
+
+        response = self.client.get(
+            reverse("publicimportmetadata-detail", kwargs={"pk": invalid_uuid})
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(response.data["error"], "Invalid UUID format.")
+
     def test_schema_version_too_low(self):
         response = self.client.get(
             reverse("publicimportmetadata-detail", kwargs={"pk": self.node.id})

--- a/contentcuration/kolibri_public/views.py
+++ b/contentcuration/kolibri_public/views.py
@@ -10,6 +10,7 @@ import logging
 import re
 from collections import OrderedDict
 from functools import reduce
+from uuid import UUID
 
 from django.core.exceptions import ValidationError
 from django.db.models import Exists
@@ -35,6 +36,7 @@ from kolibri_public import models
 from kolibri_public.search import get_available_metadata_labels
 from kolibri_public.stopwords import stopwords_set
 from le_utils.constants import content_kinds
+from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
@@ -44,7 +46,6 @@ from contentcuration.models import generate_storage_url
 from contentcuration.utils.pagination import ValuesViewsetCursorPagination
 from contentcuration.viewsets.base import BaseValuesViewset
 from contentcuration.viewsets.base import ReadOnlyValuesViewset
-
 
 logger = logging.getLogger(__name__)
 
@@ -697,8 +698,15 @@ class ContentNodeTreeViewset(
         :return: an object representing the parent with a pagination object as "children"
         """
 
-        queryset = self.get_tree_queryset(request, pk)
+        try:
+            UUID(pk)
+        except ValueError:
+            return Response(
+                {"error": "Invalid UUID format."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
+        queryset = self.get_tree_queryset(request, pk)
         # We explicitly order by lft here, so that the nodes are in tree traversal order, so we can iterate over them and build
         # out our nested representation, being sure that any ancestors have already been processed.
         nodes = self.serialize(queryset.order_by("lft"))


### PR DESCRIPTION
## Summary
Preemptively check for pk to be UUID and return 400 bad request otherwise 

### Description of the change(s) you made
- Adds validation for UUID
- Adds Tests


### Manual verification steps performed
1. Ran tests locally

## References
closes #4788 

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [x] Code is clean and well-commented
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
