### PR TITLE
optimize garabge collection command

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -263,15 +263,10 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         # Point sole editor non-public channels' contentnodes to orphan tree to let
         # our garbage collection delete the nodes and underlying file.
-        channel_tree_id_map = dict(
-            Channel.objects.values_list('id', 'main_tree__tree_id')
-        )
+        tree_ids_to_update = non_public_channels_sole_editor.values_list('main_tree__tree_id', flat=True)
 
-        logging.debug("Queries after creating channel tree ID map: %s", connection.queries)
-
-        for id, tree_id in channel_tree_id_map.items():
-            if id in non_public_channels_sole_editor.values_list("id", flat=True):
-                ContentNode.objects.filter(tree_id=tree_id).update(parent_id=settings.ORPHANAGE_ROOT_ID)
+        for tree_id in tree_ids_to_update:
+            ContentNode.objects.filter(tree_id=tree_id).update(parent_id=settings.ORPHANAGE_ROOT_ID)
 
         logging.debug("Queries after updating content nodes parent ID: %s", connection.queries)
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -269,12 +269,9 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         logging.debug("Queries after creating channel tree ID map: %s", connection.queries)
 
-        tree_ids_to_update = [
-            tree_id for id, tree_id in channel_tree_id_map.items()
-            if id in non_public_channels_sole_editor.values_list("id", flat=True)
-        ]
-
-        ContentNode.objects.filter(tree_id__in=tree_ids_to_update).update(parent_id=settings.ORPHANAGE_ROOT_ID)
+        for id, tree_id in channel_tree_id_map.items():
+            if id in non_public_channels_sole_editor.values_list("id", flat=True):
+                ContentNode.objects.filter(tree_id=tree_id).update(parent_id=settings.ORPHANAGE_ROOT_ID)
 
         logging.debug("Queries after updating content nodes parent ID: %s", connection.queries)
 

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -264,7 +264,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         # Point sole editor non-public channels' contentnodes to orphan tree to let
         # our garbage collection delete the nodes and underlying file.
         channel_tree_id_map = dict(
-            ContentNode.objects.values_list('id', 'main_tree__tree_id')
+            Channel.objects.values_list('id', 'main_tree__tree_id')
         )
 
         logging.debug("Queries after creating channel tree ID map: %s", connection.queries)


### PR DESCRIPTION
## Summary
Restructure the way we run the query while deleting user_related data to stop the garbage_collection command from stalling. 

### Description of the change(s) you made
- Calculate tree_id separately instead of in the subquery. 
- Run the query once to set the parent_id. 

### How can a reviewer test these changes?
- Restored production database to hotfixes environment
- Manually started the job
- Observed running querie

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
closes #4780 

## Comments
We need to have the settings.DEBUG=True to log the queries.

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
