### PR TITLE
Add pagination to every place that displays long lists of nodes from loadChildren

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -66,6 +66,11 @@
               </tr>
             </template>
           </VDataTable>
+          <div class="show-more-button-container">
+            <KButton v-if="more" :disabled="moreLoading" @click="loadMore">
+              {{ showMoreLabel }}
+            </KButton>
+          </div>
         </VCard>
       </VContainer>
       <ResourceDrawer
@@ -127,6 +132,7 @@
 
   import { mapActions, mapGetters } from 'vuex';
   import sortBy from 'lodash/sortBy';
+  import NodePanel from '../NodePanel';
   import MoveModal from '../../components/move/MoveModal';
   import ResourceDrawer from '../../components/ResourceDrawer';
   import { RouteNames } from '../../constants';
@@ -136,6 +142,9 @@
   import LoadingText from 'shared/views/LoadingText';
   import FullscreenModal from 'shared/views/FullscreenModal';
   import { titleMixin, routerMixin } from 'shared/mixins';
+  import { crossComponentTranslator } from 'shared/i18n';
+
+  const showMoreTranslator = crossComponentTranslator(NodePanel);
 
   export default {
     name: 'TrashModal',
@@ -159,6 +168,8 @@
       return {
         dialog: true,
         loading: false,
+        more: null,
+        moreLoading: false,
         previewNodeId: null,
         selected: [],
         showConfirmationDialog: false,
@@ -201,6 +212,10 @@
       counts() {
         return this.getTopicAndResourceCounts(this.selected);
       },
+      showMoreLabel() {
+        // eslint-disable-next-line kolibri/vue-no-undefined-string-uses
+        return showMoreTranslator.$tr('showMore');
+      },
     },
     watch: {
       dialog(newValue) {
@@ -210,21 +225,12 @@
       },
     },
     created() {
-      Promise.all([
-        this.loadContentNodes({ parent__in: [this.rootId] }),
+      this.loadContentNodes({ parent__in: [this.rootId] }),
         this.loadAncestors({ id: this.nodeId }),
-      ]);
+        this.loadNodes();
     },
     mounted() {
-      this.loading = true;
-      if (!this.trashId) {
-        this.loading = false;
-        return;
-      }
       this.updateTabTitle(this.$store.getters.appendChannelName(this.$tr('trashModalTitle')));
-      this.loadChildren({ parent: this.trashId }).then(() => {
-        this.loading = false;
-      });
     },
     methods: {
       ...mapActions('contentNode', [
@@ -234,6 +240,17 @@
         'loadContentNodes',
         'loadAncestors',
       ]),
+      loadNodes() {
+        this.loading = true;
+        if (!this.trashId) {
+          this.loading = false;
+          return;
+        }
+        this.loadChildren({ parent: this.trashId }).then(childrenResponse => {
+          this.loading = false;
+          this.more = childrenResponse.more || null;
+        });
+      },
       moveNodes(target) {
         return this.moveContentNodes({
           id__in: this.selected,
@@ -242,6 +259,8 @@
         }).then(() => {
           this.reset();
           this.$refs.moveModal && this.$refs.moveModal.moveComplete();
+          // Reload after this to ensure that anything over the pagination fold is loaded now
+          this.loadNodes();
         });
       },
       reset() {
@@ -254,6 +273,8 @@
           this.showConfirmationDialog = false;
           this.reset();
           this.$store.dispatch('showSnackbar', { text });
+          // Reload after this to ensure that anything over the pagination fold is loaded now
+          this.loadNodes();
         });
       },
       toggleSelectAll(selectAll) {
@@ -261,6 +282,15 @@
       },
       getItemBackground(id) {
         return this.previewNodeId === id ? this.$vuetify.theme.greyBackground : 'transparent';
+      },
+      loadMore() {
+        if (this.more && !this.moreLoading) {
+          this.moreLoading = true;
+          this.loadContentNodes(this.more).then(response => {
+            this.more = response.more || null;
+            this.moreLoading = false;
+          });
+        }
       },
     },
     $trs: {
@@ -282,5 +312,11 @@
 
 </script>
 <style lang="less" scoped>
+
+  .show-more-button-container {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -55,7 +55,7 @@ function makeWrapper(items) {
     methods: {
       loadContentNodes: jest.fn(),
       loadAncestors: jest.fn(),
-      loadChildren: jest.fn(() => Promise.resolve()),
+      loadChildren: jest.fn(() => Promise.resolve({ more: null, results: [] })),
     },
     stubs: {
       ResourceDrawer: true,


### PR DESCRIPTION
## Summary
### Description of the change(s) you made
* Adds pagination to the TrashModal, the MoveModal, and the ImportFromChannels modal.
* Doesn't add it to other places that use the loadChildren method (like the navigation side panel in the main edit page) as this is covered by the NodePanel pagination logic

### Manual verification steps performed
Tested each of these modals with number of resources/folders in a folder > 25.
Verify that the pagination displayed correctly, loaded additional items, and also updated properly after actions were performed (trash modal needed a data refresh after restoring or perma-deleting items)

### Does this introduce any tech-debt items?
Adds some cross component string stealing, we should clean up in unstable


## References
Fixes #4809

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
