### PR TITLE
Update kds dp to the latest guidelines

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/styles/vuetify.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/vuetify.scss
@@ -4562,7 +4562,7 @@ p {
   transition-property: box-shadow;
 }
 .v-card--hover:hover {
-  @extend %dropshadow-4dp;
+  @extend %dropshadow-6dp;
 }
 .v-card--hover.v-card--flat:hover {
   @extend %dropshadow-2dp;


### PR DESCRIPTION
## Summary
### Description of the change(s) you made

Updates Card hover dp from the deprecated `%dropshadow-4dp` to `%dropshadow-6dp`.