### PR TITLE
Update node details query to use CTE and more robust tests

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1556,7 +1556,7 @@ class ContentNode(MPTTModel, models.Model):
             return root.get_descendants().filter(title=title)
         return cls.objects.filter(title=title)
 
-    def get_details(self, channel_id=None):
+    def get_details(self, channel=None):
         """
         Returns information about the node and its children, including total size, languages, files, etc.
 
@@ -1578,9 +1578,7 @@ class ContentNode(MPTTModel, models.Model):
         # Get resources
         resources = descendants.exclude(kind=content_kinds.TOPIC).order_by()
 
-        if channel_id:
-            channel = Channel.objects.filter(id=channel_id)[0]
-        else:
+        if not channel:
             channel = self.get_channel()
 
         if not resources.exists():

--- a/contentcuration/contentcuration/tests/views/test_nodes.py
+++ b/contentcuration/contentcuration/tests/views/test_nodes.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from contextlib import contextmanager
 
 import pytz
 from django.conf import settings
@@ -8,11 +9,18 @@ from django.urls import reverse
 from mock import Mock
 from mock import patch
 
+from contentcuration.models import ContentNode
 from contentcuration.tasks import generatenodediff_task
 from contentcuration.tests.base import BaseAPITestCase
 
 
 class NodesViewsTestCase(BaseAPITestCase):
+    persist_bucket = True
+
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()
+
     def test_get_node_diff__missing_contentnode(self):
         response = self.get(reverse("get_node_diff", kwargs=dict(updated_id="abc123", original_id="def456")))
         self.assertEqual(response.status_code, 404)
@@ -32,28 +40,140 @@ class NodesViewsTestCase(BaseAPITestCase):
         response = self.get(reverse("get_node_diff", kwargs=dict(updated_id=pk, original_id=pk)))
         self.assertEqual(response.status_code, 302)
 
-    def test_get_channel_details(self):
-        url = reverse('get_channel_details', kwargs={"channel_id": self.channel.id})
-        response = self.get(url)
 
-        details = json.loads(response.content)
-        assert details['resource_count'] > 0
-        assert details['resource_size'] > 0
-        assert len(details['kind_count']) > 0
+class DetailsTestCase(BaseAPITestCase):
+    persist_bucket = True
 
-    def test_get_channel_details_cached(self):
-        cache_key = "details_{}".format(self.channel.main_tree.id)
+    def setUp(self):
+        super().setUp()
+        self.default_details = {
+            "resource_count": 5,
+            "resource_size": 100,
+            "kind_count": {"document": 3, "video": 2}
+        }
+        # see tree.json for where this comes from
+        self.node = ContentNode.objects.get(node_id="00000000000000000000000000000001")
+        # required by get_node_details
+        self.channel.make_public()
 
-        # force the cache to update by adding a very old cache entry. Since Celery tasks run sync in the test suite,
-        # get_channel_details will return an updated cache value rather than generate it async.
-        data = {"last_update": pytz.utc.localize(datetime.datetime(1990, 1, 1)).strftime(settings.DATE_TIME_FORMAT)}
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()
+
+    def _set_cache(self, node, last_update=None):
+        data = self.default_details.copy()
+        if last_update is not None:
+            data.update(last_update=pytz.utc.localize(last_update).strftime(settings.DATE_TIME_FORMAT))
+
+        cache_key = "details_{}".format(node.node_id)
         cache.set(cache_key, json.dumps(data))
 
-        with patch("contentcuration.views.nodes.getnodedetails_task") as task_mock:
-            url = reverse('get_channel_details', kwargs={"channel_id": self.channel.id})
-            self.get(url)
+    @contextmanager
+    def _check_details(self, node=None):
+        endpoint = "get_channel_details" if node is None else "get_node_details"
+        param = {"channel_id": self.channel.id} \
+            if endpoint == "get_channel_details" \
+            else {"node_id": node.id}
+        url = reverse(endpoint, kwargs=param)
+        response = self.get(url)
+        print(response.content)
+        details = json.loads(response.content)
+        yield details
+
+    def assertDetailsEqual(self, details, expected):
+        self.assertEqual(details['resource_count'], expected['resource_count'])
+        self.assertEqual(details['resource_size'], expected['resource_size'])
+        self.assertEqual(details['kind_count'], expected['kind_count'])
+
+    @patch("contentcuration.models.ContentNode.get_details")
+    def test_get_channel_details__uncached(self, mock_get_details):
+        mock_get_details.return_value = {
+            "resource_count": 7,
+            "resource_size": 200,
+            "kind_count": {"document": 33, "video": 22}
+        }
+        with self._check_details() as details:
+            self.assertDetailsEqual(details, mock_get_details.return_value)
+
+        mock_get_details.assert_called_once_with(channel=self.channel)
+
+    @patch("contentcuration.views.nodes.getnodedetails_task")
+    def test_get_channel_details__cached(self, task_mock):
+        # force the cache to update by adding a very old cache entry. Since Celery tasks run sync in the test suite,
+        # get_channel_details will return an updated cache value rather than generate it async.
+        self._set_cache(self.channel.main_tree, last_update=datetime.datetime(1990, 1, 1))
+
+        with self._check_details() as details:
+            # check cache was returned
+            self.assertDetailsEqual(details, self.default_details)
             # Check that the outdated cache prompts an asynchronous cache update
             task_mock.enqueue.assert_called_once_with(self.user, node_id=self.channel.main_tree.id)
+
+    @patch("contentcuration.views.nodes.getnodedetails_task")
+    def test_get_channel_details__cached__not_updated__no_enqueue(self, task_mock):
+        # nothing changed,
+        self.channel.main_tree.get_descendants(include_self=False).update(changed=False)
+        self._set_cache(self.channel.main_tree, last_update=datetime.datetime(1990, 1, 1))
+
+        with self._check_details() as details:
+            # check cache was returned
+            self.assertDetailsEqual(details, self.default_details)
+            task_mock.enqueue.assert_not_called()
+
+    @patch("contentcuration.views.nodes.getnodedetails_task")
+    def test_get_channel_details__cached__no_enqueue(self, task_mock):
+        # test last update handling
+        self._set_cache(self.channel.main_tree, last_update=datetime.datetime(2099, 1, 1))
+
+        with self._check_details() as details:
+            # check cache was returned
+            self.assertDetailsEqual(details, self.default_details)
+            task_mock.enqueue.assert_not_called()
+
+    @patch("contentcuration.models.ContentNode.get_details")
+    def test_get_node_details__uncached(self, mock_get_details):
+        mock_get_details.return_value = {
+            "resource_count": 7,
+            "resource_size": 200,
+            "kind_count": {"document": 33, "video": 22}
+        }
+        with self._check_details(node=self.node) as details:
+            self.assertDetailsEqual(details, mock_get_details.return_value)
+
+        mock_get_details.assert_called_once_with(channel=self.channel)
+
+    @patch("contentcuration.views.nodes.getnodedetails_task")
+    def test_get_node_details__cached(self, task_mock):
+        # force the cache to update by adding a very old cache entry. Since Celery tasks run sync in the test suite,
+        # get_channel_details will return an updated cache value rather than generate it async.
+        self._set_cache(self.node, last_update=datetime.datetime(1990, 1, 1))
+
+        with self._check_details(node=self.node) as details:
+            # check cache was returned
+            self.assertDetailsEqual(details, self.default_details)
+            # Check that the outdated cache prompts an asynchronous cache update
+            task_mock.enqueue.assert_called_once_with(self.user, node_id=self.node.pk)
+
+    @patch("contentcuration.views.nodes.getnodedetails_task")
+    def test_get_node_details__cached__not_updated__no_enqueue(self, task_mock):
+        # nothing changed,
+        self.channel.main_tree.get_descendants(include_self=False).update(changed=False)
+        self._set_cache(self.node, last_update=datetime.datetime(1990, 1, 1))
+
+        with self._check_details(node=self.node) as details:
+            # check cache was returned
+            self.assertDetailsEqual(details, self.default_details)
+            task_mock.enqueue.assert_not_called()
+
+    @patch("contentcuration.views.nodes.getnodedetails_task")
+    def test_get_node_details__cached__no_enqueue(self, task_mock):
+        # test last update handling
+        self._set_cache(self.node, last_update=datetime.datetime(2099, 1, 1))
+
+        with self._check_details(node=self.node) as details:
+            # check cache was returned
+            self.assertDetailsEqual(details, self.default_details)
+            task_mock.enqueue.assert_not_called()
 
 
 class ChannelDetailsEndpointTestCase(BaseAPITestCase):


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->
- Updates the query that's used for validating the cache when querying a node's details
- No change in behavior was intended (even though there are lots of questions about this code https://github.com/learningequality/studio/issues/4123)
- Adds more robust tests to verify all scenarios of affected code

### Manual verification steps performed
1. Created regression tests
2. Verified new tests passed
3. Implemented changes
4. Verified tests passed
5. Updated tests and some logic further to simplify some queries, like repeated queries for the channel object

___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->
- Can you load the channel details?

### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->
- Do the tests make sense?


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->
Fixes https://github.com/learningequality/studio/issues/4795

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
