### PR TITLE
Conditionalize the JIT setting

### DIFF
--- a/contentcuration/contentcuration/signals.py
+++ b/contentcuration/contentcuration/signals.py
@@ -1,3 +1,4 @@
+from django.db.backends.postgresql.features import DatabaseFeatures
 from django.db.backends.signals import connection_created
 from django.dispatch import receiver
 
@@ -5,10 +6,13 @@ from django.dispatch import receiver
 @receiver(connection_created)
 def set_jit(sender, connection, **kwargs):
     """
-    Disable Just-In-Time compilation for PostgreSQL databases, at least until we can
+    Disable Just-In-Time compilation for PostgreSQL databases >= 11, at least until we can
     optimize its use.
     https://www.postgresql.org/docs/12/runtime-config-query.html#GUC-JIT
     """
     if connection.vendor == 'postgresql':
-        with connection.cursor() as cursor:
-            cursor.execute("SET jit = 'off';")
+        db_features = DatabaseFeatures(connection)
+        # JIT is new in v11, and for reference this returns True for v11 and following
+        if db_features.is_postgresql_11:
+            with connection.cursor() as cursor:
+                cursor.execute("SET jit = 'off';")


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- We need to rollback the hotfixes database to v9.6, but the JIT change showed clear benefit, so making this conditional to avoid breaking things still on 9.6

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/studio/pull/4834

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
### Local
I verified with no observed issues:

1. Started up devserver
2. Signed in
3. Created a new channel

### Remote
Verified in python shell that this works:
```
>>> from django.db.backends.postgresql.features import DatabaseFeatures
>>> f = DatabaseFeatures(connection)
>>> f.is_postgresql_12
True
>>> f.is_postgresql_13
False
>>> f.is_postgresql_11
True
```