### PR TITLE
Implemented Method to check page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -191,6 +191,7 @@
       fetch() {
         this.loading = true;
         this.loadFailed = false;
+        this.checkPageToLoad();
         this.fetchResultsDebounced();
         this.loadSavedSearches();
       },
@@ -224,6 +225,20 @@
       },
       toggleSelected(node) {
         this.$emit('change_selected', { nodes: [node], isSelected: !this.isSelected(node) });
+      },
+      checkPageToLoad() {
+        if (this.prevSearchTerm !== this.currentSearchTerm) {
+          this.prevSearchTerm = this.currentSearchTerm;
+          if (this.$route.query.page !== "1") { 
+            this.$router.push({
+              ...this.$route,
+              query: {
+                ...this.$route.query,
+                page: 1,
+              },
+            });
+          }
+        }
       },
     },
     $trs: {


### PR DESCRIPTION


## Summary
I have added a checkPageToLoad() Method in SearchResultsList.vue. 
This method makes sure that fresh searches always load with Page One. 

…

## References
Here is the issue link: https://github.com/learningequality/studio/issues/4813#issuecomment-2499005320

…

## Reviewer guidance
The reviewer, while trying to search for resources, should first search for a resource or keyword that will at least result in 11 search options and then navigate to page 2. Post navigating to page 2, the reviewer should search for something random that is likely to not produce any results. The fresh search will load with page one.  

…
