### PR TITLE
Adds check to the "Imported from" link to verify source nodes exist before attempting a navigation

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -354,15 +354,14 @@
               {{ $tr('resources') }}
             </div>
             <DetailsRow
-              v-if="isImported && importedChannelLink"
+              v-if="showImportedChannelLink"
               :label="$tr('originalChannel')"
             >
               <ActionLink
                 :text="importedChannelName"
-                :href="importedChannelLink"
                 truncate
                 notranslate
-                target="_blank"
+                @click="onClickImportedFrom()"
               />
             </DetailsRow>
             <DetailsRow :label="$tr('totalResources')">
@@ -395,15 +394,14 @@
               {{ $tr('source') }}
             </div>
             <DetailsRow
-              v-if="isImported && importedChannelLink"
+              v-if="showImportedChannelLink"
               :label="$tr('originalChannel')"
             >
               <ActionLink
                 :text="importedChannelName"
-                :href="importedChannelLink"
                 truncate
                 notranslate
-                target="_blank"
+                @click="onClickImportedFrom()"
               />
             </DetailsRow>
             <DetailsRow
@@ -661,6 +659,9 @@
       importedChannelName() {
         return this.node.original_channel_name;
       },
+      showImportedChannelLink() {
+        return this.isImported && this.importedChannelLink;
+      },
       sortedTags() {
         return orderBy(this.node.tags, ['count'], ['desc']);
       },
@@ -766,7 +767,7 @@
       this.tab = this.isExercise ? 'questions' : 'details';
     },
     methods: {
-      ...mapActions('contentNode', ['loadRelatedResources']),
+      ...mapActions('contentNode', ['loadContentNodes', 'loadRelatedResources']),
       ...mapActions('file', ['loadFiles']),
       ...mapActions('assessmentItem', ['loadNodeAssessmentItems']),
       getText(field) {
@@ -849,6 +850,23 @@
           }
         }
       },
+      onClickImportedFrom() {
+        if (this.showImportedChannelLink) {
+          const originalNodeId = this.node.original_source_node_id;
+          const originalChannelId = this.node.original_channel_id;
+          this.loadContentNodes({
+            '[node_id+channel_id]__in': [[originalNodeId, originalChannelId]],
+          }).then(nodes => {
+            if (nodes.length > 0) {
+              window.open(this.importedChannelLink, '_blank');
+            } else {
+              this.$store.dispatch('showSnackbar', {
+                text: this.$tr('sourceContentDoesntExist'),
+              });
+            }
+          });
+        }
+      },
     },
     $trs: {
       questions: 'Questions',
@@ -892,6 +910,8 @@
       noQuestionsError: 'Exercise is empty',
       incompleteQuestionError:
         '{count, plural, one {# incomplete question} other {# incomplete questions}}',
+      sourceContentDoesntExist:
+        'Source content no longer exists. Please contact your administrator.',
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr improves the user experience when a user clicks the "Imported from" link whose source content no longer exists (or has been deleted). A check is performed to ascertain that the source node  still exists before attempting to perform navigation.

https://github.com/user-attachments/assets/567fca16-c6c6-41ee-ae9e-56a5ae5ccc65

⚠ **i18n** ⚠ 
_Please note that this pr introduces a new string that will require translation before deployment to production. Adding @radinamatic as reviewer to keep track._

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #4828

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
⚠ **DO NOT do this in Production** ⚠ 

1. Import content from another channel
2. Delete the source content node
3. Click the 'Import from' link on the copy


