### PR TITLE
Fixes sorting order of trash items

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -201,7 +201,7 @@
         ];
       },
       items() {
-        return sortBy(this.getContentNodeChildren(this.trashId), 'modified').reverse();
+        return sortBy(this.getContentNodeChildren(this.trashId), 'modified');
       },
       backLink() {
         return {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes a pagination issue in the trashed items where newly shown resources are displayed on top of the page making it seems like nothing has happened on clicking the "Show more" button.

https://github.com/user-attachments/assets/979d6951-6f8a-4b17-ab92-3f33ca395d9b

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #4837

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Sign in to studio
2. Delete a large number of resources and open the channel's Trash page
3. Click on 'Show more'
4. Observe the behavior
