### PR TITLE
Hotfix: Centered the 'Show more' button in Import from other channels

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -223,4 +223,11 @@
 </script>
 
 
-<style scoped></style>
+<style scoped>
+.show-more-button-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 10px;
+}
+</style>


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR addresses **issue #4838**, where the 'Show more' button in the "Import from other channels" section was not centered.  

### Changes made:
- Updated the CSS in `ContentTreeList.vue` to center-align the 'Show more' button using `flexbox`.
- Verified manually to ensure proper alignment across different screen sizes and browsers.

### Before and After Screenshots:
#### Before:
![image](https://github.com/user-attachments/assets/22aed855-0260-4e95-9bcb-ee4f2e0c7f54)
#### After:
![Screenshot from 2024-12-22 18-43-31](https://github.com/user-attachments/assets/4ebf8800-5951-4586-9c31-8a3ebbb85f50)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
- **Fixes:** #4838
- No new dependencies or mockups are introduced in this PR.

---

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
To test the changes:
1. Navigate to the "Import from other channels" section in the application.
2. Verify that the 'Show more' button is centered as intended.
3. Test the UI alignment on various screen sizes to ensure responsiveness.
