### PR TITLE
Used KTextTruncator in ReviewSelectionsPage to avoid text collision

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
@@ -16,13 +16,18 @@
               <VFlex md5 sm12>
                 <VListTileContent>
                   <VListTileTitle>
-                    <KTextTruncator
+                    <ActionLink
                       class="subheading"
                       :class="getTitleClass(node)"
                       :text="getTitle(node)"
-                      :maxLines="1"
                       @click="preview(node)"
-                    />
+                    >
+                      
+                      <KTextTruncator
+                        :text="getTitle(node)"
+                        :maxLines="1"
+                      />
+                    </ActionLink>
                   </VListTileTitle>
                   <VListTileSubTitle v-if="node.kind === 'topic'">
                     {{ $tr('resourcesInTopic', { count: numberOfResources(node) }) }}
@@ -107,5 +112,6 @@
   /deep/ .v-list__tile {
     height: auto;
   }
+ 
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
@@ -22,7 +22,7 @@
                       :text="getTitle(node)"
                       @click="preview(node)"
                     >
-                      
+                    
                       <KTextTruncator
                         :text="getTitle(node)"
                         :maxLines="1"
@@ -112,6 +112,5 @@
   /deep/ .v-list__tile {
     height: auto;
   }
- 
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
@@ -16,10 +16,11 @@
               <VFlex md5 sm12>
                 <VListTileContent>
                   <VListTileTitle>
-                    <ActionLink
+                    <KTextTruncator
                       class="subheading"
                       :class="getTitleClass(node)"
                       :text="getTitle(node)"
+                      :maxLines="1"
                       @click="preview(node)"
                     />
                   </VListTileTitle>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Added KTextTruncator in ReviewSelectionsPage to avoid resource title collision with Channel name.
After Change:
![Screenshot from 2025-01-15 19-41-36](https://github.com/user-attachments/assets/cf9a949d-11d3-4264-aeb7-acd6bc081da4)


…

## References
Fixes issue #4086 

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…
