### PR TITLE
Migrate kradiobutton usages

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
@@ -24,15 +24,17 @@
     <div
       data-test="roles-options-list"
     >
-      <KRadioButton
-        v-for="rol in rolesOptions"
-        :key="rol.value"
-        v-model="selectedRol"
-        data-test="rol-radio-button"
-        :label="rol.label"
-        :value="rol.value"
-        :description="rol.description"
-      />
+      <KRadioButtonGroup>
+        <KRadioButton
+          v-for="rol in rolesOptions"
+          :key="rol.value"
+          v-model="selectedRol"
+          data-test="rol-radio-button"
+          :label="rol.label"
+          :value="rol.value"
+          :description="rol.description"
+        />
+      </KRadioButtonGroup>
     </div>
     <Divider />
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditAudienceModal.vue
@@ -31,7 +31,7 @@
           v-model="selectedRol"
           data-test="rol-radio-button"
           :label="rol.label"
-          :value="rol.value"
+          :buttonValue="rol.value"
           :description="rol.description"
         />
       </KRadioButtonGroup>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -36,14 +36,16 @@
       class="languages-options"
       data-test="language-options-list"
     >
-      <KRadioButton
-        v-for="language in languageOptions"
-        :key="language.id"
-        v-model="selectedLanguage"
-        :buttonValue="language.id"
-        :label="languageText(language)"
-        :labelDir="null"
-      />
+      <KRadioButtonGroup>
+        <KRadioButton
+          v-for="language in languageOptions"
+          :key="language.id"
+          v-model="selectedLanguage"
+          :buttonValue="language.id"
+          :label="languageText(language)"
+          :labelDir="null"
+        />
+      </KRadioButtonGroup>
       <p
         v-if="!languageOptions.length"
         :style="{ color: $themeTokens.annotation }"

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditAudienceModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/__tests__/EditAudienceModal.spec.js
@@ -14,8 +14,8 @@ const getRolesValues = wrapper => {
   const roles = {};
   const radioBtns = wrapper.findAll('[data-test="rol-radio-button"]');
   radioBtns.wrappers.forEach(checkbox => {
-    const { value, currentValue } = checkbox.vm.$props || {};
-    roles[value] = currentValue === value;
+    const { buttonValue, currentValue } = checkbox.vm.$props || {};
+    roles[buttonValue] = currentValue === buttonValue;
   });
   return roles;
 };

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -138,16 +138,18 @@
       </div>
       <label>{{ $tr('organizationalAffiliationLabel') }}</label>
     </div>
-    <KRadioButton
-      v-for="affiliation in affiliationOptions"
-      :key="affiliation.value"
-      v-model="org_or_personal"
-      :buttonValue="affiliation.value"
-      :invalid="errors.org_or_personal"
-      :showInvalidText="errors.org_or_personal"
-      :invalidText="$tr('fieldRequiredText')"
-      :label="affiliation.text"
-    />
+    <KRadioButtonGroup>
+      <KRadioButton
+        v-for="affiliation in affiliationOptions"
+        :key="affiliation.value"
+        v-model="org_or_personal"
+        :buttonValue="affiliation.value"
+        :invalid="errors.org_or_personal"
+        :showInvalidText="errors.org_or_personal"
+        :invalidText="$tr('fieldRequiredText')"
+        :label="affiliation.text"
+      />
+    </KRadioButtonGroup>
     <KTextbox
       v-model="organization"
       :invalid="errors.organization"
@@ -168,17 +170,19 @@
         {{ $tr('typeOfOrganizationLabel') }}
       </label>
     </div>
-    <KRadioButton
-      v-for="orgType in organizationTypeOptions"
-      :key="orgType.value"
-      v-model="organization_type"
-      :buttonValue="orgType.value"
-      :invalid="errors.organization_type"
-      :showInvalidText="errors.organization_type"
-      :invalidText="$tr('fieldRequiredText')"
-      :label="orgType.text"
-      :disabled="!orgSelected"
-    />
+    <KRadioButtonGroup>
+      <KRadioButton
+        v-for="orgType in organizationTypeOptions"
+        :key="orgType.value"
+        v-model="organization_type"
+        :buttonValue="orgType.value"
+        :invalid="errors.organization_type"
+        :showInvalidText="errors.organization_type"
+        :invalidText="$tr('fieldRequiredText')"
+        :label="orgType.text"
+        :disabled="!orgSelected"
+      />
+    </KRadioButtonGroup>
     <KTextbox
       v-model="organization_other"
       :invalid="errors.organization_other"
@@ -195,13 +199,15 @@
     <div class="mb-1">
       <label>{{ $tr('timelineLabel') }}</label>
     </div>
-    <KRadioButton
-      v-for="constraint in timeConstraintOptions"
-      :key="constraint.value"
-      v-model="time_constraint"
-      :buttonValue="constraint.value"
-      :label="constraint.text"
-    />
+    <KRadioButtonGroup>
+      <KRadioButton
+        v-for="constraint in timeConstraintOptions"
+        :key="constraint.value"
+        v-model="time_constraint"
+        :buttonValue="constraint.value"
+        :label="constraint.text"
+      />
+    </KRadioButtonGroup>
 
     <!-- Use case -->
     <div class="mb-1 mt-4">

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherModal.vue
@@ -8,14 +8,14 @@
     @submit="setLang"
   >
     <KGrid>
-      <KGridItem
-        v-for="(languageCol, index) in splitLanguageOptions"
-        :key="index"
-        :class="{ 'offset-col': $vuetify.smAndDown && index === 1 }"
-        :layout8="{ span: 4 }"
-        :layout12="{ span: 6 }"
-      >
-        <KRadioButtonGroup>
+      <KRadioButtonGroup>
+        <KGridItem
+          v-for="(languageCol, index) in splitLanguageOptions"
+          :key="index"
+          :class="{ 'offset-col': $vuetify.smAndDown && index === 1 }"
+          :layout8="{ span: 4 }"
+          :layout12="{ span: 6 }"
+        >
           <KRadioButton
             v-for="language in languageCol"
             :key="language.id"
@@ -25,8 +25,8 @@
             :title="language.english_name"
             class="language-name"
           />
-        </KRadioButtonGroup>
-      </KGridItem>
+        </KGridItem>
+      </KRadioButtonGroup>
     </KGrid>
 
   </KModal>

--- a/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/languageSwitcher/LanguageSwitcherModal.vue
@@ -15,15 +15,17 @@
         :layout8="{ span: 4 }"
         :layout12="{ span: 6 }"
       >
-        <KRadioButton
-          v-for="language in languageCol"
-          :key="language.id"
-          v-model="selectedLanguage"
-          :buttonValue="language.id"
-          :label="language.lang_name"
-          :title="language.english_name"
-          class="language-name"
-        />
+        <KRadioButtonGroup>
+          <KRadioButton
+            v-for="language in languageCol"
+            :key="language.id"
+            v-model="selectedLanguage"
+            :buttonValue="language.id"
+            :label="language.lang_name"
+            :title="language.english_name"
+            class="language-name"
+          />
+        </KRadioButtonGroup>
       </KGridItem>
     </KGrid>
 

--- a/contentcuration/contentcuration/frontend/shared/views/form/ExpandableSelect.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/ExpandableSelect.vue
@@ -36,13 +36,15 @@
     </h5>
     <div>
       <template v-if="!multiple">
-        <KRadioButton
-          v-for="option in options"
-          :key="option.value"
-          v-model="valueModel"
-          :buttonValue="option.value"
-          :label="option.text"
-        />
+        <KRadioButtonGroup>
+          <KRadioButton
+            v-for="option in options"
+            :key="option.value"
+            v-model="valueModel"
+            :buttonValue="option.value"
+            :label="option.text"
+          />
+        </KRadioButtonGroup>
       </template>
       <template v-else>
         <KCheckbox


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr wraps the `KRadioButtonGroup` around the `KRadioButton` as specified in the [design docs](https://design-system.learningequality.org/kradiobutton?filter=kRa). It also migrates the `KRadioButton` to use the `buttonValue` over the deprecated `value` prop.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #4869

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Test all areas in studio that used the KRadioButton to ensure no regressions
  - Change language
  - Edit language (bulk editing)
  - Edit audience (bulk editing)
  - Storage request form (`/settings/#/storage`)
- Run all frontend tests successfully
- Inspect the test logs to ensure there are no warning. For reference of the warnings, see #4869
