### PR TITLE
Migrate accounts section from less to scss

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -592,7 +592,7 @@
     display: flex;
     margin-left: 40px;
 
-    .span{
+    .span {
       margin-left: 2px;
       font-size: 16px;
     }

--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -562,15 +562,13 @@
 </script>
 
 
-<style lang="less" scoped>
+<style lang="scss" scoped>
 
   .v-text-field {
     margin-top: 8px !important;
   }
 
-  .policy-checkbox /deep/ .v-input__slot {
-    margin-bottom: 4px !important;
-
+  .policy-checkbox {
     label {
       color: var(--v-grey-darken1) !important;
     }
@@ -593,11 +591,11 @@
   .span-spacing {
     display: flex;
     margin-left: 40px;
-  }
 
-  .span-spacing span {
-    margin-left: 2px;
-    font-size: 16px;
+    .span{
+      margin-left: 2px;
+      font-size: 16px;
+    }
   }
 
   .span-spacing-email {

--- a/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Main.vue
@@ -206,20 +206,24 @@
 </script>
 
 
-<style lang="less" scoped>
+<style lang="scss" scoped>
 
   .main {
     overflow: auto;
-    /* stylelint-disable-next-line custom-property-pattern */
+    // stylelint-disable-next-line custom-property-pattern
     background-color: var(--v-backgroundColor-base);
   }
 
-  .links span:not(:last-child)::after {
-    margin: 0 8px 0 12px;
-    font-size: 14pt;
-    color: var(--v-grey-base);
-    vertical-align: middle;
-    content: '•';
+  .links {
+    span {
+      &:not(:last-child)::after {
+        margin: 0 8px 0 12px;
+        font-size: 14pt;
+        color: var(--v-grey-base);
+        vertical-align: middle;
+        content: '•';
+      }
+    }
   }
 
   .w-100 {

--- a/contentcuration/contentcuration/frontend/accounts/pages/activateAccount/RequestNewActivationLink.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/activateAccount/RequestNewActivationLink.vue
@@ -68,7 +68,7 @@
 
 </script>
 
-<style lang="less" scoped>
+<style lang="scss" scoped>
 
   .w-100 {
     width: 100%;

--- a/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ForgotPassword.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ForgotPassword.vue
@@ -69,7 +69,7 @@
 
 </script>
 
-<style lang="less" scoped>
+<style lang="scss" scoped>
 
   .w-100 {
     width: 100%;

--- a/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ResetPassword.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ResetPassword.vue
@@ -93,7 +93,7 @@
 
 </script>
 
-<style lang="less" scoped>
+<style lang="scss" scoped>
 
   .w-100 {
     width: 100%;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
This PR migrates the LESS used in the entire accounts section to SCSS.
- Main.vue 
- Create.vue
In Create.vue I removed unused styling that has been included previously. We can confirm that it's unused by looking at the browsers developer tools. There is no `.v-input__slot` deeply nested within `policy-checkbox` thereby ensuring us that it's unused and safe to remove.
<img width="1440" alt="Screenshot 2025-02-01 at 22 23 59" src="https://github.com/user-attachments/assets/1b94f2c5-edf7-488c-976c-109d23dc3309" />

- RequestNewActivationLink.vue
- ForgotPassword.vue
- ResetPassword.vue



…

## References

- https://github.com/learningequality/studio/issues/4827
- https://github.com/learningequality/studio/pull/4880

…
