### PR TITLE
Fix channel revision overwrite on frontend user session

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1116,10 +1116,16 @@ export const Session = new IndexedDBResource({
   async getSession() {
     return this.get(CURRENT_USER);
   },
-  setSession(currentUser) {
-    return this.table.put({ CURRENT_USER, ...currentUser });
+  async setSession(currentUser) {
+    return this.transaction({ mode: 'rw' }, CHANGES_TABLE, async () => {
+      const current = await this.getSession();
+      if (current) {
+        return this.updateSession(currentUser);
+      }
+      return this.table.put({ CURRENT_USER, ...currentUser });
+    });
   },
-  updateSession(currentUser) {
+  async updateSession(currentUser) {
     return this.update(CURRENT_USER, currentUser);
   },
 });

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -22,6 +22,9 @@ from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import CREATED
 
 
+CHANGE_RETURN_LIMIT = 200
+
+
 class SyncView(APIView):
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
@@ -104,7 +107,7 @@ class SyncView(APIView):
                 "table",
                 "change_type",
                 "kwargs"
-            ).order_by("server_rev")
+            ).order_by("server_rev")[:CHANGE_RETURN_LIMIT]
         )
 
         if not changes_to_return:


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Ensures the frontend user session isn't overwritten
- Adds limit to the number of changes that can be returned from the sync API

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/studio/issues/4896

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
See STR in issue
