### PR TITLE
Replace Material Icons with Kolibri Design System Icon

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -553,10 +553,6 @@
 
   .printing /deep/ * {
     font-family: 'Noto Sans', helvetica !important;
-
-    &.material-icons {
-      font-family: 'Material Icons' !important;
-    }
   }
 
   .v-toolbar__title {

--- a/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/details/Details.vue
@@ -553,6 +553,10 @@
 
   .printing /deep/ * {
     font-family: 'Noto Sans', helvetica !important;
+
+    &.material-icons {
+      font-family: 'Material Icons' !important;
+    }
   }
 
   .v-toolbar__title {

--- a/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
@@ -26,19 +26,15 @@
     </div>
     <svg
       v-else
-      viewBox="0 0 24 24"
+      viewBox="0 0 40 40"
       :aria-label="title"
       class="nothumbnail-image"
       :class="$isRTL ? 'rtl-image' : 'ltr-image'"
     >
-      <text
+    <KIcon icon="image" 
         :x="-1"
-        :y="y - 3"
-        :fill="$vuetify.theme.greyBorder"
-        class="material-icons notranslate v-icon"
-      >
-        image
-      </text>
+        :y="y - 14"
+        :style="{ fill: '#999999' }"  />
     </svg>
 
   </figure>

--- a/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
@@ -31,10 +31,12 @@
       class="nothumbnail-image"
       :class="$isRTL ? 'rtl-image' : 'ltr-image'"
     >
-    <KIcon icon="image" 
+      <KIcon
+        icon="image" 
         :x="-1"
         :y="y - 14"
-        :style="{ fill: '#999999' }"  />
+        :style="{ fill: '#999999' }"
+      />
     </svg>
 
   </figure>

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -52,26 +52,22 @@
       :aria-label="kindTitle"
       class="thumbnail-image"
     >
-      <text
-        :x="-1"
-        :y="y"
-        fill="#ffffff"
-        class="material-icons notranslate v-icon"
-      >{{ icon }}</text>
+    <KIcon icon="infoOutline" 
+        :x="+10"
+        :y="y+20"
+        :style="{ fill: '#ffffff' }"  />
     </svg>
     <svg
       v-else
-      viewBox="0 0 24 24"
+      viewBox="0 0 40 40"
       :aria-label="kindTitle"
       class="nothumbnail-image"
       :class="$isRTL ? 'rtl-image' : 'ltr-image'"
     >
-      <text
-        :x="-1"
-        :y="y - 3"
-        :fill="$vuetify.theme.greyBorder"
-        class="material-icons notranslate v-icon"
-      >image</text>
+    <KIcon icon="image" 
+        :x="-3"
+        :y="y - 14"
+        :style="{ fill: '#999999' }"  />
     </svg>
 
   </figure>

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -52,10 +52,12 @@
       :aria-label="kindTitle"
       class="thumbnail-image"
     >
-    <KIcon icon="infoOutline" 
+      <KIcon
+        icon="infoOutline" 
         :x="+10"
-        :y="y+20"
-        :style="{ fill: '#ffffff' }"  />
+        :y="y + 20"
+        :style="{ fill: '#ffffff' }"
+      />
     </svg>
     <svg
       v-else
@@ -64,10 +66,12 @@
       class="nothumbnail-image"
       :class="$isRTL ? 'rtl-image' : 'ltr-image'"
     >
-    <KIcon icon="image" 
+      <KIcon
+        icon="image" 
         :x="-3"
         :y="y - 14"
-        :style="{ fill: '#999999' }"  />
+        :style="{ fill: '#999999' }"
+      />
     </svg>
 
   </figure>

--- a/contentcuration/contentcuration/templates/base.html
+++ b/contentcuration/contentcuration/templates/base.html
@@ -122,11 +122,11 @@
       <!-- Navigation bar -->
     {% if INCIDENT %}
       <div id="emergency-banner" class="text-center main-banner {% if INCIDENT.readonly %}error-banner{% else %}warning-banner{% endif %}">
-        <i class="material-icons">error</i> {{INCIDENT.message | safe}}
+       {{INCIDENT.message | safe}}
       </div>
     {% elif DEPRECATED %}
       <div class="text-center main-banner warning-banner" id="redirect-banner">
-        <i class="material-icons">error</i> {% blocktrans %}Contentworkshop.learningequality.org has been deprecated. Please go to <a href="https://studio.learningequality.org">studio.learningequality.org</a> for the latest version of Studio{% endblocktrans %}
+        {% blocktrans %}Contentworkshop.learningequality.org has been deprecated. Please go to <a href="https://studio.learningequality.org">studio.learningequality.org</a> for the latest version of Studio{% endblocktrans %}
       </div>
     {% endif %}
     {% endblock nav %}


### PR DESCRIPTION


## Summary
Fixes: #4907 
This PR removes all instances of `material-icons` from the codebase and replaces them with corresponding icons from the [Kolibri Design System](https://design-system.learningequality.org/icons) where applicable. In cases where no direct replacement was available, the icons were removed (e.g., in `base.html`).

## Changes Made
- Replaced all usages of `material-icons` with equivalent Kolibri Design System icons.

```
<svg
      v-else
      viewBox="0 0 40 40"
      :aria-label="kindTitle"
      class="nothumbnail-image"
      :class="$isRTL ? 'rtl-image' : 'ltr-image'"
    >
    <KIcon icon="image" 
        :x="-3"
        :y="y - 14"
        :style="{ fill: '#999999' }"  />
    </svg>
```
### Before
![Screenshot 2025-02-14 at 11 56 37 PM](https://github.com/user-attachments/assets/59882783-45c0-4b7c-9bd7-9ec27f40c781)
### After
![Screenshot 2025-02-14 at 11 59 13 PM](https://github.com/user-attachments/assets/47d0113c-95fa-4558-b530-aed3b2a0d148)

```
<svg
      v-else-if="compact"
      viewBox="0 0 24 24"
      :aria-label="kindTitle"
      class="thumbnail-image"
    >
    <KIcon icon="infoOutline" 
        :x="+10"
        :y="y+20"
        :style="{ fill: '#ffffff' }"  />
    </svg>
```
### Before
![Screenshot 2025-02-14 at 11 58 18 PM](https://github.com/user-attachments/assets/81390a21-0e33-407a-8d16-d8d5112a5aa7)
### After
![Screenshot 2025-02-14 at 11 59 37 PM](https://github.com/user-attachments/assets/81ed7c94-58c6-433e-acde-d9c276896af0)

```
<svg
      v-else
      viewBox="0 0 40 40"
      :aria-label="title"
      class="nothumbnail-image"
      :class="$isRTL ? 'rtl-image' : 'ltr-image'"
    >
    <KIcon icon="image" 
        :x="-1"
        :y="y - 14"
        :style="{ fill: '#999999' }"  />
    </svg>
```
### Before 
![Screenshot 2025-02-15 at 12 10 53 AM](https://github.com/user-attachments/assets/945ff618-ec1b-40b0-8c70-2bb6dd323f76)
### After 
![Screenshot 2025-02-15 at 12 12 50 AM](https://github.com/user-attachments/assets/607e1f95-2659-4545-b2b8-3267e78a4019)

- Removed instances where material-icons were referenced but not actively used. in `base.html`
### Testing 

- Verified that all updated icons render correctly in the UI.
- Ensured no broken references remain in the code.
- Manually tested affected pages to confirm visual correctness.


- **Please feel free to share any suggestions or further changes you'd like me to make. I'm happy to update the PR as needed. Looking forward to your feedback!**





