### PR TITLE
Swap order of backends

### DIFF
--- a/contentcuration/contentcuration/utils/gcs_storage.py
+++ b/contentcuration/contentcuration/utils/gcs_storage.py
@@ -212,10 +212,10 @@ class GoogleCloudStorage(Storage):
 class CompositeGCS(Storage):
     def __init__(self):
         self.backends = []
+        self.backends.append(GoogleCloudStorage(_create_default_client(), settings.AWS_S3_BUCKET_NAME))
         # Only add the studio-content bucket (the production bucket) if we're not in production
         if settings.SITE_ID != settings.PRODUCTION_SITE_ID:
             self.backends.append(GoogleCloudStorage(Client.create_anonymous_client(), "studio-content"))
-        self.backends.append(GoogleCloudStorage(_create_default_client(), settings.AWS_S3_BUCKET_NAME))
 
     def _get_writeable_backend(self):
         """


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Corrects the order of backends: on a non-production server, we should check the non-production bucket first, to see if it has newer files. This shouldn't have a real effect on most storage since the files are stored by their checksum.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Original https://github.com/learningequality/studio/pull/4926


