### PR TITLE
Add more robust input sanitization to the upload_url endpoint

### DIFF
--- a/contentcuration/contentcuration/tests/test_sync.py
+++ b/contentcuration/contentcuration/tests/test_sync.py
@@ -417,7 +417,7 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         return {
             "size": 2500,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio_file",
+            "name": "le_studio_file",
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
         }

--- a/contentcuration/contentcuration/tests/test_sync.py
+++ b/contentcuration/contentcuration/tests/test_sync.py
@@ -417,7 +417,7 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         return {
             "size": 2500,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio_file",
+            "filename": "le_studio_file",
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
         }

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -349,7 +349,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
         }
 
     def test_required_keys(self):
-        del self.file["filename"]  # Changed key to "filename"
+        del self.file["filename"]  
     
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
@@ -374,7 +374,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
         file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio",  # Changed key to "filename"
+            "filename": "le_studio",  
             "file_format": "ppx",
             "preset": format_presets.AUDIO,
             "duration": 10.123
@@ -444,7 +444,7 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         return {
             "size": 2500,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio_file",  # Changed key to "filename"
+            "filename": "le_studio_file",  
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
         }

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -342,22 +342,19 @@ class UploadFileURLTestCase(StudioAPITestCase):
         self.file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio",      
+            "name": "le_studio",
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
             "duration": 10.123
         }
 
     def test_required_keys(self):
-        del self.file["name"]  
-    
+        del self.file["name"]
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
             reverse("file-upload-url"), self.file, format="json",
         )
-    
         self.assertEqual(response.status_code, 400)
-
 
     def test_duration_invalid(self):
         self.file["duration"] = '1.23'
@@ -374,7 +371,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
         file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio",  
+            "name": "le_studio",
             "file_format": "ppx",
             "preset": format_presets.AUDIO,
             "duration": 10.123
@@ -382,7 +379,6 @@ class UploadFileURLTestCase(StudioAPITestCase):
         response = self.client.post(
             reverse("file-upload-url"), file, format="json",
         )
-    
         self.assertEqual(response.status_code, 400)
 
     def test_invalid_preset_upload(self):
@@ -397,7 +393,6 @@ class UploadFileURLTestCase(StudioAPITestCase):
         }
         response = self.client.post(reverse("file-upload-url"), file, format="json")
         self.assertEqual(response.status_code, 400)
-    
 
     def test_insufficient_storage(self):
         self.file["size"] = 100000000000000
@@ -444,11 +439,10 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         return {
             "size": 2500,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio_file",  
+            "name": "le_studio_file",
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
         }
-    
 
     def _upload_file_to_contentnode(self, file_metadata=None, contentnode_id=None):
         """

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -342,21 +342,22 @@ class UploadFileURLTestCase(StudioAPITestCase):
         self.file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio",
+            "filename": "le_studio",      
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
             "duration": 10.123
         }
 
     def test_required_keys(self):
-        del self.file["name"]
-
+        del self.file["filename"]  # Changed key to "filename"
+    
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
             reverse("file-upload-url"), self.file, format="json",
         )
-
+    
         self.assertEqual(response.status_code, 400)
+
 
     def test_duration_invalid(self):
         self.file["duration"] = '1.23'
@@ -373,7 +374,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
         file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio",
+            "filename": "le_studio",  # Changed key to "filename"
             "file_format": "ppx",
             "preset": format_presets.AUDIO,
             "duration": 10.123
@@ -381,8 +382,22 @@ class UploadFileURLTestCase(StudioAPITestCase):
         response = self.client.post(
             reverse("file-upload-url"), file, format="json",
         )
-
+    
         self.assertEqual(response.status_code, 400)
+
+    def test_invalid_preset_upload(self):
+        self.client.force_authenticate(user=self.user)
+        file = {
+            "size": 1000,
+            "checksum": uuid.uuid4().hex,
+            "filename": "le_studio",
+            "file_format": file_formats.MP3,
+            "preset": "invalid_preset",  # Deliberately invalid
+            "duration": 10.123
+        }
+        response = self.client.post(reverse("file-upload-url"), file, format="json")
+        self.assertEqual(response.status_code, 400)
+    
 
     def test_insufficient_storage(self):
         self.file["size"] = 100000000000000
@@ -429,10 +444,11 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         return {
             "size": 2500,
             "checksum": uuid.uuid4().hex,
-            "name": "le_studio_file",
+            "filename": "le_studio_file",  # Changed key to "filename"
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
         }
+    
 
     def _upload_file_to_contentnode(self, file_metadata=None, contentnode_id=None):
         """

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -342,14 +342,14 @@ class UploadFileURLTestCase(StudioAPITestCase):
         self.file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio",      
+            "name": "le_studio",      
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
             "duration": 10.123
         }
 
     def test_required_keys(self):
-        del self.file["filename"]  
+        del self.file["name"]  
     
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
@@ -374,7 +374,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
         file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio",  
+            "name": "le_studio",  
             "file_format": "ppx",
             "preset": format_presets.AUDIO,
             "duration": 10.123
@@ -390,7 +390,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
         file = {
             "size": 1000,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio",
+            "name": "le_studio",
             "file_format": file_formats.MP3,
             "preset": "invalid_preset",  # Deliberately invalid
             "duration": 10.123
@@ -444,7 +444,7 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         return {
             "size": 2500,
             "checksum": uuid.uuid4().hex,
-            "filename": "le_studio_file",  
+            "name": "le_studio_file",  
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
         }

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -52,7 +52,7 @@ class FileUploadURLSerializer(serializers.Serializer):
       - duration: a number that will be floored to an integer and must be > 0
     """
     size = serializers.FloatField(required=True)
-    checksum = serializers.RegexField(regex=r'^[0-9a-fA-F]{32}$', required=True)
+    checksum = serializers.RegexField(regex=r'^[0-9a-f]{32}$', required=True)
     filename = serializers.CharField(required=True)
     file_format = serializers.ChoiceField(choices=file_formats.choices, required=True)
     preset = serializers.ChoiceField(choices=format_presets.choices, required=True)
@@ -199,9 +199,8 @@ class FileViewSet(BulkDeleteMixin, UpdateModelMixin, ReadOnlyValuesViewset):
     def upload_url(self, request):
         # Validate input using the new serializer
         serializer = FileUploadURLSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
-
+        serializer.is_valid(raise_exception=True)
+        
         validated_data = serializer.validated_data
         size = validated_data["size"]
         checksum = validated_data["checksum"]

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -4,9 +4,11 @@ import math
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest
 from le_utils.constants import file_formats
+from le_utils.constants import format_presets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework import serializers
 
 from contentcuration.models import AssessmentItem
 from contentcuration.models import Change
@@ -28,6 +30,39 @@ from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
 from contentcuration.viewsets.common import UUIDInFilter
 from contentcuration.viewsets.sync.constants import CONTENTNODE
 from contentcuration.viewsets.sync.utils import generate_update_event
+
+class StrictFloatField(serializers.FloatField):
+    def to_internal_value(self, data):
+        # If data is a string, reject it even if it represents a number.
+        if isinstance(data, str):
+            raise serializers.ValidationError("A valid number is required.")
+        return super().to_internal_value(data)
+
+# New Serializer for validating upload_url inputs
+class FileUploadURLSerializer(serializers.Serializer):
+    """
+    Serializer to validate inputs for the upload_url endpoint.
+    Required:
+      - size: a float value
+      - checksum: a 32-digit hex string
+      - filename: a string (note: mapped from request.data['name'])
+      - file_format: a valid file format choice from file_formats.choices
+      - preset: a valid preset choice from format_presets.choices
+    Optional:
+      - duration: a number that will be floored to an integer and must be > 0
+    """
+    size = serializers.FloatField(required=True)
+    checksum = serializers.RegexField(regex=r'^[0-9a-fA-F]{32}$', required=True)
+    filename = serializers.CharField(required=True)
+    file_format = serializers.ChoiceField(choices=file_formats.choices, required=True)
+    preset = serializers.ChoiceField(choices=format_presets.choices, required=True)
+    duration = StrictFloatField(required=False)
+
+    def validate_duration(self, value):
+        floored = math.floor(value)
+        if floored <= 0:
+            raise serializers.ValidationError("File duration is equal to or less than 0")
+        return floored
 
 
 class FileFilter(RequiredFilterSet):
@@ -162,26 +197,18 @@ class FileViewSet(BulkDeleteMixin, UpdateModelMixin, ReadOnlyValuesViewset):
 
     @action(detail=False, methods=["post"])
     def upload_url(self, request):
-        try:
-            size = request.data["size"]
-            checksum = request.data["checksum"]
-            filename = request.data["name"]
-            file_format = request.data["file_format"]
-            preset = request.data["preset"]
-        except KeyError:
-            return HttpResponseBadRequest(
-                reason="Must specify: size, checksum, name, file_format, and preset"
-            )
+        # Validate input using the new serializer
+        serializer = FileUploadURLSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
 
-        duration = request.data.get("duration")
-        if duration is not None:
-            if not isinstance(duration, (int, float)):
-                return HttpResponseBadRequest(reason="File duration must be a number")
-            duration = math.floor(duration)
-            if duration <= 0:
-                return HttpResponseBadRequest(
-                    reason="File duration is equal to or less than 0"
-                )
+        validated_data = serializer.validated_data
+        size = validated_data["size"]
+        checksum = validated_data["checksum"]
+        filename = validated_data["filename"]
+        file_format = validated_data["file_format"]
+        preset = validated_data["preset"]
+        duration = validated_data.get("duration")
 
         try:
             request.user.check_space(float(size), checksum)
@@ -202,9 +229,6 @@ class FileViewSet(BulkDeleteMixin, UpdateModelMixin, ReadOnlyValuesViewset):
         retval = get_presigned_upload_url(
             filepath, checksum_base64, 600, content_length=size
         )
-
-        if file_format not in dict(file_formats.choices):
-            return HttpResponseBadRequest("Invalid file_format!")
 
         file = File(
             file_size=size,

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -45,7 +45,7 @@ class FileUploadURLSerializer(serializers.Serializer):
     Required:
       - size: a float value
       - checksum: a 32-digit hex string
-      - filename: a string (note: mapped from request.data['name'])
+      - name: a string (note: mapped from request.data['name'])
       - file_format: a valid file format choice from file_formats.choices
       - preset: a valid preset choice from format_presets.choices
     Optional:
@@ -53,7 +53,7 @@ class FileUploadURLSerializer(serializers.Serializer):
     """
     size = serializers.FloatField(required=True)
     checksum = serializers.RegexField(regex=r'^[0-9a-f]{32}$', required=True)
-    filename = serializers.CharField(required=True)
+    name = serializers.CharField(required=True)
     file_format = serializers.ChoiceField(choices=file_formats.choices, required=True)
     preset = serializers.ChoiceField(choices=format_presets.choices, required=True)
     duration = StrictFloatField(required=False)
@@ -204,7 +204,7 @@ class FileViewSet(BulkDeleteMixin, UpdateModelMixin, ReadOnlyValuesViewset):
         validated_data = serializer.validated_data
         size = validated_data["size"]
         checksum = validated_data["checksum"]
-        filename = validated_data["filename"]
+        name = validated_data["name"]
         file_format = validated_data["file_format"]
         preset = validated_data["preset"]
         duration = validated_data.get("duration")
@@ -220,7 +220,7 @@ class FileViewSet(BulkDeleteMixin, UpdateModelMixin, ReadOnlyValuesViewset):
         might_skip = File.objects.filter(checksum=checksum).exists()
 
         filepath = generate_object_storage_name(
-            checksum, filename, default_ext=file_format
+            checksum, name, default_ext=file_format
         )
         checksum_base64 = codecs.encode(
             codecs.decode(checksum, "hex"), "base64"
@@ -232,7 +232,7 @@ class FileViewSet(BulkDeleteMixin, UpdateModelMixin, ReadOnlyValuesViewset):
         file = File(
             file_size=size,
             checksum=checksum,
-            original_filename=filename,
+            original_filename=name,
             file_on_disk=filepath,
             file_format_id=file_format,
             preset_id=preset,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR fixes an issue where the `upload_url` endpoint was not properly sanitizing inputs, resulting in a possible `IntegrityError` on the `contentcuration_file` table (related to `preset_id` foreign key constraints).  

**Key changes include:**
- Created a new `FileUploadURLSerializer` to validate `size`, `checksum`, `filename`, `file_format`, `preset`, and `duration`.
- Added a custom `StrictFloatField` to ensure `duration` must be numeric (int/float) rather than a string.
- Updated the test suite (`test_file.py`) to:
  - Use `"filename"` instead of `"name"`.
  - Add a new test for invalid presets.
  - Verify that string-based durations receive a `400` error.
- Ensured that large file sizes still trigger a `412` error for insufficient storage.

**Manual Verification Steps:**
1. Manually tested endpoint by sending requests with missing fields, invalid `preset`, and invalid `duration` (string vs. numeric) to confirm appropriate `400` or `412` errors.
2. Verified successful uploads with valid data return `200`.
3. Ran all tests with `pytest contentcuration/contentcuration/tests/viewsets/test_file.py` and confirmed they pass.

_No UI changes were introduced, so no screenshots are needed._

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Addresses Issue #4925 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

 **Run Tests:**  
   ```bash
   pytest contentcuration/contentcuration/tests/viewsets/test_file.py
