### PR TITLE
Include Contains content from field in CSV export

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/mixins.js
@@ -28,6 +28,7 @@ const exportStrings = createTranslator('ChannelExportStrings', {
   aggregators: 'Aggregators',
   licenses: 'Licenses',
   copyrightHolders: 'Copyright holders',
+  containsContentFrom: 'Contains content from',
   yes: 'Yes',
   no: 'No',
   downloadFilename: '{year}_{month}_Kolibri_Content_Library',
@@ -99,6 +100,7 @@ export const channelExportMixin = {
         this.exportStrings.$tr('aggregators'),
         this.exportStrings.$tr('licenses'),
         this.exportStrings.$tr('copyrightHolders'),
+        this.exportStrings.$tr('containsContentFrom'),
       ];
       const csv = Papa.unparse({
         fields: headers,
@@ -125,6 +127,7 @@ export const channelExportMixin = {
           channel.aggregators,
           channel.licenses,
           channel.copyright_holders,
+          channel.original_channels ? channel.original_channels.map(ch => ch.name).join(', ') : '',
         ]),
       });
       const blob = new Blob([csv], {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- I have added the "Contains content from" field to the CSV export functionality to ensure consistency across all export methods. This enhancement addresses a UX gap where this information was displayed on the channel details page and PDF export but was missing from the CSV export.
- The implementation extracts channel names from the original_channels array for each channel and formats them as a comma-separated list in the new CSV column. This matches the visual presentation shown in the Details page, making the data consistent across all views and exports.
- Manual verification was performed by creating and exporting a test channel that imports content from other channels, confirming that the exported CSV properly includes the new column with expected values.

**Relevant Images** -->
![image](https://github.com/user-attachments/assets/9db23256-cb8f-46fd-a220-1a13594afa6d)
![image](https://github.com/user-attachments/assets/33900b51-1cd6-401e-ac70-cb6b2a997d14)

**NOTE** --> In case where channel doesn't import content from other published channel , this field would be empty like below one.
![image](https://github.com/user-attachments/assets/14d98716-cb64-4384-995f-a2da367446f2)
![image](https://github.com/user-attachments/assets/32dcebb4-8f04-4657-8761-29f5fe869019)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Addresses #3198 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test this change:

- Set up a local instance with at least two channels, where one channel imports content from the other
- Navigate to the channel listing page
- Export the channel list as CSV
- Verify the "Contains content from" column appears in the CSV export
- Verify the column shows the correct channel names for channels with imported content

Also check that channels without imported content display an empty field for this column
