### PR TITLE
Save numerical input answers

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -389,10 +389,6 @@
         }
       },
       updateAnswerText(newAnswerText, answerIdx) {
-        if (newAnswerText === this.answers[answerIdx].answer) {
-          return;
-        }
-
         const updatedAnswers = [...this.answers];
         updatedAnswers[answerIdx].answer = newAnswerText;
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AnswersEditor/AnswersEditor.vue
@@ -63,6 +63,7 @@
                       class="answer-number"
                       type="number"
                       :rules="[numericRule]"
+                      @change="updateAnswerText($event, answerIdx)"
                     />
                     <VTextField v-else :value="answer.answer" class="no-border" type="number" />
                   </div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes a bug where a numeric input answer is not saved and question is marked as incomplete after closing the exercise editor.

**Before**

https://github.com/user-attachments/assets/c510ea9f-884b-4c82-a4a7-cbecc7a70095

**After**

https://github.com/user-attachments/assets/c00bc6f7-eca5-4b0f-8b07-a77dea4693a4

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #4910

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Select Numeric input type of question in the exercise editor.
2. Add 1 answer and close the editor.
3. Reopen the exercise and ensure the ❗ mark indicating the incomplete question is not displayed
4. Try different variations as illustrated in the before video to check if the issue can be replicated
