### PR TITLE
Allow duration to be nullable, but only for non-media file types.

### DIFF
--- a/contentcuration/contentcuration/tests/test_sync.py
+++ b/contentcuration/contentcuration/tests/test_sync.py
@@ -418,6 +418,7 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
             "name": "le_studio_file",
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
+            "duration": 17,
         }
 
     def _upload_file_to_contentnode(self, file_metadata=None, contentnode_id=None):

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -364,6 +364,50 @@ class UploadFileURLTestCase(StudioAPITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_duration_missing(self):
+        del self.file["duration"]
+        self.file["file_format"] = file_formats.EPUB
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"), self.file, format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_duration_missing_but_required(self):
+        del self.file["duration"]
+        self.file["file_format"] = file_formats.MP4
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"), self.file, format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_duration_null(self):
+        self.file["duration"] = None
+        self.file["file_format"] = file_formats.EPUB
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"), self.file, format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_duration_null_but_required(self):
+        self.file["duration"] = None
+        self.file["file_format"] = file_formats.MP4
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"), self.file, format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
     def test_invalid_file_format_upload(self):
         self.client.force_authenticate(user=self.user)
         file = {
@@ -440,6 +484,7 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
             "name": "le_studio_file",
             "file_format": file_formats.MP3,
             "preset": format_presets.AUDIO,
+            "duration": 17,
         }
 
     def _upload_file_to_contentnode(self, file_metadata=None, contentnode_id=None):
@@ -541,7 +586,9 @@ class ContentIDTestCase(SyncTestMixin, StudioAPITestCase):
         thumbnail_file_meta_1 = self._get_file_metadata()
         thumbnail_file_meta_2 = self._get_file_metadata()
         thumbnail_file_meta_1.update({"preset": format_presets.AUDIO_THUMBNAIL, "file_format": file_formats.JPEG, })
+        del thumbnail_file_meta_1["duration"]
         thumbnail_file_meta_2.update({"preset": format_presets.AUDIO_THUMBNAIL, "file_format": file_formats.JPEG, })
+        del thumbnail_file_meta_2["duration"]
 
         # Upload thumbnail to original contentnode and copied contentnode.
         # content_id should remain same for both these nodes.

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -58,13 +58,21 @@ class FileUploadURLSerializer(serializers.Serializer):
     name = serializers.CharField(required=True)
     file_format = serializers.ChoiceField(choices=file_formats.choices, required=True)
     preset = serializers.ChoiceField(choices=format_presets.choices, required=True)
-    duration = StrictFloatField(required=False)
+    duration = StrictFloatField(required=False, allow_null=True)
 
     def validate_duration(self, value):
+        if value is None:
+            return None
         floored = math.floor(value)
         if floored <= 0:
             raise serializers.ValidationError("File duration is equal to or less than 0")
         return floored
+
+    def validate(self, attrs):
+        if attrs["file_format"] in {file_formats.MP4, file_formats.WEBM, file_formats.MP3}:
+            if "duration" not in attrs or attrs["duration"] is None:
+                raise serializers.ValidationError("Duration is required for audio/video files")
+        return attrs
 
 
 class FileFilter(RequiredFilterSet):


### PR DESCRIPTION
## Summary
* Updates the new FileUploadSerializer to let the duration field be nullable
* Adds additional validation check to ensure that it is not null or non-existent for MP4, WEBM, and MP3 files
* Adds tests to ensure behaviour.
* Updates existing tests that violated these restrictions.

## References
Fixes #4955

## Reviewer guidance
Can you upload video and audio files? Can you upload non-video and non-audio files?
