### PR TITLE
Fixed issue #4757 by modying ContextMenuCloak.vue

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue
@@ -28,6 +28,12 @@
         return !this.disabled && this.currentContextMenu === this._uid;
       },
     },
+    mounted() {
+      document.addEventListener('click', this.hideMenu);
+    },
+    beforeDestroy() {
+      document.removeEventListener('click', this.hideMenu);
+    },
     methods: {
       ...mapMutations('contextMenu', { setMenu: 'SET_CONTEXT_MENU' }),
       showMenu(e) {
@@ -37,8 +43,14 @@
         this.y = e.clientY;
         this.setMenu(this._uid);
       },
+      hideMenu(e) {
+        if (this.currentContextMenu && !this.$el.contains(e.target)) {
+          this.setMenu('');
+        }
+      },
       extendSlot,
     },
+
     render() {
       if (this.disabled) {
         return this.extendSlot('default');


### PR DESCRIPTION
##Summary
Added an event listener to ContextMenuCloak such that menu variables are reset on right click and menu is displayed.

…

##References
In response to issue: https://github.com/learningequality/studio/issues/4757

…

##Reviewer guidance
Reviewer can look through the code for file kolibri_studio/contentcuration/contentcuration/frontend/shared/views/ContextMenuCloak.vue where an eventlistener object has been added to reset variables. Reviewer can go to a dummy channel and repeatedly right click on the channel resources to make sure context menu is displayed every time.
