### PR TITLE
Add survey completion option for exercise

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -288,7 +288,7 @@ export const CompletionOptionsDropdownMap = {
   [ContentKindsNames.EXERCISE]: [
     CompletionDropdownMap.goal,
     CompletionDropdownMap.practiceQuiz,
-    CompletionDropdownMap.survey
+    CompletionDropdownMap.survey,
   ],
   [ContentKindsNames.HTML5]: [
     CompletionDropdownMap.completeDuration,

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -202,6 +202,7 @@ export const FeatureFlagKeys = Object.keys(FeatureFlagsSchema.properties).reduce
 
 export const ContentModalities = {
   QUIZ: 'QUIZ',
+  SURVEY: 'SURVEY',
 };
 
 export const AccessibilityCategoriesMap = {

--- a/contentcuration/contentcuration/frontend/shared/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/constants.js
@@ -223,6 +223,7 @@ export const CompletionDropdownMap = {
   goal: 'goal',
   practiceQuiz: 'practiceQuiz',
   reference: 'reference',
+  survey: 'survey',
 };
 
 export const DurationDropdownMap = {
@@ -284,7 +285,11 @@ export const CompletionOptionsDropdownMap = {
     CompletionDropdownMap.completeDuration,
     CompletionDropdownMap.reference,
   ],
-  [ContentKindsNames.EXERCISE]: [CompletionDropdownMap.goal, CompletionDropdownMap.practiceQuiz],
+  [ContentKindsNames.EXERCISE]: [
+    CompletionDropdownMap.goal,
+    CompletionDropdownMap.practiceQuiz,
+    CompletionDropdownMap.survey
+  ],
   [ContentKindsNames.HTML5]: [
     CompletionDropdownMap.completeDuration,
     CompletionDropdownMap.determinedByResource,

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -261,6 +261,10 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
     context:
       'One of the completion criteria types specific to exercises. An exercise with this criteria represents a quiz.',
   },
+  survey: {
+    message: 'Survey',
+    context: 'One of the completion criteria types specific to exercises. An exercise with this criteria represents a survey.',
+  },
 
   // Learning Activities
   all: {

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -263,7 +263,8 @@ export const metadataStrings = createTranslator('CommonMetadataStrings', {
   },
   survey: {
     message: 'Survey',
-    context: 'One of the completion criteria types specific to exercises. An exercise with this criteria represents a survey.',
+    context:
+      'One of the completion criteria types specific to exercises. An exercise with this criteria represents a survey.',
   },
 
   // Learning Activities

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -105,6 +105,7 @@
 <script>
 
   import get from 'lodash/get';
+  import { mapGetters } from 'vuex/dist/vuex.common.js';
   import ActivityDuration from './ActivityDuration';
   import MasteryCriteriaGoal from './MasteryCriteriaGoal';
   import MasteryCriteriaMofNFields from './MasteryCriteriaMofNFields';
@@ -173,6 +174,7 @@
       },
     },
     computed: {
+      ...mapGetters(['hasFeatureEnabled']),
       notUnique() {
         return this.value === nonUniqueValue;
       },
@@ -199,9 +201,6 @@
           return showDropDown;
         }
         return false;
-      },
-      allowSurvey() {
-        return this.$store.getters.hasFeatureEnabled(FeatureFlagKeys.survey);
       },
       audioVideoResource() {
         return this.kind === ContentKindsNames.AUDIO || this.kind === ContentKindsNames.VIDEO;
@@ -242,7 +241,6 @@
         },
         set(value) {
           const update = {};
-
           if (value === CompletionDropdownMap.reference) {
             update.model = CompletionCriteriaModels.REFERENCE;
             update.durationType = null;
@@ -275,7 +273,7 @@
             update.modality = null;
             update.model = CompletionCriteriaModels.MASTERY;
           } else if (value === CompletionDropdownMap.survey) {
-            update.modality = ContentModalities.survey;
+            update.modality = ContentModalities.SURVEY;
             update.threshold = { mastery_model: MasteryModelsNames.DO_ALL };
           }
           this.handleInput(update);
@@ -381,13 +379,14 @@
         },
       },
       showCorrectCompletionOptions() {
+
         if (this.kind) {
           return CompletionOptionsDropdownMap[this.kind]
             .map(model => ({
               text: this.translateMetadataString(model),
               value: CompletionDropdownMap[model],
             }))
-            .filter(option => !(option.value === 'survey' && !this.allowSurvey));
+            .filter(option => !(option.value === 'survey' && !this.hasFeatureEnabled(FeatureFlagKeys.survey)));
         }
         return [];
       },

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -379,14 +379,16 @@
         },
       },
       showCorrectCompletionOptions() {
-
         if (this.kind) {
           return CompletionOptionsDropdownMap[this.kind]
             .map(model => ({
               text: this.translateMetadataString(model),
               value: CompletionDropdownMap[model],
             }))
-            .filter(option => !(option.value === 'survey' && !this.hasFeatureEnabled(FeatureFlagKeys.survey)));
+            .filter(
+              option =>
+                !(option.value === 'survey' && !this.hasFeatureEnabled(FeatureFlagKeys.survey))
+            );
         }
         return [];
       },

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -256,6 +256,9 @@
           } else if (value === CompletionDropdownMap.goal) {
             update.modality = null;
             update.model = CompletionCriteriaModels.MASTERY;
+          } else if (value === CompletionDropdownMap.survey){
+            update.modality = ContentModalities.QUIZ;
+            update.threshold = { mastery_model: MasteryModelsNames.DO_ALL };
           }
           this.handleInput(update);
         },

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -190,8 +190,10 @@
           //this ensures that anytime the completion dropdown is practice quiz or
           // survey we dont show the mastery criteria goal dropdown
           let showDropDown = true;
-          if (this.value.modality === ContentModalities.QUIZ ||
-          this.value.modality === ContentModalities.SURVEY) {
+          if (
+            this.value.modality === ContentModalities.QUIZ ||
+            this.value.modality === ContentModalities.SURVEY
+          ) {
             showDropDown = false;
           }
           return showDropDown;
@@ -233,8 +235,7 @@
           if (
             this.value.modality === ContentModalities.SURVEY &&
             this.model === CompletionCriteriaModels.MASTERY
-          )
-          {
+          ) {
             return CompletionDropdownMap.survey;
           }
           return completionCriteriaToDropdownMap[this.model];

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -187,8 +187,14 @@
       },
       showMasteryCriteriaGoalDropdown() {
         if (this.kind === ContentKindsNames.EXERCISE) {
-          //this ensures that anytime the completion dropdown is practice quiz
-          return this.value.modality !== ContentModalities.QUIZ;
+          //this ensures that anytime the completion dropdown is practice quiz or
+          // survey we dont show the mastery criteria goal dropdown
+          let showDropDown = true;
+          if (this.value.modality === ContentModalities.QUIZ ||
+          this.value.modality === ContentModalities.SURVEY) {
+            showDropDown = false;
+          }
+          return showDropDown;
         }
         return false;
       },
@@ -223,6 +229,13 @@
             this.model === CompletionCriteriaModels.MASTERY
           ) {
             return CompletionDropdownMap.practiceQuiz;
+          }
+          if (
+            this.value.modality === ContentModalities.SURVEY &&
+            this.model === CompletionCriteriaModels.MASTERY
+          )
+          {
+            return CompletionDropdownMap.survey;
           }
           return completionCriteriaToDropdownMap[this.model];
         },
@@ -261,7 +274,7 @@
             update.modality = null;
             update.model = CompletionCriteriaModels.MASTERY;
           } else if (value === CompletionDropdownMap.survey) {
-            update.modality = ContentModalities.QUIZ;
+            update.modality = ContentModalities.survey;
             update.threshold = { mastery_model: MasteryModelsNames.DO_ALL };
           }
           this.handleInput(update);
@@ -285,6 +298,9 @@
           return false;
         }
         if (this.value.modality === ContentModalities.QUIZ) {
+          return false;
+        }
+        if (this.value.modality === ContentModalities.SURVEY) {
           return false;
         }
         return get(this, 'threshold.mastery_model') === MasteryModelsNames.M_OF_N;

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/index.vue
@@ -119,6 +119,7 @@
     completionCriteriaToDropdownMap,
     defaultCompletionCriteriaModels,
     defaultCompletionCriteriaThresholds,
+    FeatureFlagKeys,
   } from 'shared/constants';
   import { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
   import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
@@ -191,6 +192,9 @@
         }
         return false;
       },
+      allowSurvey() {
+        return this.$store.getters.hasFeatureEnabled(FeatureFlagKeys.survey);
+      },
       audioVideoResource() {
         return this.kind === ContentKindsNames.AUDIO || this.kind === ContentKindsNames.VIDEO;
       },
@@ -256,7 +260,7 @@
           } else if (value === CompletionDropdownMap.goal) {
             update.modality = null;
             update.model = CompletionCriteriaModels.MASTERY;
-          } else if (value === CompletionDropdownMap.survey){
+          } else if (value === CompletionDropdownMap.survey) {
             update.modality = ContentModalities.QUIZ;
             update.threshold = { mastery_model: MasteryModelsNames.DO_ALL };
           }
@@ -361,10 +365,12 @@
       },
       showCorrectCompletionOptions() {
         if (this.kind) {
-          return CompletionOptionsDropdownMap[this.kind].map(model => ({
-            text: this.translateMetadataString(model),
-            value: CompletionDropdownMap[model],
-          }));
+          return CompletionOptionsDropdownMap[this.kind]
+            .map(model => ({
+              text: this.translateMetadataString(model),
+              value: CompletionDropdownMap[model],
+            }))
+            .filter(option => !(option.value === 'survey' && !this.allowSurvey));
         }
         return [];
       },

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/__tests__/completionOptions.spec.js
@@ -1,19 +1,31 @@
 import Vue from 'vue';
 import Vuetify from 'vuetify';
 import { shallowMount, mount } from '@vue/test-utils';
+import Vuex from 'vuex';
 import CompletionOptions from '../CompletionOptions';
 import { CompletionCriteriaModels } from 'shared/constants';
 
 Vue.use(Vuetify);
+Vue.use(Vuex);
+let store;
 
 describe('CompletionOptions', () => {
+  beforeEach(() => {
+    store = new Vuex.Store({
+        getters: {
+            hasFeatureEnabled: () => () => true
+        },
+    });
+  });
   it('smoke test', () => {
-    const wrapper = shallowMount(CompletionOptions);
+    const wrapper = shallowMount(CompletionOptions,  {store,});
     expect(wrapper.isVueInstance()).toBe(true);
   });
   describe(`completion dropdown`, () => {
     it(`renders the completion dropdown`, () => {
-      const wrapper = mount(CompletionOptions);
+      const wrapper = mount(CompletionOptions,
+        {store,}
+      );
       const dropdown = wrapper.find({ ref: 'completion' });
       expect(dropdown.exists()).toBe(true);
     });
@@ -147,6 +159,7 @@ describe('CompletionOptions', () => {
       describe(`exercise`, () => {
         it(`'When goal is met' should be displayed by default`, () => {
           const wrapper = mount(CompletionOptions, {
+            store,
             propsData: {
               kind: 'exercise',
               value: { model: null, threshold: { m: null, n: null } },
@@ -195,6 +208,7 @@ describe('CompletionOptions', () => {
       describe(`exercise`, () => {
         it(`Goal and MofN components should not be displayed when 'Practice Quiz' is selected`, async () => {
           const wrapper = mount(CompletionOptions, {
+            store,
             propsData: {
               kind: 'exercise',
               value: { model: 'mastery', threshold: { m: 3, n: 5 }, modality: 'QUIZ' },
@@ -233,6 +247,7 @@ describe('CompletionOptions', () => {
       });
       it(`duration dropdown is hidden by default for documents`, () => {
         const wrapper = mount(CompletionOptions, {
+          store,
           propsData: {
             kind: 'document',
             value: { suggested_duration: null },
@@ -243,6 +258,7 @@ describe('CompletionOptions', () => {
       });
       it(`duration dropdown is hidden by default for exercises`, () => {
         const wrapper = mount(CompletionOptions, {
+          store,
           propsData: {
             kind: 'exercise',
             value: { model: 'mastery', threshold: { m: 3, n: 5 }, suggested_duration: null },
@@ -253,6 +269,7 @@ describe('CompletionOptions', () => {
       });
       it(`'Reference' is disabled for exercises`, async () => {
         const wrapper = mount(CompletionOptions, {
+          store,
           propsData: {
             kind: 'exercise',
             value: { model: 'mastery', threshold: { m: 3, n: 5 } },

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/__tests__/completionOptions.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/__tests__/completionOptions.spec.js
@@ -12,20 +12,18 @@ let store;
 describe('CompletionOptions', () => {
   beforeEach(() => {
     store = new Vuex.Store({
-        getters: {
-            hasFeatureEnabled: () => () => true
-        },
+      getters: {
+        hasFeatureEnabled: () => () => true,
+      },
     });
   });
   it('smoke test', () => {
-    const wrapper = shallowMount(CompletionOptions,  {store,});
+    const wrapper = shallowMount(CompletionOptions, { store });
     expect(wrapper.isVueInstance()).toBe(true);
   });
   describe(`completion dropdown`, () => {
     it(`renders the completion dropdown`, () => {
-      const wrapper = mount(CompletionOptions,
-        {store,}
-      );
+      const wrapper = mount(CompletionOptions, { store });
       const dropdown = wrapper.find({ ref: 'completion' });
       expect(dropdown.exists()).toBe(true);
     });

--- a/contentcuration/contentcuration/static/feature_flags.json
+++ b/contentcuration/contentcuration/static/feature_flags.json
@@ -13,6 +13,11 @@
       "type": "boolean",
       "title":"Test AI feature",
       "description": "Allow user access to AI features"
+    },
+    "survey":{
+      "type": "boolean",
+      "title":"Test Survey feature",
+      "description": "Allow user access to Survey"
     }
   },
   "examples": [

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -288,7 +288,7 @@ class CompletionCriteriaSerializer(JSONFieldDictSerializer):
 
 
 class ExtraFieldsOptionsSerializer(JSONFieldDictSerializer):
-    modality = ChoiceField(choices=(("QUIZ", "Quiz"),), allow_null=True, required=False)
+    modality = ChoiceField(choices=(("QUIZ", "Quiz"),("SURVEY","Survey")), allow_null=True, required=False)
     completion_criteria = CompletionCriteriaSerializer(required=False)
 
 


### PR DESCRIPTION
## Summary
- Adds an option for survey type for completion in exercise UI.
- add a feature flag for the new survey feature.
![image](https://github.com/user-attachments/assets/75c56a70-ace9-4ab4-8d63-48d54f1efd2a)

## References
closes #4875


## Reviewer guidance
- Enable the survey feature flag for one of the example users.
- Login with that user and create an exercise.
- Check that there is an option to set completion as survey.  

