### PR TITLE
Use CTE to get user server rev

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -415,6 +415,18 @@ class User(AbstractBaseUser, PermissionsMixin):
         if changed:
             self.save()
 
+    def get_server_rev(self):
+        changes_cte = With(
+            Change.objects.filter(user=self).values("server_rev", "applied"),
+        )
+        return (
+            changes_cte.queryset()
+            .with_cte(changes_cte)
+            .filter(applied=True)
+            .values_list("server_rev", flat=True)
+            .order_by("-server_rev").first()
+        ) or 0
+
     class Meta:
         verbose_name = "User"
         verbose_name_plural = "Users"

--- a/contentcuration/contentcuration/tests/test_models.py
+++ b/contentcuration/contentcuration/tests/test_models.py
@@ -962,6 +962,28 @@ class UserTestCase(StudioTestCase):
         user_hard_delete_history = UserHistory.objects.filter(user_id=user.id, action=user_history.RELATED_DATA_HARD_DELETION).first()
         self.assertIsNotNone(user_hard_delete_history)
 
+    def test_get_server_rev(self):
+        user = testdata.user()
+
+        def create_change(server_rev, applied):
+            return Change(
+                user=user,
+                server_rev=server_rev,
+                created_by=user,
+                change_type=DELETED,
+                table=User.__name__,
+                applied=applied,
+                kwargs={},
+            )
+
+        Change.objects.bulk_create([
+            create_change(1, True),
+            create_change(2, True),
+            create_change(3, False),
+        ])
+
+        self.assertEqual(user.get_server_rev(), 2)
+
 
 class ChannelHistoryTestCase(StudioTestCase):
     def setUp(self):

--- a/contentcuration/contentcuration/views/base.py
+++ b/contentcuration/contentcuration/views/base.py
@@ -85,7 +85,7 @@ def current_user_for_context(user):
 
     user_data = {field: getattr(user, field) for field in user_fields}
 
-    user_data["user_rev"] = Change.objects.filter(applied=True, user=user).values_list("server_rev", flat=True).order_by("-server_rev").first() or 0
+    user_data["user_rev"] = user.get_server_rev()
 
     return json_for_parse_from_data(user_data)
 


### PR DESCRIPTION
## Summary
* Use CTE to optimize query performance to get latest user server rev.

## References
Closes #4948.

## Reviewer guidance
* Does an error occur if you navigate through studio channels list, channels edit?