### PR TITLE
unassign inactive users

### DIFF
--- a/.github/workflows/unassign-inactive.yaml
+++ b/.github/workflows/unassign-inactive.yaml
@@ -1,0 +1,15 @@
+name: "Unassign Inactive Contributors"
+run-name: Unassign Inactive Contributors
+
+on:
+  schedule:
+    - cron: "1 0 * * 1" # Every Monday at 00:01 UTC
+  workflow_dispatch:
+
+jobs:
+  unassign-inactive:
+    uses: learningequality/.github/.github/workflows/unassign-inactive-issues.yaml@main
+    secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+      SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
This PR implements a GitHub Action to automatically unassign inactive issues based on a predefined period of inactivity. This action will help maintain cleaner issue assignments and prevent outdated issues from cluttering the project.

[#12837](https://github.com/learningequality/kolibri/issues/12837)

```
on:
  schedule:
    - cron: "1 0 * * 1" 
  workflow_dispatch:
```
Action is scheduled to run every monday at 00:01 UTC