### PR TITLE
raise rest_framework.ValidationError when lft is not an integer

### DIFF
--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -689,6 +689,11 @@ class ContentNodePagination(ValuesViewsetCursorPagination):
         if value is None:
             return None
 
+        try:
+            value = int(value)
+        except ValueError as e:
+            raise ValidationError("lft must be an integer but {} was given: {}".format(value,e))
+
         return Cursor(offset=0, reverse=False, position=value)
 
     def encode_cursor(self, cursor):

--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -691,8 +691,8 @@ class ContentNodePagination(ValuesViewsetCursorPagination):
 
         try:
             value = int(value)
-        except ValueError as e:
-            raise ValidationError("lft must be an integer but {} was given: {}".format(value,e))
+        except ValueError:
+            raise ValidationError("lft must be an integer but an invalid value was given.")
 
         return Cursor(offset=0, reverse=False, position=value)
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Due to how we handle client-side sorting, the `lft` value of client-side data can become floats if the user sorts their nodes - not always, but when done repeatedly, the `lft` values eventually half into infinitesimally small values. This results in a 500 error when the user goes to "Show more" nodes because we're using the float value as `lft` in our call to fetch the ContentNodes that we need to show.

This PR simply ensures we get a 400 rather than a 500 when this happens (effectively silencing the Sentry error)

Ultimately, @rtibbles noted that the ideal solution here would be to refactor some of the pagination machinery and how client<>server interact related to it.

This is an edge case that has only been seen a handful of times in Sentry (one of which was when I tried replicating it) so in discussing w/ Richard it was clear that the level of effort for a more robust solution vs the potential impact on the user  makes this a relatively low priority for the time being.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#4854 (idk if it closes it... perhaps it does if we have a follow-up issue re: updating the pagination more robustly)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

In a channel with enough resources in it to need pagination (>25 but ideally more) go like this:
- Select all (should be 25 nodes) and "Sort nodes alphabetically"
- Rearrange a couple nodes, then repeat the process
- Now do "Show more" - if you don't get an error, then sort all of the visible nodes
- Refresh the page (now you only see the first 25 items again) - sort them all again
- Now do "Show more" - if you don't get an error, then sort all visible nodes
- ...... rinse and repeat until you get a 400 error on the contentnode API call after you click Show More

This worked pretty reliably for me and I felt like the more pages of nodes the easier it was (ie, having 80 nodes gives you more pages which gives you more "Show more" buttons to click which would trigger the error).

The error message should indicate the `lft` value needs to be an int and should be HTTP Status 400
