### PR TITLE
Interpolate scss variables in calc functions

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/AdministrationIndex.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/AdministrationIndex.vue
@@ -72,9 +72,6 @@
 
 <style lang="scss">
 
-  $first-col-width: 75px;
-  $first-col-expanded-width: 350px;
-
   @mixin freeze {
     position: sticky;
     z-index: 3;

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -475,11 +475,11 @@
 
   .description-col {
     flex-shrink: 1 !important;
-    width: calc(100% - $thumbnail-width - 206px);
+    width: calc(100% - #{$thumbnail-width} - 206px);
     word-break: break-word;
 
     .compact & {
-      width: calc(100% - $compact-thumbnail-width - 206px);
+      width: calc(100% - #{$compact-thumbnail-width} - 206px);
     }
   }
 

--- a/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LazyListGroup.vue
@@ -82,7 +82,7 @@
 
   $icon-padding: 16px;
   $icon-width: 25px;
-  $header-width: calc(2 * $icon-padding + $icon-width);
+  $header-width: calc(2 * #{$icon-padding} + #{$icon-width});
 
   .list-group {
     box-sizing: border-box;
@@ -108,7 +108,7 @@
   }
 
   .header-content.has-icon {
-    width: calc(100% - $header-width);
+    width: calc(100% - #{$header-width});
   }
 
   .list-group.open > .list-group-header .v-icon {

--- a/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/ImageOnlyThumbnail.vue
@@ -32,7 +32,7 @@
       :class="$isRTL ? 'rtl-image' : 'ltr-image'"
     >
       <KIcon
-        icon="image" 
+        icon="image"
         :x="-1"
         :y="y - 14"
         :style="{ fill: '#999999' }"
@@ -167,18 +167,18 @@
     overflow: hidden; // Don't show alt text outside of img boundaries
 
     .caption + & {
-      height: calc(100% - $caption-height);
+      height: calc(100% - #{$caption-height});
     }
   }
 
   $svg-scale: 1.25;
-  $svg-width: calc(100% * 9 / 16 / $svg-scale);
-  $svg-top: calc((100% * 9 / 16 / 2) - ($svg-width / 2));
+  $svg-width: calc(100% * 9 / 16 / #{$svg-scale});
+  $svg-top: calc((100% * 9 / 16 / 2) - (#{$svg-width} / 2));
 
   svg.thumbnail-image {
     top: 0;
-    left: calc(50% - ($svg-width / 4));
-    width: calc($svg-width / 4);
+    left: calc(50% - (#{$svg-width} / 4));
+    width: calc(#{$svg-width} / 4);
     margin: 0 auto;
     overflow: visible;
 
@@ -214,7 +214,7 @@
     }
 
     .caption + & {
-      top: calc(($caption-height / 2) + $svg-top);
+      top: calc((#{$caption-height} / 2) + #{$svg-top});
     }
 
     .icon-only & {

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -53,7 +53,7 @@
       class="thumbnail-image"
     >
       <KIcon
-        icon="infoOutline" 
+        icon="infoOutline"
         :x="+10"
         :y="y + 20"
         :style="{ fill: '#ffffff' }"
@@ -67,7 +67,7 @@
       :class="$isRTL ? 'rtl-image' : 'ltr-image'"
     >
       <KIcon
-        icon="image" 
+        icon="image"
         :x="-3"
         :y="y - 14"
         :style="{ fill: '#999999' }"
@@ -212,18 +212,18 @@
     overflow: hidden; // Don't show alt text outside of img boundaries
 
     .caption + & {
-      height: calc(100% - $caption-height);
+      height: calc(100% - #{$caption-height});
     }
   }
 
   $svg-scale: 1.25;
-  $svg-width: calc(100% * 9 / 16 / $svg-scale);
+  $svg-width: calc(100% * 9 / 16 / #{$svg-scale});
   $svg-top: calc((100% * 9 / 16 / 2) - ($svg-width / 2));
 
   svg.thumbnail-image {
     top: 0;
-    left: calc(50% - ($svg-width / 4));
-    width: calc($svg-width / 4);
+    left: calc(50% - (#{$svg-width} / 4));
+    width: calc(#{$svg-width} / 4);
     margin: 0 auto;
     overflow: visible;
 
@@ -259,7 +259,7 @@
     }
 
     .caption + & {
-      top: calc(($caption-height / 2) + $svg-top);
+      top: calc((#{$caption-height} / 2) + #{$svg-top});
     }
 
     .icon-only & {


### PR DESCRIPTION
## Summary

After the migration from less to scss, we were missing the [scss vars interpoletion](https://sass-lang.com/documentation/interpolation/) when we use scss variables inside css functions.  This PR corrects it in all places I've found that scss variables were used. 

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/156fe1b0-24ba-45af-910e-242f868cfa6e) | ![image](https://github.com/user-attachments/assets/3a33b436-e081-49d5-aa6d-a0df4ba0e471) |
| ![image](https://github.com/user-attachments/assets/8f2ff3dd-88bb-4de9-8d5b-c55b28e9bef3) | ![image](https://github.com/user-attachments/assets/fbba8361-65c4-4342-a7f9-57f4808b87f6) |
| ![image](https://github.com/user-attachments/assets/f77a656e-bd58-47a4-b9ef-3379969a6712) | ![image](https://github.com/user-attachments/assets/e33d0e9d-fba2-430e-b1eb-54b4ae9ae110) |


## References
Closes #4988.

## Reviewer guidance
* Look that there are not more unprocessed scss variables out there.
* Double check that all scss variables have been interpolated correctly when needed
