### PR TITLE
Adds go to navigation to recommended resource card popout icon

### DIFF
--- a/contentcuration/contentcuration/frontend/RecommendedResourceCard/components/RecommendedResourceCard.vue
+++ b/contentcuration/contentcuration/frontend/RecommendedResourceCard/components/RecommendedResourceCard.vue
@@ -37,7 +37,11 @@
     <template #footer>
       <KFixedGrid :numCols="2">
         <KFixedGridItem alignment="right">
-          <KIconButton icon="openNewTab" />
+          <KIconButton
+            icon="openNewTab"
+            :tooltip="$tr('goToLocationTooltip')"
+            @click.stop="goToLocation"
+          />
           <KIconButton icon="thumbDown" />
         </KFixedGridItem>
       </KFixedGrid>
@@ -52,7 +56,10 @@
   import find from 'lodash/find';
   import LearningActivities from 'kolibri-constants/labels/LearningActivities';
   import { mapState } from 'vuex';
-  import { ContentKindLearningActivityDefaults } from 'shared/leUtils/ContentKinds';
+  import {
+    ContentKindLearningActivityDefaults,
+    ContentKindsNames,
+  } from 'shared/leUtils/ContentKinds';
   import Checkbox from 'shared/views/form/Checkbox';
   import ContentNodeLearningActivityIcon from 'shared/views/ContentNodeLearningActivityIcon';
 
@@ -86,6 +93,16 @@
           return Boolean(find(this.selected, { id: node.id }));
         };
       },
+      goToLocationUrl() {
+        const baseUrl = window.Urls.channel(this.node.channel_id);
+        if (this.isTopic) {
+          return `${baseUrl}#/${this.node.id}`;
+        }
+        return `${baseUrl}#/${this.node.parent}/${this.node.id}`;
+      },
+      isTopic() {
+        return this.node.kind === ContentKindsNames.TOPIC;
+      },
     },
     methods: {
       toggleSelected(node) {
@@ -94,9 +111,13 @@
       onClick() {
         this.$emit('preview', this.node);
       },
+      goToLocation() {
+        window.open(this.goToLocationUrl, '_blank');
+      },
     },
     $trs: {
       selectCard: 'Select { title }',
+      goToLocationTooltip: 'Go to location',
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds navigation to the pop-out icon of the recommended resource card. (This was missed)
<img width="611" alt="Screenshot 2025-04-23 at 00 18 33" src="https://github.com/user-attachments/assets/a709af33-ee9b-4114-b60f-9d6fbb56ffa0" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/studio/pull/5014

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Clicking the pop-out icon should open the location location of a resource in a new tab.
