### PR TITLE
Parse as float, then cast to int

### DIFF
--- a/contentcuration/contentcuration/viewsets/contentnode.py
+++ b/contentcuration/contentcuration/viewsets/contentnode.py
@@ -690,7 +690,7 @@ class ContentNodePagination(ValuesViewsetCursorPagination):
             return None
 
         try:
-            value = int(value)
+            value = int(float(value))
         except ValueError:
             raise ValidationError("lft must be an integer but an invalid value was given.")
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
In python:
- if `x = 25.5`, then `int(x) == 25` 
- if `x = '25.5'`, then `int(x)` throws an exception
- if `x = '25.5'`, then `float(x) == 25.5` and thus `int(float(x)) == 25` works for both strings, floats, and ints

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/studio/pull/4990#issuecomment-2827588715
