### PR TITLE
Fix various file upload validation omissions

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1891,6 +1891,8 @@ class ContentNode(MPTTModel, models.Model):
                 errors.append("Missing required copyright holder")
             if self.kind_id != content_kinds.EXERCISE and not self.files.filter(preset__supplementary=False).exists():
                 errors.append("Missing default file")
+            if self.files.exclude(preset__kind_id=self.kind_id).exists():
+                errors.append("Node has files that do not match its kind")
             if self.kind_id == content_kinds.EXERCISE:
                 # Check to see if the exercise has at least one assessment item that has:
                 if not self.assessment_items.filter(

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -93,7 +93,7 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
                     "source_url": fileobj.source_url,
                 }
             ],
-            "kind": "document",
+            "kind": "video",
             "license": "CC BY",
             "license_description": None,
             "copyright_holder": random_data.copyright_holder,
@@ -296,6 +296,25 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
         self.assertEqual(response.status_code, 200, response.content)
         node = ContentNode.objects.get(title=invalid_file_data_node["title"])
         self.assertEqual(node.files.count(), 1)
+
+    def test_mismatched_kind_and_preset(self):
+        mismatched_kind_and_preset_node = self._make_node_data()
+        mismatched_kind_and_preset_node["title"] = "invalid file data title"
+        mismatched_kind_and_preset_node["kind"] = "document"
+        test_data = {
+            "root_id": self.root_node.id,
+            "content_data": [
+                mismatched_kind_and_preset_node,
+            ],
+        }
+
+        response = self.admin_client().post(
+            reverse_lazy("api_add_nodes_to_tree"), data=test_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        node = ContentNode.objects.get(title=mismatched_kind_and_preset_node["title"])
+        self.assertFalse(node.complete)
 
 
 class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):

--- a/contentcuration/contentcuration/tests/views/test_views_internal.py
+++ b/contentcuration/contentcuration/tests/views/test_views_internal.py
@@ -276,6 +276,27 @@ class ApiAddNodesToTreeTestCase(StudioTestCase):
 
         self.assertEqual(response.status_code, 400, response.content)
 
+    def test_invalid_file_data_excluded(self):
+        invalid_file_data_node = self._make_node_data()
+        invalid_file_data_node["title"] = "invalid file data title"
+        bad_file = invalid_file_data_node["files"][0].copy()
+        bad_file["preset"] = format_presets.DOCUMENT_THUMBNAIL
+        invalid_file_data_node["files"] += [bad_file]
+        test_data = {
+            "root_id": self.root_node.id,
+            "content_data": [
+                invalid_file_data_node,
+            ],
+        }
+
+        response = self.admin_client().post(
+            reverse_lazy("api_add_nodes_to_tree"), data=test_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        node = ContentNode.objects.get(title=invalid_file_data_node["title"])
+        self.assertEqual(node.files.count(), 1)
+
 
 class ApiAddExerciseNodesToTreeTestCase(StudioTestCase):
     """

--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -386,6 +386,17 @@ class UploadFileURLTestCase(StudioAPITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_duration_present_but_not_allowed(self):
+        self.file["file_format"] = file_formats.EPUB
+        self.file["preset"] = format_presets.DOCUMENT
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"), self.file, format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
     def test_duration_null(self):
         self.file["duration"] = None
         self.file["file_format"] = file_formats.EPUB
@@ -434,6 +445,16 @@ class UploadFileURLTestCase(StudioAPITestCase):
             "duration": 10.123
         }
         response = self.client.post(reverse("file-upload-url"), file, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_mismatched_preset_upload(self):
+        self.file["file_format"] = file_formats.EPUB
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"), self.file, format="json",
+        )
+
         self.assertEqual(response.status_code, 400)
 
     def test_insufficient_storage(self):

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -20,6 +20,7 @@ from contentcuration.models import File
 from contentcuration.models import FormatPreset
 from contentcuration.models import generate_object_storage_name
 from contentcuration.models import Language
+from contentcuration.models import MEDIA_PRESETS
 from contentcuration.models import User
 from contentcuration.utils.cache import ResourceSizeCache
 from contentcuration.utils.files import get_thumbnail_encoding
@@ -71,6 +72,10 @@ def map_files_to_node(user, node, data):  # noqa: C901
             invalid_lang = file_data.get('language')
             logging.warning("file_data with language {} does not exist.".format(invalid_lang))
             errors.append("file_data given was invalid; expected string, got {}".format(invalid_lang))
+            continue
+
+        if file_data.get("duration") and kind_preset.id not in MEDIA_PRESETS:
+            errors.append("duration was included for a file with a non-media preset")
             continue
 
         resource_obj = File(

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -651,7 +651,7 @@ def convert_data_to_nodes(user, content_data, parent_node):  # noqa: C901
                     if "source_channel_id" in node_data:
                         new_node = handle_remote_node(user, node_data, parent_node)
 
-                        map_files_to_node(user, new_node, node_data.get("files", []))
+                        file_errors = map_files_to_node(user, new_node, node_data.get("files", []))
 
                         add_tags(new_node, node_data)
 
@@ -660,7 +660,7 @@ def convert_data_to_nodes(user, content_data, parent_node):  # noqa: C901
                         new_node = create_node(node_data, parent_node, sort_order)
 
                         # Create files associated with node
-                        map_files_to_node(user, new_node, node_data["files"])
+                        file_errors = map_files_to_node(user, new_node, node_data["files"])
 
                         # Create questions associated exercise nodes
                         create_exercises(user, new_node, node_data["questions"])
@@ -687,10 +687,10 @@ def convert_data_to_nodes(user, content_data, parent_node):  # noqa: C901
                     # as some node kinds are counted as incomplete if they lack a default file.
                     completion_errors = new_node.mark_complete()
 
-                    if completion_errors:
+                    if completion_errors or file_errors:
                         try:
                             # we need to raise it to get Python to fill out the stack trace.
-                            raise IncompleteNodeError(new_node, completion_errors)
+                            raise IncompleteNodeError(new_node, completion_errors + file_errors)
                         except IncompleteNodeError as e:
                             report_exception(e)
 

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -686,6 +686,7 @@ def convert_data_to_nodes(user, content_data, parent_node):  # noqa: C901
                     # Wait until after files have been set on the node to check for node completeness
                     # as some node kinds are counted as incomplete if they lack a default file.
                     completion_errors = new_node.mark_complete()
+                    new_node.save()
 
                     if completion_errors or file_errors:
                         try:

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -32,6 +32,9 @@ from contentcuration.viewsets.sync.constants import CONTENTNODE
 from contentcuration.viewsets.sync.utils import generate_update_event
 
 
+PRESET_LOOKUP = {p.id: p for p in format_presets.PRESETLIST}
+
+
 class StrictFloatField(serializers.FloatField):
     def to_internal_value(self, data):
         # If data is a string, reject it even if it represents a number.
@@ -72,6 +75,9 @@ class FileUploadURLSerializer(serializers.Serializer):
         if attrs["file_format"] in {file_formats.MP4, file_formats.WEBM, file_formats.MP3}:
             if "duration" not in attrs or attrs["duration"] is None:
                 raise serializers.ValidationError("Duration is required for audio/video files")
+        preset_obj = PRESET_LOOKUP[attrs["preset"]]
+        if attrs["file_format"] not in preset_obj.allowed_formats:
+            raise serializers.ValidationError(f"File format {attrs['file_format']} is not an allowed format for this preset {attrs['preset']}")
         return attrs
 
 


### PR DESCRIPTION
## Summary
* Fixes the file upload URL endpoint to ensure that the file format and format preset are compatible
* Slightly reworks file adding during internal node upload to skip the file on errors but attempt the rest of the files for the node
* Adds handling for mismatched file format and presets during node upload
* Ensures that nodes are marked as incomplete if they have any files with presets that don't match their kind
* Adds handling for incorrect setting of duration before we hit an integrity error

## References
Fixes #5022

## Reviewer guidance
Do the changes make sense? Are they covered by tests? What might this now be allowing or disallowing that might cause issues I haven't anticipated?
