### PR TITLE
Remove stylus module replacement causing non-hot devserver to break

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/styles/modulePlaceholder.js
+++ b/contentcuration/contentcuration/frontend/shared/styles/modulePlaceholder.js
@@ -1,7 +1,0 @@
-// This file is used as a placeholder, following the same pattern established in
-// jest_config/globalMocks/fileMock.js
-
-// It is used to help use properly overwrite the vuetify stylus files using webpack
-// (see also webpack.config.js > webpack.NormalModuleReplacementPlugin())
-
-'module-file-stub';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,6 @@ const WebpackRTLPlugin = require('kolibri-tools/lib/webpackRtlPlugin');
 
 const { InjectManifest } = require('workbox-webpack-plugin');
 
-const webpack = require('webpack');
-
 // Function to detect if running in WSL
 function isWSL() {
   try {
@@ -42,7 +40,6 @@ function getWSLIP() {
 const djangoProjectDir = path.resolve('contentcuration');
 const staticFilesDir = path.resolve(djangoProjectDir, 'contentcuration', 'static');
 const srcDir = path.resolve(djangoProjectDir, 'contentcuration', 'frontend');
-const dummyModule = path.resolve(srcDir, 'shared', 'styles', 'modulePlaceholder.js')
 
 const bundleOutputDir = path.resolve(staticFilesDir, 'studio');
 
@@ -177,16 +174,7 @@ module.exports = (env = {}) => {
         cwd: process.cwd(),
       }),
       workboxPlugin,
-    ].concat(
-      hot
-        ? []
-        : [
-          new webpack.NormalModuleReplacementPlugin(
-            /vuetify\/src\/stylus\//,
-            dummyModule
-          )
-        ]
-    ),
+    ],
     stats: 'normal',
   });
 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Historically, we've had some module replacement in our webpack config for Vuetify's stylus files. At one point, it was always enabled (hot and non-hot devservers), then we made it only enabled for non-hot, and now the solution seems to be to remove it entirely.

The issue was that running `pnpm run devserver` complained about `.styl` files:
```
ERROR in ../../../node_modules/.pnpm/vuetify@1.5.24_vue@2.7.16/node_modules/vuetify/src/stylus/components/_system-bars.styl 6:24-183
Module not found: Error: Can't resolve '../../../../../node_modules/.pnpm/mini-css-extract-plugin@2.9.2_webpack@5.98.0/node_modules/mini-css-extract-plugin/dist/hmr/hotModuleReplacement.js' in '/home/bjester/Projects/learningequality/studio/webpack-node-probs/node_modules/.pnpm/vuetify@1.5.24_vue@2.7.16/node_modules/vuetify/src/stylus/components'
 @ ../../../node_modules/.pnpm/vuetify@1.5.24_vue@2.7.16/node_modules/vuetify/lib/components/VSystemBar/VSystemBar.js 3:0-58
 @ ../../../node_modules/.pnpm/vuetify@1.5.24_vue@2.7.16/node_modules/vuetify/lib/components/VSystemBar/index.js 1:0-38 2:0-22 3:15-25
 @ ../../../node_modules/.pnpm/vuetify@1.5.24_vue@2.7.16/node_modules/vuetify/lib/components/index.js 57:0-29 57:0-29
 @ ../../../node_modules/.pnpm/vuetify@1.5.24_vue@2.7.16/node_modules/vuetify/lib/index.js 3:0-29 3:0-29
 @ ./shared/app.js 6:0-88:21 160:8-15 164:4-10 165:4-8 166:4-17 167:4-10 168:4-16 169:4-20 170:4-8 171:4-9 172:4-16 173:4-13 174:4-14 175:4-13 176:4-9 177:4-13 178:4-14 179:4-12 180:4-14 181:4-15 182:4-11 183:4-12 184:4-15 185:4-21 186:4-22 187:4-19 188:4-26 189:4-19 190:4-9 191:4-11 192:4-9 193:4-10 194:4-8 195:4-10 196:4-11 197:4-9 198:4-13 199:4-19 200:4-20 201:4-21 202:4-18 203:4-19 204:4-21 205:4-15 206:4-21 207:4-19 208:4-10 209:4-15 210:4-20 211:4-11 212:4-10 213:4-28 214:4-21 215:4-21 216:4-13 217:4-11 218:4-14 219:4-14 220:4-8 221:4-12 222:4-14 223:4-13 224:4-14 225:4-12 226:4-17 227:4-20 228:4-17 229:4-12 230:4-11 231:4-15
 @ ./channelEdit/index.js 4:0-34 6:0-8
```

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/studio/pull/4119

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Ran the following, observed no errors:
1) `pnpm run devserver` 
2) `pnpm run devserver:hot`
