### PR TITLE
Ensure that file_format and preset match during file_upload requests.

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_file.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_file.py
@@ -438,6 +438,7 @@ class UploadFileURLTestCase(StudioAPITestCase):
     def test_duration_missing(self):
         del self.file["duration"]
         self.file["file_format"] = file_formats.EPUB
+        self.file["preset"] = format_presets.EPUB
 
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
@@ -461,9 +462,23 @@ class UploadFileURLTestCase(StudioAPITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_duration_present_but_not_allowed(self):
+        self.file["file_format"] = file_formats.EPUB
+        self.file["preset"] = format_presets.DOCUMENT
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"),
+            self.file,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
     def test_duration_null(self):
         self.file["duration"] = None
         self.file["file_format"] = file_formats.EPUB
+        self.file["preset"] = format_presets.EPUB
 
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
@@ -515,6 +530,18 @@ class UploadFileURLTestCase(StudioAPITestCase):
             "duration": 10.123,
         }
         response = self.client.post(reverse("file-upload-url"), file, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_mismatched_preset_upload(self):
+        self.file["file_format"] = file_formats.EPUB
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("file-upload-url"),
+            self.file,
+            format="json",
+        )
+
         self.assertEqual(response.status_code, 400)
 
     def test_insufficient_storage(self):

--- a/contentcuration/contentcuration/viewsets/file.py
+++ b/contentcuration/contentcuration/viewsets/file.py
@@ -32,6 +32,9 @@ from contentcuration.viewsets.sync.constants import CONTENTNODE
 from contentcuration.viewsets.sync.utils import generate_update_event
 
 
+PRESET_LOOKUP = {p.id: p for p in format_presets.PRESETLIST}
+
+
 class StrictFloatField(serializers.FloatField):
     def to_internal_value(self, data):
         # If data is a string, reject it even if it represents a number.
@@ -81,6 +84,11 @@ class FileUploadURLSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     "Duration is required for audio/video files"
                 )
+        preset_obj = PRESET_LOOKUP[attrs["preset"]]
+        if attrs["file_format"] not in preset_obj.allowed_formats:
+            raise serializers.ValidationError(
+                f"File format {attrs['file_format']} is not an allowed format for this preset {attrs['preset']}"
+            )
         return attrs
 
 


### PR DESCRIPTION
## Summary
* Adds a small validation check to file uploads to ensure that we don't allow uploads of files with mismatched file formats and format presets
* Adds/updates tests for the same