### PR TITLE
Fix ResizeObserver errors when uploading epub files

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/EpubRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/EpubRenderer.vue
@@ -81,6 +81,15 @@
         });
       }); // There seems to be some lag for loading, so add delay to be safe
     },
+    beforeDestroy() {
+      if (this.book) {
+        /**
+         * Destroy the book instance to remove listeners that causes some
+         * ResizeObserver errors in the console on unmount.
+         */
+        this.book.destroy();
+      }
+    },
   };
 
 </script>


### PR DESCRIPTION
## Summary

EPubJs was registering some ResizeObserver listeners when rendering the epub books, and somehow these listeners caused an infinite resize observer loop when the EPubRenderer component was unmounted. This PR destroys de epub book, which cleans these listeners, before EPubRenderer is unmounted.

Before:


https://github.com/user-attachments/assets/addf9e1f-a24a-48e0-be16-dbeba41e7867

After:


https://github.com/user-attachments/assets/c30d5feb-b925-4af2-8569-d08517240777



## References

https://github.com/learningequality/kolibri-design-system/issues/960

## Reviewer guidance

1. Open a channel
2. Click to add/upload a file
3. Upload an EPUB file
4. Click 'Finish'
5. Check that no errors are triggered