### PR TITLE
Fixes missing scheme error when hitting recommendations API

### DIFF
--- a/contentcuration/contentcuration/utils/recommendations.py
+++ b/contentcuration/contentcuration/utils/recommendations.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Union
+from urllib.parse import urlparse
 
 from automation.models import RecommendationsCache
 from automation.utils.appnexus import errors
@@ -72,9 +73,23 @@ class EmbeddingsResponse(RecommendationsBackendResponse):
 
 
 class RecommendationsBackendFactory(BackendFactory):
+
+    def _ensure_url_has_scheme(self, url):
+        """
+        Checks whether the URL has a scheme. Default to http:// if no scheme exists.
+
+        :param url: The URL to check
+        :return: A URL with a scheme
+        """
+        if url:
+            parsed_url = urlparse(url)
+            if not parsed_url.scheme:
+                url = "http://" + url
+        return url
+
     def create_backend(self) -> Backend:
         backend = Recommendations()
-        backend.base_url = settings.CURRICULUM_AUTOMATION_API_URL
+        backend.base_url = self._ensure_url_has_scheme(settings.CURRICULUM_AUTOMATION_API_URL)
         backend.connect_endpoint = "/connect"
         return backend
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the missing scheme error when hitting recommendations API by appending the `http://` scheme if it doesn't exist on the passed url.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5041

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Check that tests pass and make sense.
