### PR TITLE
Make 'updateDescendants' true by default

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditBooleanMapModal.vue
@@ -83,7 +83,7 @@
     },
     data() {
       return {
-        updateDescendants: false,
+        updateDescendants: true,
         error: '',
         /**
          * selectedValues is an object with the following structure:

--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -81,7 +81,7 @@
       return {
         selectedLanguage: '',
         searchQuery: '',
-        updateDescendants: false,
+        updateDescendants: true,
         isMultipleNodeLanguages: false,
         changed: false,
       };


### PR DESCRIPTION
## Summary
This PR sets the default data value of `updateDescendants` to true, so that when bulk/quick editing, the checkbox is checked by default. This makes it less likely to get "missed" be editors.

## References
Fixes [#5043](https://github.com/learningequality/studio/issues/5043)

https://github.com/user-attachments/assets/2f30d46b-939c-4d78-bb1e-7d7e4ddc776a


## Reviewer guidance
Navigate into a channel and check each bulk editing action modal: 
- level
- categories
- requirements 
- language 

For each, the checkbox for applying to the resources and folders within a folder should be checked by default. 


