### PR TITLE
 Migrate 'Failed to delete account' alert from Vuetify to Kolibri Des…

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Account/DeleteAccountForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Account/DeleteAccountForm.vue
@@ -20,11 +20,15 @@
         @input="deletionEmailInvalidMessage = ''"
       />
     </KModal>
-    <Alert
-      v-model="deletionFailed"
-      :header="$tr('deletionFailed')"
-      :text="$tr('deletionFailedText')"
-    />
+
+    <KModal
+      v-if="deletionFailed"
+      :title="$tr('deletionFailed')"
+      :submitText="$tr('ok')"
+      @submit="deletionFailed = false"
+    >
+      <p>{{ $tr('deletionFailedText') }}</p>
+    </KModal>
   </div>
 
 </template>
@@ -33,13 +37,9 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
-  import Alert from 'shared/views/Alert';
 
   export default {
     name: 'DeleteAccountForm',
-    components: {
-      Alert,
-    },
     props: {
       value: {
         type: Boolean,
@@ -98,6 +98,7 @@
       deletionFailed: 'Failed to delete account',
       deletionFailedText:
         'Failed to delete your account. Please contact us here: https://community.learningequality.org.',
+      ok: 'OK',
     },
   };
 

--- a/contentcuration/contentcuration/frontend/settings/pages/__tests__/deleteAccountForm.spec.js
+++ b/contentcuration/contentcuration/frontend/settings/pages/__tests__/deleteAccountForm.spec.js
@@ -42,11 +42,20 @@ describe('deleteAccountForm', () => {
     wrapper.vm.deleteUserAccount();
     expect(deleteAccount).toHaveBeenCalled();
   });
-  it('should show alert if account deletion fails', async () => {
+  it('should show KModal if account deletion fails', async () => {
     await wrapper.setData({ accountDeletionEmail: email });
     deleteAccount.mockImplementation(() => Promise.reject('error'));
-    wrapper.vm.deleteUserAccount().catch(() => {
-      expect(wrapper.vm.deletionFailed).toBe(true);
-    });
+    try {
+      await wrapper.vm.deleteUserAccount();
+    } catch (e) {
+      throw new Error(e);
+    }
+    await wrapper.vm.$nextTick();
+    const modals = wrapper.findAllComponents({ name: 'KModal' });
+    const errorModal = modals.at(1);
+    expect(errorModal.exists()).toBe(true);
+    expect(errorModal.text()).toContain(
+      'Failed to delete your account. Please contact us here: https://community.learningequality.org.',
+    );
   });
 });


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Replaced Vuetify Alert with K-Modal
- No UI changed
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
#5062 
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Login as [user@a.com](mailto:user@a.com)
- Go to Settings > Account
- In code, temporarily modify deletionFailed to display the alert

![Screenshot from 2025-05-30 17-54-28](https://github.com/user-attachments/assets/91dcd925-6c21-4a4c-a4b7-7b388b2f4881)

…
