### PR TITLE
Updated the license info section to use the KExternalLink component for license URLs

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -79,7 +79,7 @@
             class="mt-1"
           >
             <KExternalLink
-              class="link-css notranslate"
+              class="license-link"
               :href="getLicenseUrl(item)"
               :text="$tr('learnMoreButton')"
               openInNewTab
@@ -508,8 +508,9 @@
     margin-bottom: 8px;
   }
 
-  .link-css ::v-deep span {
-    margin-left: 0px !important;
+  /* fixes unintended margin caused by KDS styles */
+  .license-link ::v-deep span {
+    margin-left: 0 !important;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -78,10 +78,11 @@
             v-if="item.license_url"
             class="mt-1"
           >
-            <ActionLink
+            <KExternalLink
+              class="link-css notranslate"
               :href="getLicenseUrl(item)"
-              target="_blank"
               :text="$tr('learnMoreButton')"
+              openInNewTab
             />
           </p>
         </template>
@@ -505,6 +506,10 @@
   h3 {
     margin-top: 32px;
     margin-bottom: 8px;
+  }
+
+  .link-css ::v-deep span {
+    margin-left: 0px !important;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -508,6 +508,10 @@
     margin-bottom: 8px;
   }
 
+  .license-link {
+    font-size: 14px;
+  }
+
   /* fixes unintended margin caused by KDS styles */
   .license-link ::v-deep span {
     margin-left: 0 !important;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Updated the license info section to use the KExternalLink component for license URLs
Screen shot
<img width="1198" alt="Screenshot 2025-06-12 at 10 21 50 PM" src="https://github.com/user-attachments/assets/12b8a56e-633a-4ce2-a682-73c34b40f770" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/studio/issues/5092

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Areas to test 
Learn More links in Settings > Storage > 'Request more space' form > 'About licenses' modal
