### PR TITLE
Remove unused Vuetify styles from InfoModal.vue

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
@@ -70,10 +70,4 @@
 
 <style lang="scss" scoped>
 
-  ::v-deep p {
-    font-size: 12pt;
-    line-height: normal;
-    color: var(--v-grey-darken3);
-  }
-
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/InfoModal.vue
@@ -69,5 +69,4 @@
 
 
 <style lang="scss" scoped>
-
 </style>


### PR DESCRIPTION
## Summary

This PR removes unused `::v-deep` scoped styles from the `InfoModal.vue` component that were referencing Vuetify-specific variables (e.g., `--v-grey-darken3`). These styles were not affecting the rendered UI and are no longer needed, especially as part of the transition away from Vuetify.

### Manual Verification:
- Visited **Settings > Storage > Request more space**
- Opened the **About licenses** modal using the info button near *"Who can use your content?"*
- Manually forced the modal open by modifying visibility in the component since the button click is currently broken (as per instructions in the issue).
- Confirmed that:
  - Modal renders correctly
  - Text styling remains consistent
  - No visual regressions observed

✅ No Vuetify-specific styles are used  
✅ Functionality and layout remain unchanged

---

## References

- Fixes: [#5095 - Remove unused `:v-deep` styles from info modal](https://github.com/learningequality/studio/issues/5095)
- Part of broader effort: [#5060 - Remove Vuetify from Studio](https://github.com/learningequality/studio/issues/5060)

---

## Reviewer guidance

To test:
1. Log in using `user@a.com` / password: `a`
2. Navigate to **Settings > Storage > Request more space**
3. Open the **info modal** next to *Who can use your content?*
   - If the modal doesn't open, manually make it visible in the Vue component.
4. Confirm that the text styling is intact and the modal displays as expected.
---
## Note:
 No visual differences should be present; the only change is cleanup of unused styles and removal of dependency on Vuetify color tokens.

---
…
