### PR TITLE
Apply grade_levels tags styling to category metadata tags 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -98,12 +98,6 @@
                       v-if="subtitle"
                       class="text"
                     >{{ subtitle }}</span>
-                    <span
-                      v-if="node.categories ? Object.keys(node.categories).length > 0 : null"
-                      class="text"
-                    >
-                      {{ category(node.categories) }}
-                    </span>
                     <span v-if="isTopic && node.coach_count">
                       <!-- for each learning activity -->
                       <VTooltip
@@ -153,6 +147,16 @@
                         :style="{ backgroundColor: $themeTokens.fineLine }"
                       >
                         {{ levels(key) }}
+                      </span>
+                    </span>
+                    <span v-if="node.categories">
+                      <span
+                        v-for="(key, index) in category(node.categories)"
+                        :key="index"
+                        class="small-chip"
+                        :style="{ backgroundColor: $themeTokens.fineLine }"
+                      >
+                        {{ key }}
                       </span>
                     </span>
                   </span>
@@ -356,7 +360,7 @@
         // is created here (unlike in ResourcePanel), because the values
         // are used to create one or more individual "chips" to display
         // rather than a string of text
-        return ids.map(i => this.translateMetadataString(camelCase(i))).join(', ');
+        return ids.map(i => this.translateMetadataString(camelCase(i)));
       },
       category(options) {
         const ids = Object.keys(options);
@@ -512,10 +516,6 @@
     flex: 1 1 auto;
     align-items: flex-start;
     justify-content: center;
-  }
-
-  .metadata > span:not(:last-child)::after {
-    content: ' • ';
   }
 
   .small-chip {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request updates the styling of the metadata category tags to ensure visual consistency and enhance their styling, so that it is easier to more quickly identify when category tags have been successfully updated during bulk editing.

Before:

![Before](https://github.com/user-attachments/assets/d758cce2-6c9a-4a4d-ae98-41355f6f8877)


After:

![After](https://github.com/user-attachments/assets/0028b1ac-a8dd-427c-a514-4904a5d2688c)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5042 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Ensure that the category tags have the same visual styling as the grade level tags and that there are no regressions when updating the category tags.
