### PR TITLE
Explicitly specify localhost as an allowed host, and add WSLIP IP in WSLEnvironments.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,6 +117,13 @@ module.exports = (env = {}) => {
       headers: {
         'Access-Control-Allow-Origin': '*',
       },
+      allowedHosts: [
+        '127.0.0.1',
+        'localhost',
+      ].concat(
+        // For WSL, allow the WSL IP address
+        isWSLEnvironment ? [getWSLIP()] : []
+      ),
     },
     module: {
       rules: [


### PR DESCRIPTION
## Summary
* Fixes issue where the default allowedHosts is too strict in webpack dev server
* Adds explicit access via the WSL IP address
