### PR TITLE
Fix double wrapped thumbnail icon

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/utils/icons.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/icons.js
@@ -1,3 +1,4 @@
+import camelCase from 'lodash/camelCase';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
 const EMPTY = '_empty';
@@ -19,4 +20,14 @@ export function getContentKindIcon(kind, isEmpty = false) {
     throw new Error(`Icon not found for content kind: ${kind}`);
   }
   return CONTENT_KIND_ICONS[icon];
+}
+
+export function getLearningActivityIcon(activity) {
+  if (activity.toLowerCase() === 'explore') {
+    return 'interactShaded';
+  } else if (activity === 'multiple') {
+    return 'allActivities';
+  } else {
+    return `${camelCase(activity) + 'Solid'}`;
+  }
 }

--- a/contentcuration/contentcuration/frontend/shared/utils/icons.js
+++ b/contentcuration/contentcuration/frontend/shared/utils/icons.js
@@ -1,4 +1,3 @@
-import camelCase from 'lodash/camelCase';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 
 const EMPTY = '_empty';
@@ -20,14 +19,4 @@ export function getContentKindIcon(kind, isEmpty = false) {
     throw new Error(`Icon not found for content kind: ${kind}`);
   }
   return CONTENT_KIND_ICONS[icon];
-}
-
-export function getLearningActivityIcon(activity) {
-  if (activity.toLowerCase() === 'explore') {
-    return 'interactShaded';
-  } else if (activity === 'multiple') {
-    return 'allActivities';
-  } else {
-    return `${camelCase(activity) + 'Solid'}`;
-  }
 }

--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelThumbnail.vue
@@ -16,7 +16,7 @@
           >
             <VCard
               ref="thumbnail"
-              class="thumbnail"
+              class="thumbnail-wrapper"
               data-test="loading"
             >
               <VLayout
@@ -355,7 +355,7 @@
     border: 2px solid var(--v-grey-darken2);
   }
 
-  .thumbnail {
+  .thumbnail-wrapper {
     padding: 28% 0;
     /* stylelint-disable-next-line custom-property-pattern */
     border-color: var(--v-greyBorder-base) !important;

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -75,7 +75,7 @@
       <KIcon
         icon="image"
         class="icon-thumbnail"
-        :style="{ fill: '#999999', fontSize: '3em' }"
+        :style="{ fill: '#123345', width: '40%', height: 'auto' }"
       />
     </div>
   </figure>

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -6,11 +6,12 @@
       [kind]: compact,
       'icon-only': compact,
       nothumbnail: !showThumbnail && !compact,
+      'with-caption': showCaption,
     }"
     :style="{ 'max-width': maxWidth }"
   >
     <VLayout
-      v-if="kind && !printing && showKind && !compact"
+      v-if="showCaption"
       tag="figcaption"
       row
       align-center
@@ -21,12 +22,10 @@
         shrink
         class="px-1"
       >
-        <VIconWrapper
-          v-if="!compact"
-          dark
-          small
-          :aria-label="kindTitle"
-          v-text="icon"
+        <KIcon
+          :icon="icon"
+          class="icon-thumbnail"
+          :style="{ fill: '#ffffff' }"
         />
       </VFlex>
       <VFlex shrink>
@@ -55,33 +54,26 @@
     </div>
 
     <!-- Bury icon within SVG so it's more responsive, since font-size scaling is more difficult -->
-    <svg
+    <div
       v-else-if="compact"
-      viewBox="0 0 24 24"
-      :aria-label="kindTitle"
-      class="thumbnail-image"
+      class="kicon-wrapper"
     >
       <KIcon
-        icon="infoOutline"
-        :x="+10"
-        :y="y + 20"
+        :icon="icon"
+        class="icon-thumbnail"
         :style="{ fill: '#ffffff' }"
       />
-    </svg>
-    <svg
+    </div>
+    <div
       v-else
-      viewBox="0 0 40 40"
-      :aria-label="kindTitle"
-      class="nothumbnail-image"
-      :class="$isRTL ? 'rtl-image' : 'ltr-image'"
+      class="kicon-wrapper"
     >
       <KIcon
         icon="image"
-        :x="-3"
-        :y="y - 14"
-        :style="{ fill: '#999999' }"
+        class="icon-thumbnail"
+        :style="{ fill: '#999999', fontSize: '3em' }"
       />
-    </svg>
+    </div>
   </figure>
 
 </template>
@@ -89,8 +81,8 @@
 
 <script>
 
+  import { getContentKindIcon } from 'shared/utils/icons';
   import { constantsTranslationMixin, printingMixin } from 'shared/mixins';
-  import { getContentKindIcon } from 'shared/vuetify/icons';
 
   export default {
     name: 'Thumbnail',
@@ -136,21 +128,14 @@
       },
     },
     computed: {
-      y() {
-        switch (this.kind) {
-          case 'exercise':
-            return 28;
-          case 'topic':
-          case 'audio':
-          default:
-            return 26;
-        }
-      },
       objectFit() {
         return this.kind ? 'cover' : 'contain';
       },
       icon() {
         return getContentKindIcon(this.kind, this.isEmpty);
+      },
+      showCaption() {
+        return this.kind && !this.printing && this.showKind && !this.compact;
       },
       thumbnailSrc() {
         return this.encoding && this.encoding.base64 ? this.encoding.base64 : this.src;
@@ -299,6 +284,25 @@
 
     .v-icon {
       font-size: 300%;
+    }
+  }
+
+  .kicon-wrapper {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    .icon-thumbnail {
+      top: 0;
+    }
+  }
+
+  .thumbnail.with-caption {
+    .kicon-wrapper {
+      height: calc(100% - #{$caption-height});
     }
   }
 

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -45,12 +45,16 @@
       v-else-if="printing"
       class="printable-icon"
     >
-      <VIconWrapper
+      <!-- <VIconWrapper
         :color="$vuetify.theme[kind]"
         capture-as-image
       >
         {{ icon }}
-      </VIconWrapper>
+      </VIconWrapper> -->
+      <KIcon
+        class="icon-thumbnail"
+        :icon="icon"
+      />
     </div>
 
     <!-- Bury icon within SVG so it's more responsive, since font-size scaling is more difficult -->

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -25,7 +25,7 @@
         <KIcon
           :icon="icon"
           class="icon-thumbnail"
-          :style="{ fill: '#ffffff' }"
+          :style="{ fill: $themeTokens.textInverted }"
         />
       </VFlex>
       <VFlex shrink>
@@ -45,19 +45,13 @@
       v-else-if="printing"
       class="printable-icon"
     >
-      <!-- <VIconWrapper
-        :color="$vuetify.theme[kind]"
-        capture-as-image
-      >
-        {{ icon }}
-      </VIconWrapper> -->
       <KIcon
         class="icon-thumbnail"
         :icon="icon"
+        capture-as-image
       />
     </div>
 
-    <!-- Bury icon within SVG so it's more responsive, since font-size scaling is more difficult -->
     <div
       v-else-if="compact"
       class="kicon-wrapper"
@@ -65,7 +59,7 @@
       <KIcon
         :icon="icon"
         class="icon-thumbnail"
-        :style="{ fill: '#ffffff' }"
+        :style="{ fill: $themeTokens.textInverted }"
       />
     </div>
     <div
@@ -75,7 +69,7 @@
       <KIcon
         icon="image"
         class="icon-thumbnail"
-        :style="{ fill: '#123345', width: '40%', height: 'auto' }"
+        :style="{ fill: $themePalette.grey.v_400, width: '40%', height: '50px' }"
       />
     </div>
   </figure>
@@ -165,16 +159,8 @@
 <style lang="scss" scoped>
 
   $caption-height: 25px;
-  $svg-scale: 1.25;
   $aspect-ratio: 9 / 16;
-
   $aspect-percentage: $aspect-ratio * 100%;
-  $half-aspect-percentage: $aspect-percentage / 2;
-
-  $svg-width: $aspect-percentage / $svg-scale;
-  $svg-top: $half-aspect-percentage - ($svg-width / 2);
-  $svg-width-quarter: $svg-width / 4;
-  $svg-left-position: 50% - $svg-width-quarter;
 
   .thumbnail {
     position: relative;
@@ -207,76 +193,17 @@
     line-height: 11px;
   }
 
-  .thumbnail-image,
-  .nothumbnail-image {
+  .thumbnail-image {
     position: absolute;
-    display: block;
-  }
-
-  img.thumbnail-image {
     bottom: 0;
     left: 0;
+    display: block;
     width: 100%;
     height: 100%;
     overflow: hidden; // Don't show alt text outside of img boundaries
 
     .caption + & {
       height: calc(100% - #{$caption-height});
-    }
-  }
-
-  svg.thumbnail-image {
-    top: 0;
-    left: $svg-left-position;
-    width: $svg-width-quarter;
-    margin: 0 auto;
-    overflow: visible;
-
-    .icon-only & {
-      top: 18%;
-      left: 21%;
-      display: block;
-      width: 55%;
-
-      [dir='rtl'] & {
-        left: -10px;
-      }
-    }
-
-    text {
-      font-size: 1.8em;
-      line-height: 1.8em;
-    }
-  }
-
-  svg.nothumbnail-image {
-    top: 0;
-    width: $svg-width;
-    margin: 0 auto;
-    overflow: visible;
-
-    &.ltr-image {
-      left: 36%;
-    }
-
-    &.rtl-image {
-      right: 66%;
-    }
-
-    .caption + & {
-      top: calc(#{$caption-height / 2} + #{$svg-top});
-    }
-
-    .icon-only & {
-      top: 18%;
-      left: 21%;
-      display: block;
-      width: 55%;
-    }
-
-    text {
-      font-size: 1em;
-      line-height: 1em;
     }
   }
 

--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -25,7 +25,7 @@
         <KIcon
           :icon="icon"
           class="icon-thumbnail"
-          :style="{ fill: $themeTokens.textInverted }"
+          :color="$themeTokens.textInverted"
         />
       </VFlex>
       <VFlex shrink>
@@ -48,7 +48,6 @@
       <KIcon
         class="icon-thumbnail"
         :icon="icon"
-        capture-as-image
       />
     </div>
 
@@ -59,7 +58,7 @@
       <KIcon
         :icon="icon"
         class="icon-thumbnail"
-        :style="{ fill: $themeTokens.textInverted }"
+        :color="$themeTokens.textInverted"
       />
     </div>
     <div
@@ -69,7 +68,8 @@
       <KIcon
         icon="image"
         class="icon-thumbnail"
-        :style="{ fill: $themePalette.grey.v_400, width: '40%', height: '50px' }"
+        :color="$themePalette.grey.v_400"
+        :style="{ width: '40%', height: '50px' }"
       />
     </div>
   </figure>


### PR DESCRIPTION
## Summary
- Fix regressions after removing the SVG wrapper around KIcons.
- Add utility component to support contentKindIcon functionality. 

## References
closes #4991


## Reviewer guidance
- We would want to regression test Thumbnail component and see if things do not break. 
