### PR TITLE
Fixes unprocessed SASS expression in Thumbnail

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/files/Thumbnail.vue
@@ -176,11 +176,21 @@
 <style lang="scss" scoped>
 
   $caption-height: 25px;
+  $svg-scale: 1.25;
+  $aspect-ratio: 9 / 16;
+
+  $aspect-percentage: $aspect-ratio * 100%;
+  $half-aspect-percentage: $aspect-percentage / 2;
+
+  $svg-width: $aspect-percentage / $svg-scale;
+  $svg-top: $half-aspect-percentage - ($svg-width / 2);
+  $svg-width-quarter: $svg-width / 4;
+  $svg-left-position: 50% - $svg-width-quarter;
 
   .thumbnail {
     position: relative;
     /* stylelint-disable-next-line  */
-    padding-bottom: calc(100% * 9 / 16);
+    padding-bottom: $aspect-percentage;
 
     &.icon-only {
       padding-top: 0;
@@ -226,14 +236,10 @@
     }
   }
 
-  $svg-scale: 1.25;
-  $svg-width: calc(100% * 9 / 16 / #{$svg-scale});
-  $svg-top: calc((100% * 9 / 16 / 2) - ($svg-width / 2));
-
   svg.thumbnail-image {
     top: 0;
-    left: calc(50% - (#{$svg-width} / 4));
-    width: calc(#{$svg-width} / 4);
+    left: $svg-left-position;
+    width: $svg-width-quarter;
     margin: 0 auto;
     overflow: visible;
 
@@ -269,7 +275,7 @@
     }
 
     .caption + & {
-      top: calc((#{$caption-height} / 2) + #{$svg-top});
+      top: calc(#{$caption-height / 2} + #{$svg-top});
     }
 
     .icon-only & {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes any unprocessed sass expression that was causing UI glitches in the Thumbnail.vue component. It also refactors the css code to limit the use of the `calc()` to only situations when there are differences in units used. Other computations are not done during compile time, not at runtime as previously done.

**Before**
![image](https://github.com/user-attachments/assets/b320d766-28bc-4c9a-a4ee-26713642ea67)
![image](https://github.com/user-attachments/assets/fdc08f71-5ad6-4b00-8c71-0aca2a0f80f7)

**After**
<img width="1788" alt="Screenshot 2025-07-01 at 11 54 00" src="https://github.com/user-attachments/assets/e8f07a1b-9c54-4f5b-810d-8b4bfa0efe1d" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5065

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Have a large-ish channel on your Studio instance, with some nodes that have no thumbnail
- Open the Channel's details view
- Observe at the very bottom the Sample content from this channel has thumbnails (with and without an actual thumbnail picture), and in particular these thumbnails have an embedded kind header
- Open dev tools and inspect it
- Ensure that all SASS is processed
