### PR TITLE
Block double-submission of registration form

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -227,6 +227,7 @@
     },
     data() {
       return {
+        submitting: false,
         valid: true,
         registrationFailed: false,
         form: {
@@ -448,6 +449,10 @@
         return id === uses.OTHER && this.form.uses.includes(id);
       },
       submit() {
+        if (this.submitting) {
+          return;
+        }
+        this.submitting = true;
         // We need to check the "acceptedAgreement" here explicitly because it is not a
         // Vuetify form field and does not trigger the form validation.
         if (this.$refs.form.validate() && this.acceptedAgreement) {
@@ -486,10 +491,12 @@
                 this.registrationFailed = true;
                 this.valid = false;
               }
+              this.submitting = false;
             });
         } else if (this.$refs.top.scrollIntoView) {
           this.$refs.top.scrollIntoView({ behavior: 'smooth' });
         }
+        this.submitting = false;
         return Promise.resolve();
       },
       resetErrors(field) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When a user double-clicks the Submit button during account creation, the subsequent requests after the first cause a database error as reported in #4779 

This introduces a simple data property `submitting` to track if the user has submitted the form and ensures it is unset when an error occurs, reenabling the submit button.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #4779 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Open Dev Tools > Networking tab > [Filter to xhr]
- Double click the Submit button while making an account and you should only see one request made.

- Start over
- Trigger errors while filling out the form, then click Submit while the errors are present
- Fix the errors
- Click Submit and expect success
