### PR TITLE
chore: remove .kexternal-redirect margin override from UsingStudio page

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -29,7 +29,6 @@
     </p>
     <p>
       <KExternalLink
-        class="kexternal-redirect"
         href="https://kolibri-studio.readthedocs.io/en/latest/index.html"
         openInNewTab
         :text="$tr('userDocsLink')"
@@ -59,7 +58,6 @@
       <li>
         <p>
           <KExternalLink
-            class="kexternal-redirect"
             href="https://ricecooker.readthedocs.io/en/latest/video_compression.html"
             :text="$tr('bestPractice6')"
             openInNewTab
@@ -78,7 +76,6 @@
     <!-- Issues -->
     <h2>{{ $tr('notableIssues') }}</h2>
     <KExternalLink
-      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues/3992"
       :text="$tr('issueLink1')"
       openInNewTab
@@ -86,7 +83,6 @@
     />
     <p>{{ $tr('issue1') }}</p>
     <KExternalLink
-      class="kexternal-redirect"
       href="https://github.com/learningequality/studio/issues"
       :text="$tr('issuesPageLink')"
       openInNewTab
@@ -156,10 +152,6 @@
 
   h2 {
     margin-top: 32px;
-  }
-
-  .kexternal-redirect {
-    margin-left: -8px;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR removes the `.kexternal-redirect` margin override from the `UsingStudio.vue` page. This is part of a two-step fix — it depends on the [KDS PR #1067](https://github.com/learningequality/kolibri-design-system/pull/1067) being merged and released.

Once **both this PR and [KDS PR #1067](https://github.com/learningequality/kolibri-design-system/pull/1067)** are merged, the Studio-side layout will display correctly without requiring manual overrides.


### Manual Verification
- Open Studio → Settings → About Kolibri Studio
- Verify all `KExternalLink` components display correct spacing between icon and text
- Confirm no margin-related styling overrides remain for `.kexternal-redirect`

### Screenshots
> Note: The following screenshots were taken **after locally linking KDS with [KDS PR #1067](https://github.com/learningequality/kolibri-design-system/pull/1067) applied**, so you can see how Studio behaves when both PRs are merged.
<img width="1512" height="982" alt="Screenshot 2025-07-08 at 10 09 49 AM" src="https://github.com/user-attachments/assets/efec1256-453c-42e6-b191-96fbc26680b5" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Depends on: [KDS PR #1067](https://github.com/learningequality/kolibri-design-system/pull/1067)



## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Review this PR **only after verifying [KDS PR #1067](https://github.com/learningequality/kolibri-design-system/pull/1067) is merged or locally applied**
- Confirm that UI spacing looks correct in all `KExternalLink` instances on the page

