### PR TITLE
Do not use hardcoded colors in 'Request more space' form

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -93,7 +93,7 @@
     <div class="mt-2">
       <div
         v-if="errors.license"
-        style="color: red"
+        :style="{ color: $themeTokens.error }"
       >
         {{ $tr('fieldRequiredText') }}
       </div>
@@ -153,7 +153,7 @@
     <div class="mt-2">
       <div
         v-if="errors.org_or_personal"
-        style="color: red"
+        :style="{ color: $themeTokens.error }"
       >
         {{ $tr('fieldRequiredText') }}
       </div>
@@ -186,11 +186,11 @@
     <div class="mb-1 mt-3">
       <div
         v-if="errors.organization_type"
-        style="color: red"
+        :style="{ color: $themeTokens.error }"
       >
         {{ $tr('fieldRequiredText') }}
       </div>
-      <label :style="{ color: orgSelected ? 'black' : 'gray' }">
+      <label :style="{ color: orgSelected ? $themePalette.black : $themePalette.grey.v_300 }">
         {{ $tr('typeOfOrganizationLabel') }}
       </label>
     </div>

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -190,7 +190,7 @@
       >
         {{ $tr('fieldRequiredText') }}
       </div>
-      <label :style="{ color: orgSelected ? $themePalette.black : $themePalette.grey.v_300 }">
+      <label :style="{ color: orgSelected ? $themeTokens.text : $themeTokens.textDisabled }">
         {{ $tr('typeOfOrganizationLabel') }}
       </label>
     </div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Found three place which uses hardcoded colors in Storage/RequestForm. Updated them to KDS tokens

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

[5094](https://github.com/learningequality/studio/issues/5094)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Check everything is working as expected. 
Impacted area in requestForm. Check for below fields
- What type of organization or group is coordinating the use of Kolibri (if applicable)?
- What is the licensing of the content you are uploading? (Check all that apply)
- Organizational affiliation