### PR TITLE
Make tip tap editor sandbox completely dev only

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -11,16 +11,10 @@ import ReviewSelectionsPage from './views/ImportFromChannels/ReviewSelectionsPag
 import EditModal from './components/edit/EditModal';
 import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
 import ChannelModal from 'shared/views/channel/ChannelModal';
-import TipTapEditor from 'shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue';
 import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
 
 const router = new VueRouter({
   routes: [
-    {
-      path: '/editor-dev',
-      name: 'TipTapEditorDev',
-      component: TipTapEditor,
-    },
     {
       name: RouteNames.TREE_ROOT_VIEW,
       path: '/',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = (env = {}) => {
     })
   }
 
-  return merge(base, {
+  const config = merge(base, {
     context: srcDir,
     entry: {
       // Use arrays for every entry to allow for hot reloading.
@@ -103,7 +103,6 @@ module.exports = (env = {}) => {
       pdfJSWorker: ['pdfjs-dist/build/pdf.worker.entry.js'],
       // Utility for taking screenshots inside an iframe sandbox
       htmlScreenshot: ['./shared/utils/htmlScreenshot.js'],
-      editorDev: './editorDev/index.js',
     },
     output: {
       filename: dev ? '[name].js' : '[name]-[fullhash].js',
@@ -185,4 +184,8 @@ module.exports = (env = {}) => {
     ],
     stats: 'normal',
   });
+  if (dev) {
+    config.entry.editorDev = './editorDev/index.js';
+  }
+  return config;
 };


### PR DESCRIPTION
## Summary
Remove redundant channel edit editordev route.
Only build editordev bundle in development.
