### PR TITLE
Upgrade KDS from 5.2.0 to 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "jszip": "^3.10.1",
     "kolibri-constants": "^0.2.12",
-    "kolibri-design-system": "5.2.0",
+    "kolibri-design-system": "5.2.1",
     "lodash": "^4.17.21",
     "lowlight": "^3.3.0",
     "material-icons": "0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       kolibri-design-system:
-        specifier: 5.2.0
-        version: 5.2.0
+        specifier: 5.2.1
+        version: 5.2.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4852,8 +4852,8 @@ packages:
   kolibri-design-system@5.0.1:
     resolution: {integrity: sha512-oz5gEFUj7NYZbrqr89gPjSfRFVuuilSqILA4bbWqLWwkI9ay/uVMdsh8cY2Xajhtzccjwqa1c/NxUETr5kMfHQ==}
 
-  kolibri-design-system@5.2.0:
-    resolution: {integrity: sha512-F2dI0Oo1e6ahg+n7Jid+oFAfSq1FQWIO+DrheP7FUEK9DyrvqATvrf445anJ+jICkBcKgSkQyCPCEpsQpo8Erg==}
+  kolibri-design-system@5.2.1:
+    resolution: {integrity: sha512-KGZmhnqTBSetkrqc71BzlvWEiH4Hi8FQjqy0pYzpxdnRjb4Xx9l5Bp6w7WnAECQm10pEfbxUcfTBXUic0ecFmQ==}
 
   kolibri-format@1.0.1:
     resolution: {integrity: sha512-yGQpsJkBAzmRueAq6MG1UOuDl9pbhEtMWNxq9ObG5pPVkG8uhWJAS1L71GCuNAeaV1XG2IWo2565Ov4yXnudeA==}
@@ -13122,7 +13122,7 @@ snapshots:
       vue2-teleport: 1.1.4
       xstate: 4.38.3
 
-  kolibri-design-system@5.2.0:
+  kolibri-design-system@5.2.1:
     dependencies:
       aphrodite: https://codeload.github.com/learningequality/aphrodite/tar.gz/fdc8d7be8912a5cf17f74ff10f124013c52c3e32
       autosize: 3.0.21


### PR DESCRIPTION
## Summary

Upgrade KDS from 5.2.0 to 5.2.1.

Relevant release notes:
- https://github.com/learningequality/kolibri-design-system/releases/tag/v5.2.1

## Reviewer guidance

I think this should be fine to merge. No follow-up work is needed and I run Studio with this KDS version just fine locally.