### PR TITLE
Created new studioBanner for form validation

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -265,6 +265,7 @@
 
   import sortBy from 'lodash/sortBy';
   import { mapActions, mapState } from 'vuex';
+  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
   import { generateFormMixin, constantsTranslationMixin } from 'shared/mixins';
   import { LicensesList } from 'shared/leUtils/Licenses';
   import CountryField from 'shared/views/form/CountryField';
@@ -325,6 +326,10 @@
       InfoModal,
     },
     mixins: [constantsTranslationMixin, formMixin],
+    setup() {
+      const { sendPoliteMessage } = useKLiveRegion();
+      return { sendPoliteMessage };
+    },
     computed: {
       ...mapState('settings', ['channels']),
       orgSelected() {
@@ -393,6 +398,7 @@
         if (this.$refs.form.scrollIntoView) {
           this.$refs.form.scrollIntoView({ behavior: 'smooth' });
         }
+        this.sendPoliteMessage(this.errorText());
       },
 
       // eslint-disable-next-line kolibri/vue-no-unused-methods, vue/no-unused-properties
@@ -526,8 +532,8 @@
   }
 
   .studio-banner {
-    margin-top: 8px !important;
-    margin-bottom: 8px !important;
+    margin-top: 8px;
+    margin-bottom: 8px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/StudioBanner.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/StudioBanner.vue
@@ -15,26 +15,13 @@
 
 <script>
 
-  import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
-
   export default {
     name: 'StudioBanner',
-    setup() {
-      const { sendPoliteMessage } = useKLiveRegion();
-      return { sendPoliteMessage };
-    },
     props: {
       error: {
         type: Boolean,
         default: false,
       },
-    },
-    mounted() {
-      const slotContent = this.$slots.default;
-      const textContent = slotContent[0].text;
-      if (textContent && this.error) {
-        this.sendPoliteMessage(textContent);
-      }
     },
   };
 

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/studioBanner.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/studioBanner.spec.js
@@ -2,22 +2,9 @@ import { render, screen } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import StudioBanner from '../StudioBanner.vue';
 
-// Mock the Kolibri design system composable
-const mockSendPoliteMessage = jest.fn();
-jest.mock('kolibri-design-system/lib/composables/useKLiveRegion', () => ({
-  __esModule: true,
-  default: () => ({
-    sendPoliteMessage: mockSendPoliteMessage,
-  }),
-}));
-
 const sampleErrorMessage = 'This is an error message';
 
 describe('StudioBanner', () => {
-  beforeEach(() => {
-    mockSendPoliteMessage.mockClear();
-  });
-
   test('render with defaults values', () => {
     render(StudioBanner, {
       props: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Created a new studioBanner for form validation. 
Replaced Banner component with new studioBanner

Screenshots:
<img width="381" height="751" alt="Screenshot 2025-07-28 at 2 28 36 PM" src="https://github.com/user-attachments/assets/49d21426-043a-4d07-b5cc-95a59d0a720b" />
<img width="368" height="759" alt="Screenshot 2025-07-28 at 2 29 12 PM" src="https://github.com/user-attachments/assets/0abaef57-8f1f-484c-a53f-cdf0af5c3285" />
<img width="1512" height="826" alt="Screenshot 2025-07-28 at 2 28 44 PM" src="https://github.com/user-attachments/assets/4c3907e5-5b38-4fda-aa2e-47a6a7ff61d1" />
<img width="1512" height="845" alt="Screenshot 2025-07-28 at 2 29 01 PM" src="https://github.com/user-attachments/assets/6e8663a4-047b-40d7-86a8-fb93691a1c4e" />




## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
[5082](https://github.com/learningequality/studio/issues/5082)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Check storage request form validation.
If there are any errors new banner should be shown. 
On change of any field. Should update error count in banner
