### PR TITLE
[Remove Vuetify from Studio] Top-level buttons in Channels

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -14,16 +14,15 @@
       >
         <VLayout>
           <VSpacer />
-         <KButton
-  v-if="isEditable && !loading"
-  appearance="raised-button"
-  primary
-  class="add-channel-button"
-  data-test="add-channel"
-  @click="newChannel"
-  :text="$tr('channel')"
->
-         </KButton>
+          <KButton
+            v-if="isEditable && !loading"
+            appearance="raised-button"
+            primary
+            class="add-channel-button"
+            data-test="add-channel"
+            :text="$tr('channel')"
+            @click="newChannel"
+          />
         </VLayout>
       </VFlex>
     </VLayout>
@@ -78,7 +77,7 @@
   import LoadingText from 'shared/views/LoadingText';
   import { ChannelListTypes } from 'shared/constants';
 
-function listTypeValidator(value) {
+  function listTypeValidator(value) {
     // The value must match one of the ListTypes
     return Object.values(ChannelListTypes).includes(value);
   }
@@ -88,7 +87,7 @@ function listTypeValidator(value) {
     components: {
       ChannelItem,
       LoadingText,
-     },
+    },
     props: {
       listType: {
         type: String,

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/ChannelList.vue
@@ -14,15 +14,16 @@
       >
         <VLayout>
           <VSpacer />
-          <VBtn
-            v-if="isEditable && !loading"
-            color="primary"
-            class="add-channel-button"
-            data-test="add-channel"
-            @click="newChannel"
-          >
-            {{ $tr('channel') }}
-          </VBtn>
+         <KButton
+  v-if="isEditable && !loading"
+  appearance="raised-button"
+  primary
+  class="add-channel-button"
+  data-test="add-channel"
+  @click="newChannel"
+  :text="$tr('channel')"
+>
+         </KButton>
         </VLayout>
       </VFlex>
     </VLayout>
@@ -77,7 +78,7 @@
   import LoadingText from 'shared/views/LoadingText';
   import { ChannelListTypes } from 'shared/constants';
 
-  function listTypeValidator(value) {
+function listTypeValidator(value) {
     // The value must match one of the ListTypes
     return Object.values(ChannelListTypes).includes(value);
   }
@@ -87,7 +88,7 @@
     components: {
       ChannelItem,
       LoadingText,
-    },
+     },
     props: {
       listType: {
         type: String,

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -44,11 +44,9 @@
           appearance="raised-button"
           primary
           data-test="add-channelset"
+          :text="$tr('addChannelSetTitle')"
           @click="newChannelSet"
-          :text= "$tr('addChannelSetTitle')"
-        >
-        
-        </KButton>
+        />
       </VFlex>
     </VLayout>
     <VLayout

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -39,14 +39,16 @@
       </VFlex>
       <VSpacer />
       <VFlex class="text-xs-right">
-        <VBtn
+        <KButton
           v-if="!loading"
-          color="primary"
+          appearance="raised-button"
+          primary
           data-test="add-channelset"
           @click="newChannelSet"
+          :text= "$tr('addChannelSetTitle')"
         >
-          {{ $tr('addChannelSetTitle') }}
-        </VBtn>
+        
+        </KButton>
       </VFlex>
     </VLayout>
     <VLayout


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary

**Solves Issue #5218** 

Removed Vuetify that used  `VBtn`  from the following buttons in Channels:
That is `<NewChannel>` and `< NewCollection>` and used `KButton` to replace them which is a KDS component.



<img width="1486" height="433" alt="image" src="https://github.com/user-attachments/assets/1184c210-75a7-4bdb-bdf9-f22e36dbdd8d" />

<img width="1156" height="433" alt="image" src="https://github.com/user-attachments/assets/89d07b6e-e736-4897-80e5-5190b2d64eb2" />



…

## References


1) https://design-system.learningequality.org/buttons/ [ The buttons are supposed to be like this]
2) https://design-system.learningequality.org/kbutton [ the KButton format]

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Upadted VBtn with KButton
…
