### PR TITLE
Ensure channel version database exists when adding to community library

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -2601,6 +2601,9 @@ class CommunityLibrarySubmission(models.Model):
     internal_notes = models.TextField(blank=True, null=True)
 
     def save(self, *args, **kwargs):
+        # Not a top-level import to avoid circular import issues
+        from contentcuration.utils.publish import ensure_versioned_database_exists
+
         # Validate on save that the submission author is an editor of the channel
         # and that the version is not greater than the current channel version.
         # These cannot be expressed as constraints because traversing
@@ -2622,6 +2625,12 @@ class CommunityLibrarySubmission(models.Model):
                 "Channel version must be less than or equal to the current channel version",
                 code="impossibly_high_channel_version",
             )
+
+        if self.pk is None:
+            # When creating a new submission, ensure the channel has a versioned database
+            # (it might not have if the channel was published before versioned databases
+            # were introduced).
+            ensure_versioned_database_exists(self.channel)
 
         super().save(*args, **kwargs)
 

--- a/contentcuration/contentcuration/tasks.py
+++ b/contentcuration/contentcuration/tasks.py
@@ -19,6 +19,7 @@ from contentcuration.models import User
 from contentcuration.utils.csv_writer import write_user_csv
 from contentcuration.utils.nodes import calculate_resource_size
 from contentcuration.utils.nodes import generate_diff
+from contentcuration.utils.publish import ensure_versioned_database_exists
 from contentcuration.viewsets.user import AdminUserFilter
 
 
@@ -159,3 +160,8 @@ def sendcustomemails_task(subject, message, query):
             text,
             settings.DEFAULT_FROM_EMAIL,
         )
+
+
+@app.task(name="ensure_versioned_database_exists_task")
+def ensure_versioned_database_exists_task(channel_id, channel_version):
+    ensure_versioned_database_exists(channel_id, channel_version)

--- a/contentcuration/contentcuration/tests/test_models.py
+++ b/contentcuration/contentcuration/tests/test_models.py
@@ -710,7 +710,7 @@ class CommunityLibrarySubmissionTestCase(PermissionQuerysetTestCase):
         )
         self.assertQuerysetContains(queryset, pk=submission_a.id)
 
-    def test_mark_live(self):
+    def test_mark_live(self, mock_ensure_db_exists):
         submission_a = testdata.community_library_submission()
         submission_b = testdata.community_library_submission()
 

--- a/contentcuration/contentcuration/tests/utils/restricted_filesystemstorage.py
+++ b/contentcuration/contentcuration/tests/utils/restricted_filesystemstorage.py
@@ -1,0 +1,32 @@
+from django.core.files.storage import FileSystemStorage
+
+
+class RestrictedFileSystemStorage:
+    """
+    A wrapper around FileSystemStorage that is restricted to more closely match
+    the behavior of S3Storage which is used in production. In particuler,
+    it does not expose the `path` method, and opening files for writing
+    is not allowed.
+    This cannot be solved by just mocking the `path` method, because
+    it is used by the `FileSystemStorage` class internally.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._inner = FileSystemStorage(*args, **kwargs)
+
+    def __getattr__(self, name):
+        if name == "path":
+            raise NotImplementedError(
+                "The 'path' method is intentionally not available."
+            )
+        return getattr(self._inner, name)
+
+    def open(self, name, mode="rb"):
+        if "w" in mode:
+            raise ValueError(
+                "Opening files for writing will not be available in production."
+            )
+        return self._inner.open(name, mode)
+
+    def __dir__(self):
+        return [x for x in dir(self._inner) if x != "path"]

--- a/contentcuration/contentcuration/tests/utils/test_publish.py
+++ b/contentcuration/contentcuration/tests/utils/test_publish.py
@@ -3,10 +3,12 @@ import tempfile
 from unittest import mock
 
 from django.conf import settings
-from django.core.files.storage import FileSystemStorage
 
 from contentcuration.tests import testdata
 from contentcuration.tests.base import StudioTestCase
+from contentcuration.tests.utils.restricted_filesystemstorage import (
+    RestrictedFileSystemStorage,
+)
 from contentcuration.utils.publish import ensure_versioned_database_exists
 
 
@@ -17,7 +19,7 @@ class EnsureVersionedDatabaseTestCase(StudioTestCase):
         self._temp_directory_ctx = tempfile.TemporaryDirectory()
         self.test_db_root_dir = self._temp_directory_ctx.__enter__()
 
-        storage = FileSystemStorage(location=self.test_db_root_dir)
+        storage = RestrictedFileSystemStorage(location=self.test_db_root_dir)
 
         self._storage_patch_ctx = mock.patch(
             "contentcuration.utils.publish.storage",

--- a/contentcuration/contentcuration/tests/utils/test_publish.py
+++ b/contentcuration/contentcuration/tests/utils/test_publish.py
@@ -63,7 +63,7 @@ class EnsureVersionedDatabaseTestCase(StudioTestCase):
         with open(self.unversioned_db_path, "w") as f:
             f.write(unversioned_db_content)
 
-        ensure_versioned_database_exists(self.channel)
+        ensure_versioned_database_exists(self.channel.id, self.channel.version)
 
         with open(self.versioned_db_path) as f:
             read_versioned_content = f.read()
@@ -75,7 +75,7 @@ class EnsureVersionedDatabaseTestCase(StudioTestCase):
         with open(self.unversioned_db_path, "w") as f:
             f.write(unversioned_db_content)
 
-        ensure_versioned_database_exists(self.channel)
+        ensure_versioned_database_exists(self.channel.id, self.channel.version)
 
         with open(self.versioned_db_path) as f:
             read_versioned_content = f.read()
@@ -91,4 +91,4 @@ class EnsureVersionedDatabaseTestCase(StudioTestCase):
         )
 
         with self.assertRaises(ValueError):
-            ensure_versioned_database_exists(self.channel)
+            ensure_versioned_database_exists(self.channel.id, self.channel.version)

--- a/contentcuration/contentcuration/tests/utils/test_publish.py
+++ b/contentcuration/contentcuration/tests/utils/test_publish.py
@@ -1,0 +1,92 @@
+import os
+import tempfile
+from unittest import mock
+
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioTestCase
+from contentcuration.utils.publish import ensure_versioned_database_exists
+
+
+class EnsureVersionedDatabaseTestCase(StudioTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self._temp_directory_ctx = tempfile.TemporaryDirectory()
+        self.test_db_root_dir = self._temp_directory_ctx.__enter__()
+
+        storage = FileSystemStorage(location=self.test_db_root_dir)
+
+        self._storage_patch_ctx = mock.patch(
+            "contentcuration.utils.publish.storage",
+            new=storage,
+        )
+        self._storage_patch_ctx.__enter__()
+
+        os.makedirs(
+            os.path.join(self.test_db_root_dir, settings.DB_ROOT), exist_ok=True
+        )
+
+        self.channel = testdata.channel()
+        self.channel.version = 2
+        self.channel.save()
+
+        self.versioned_db_path = os.path.join(
+            self.test_db_root_dir,
+            settings.DB_ROOT,
+            f"{self.channel.id}-{self.channel.version}.sqlite3",
+        )
+        self.unversioned_db_path = os.path.join(
+            self.test_db_root_dir, settings.DB_ROOT, f"{self.channel.id}.sqlite3"
+        )
+
+    def tearDown(self):
+        self._temp_directory_ctx.__exit__(None, None, None)
+        self._storage_patch_ctx.__exit__(None, None, None)
+
+        super().tearDown()
+
+    def test_versioned_database_exists(self):
+        # In reality, the versioned database for the current version
+        # and the unversioned database would have the same content,
+        # but here we provide different content so that we can test
+        # that the versioned database is not overwritten.
+        versioned_db_content = "Versioned content"
+        unversioned_db_content = "Unversioned content"
+
+        with open(self.versioned_db_path, "w") as f:
+            f.write(versioned_db_content)
+        with open(self.unversioned_db_path, "w") as f:
+            f.write(unversioned_db_content)
+
+        ensure_versioned_database_exists(self.channel)
+
+        with open(self.versioned_db_path) as f:
+            read_versioned_content = f.read()
+        self.assertEqual(read_versioned_content, versioned_db_content)
+
+    def test_versioned_database_does_not_exist(self):
+        unversioned_db_content = "Unversioned content"
+
+        with open(self.unversioned_db_path, "w") as f:
+            f.write(unversioned_db_content)
+
+        ensure_versioned_database_exists(self.channel)
+
+        with open(self.versioned_db_path) as f:
+            read_versioned_content = f.read()
+        self.assertEqual(read_versioned_content, unversioned_db_content)
+
+    def test_not_published(self):
+        self.channel.version = 0
+        self.channel.save()
+        self.versioned_db_path = os.path.join(
+            self.test_db_root_dir,
+            settings.DB_ROOT,
+            f"{self.channel.id}-{self.channel.version}.sqlite3",
+        )
+
+        with self.assertRaises(ValueError):
+            ensure_versioned_database_exists(self.channel)

--- a/contentcuration/contentcuration/tests/utils/test_restricted_filesystemstorage.py
+++ b/contentcuration/contentcuration/tests/utils/test_restricted_filesystemstorage.py
@@ -1,0 +1,44 @@
+import tempfile
+
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from contentcuration.tests.utils.restricted_filesystemstorage import (
+    RestrictedFileSystemStorage,
+)
+
+
+class RestrictedFileSystemStorageTestCase(TestCase):
+    # Sanity-checks that the RestrictedFileSystemStorage wrapper used in tests
+    # works as expected, not actually testing application code
+
+    def setUp(self):
+        super().setUp()
+
+        self._temp_directory_ctx = tempfile.TemporaryDirectory()
+        self.temp_dir = self._temp_directory_ctx.__enter__()
+
+        self.storage = RestrictedFileSystemStorage(location=self.temp_dir)
+
+    def tearDown(self):
+        self._temp_directory_ctx.__exit__(None, None, None)
+        super().tearDown()
+
+    def test_opening_for_read_works(self):
+        test_content = "test content"
+
+        self.storage.save("filename", ContentFile(test_content))
+        with self.storage.open("filename", "r") as f:
+            content = f.read()
+            self.assertEqual(content, test_content)
+
+    def test_opening_for_write_does_not_work(self):
+        test_content = "test content"
+
+        with self.assertRaises(ValueError):
+            with self.storage.open("filename", "w") as f:
+                f.write(test_content)
+
+    def test_path_does_not_work(self):
+        with self.assertRaises(NotImplementedError):
+            self.storage.path("filename")

--- a/contentcuration/contentcuration/tests/viewsets/base.py
+++ b/contentcuration/contentcuration/tests/viewsets/base.py
@@ -2,9 +2,8 @@ import random
 
 from django.urls import reverse
 
-from contentcuration.celery import app
 from contentcuration.models import Change
-from contentcuration.tests.helpers import clear_tasks
+from contentcuration.tests.helpers import EagerTasksTestMixin
 from contentcuration.viewsets.sync.constants import CHANNEL
 from contentcuration.viewsets.sync.constants import SYNCED
 from contentcuration.viewsets.sync.utils import _generate_event as base_generate_event
@@ -102,25 +101,7 @@ def generate_publish_next_event(channel_id, use_staging_tree=False):
     return event
 
 
-class SyncTestMixin(object):
-    celery_task_always_eager = None
-
-    @classmethod
-    def setUpClass(cls):
-        super(SyncTestMixin, cls).setUpClass()
-        # update celery so tasks are always eager for this test, meaning they'll execute synchronously
-        cls.celery_task_always_eager = app.conf.task_always_eager
-        app.conf.update(task_always_eager=True)
-
-    def setUp(self):
-        super(SyncTestMixin, self).setUp()
-        clear_tasks()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(SyncTestMixin, cls).tearDownClass()
-        app.conf.update(task_always_eager=cls.celery_task_always_eager)
-
+class SyncTestMixin(EagerTasksTestMixin):
     @property
     def sync_url(self):
         return reverse("sync")

--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -547,8 +547,11 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         self.assertEqual(len(response.json()["allowed"]), 0, response.content)
         self.assertEqual(len(response.json()["disallowed"]), 1, response.content)
 
+    @mock.patch("contentcuration.utils.publish.ensure_versioned_database_exists")
     @mock.patch("contentcuration.viewsets.channel.export_channel_to_kolibri_public")
-    def test_process_added_to_community_library_change(self, mock_export_func):
+    def test_process_added_to_community_library_change(
+        self, mock_export_func, mock_ensure_db_exists
+    ):
         # Creating the change on the backend should be supported
         self.client.force_authenticate(self.admin_user)
 

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -2,7 +2,6 @@ import itertools
 import json
 import logging as logmodule
 import os
-import shutil
 import tempfile
 import time
 import uuid
@@ -1119,8 +1118,7 @@ def ensure_versioned_database_exists(channel):
             )
 
         with storage.open(unversioned_db_storage_path, "rb") as unversioned_db_file:
-            with storage.open(versioned_db_storage_path, "wb") as versioned_db_file:
-                shutil.copyfileobj(unversioned_db_file, versioned_db_file)
+            storage.save(versioned_db_storage_path, unversioned_db_file)
 
         logging.info(
             f"Versioned database for channel {channel.id} did not exist, copied the unversioned database to {versioned_db_storage_path}."

--- a/contentcuration/kolibri_public/tests/test_export_channels_to_kolibri_public.py
+++ b/contentcuration/kolibri_public/tests/test_export_channels_to_kolibri_public.py
@@ -126,7 +126,7 @@ class ExportTestCase(TestCase):
         super().tearDown()
 
     @mock.patch("kolibri_public.utils.export_channel_to_kolibri_public.ChannelMapper")
-    def test_export_channel_to_kolibri_public__existing_version__versioned(
+    def test_export_channel_to_kolibri_public__existing_version(
         self, mock_channel_mapper
     ):
         categories = ["Category1", "Category2"]
@@ -147,29 +147,6 @@ class ExportTestCase(TestCase):
             public=True,
             categories=categories,
             countries=countries,
-        )
-        mock_channel_mapper.return_value.run.assert_called_once_with()
-
-    @mock.patch("kolibri_public.utils.export_channel_to_kolibri_public.ChannelMapper")
-    def test_export_channel_to_kolibri_public__existing_version__unversioned(
-        self, mock_channel_mapper
-    ):
-        os.remove(self.versioned_db_path)
-
-        export_channel_to_kolibri_public(
-            channel_id=self.channel_id,
-            channel_version=1,
-            public=True,
-            categories=None,
-            countries=None,
-        )
-
-        mock_channel_mapper.assert_called_once_with(
-            channel=self.exported_channel_metadata,
-            channel_version=1,
-            public=True,
-            categories=None,
-            countries=None,
         )
         mock_channel_mapper.return_value.run.assert_called_once_with()
 

--- a/contentcuration/kolibri_public/tests/test_export_channels_to_kolibri_public.py
+++ b/contentcuration/kolibri_public/tests/test_export_channels_to_kolibri_public.py
@@ -5,7 +5,6 @@ import uuid
 from unittest import mock
 
 from django.conf import settings
-from django.core.files.storage import FileSystemStorage
 from django.core.management import call_command
 from django.test import TestCase
 from kolibri_content.apps import KolibriContentConfig
@@ -18,59 +17,9 @@ from kolibri_public.utils.export_channel_to_kolibri_public import (
 )
 
 from contentcuration.models import Country
-
-
-class FileSystemStorageWithoutPath:
-    """
-    A wrapper around FileSystemStorage that does not expose the `path` method,
-    as this will not be available in production where S3Storage is used.
-    This cannot be solved by just mocking the `path` method, because
-    it is used by the `FileSystemStorage` class internally.
-    """
-
-    def __init__(self, *args, **kwargs):
-        self._inner = FileSystemStorage(*args, **kwargs)
-
-    def __getattr__(self, name):
-        if name == "path":
-            raise NotImplementedError(
-                "The 'path' method is intentionally not available."
-            )
-        return getattr(self._inner, name)
-
-    def __dir__(self):
-        return [x for x in dir(self._inner) if x != "path"]
-
-
-class FileSystemStorageWithoutPathTestCase(TestCase):
-    # Sanity-checks that the wrapper above works as expected,
-    # not actually testing application code
-
-    def setUp(self):
-        super().setUp()
-
-        self._temp_directory_ctx = tempfile.TemporaryDirectory()
-        self.temp_dir = self._temp_directory_ctx.__enter__()
-
-        self.storage = FileSystemStorageWithoutPath(location=self.temp_dir)
-
-    def tearDown(self):
-        self._temp_directory_ctx.__exit__(None, None, None)
-        super().tearDown()
-
-    def test_open_works(self):
-        test_content = "test content"
-
-        with self.storage.open("filename", "w") as f:
-            f.write(test_content)
-
-        with open(os.path.join(self.temp_dir, "filename"), "r") as f:
-            content = f.read()
-            self.assertEqual(content, test_content)
-
-    def test_path_does_not_work(self):
-        with self.assertRaises(NotImplementedError):
-            self.storage.path("filename")
+from contentcuration.tests.utils.restricted_filesystemstorage import (
+    RestrictedFileSystemStorage,
+)
 
 
 class ExportTestCase(TestCase):
@@ -80,7 +29,7 @@ class ExportTestCase(TestCase):
         self._temp_directory_ctx = tempfile.TemporaryDirectory()
         test_db_root_dir = self._temp_directory_ctx.__enter__()
 
-        self.storage = FileSystemStorageWithoutPath(location=test_db_root_dir)
+        self.storage = RestrictedFileSystemStorage(location=test_db_root_dir)
 
         self._storage_patch_ctx = mock.patch(
             "kolibri_public.utils.export_channel_to_kolibri_public.storage",

--- a/contentcuration/kolibri_public/utils/export_channel_to_kolibri_public.py
+++ b/contentcuration/kolibri_public/utils/export_channel_to_kolibri_public.py
@@ -16,7 +16,7 @@ from kolibri_public.utils.mapper import ChannelMapper
 logger = logging.getLogger(__file__)
 
 
-class using_temp_migrated_database:
+class using_temp_migrated_content_database:
     """
     A wrapper context manager for read-only access to a content database
     that might not have all current migrations applied. Works by copying
@@ -77,7 +77,7 @@ def export_channel_to_kolibri_public(
     else:
         db_storage_path = versioned_db_storage_path
 
-    with using_temp_migrated_database(db_storage_path):
+    with using_temp_migrated_content_database(db_storage_path):
         channel = ExportedChannelMetadata.objects.get(id=channel_id)
         logger.info(
             "Found channel {} for id: {} mapping now".format(channel.name, channel_id)

--- a/contentcuration/kolibri_public/utils/export_channel_to_kolibri_public.py
+++ b/contentcuration/kolibri_public/utils/export_channel_to_kolibri_public.py
@@ -84,7 +84,6 @@ def export_channel_to_kolibri_public(
         )
         mapper = ChannelMapper(
             channel=channel,
-            channel_version=channel_version,
             public=public,
             categories=categories,
             countries=countries,


### PR DESCRIPTION
## Summary

This PR ensures that if an older channel that does not have a versioned database file yet is added to the community library, the versioned database file is created.

## References

Solves #5191.

~This PR depends on changes from #5228, and must be **merged after it**.~ _(Done)_

## Reviewer guidance

~After merging #5228, this PR should first be rebased onto the merged changes and only then reviewed and merged.~ _(Done)_