### PR TITLE
Update publish_next to be able to use main_tree

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -552,7 +552,7 @@
       ...mapActions('currentChannel', [
         'loadCurrentChannelStagingDiff',
         'deployCurrentChannel',
-        'publishDraftChannel',
+        'publishStagingChannel',
         'reloadCurrentChannelStagingDiff',
       ]),
       ...mapActions('currentChannel', { loadCurrentChannel: 'loadChannel' }),
@@ -646,7 +646,7 @@
         this.displayPublishDraftDialog = false;
         this.isPublishingDraft = true;
 
-        this.publishDraftChannel()
+        this.publishStagingChannel()
           .then(() => {
             this.isPublishingDraft = false;
             this.showSnackbar({

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/actions.js
@@ -59,6 +59,10 @@ export function publishDraftChannel(context) {
   return Channel.publishDraft(context.state.currentChannelId);
 }
 
+export function publishStagingChannel(context) {
+  return Channel.publishDraft(context.state.currentChannelId, true);
+}
+
 export function channelLanguageExistsInResources(context) {
   const channelId = context.state.currentChannelId;
   return Channel.languageExistsInResources(channelId);

--- a/contentcuration/contentcuration/frontend/shared/data/changes.js
+++ b/contentcuration/contentcuration/frontend/shared/data/changes.js
@@ -439,7 +439,7 @@ export class PublishedChange extends Change {
 }
 
 export class PublishedNextChange extends Change {
-  constructor(fields) {
+  constructor({ use_staging_tree, version_notes, language, ...fields }) {
     fields.type = CHANGE_TYPES.PUBLISHED_NEXT;
     super(fields);
     if (this.table !== TABLE_NAMES.CHANNEL) {
@@ -447,6 +447,9 @@ export class PublishedNextChange extends Change {
         `${this.changeType} is only supported by ${TABLE_NAMES.CHANNEL} table but ${this.table} was passed instead`,
       );
     }
+    this.setAndValidateBoolean(use_staging_tree, 'use_staging_tree');
+    this.setAndValidateIsDefined(version_notes, 'version_notes');
+    this.setAndValidateIsDefined(language, 'language');
     this.setChannelAndUserId({ id: this.key });
   }
 }

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -1234,9 +1234,12 @@ export const Channel = new CreateModelResource({
     });
   },
 
-  publishDraft(id) {
+  publishDraft(id, use_staging_tree=false, version_notes="") {
     const change = new PublishedNextChange({
       key: id,
+      use_staging_tree: use_staging_tree,
+      version_notes: version_notes,
+      language: currentLanguage,
       table: this.tableName,
       source: CLIENTID,
     });

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -36,7 +36,7 @@ const ChangeTypeMapFields = {
     'excluded_descendants',
   ]),
   [CHANGE_TYPES.PUBLISHED]: commonFields.concat(['version_notes', 'language']),
-  [CHANGE_TYPES.PUBLISHED_NEXT]: commonFields,
+  [CHANGE_TYPES.PUBLISHED_NEXT]: commonFields.concat(['use_staging_tree', 'version_notes', 'language']),
   [CHANGE_TYPES.SYNCED]: commonFields.concat([
     'titles_and_descriptions',
     'resource_details',

--- a/contentcuration/contentcuration/tests/viewsets/base.py
+++ b/contentcuration/contentcuration/tests/viewsets/base.py
@@ -94,8 +94,8 @@ def generate_publish_channel_event(channel_id):
     return event
 
 
-def generate_publish_next_event(channel_id):
-    event = base_generate_publish_next_event(channel_id)
+def generate_publish_next_event(channel_id, use_staging_tree=False):
+    event = base_generate_publish_next_event(channel_id, use_staging_tree=use_staging_tree)
     event["rev"] = random.randint(1, 10000000)
     return event
 

--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -507,10 +507,13 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         channel.save()
         self.assertEqual(channel.staging_tree.published, False)
 
-        response = self.sync_changes([generate_publish_next_event(channel.id)])
+        response = self.sync_changes([generate_publish_next_event(channel.id, use_staging_tree=True)])
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json().get("errors", [])), 0)
+        self.assertTrue(
+            "Channel is not ready to be published"
+            in response.json()["errors"][0]["errors"][0]
+        )
         modified_channel = models.Channel.objects.get(id=channel.id)
         self.assertEqual(modified_channel.staging_tree.published, False)
 

--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -492,7 +492,7 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
 
         self.assertEqual(response.status_code, 200)
         modified_channel = models.Channel.objects.get(id=channel.id)
-        self.assertEqual(modified_channel.staging_tree.published, True)
+        self.assertEqual(modified_channel.staging_tree.published, False)
 
     def test_publish_next_with_incomplete_staging_tree(self):
         channel = testdata.channel()
@@ -510,10 +510,7 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         response = self.sync_changes([generate_publish_next_event(channel.id)])
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(
-            "Channel is not ready to be published"
-            in response.json()["errors"][0]["errors"][0]
-        )
+        self.assertEqual(len(response.json().get("errors", [])), 0)
         modified_channel = models.Channel.objects.get(id=channel.id)
         self.assertEqual(modified_channel.staging_tree.published, False)
 

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -152,7 +152,6 @@ def create_content_database(
     """
     :type progress_tracker: contentcuration.utils.celery.ProgressTracker|None
     """
-    logging.debug("create_content_database - use_staging_tree %s", use_staging_tree)
     if not is_draft_version and use_staging_tree:
         raise ValueError("Staging tree is only supported for draft versions")
 
@@ -1308,7 +1307,6 @@ def publish_channel(  # noqa: C901
     """
     :type progress_tracker: contentcuration.utils.celery.ProgressTracker|None
     """
-    logging.debug("publish_channel - use_staging_tree %s", use_staging_tree)
     channel = ccmodels.Channel.objects.get(pk=channel_id)
     base_tree = channel.staging_tree if use_staging_tree else channel.main_tree
     if base_tree is None:

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -606,9 +606,11 @@ class ChannelViewSet(ValuesViewset):
                 raise
 
     def publish_next_from_changes(self, changes):
+
         errors = []
         for publish in changes:
             try:
+                logging.debug("publish_next_from_changes - use_staging_tree %s", publish.get("use_staging_tree", False))
                 self.publish_next(
                     publish["key"],
                     version_notes=publish.get("version_notes"),
@@ -623,6 +625,7 @@ class ChannelViewSet(ValuesViewset):
 
     def publish_next(self, pk, version_notes="", language=None, use_staging_tree=False):
         logging.debug("Entering the publish staging channel endpoint")
+        logging.debug("publish_next - use_staging_tree %s", use_staging_tree)
 
         channel = self.get_edit_queryset().get(pk=pk)
 

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -610,7 +610,6 @@ class ChannelViewSet(ValuesViewset):
         errors = []
         for publish in changes:
             try:
-                logging.debug("publish_next_from_changes - use_staging_tree %s", publish.get("use_staging_tree", False))
                 self.publish_next(
                     publish["key"],
                     version_notes=publish.get("version_notes"),
@@ -625,7 +624,6 @@ class ChannelViewSet(ValuesViewset):
 
     def publish_next(self, pk, version_notes="", language=None, use_staging_tree=False):
         logging.debug("Entering the publish staging channel endpoint")
-        logging.debug("publish_next - use_staging_tree %s", use_staging_tree)
 
         channel = self.get_edit_queryset().get(pk=pk)
 

--- a/contentcuration/contentcuration/viewsets/sync/utils.py
+++ b/contentcuration/contentcuration/viewsets/sync/utils.py
@@ -97,10 +97,11 @@ def generate_update_descendants_event(key, mods, channel_id=None, user_id=None):
     return event
 
 
-def generate_publish_next_event(key, version_notes="", language=None):
+def generate_publish_next_event(key, version_notes="", language=None, use_staging_tree=False):
     event = _generate_event(key, CHANNEL, PUBLISHED_NEXT, key, None)
     event["version_notes"] = version_notes
     event["language"] = language
+    event["use_staging_tree"] = use_staging_tree
     return event
 
 


### PR DESCRIPTION
## Summary
- Enhanced publish functionality to support three publish types using is_draft_version and use_staging_tree parameters. Added ability to publish main tree content as drafts without marking content as published. For draft publishes (both staging and main tree), content remains in unpublished state - only regular publish marks content as published.

- Manual verification: Tested publish draft functionality using main tree, verified only {channel_id}-next.sqlite3 file is created, confirmed channel version is not incremented, and main tree remains unpublished after draft publish.

## References
https://github.com/learningequality/studio/issues/5192

## Reviewer guidance
Run unit tests. Test existing publish and staging tree publish are not affected.