### PR TITLE
Fix/Replace Vuetify with KDS on ‘Channel Not Found’ Page

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/errors/ChannelNotFoundError.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/ChannelNotFoundError.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <AppError>
+  <StudioAppError>
     <template #header>
       {{ $tr('channelNotFoundHeader') }}
     </template>
@@ -8,26 +8,28 @@
       {{ $tr('channelNotFoundDetails') }}
     </template>
     <template #actions>
-      <VBtn
+      <KRouterLink
         v-bind="backHomeLink"
-        color="primary"
+        appearance="raised-button"
+        :primary="true"
+        style="margin-top: 1rem;"
       >
         {{ $tr('backToHomeAction') }}
-      </VBtn>
+      </KRouterLink>
     </template>
-  </AppError>
+  </StudioAppError>
 
 </template>
 
 
 <script>
 
-  import AppError from './AppError';
+  import StudioAppError from './StudioAppError.vue';
 
   export default {
     name: 'ChannelNotFoundError',
     components: {
-      AppError,
+      StudioAppError,
     },
     props: {
       backHomeLink: {

--- a/contentcuration/contentcuration/frontend/shared/views/errors/StudioAppError.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/StudioAppError.vue
@@ -1,0 +1,44 @@
+<template>
+
+  <div class="studio-app-error">
+    <h1>
+      <slot name="header"></slot>
+    </h1>
+    <p class="details">
+      <slot name="details"></slot>
+    </p>
+    <div>
+      <slot name="actions"></slot>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'StudioAppError',
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+.studio-app-error {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 50vh;
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.details {
+  max-width: 675px;
+  margin: 1rem 0;
+}
+
+</style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR removes Vuetify usage from ChannelNotFoundError.vue and replaces it with Kolibri Design System components, as part of the Vuetify removal project #5060 .

**Changes:**

- Replaced AppError with a new StudioAppError component using custom CSS layout (no Vuetify dependency).

- Swapped VBtn with KRouterLink styled as a raised primary button.

- Preserved UI layout and spacing to match original design.

**Manual Verification:**

- Navigated to the “Channel Not Found” error page using:
`<ChannelListAppError v-if="true" :error="{ errorType: 'CHANNEL_NOT_FOUND' }" />`


- Layout is centered and responsive.

- Checked RTL and LTR alignment using pnpm run devserver.

**Screenshots**
Screenshot after changes:
<img width="1512" height="982" alt="Screenshot 2025-08-02 at 9 16 07 AM" src="https://github.com/user-attachments/assets/7bfa740c-78ac-4c59-8525-3a5d3f008171" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- Issue: #5235 

- Parent: #5060

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Verify no visual regression from the old AppError.vue version

2. Confirm that KRouterLink correctly replaces VBtn
3. Review responsiveness and spacing

…
