### PR TITLE
[Remove Vuetify from Studio] 'About collections' link and modal in Channels #5234

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -11,14 +11,16 @@
       justify-center
     >
       <VFlex>
-        <ActionLink
+        <KButton
           :text="$tr('aboutChannelSetsLink')"
+          appearance="basic-link"
           class="mx-2"
           @click="infoDialog = true"
         />
-        <MessageDialog
-          v-model="infoDialog"
-          :header="$tr('aboutChannelSets')"
+        <KModal
+          :title="$tr('aboutChannelSets')"
+          :isOpen="infoDialog"
+          @cancel="infoDialog = false"
         >
           <p>
             {{ $tr('channelSetsDescriptionText') }}
@@ -26,16 +28,18 @@
           <p>
             {{ $tr('channelSetsInstructionsText') }}
           </p>
-          <p class="red--text">
+          <p :style="{ color: palette.red.v_500 }">
             {{ $tr('channelSetsDisclaimer') }}
           </p>
-          <template #buttons>
-            <VSpacer />
-            <VBtn @click="infoDialog = false">
+          <template #actions>
+            <KButton
+              appearance="basic"
+              @click="infoDialog = false"
+            >
               {{ $tr('cancelButtonLabel') }}
-            </VBtn>
+            </KButton>
           </template>
-        </MessageDialog>
+        </KModal>
       </VFlex>
       <VSpacer />
       <VFlex class="text-xs-right">
@@ -87,15 +91,16 @@
   import sortBy from 'lodash/sortBy';
   import { mapGetters, mapActions } from 'vuex';
   import { RouteNames } from '../../constants';
+  import { KButton, KModal, palette } from 'kolibri-design-system';
   import ChannelSetItem from './ChannelSetItem.vue';
-  import MessageDialog from 'shared/views/MessageDialog';
   import LoadingText from 'shared/views/LoadingText';
 
   export default {
     name: 'ChannelSetList',
     components: {
       ChannelSetItem,
-      MessageDialog,
+      KButton,
+      KModal,
       LoadingText,
     },
     data() {


### PR DESCRIPTION

## Summary

This PR removes Vuetify from 'Learn about collections' button/link and 'About collections' modal in Channels > Collections.
Changes made-
- Updated imports
- Replaced `ActionLink` with `KButton` using `basic-link` appearance
- Replaced `MessageDialog` with `KModal`
- Replaced Vuetify’s `red--text` class with KDS palette-based color
- Updated modal footer buttons to use `KButton`
- Removed unused `VSpacer` component

Manual verification-
- Navigated to Channels > Collections
- Opened "About collections" modal
- Verified that styling and functionality are intact and match expected KDS behavior. Only slight change in the position of 'Learn about collections' and 'New collection' noticed.

Screenshots-
<img width="1918" height="875" alt="kolibri" src="https://github.com/user-attachments/assets/3220cd1e-985a-4d83-b561-8462575e7f77" />


## References

Fixes #5234 

## Reviewer guidance

-Login as user@a.com with password a
-Go to Channels > Collections
