### PR TITLE
Avoid string message ID collisions with component of same name

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/Clipboard/ContentNodeOptions.vue
@@ -28,7 +28,7 @@
       />
     </VListTile>
     <VListTile @click="removeNode()">
-      <VListTileTitle>{{ $tr('remove') }}</VListTileTitle>
+      <VListTileTitle>{{ $tr('removeNode') }}</VListTileTitle>
     </VListTile>
   </VList>
 
@@ -151,7 +151,7 @@
       goToOriginalLocation: 'Go to original location',
       makeACopy: 'Make a copy',
       moveTo: 'Move to...',
-      remove: 'Delete',
+      removeNode: 'Delete',
       // undo: 'Undo',
       copiedItemsToClipboard: 'Copied in clipboard',
       removedFromClipboard: 'Deleted from clipboard',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
There are two components named `ContentNodeOptions` which had the same string message ID with different string content. This renames one of the messages ID so it's unique

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
ran `make i18n-extract-frontend`
