### PR TITLE
Default to channel_name during review

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ReviewSelectionsPage.vue
@@ -67,7 +67,7 @@
                 class="center-contents channel-name"
               >
                 <KTextTruncator
-                  :text="node.original_channel_name"
+                  :text="node.original_channel_name || node.channel_name"
                   :maxLines="2"
                   class="notranslate"
                 />


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Fixes the empty channel name for recommendations displayed in the review selections page.

**Before:**
<img width="3598" height="1754" alt="image" src="https://github.com/user-attachments/assets/f658f683-d66f-487e-a9fc-7cc4513d12e2" />

**After:**
<img width="1915" height="965" alt="Screenshot 2025-08-05 at 20 36 04" src="https://github.com/user-attachments/assets/6172d2e2-f109-494e-8e2d-e2a7ee833e97" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
NA

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Import any of the recommendations and observe the review selections page--the channel name should be displayed.
