### PR TITLE
Adds missing KPub string

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -117,6 +117,7 @@ export const constantStrings = createTranslator('ConstantStrings', {
   mp3: 'MP3 audio',
   pdf: 'PDF document',
   epub: 'EPub document',
+  kpub: 'KPub document',
   bloompub: 'BloomPub document',
   jpg: 'JPG image',
   jpeg: 'JPEG image',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds the missing KPub string. Please note that the UI has since changed from what is present in hotfixes and production. However, the string was also still missing with the new implementation as seen in [this pr](https://github.com/learningequality/studio/pull/4872)

**Before**
<img width="3580" height="2066" alt="image" src="https://github.com/user-attachments/assets/4a90dfa9-ee63-4cd6-8177-6db795a391ba" />

**After**
<img width="3596" height="2062" alt="image" src="https://github.com/user-attachments/assets/571b96ef-cf54-405b-b049-e4954fb06ded" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5231

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Create a zip file but change the extension to .kpub
- Upload the kpub file and ensure the KPub string isn't missing
