### PR TITLE
Refactor unsaved changes dialog to use KModal component and update te…

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -155,29 +155,18 @@
         </VContainer>
       </VWindowItem>
     </VWindow>
-    <MessageDialog
-      v-model="showUnsavedDialog"
-      :header="$tr('unsavedChangesHeader')"
-      :text="$tr('unsavedChangesText')"
+    <KModal
+      v-if="showUnsavedDialog"
+      :title="$tr('unsavedChangesHeader')"
+      :submitText="$tr('saveButton')"
+      :cancelText="$tr('closeButton')"
       data-test="dialog-unsaved"
       :data-test-visible="showUnsavedDialog"
+      @submit="save"
+      @cancel="confirmCancel"
     >
-      <template #buttons>
-        <VSpacer />
-        <VBtn
-          flat
-          @click="confirmCancel"
-        >
-          {{ $tr('closeButton') }}
-        </VBtn>
-        <VBtn
-          color="primary"
-          @click="save"
-        >
-          {{ $tr('saveButton') }}
-        </VBtn>
-      </template>
-    </MessageDialog>
+      {{ $tr('unsavedChangesText') }}
+    </KModal>
     <template #bottom>
       <div class="mx-4 subheading">
         {{ $tr('channelSelectedCountText', { channelCount: channels.length }) }}
@@ -210,13 +199,13 @@
   import { set } from 'vue';
   import { mapGetters, mapActions } from 'vuex';
   import difference from 'lodash/difference';
+  import KModal from 'kolibri-design-system/lib/KModal';
   import { RouteNames } from '../../constants';
   import ChannelItem from './ChannelItem';
   import ChannelSelectionList from './ChannelSelectionList';
   import { ChannelListTypes, ErrorTypes } from 'shared/constants';
   import { constantsTranslationMixin, routerMixin } from 'shared/mixins';
   import CopyToken from 'shared/views/CopyToken';
-  import MessageDialog from 'shared/views/MessageDialog';
   import FullscreenModal from 'shared/views/FullscreenModal';
   import Tabs from 'shared/views/Tabs';
   import LoadingText from 'shared/views/LoadingText';
@@ -226,9 +215,9 @@
     components: {
       CopyToken,
       ChannelSelectionList,
-      MessageDialog,
       ChannelItem,
       FullscreenModal,
+      KModal,
       Tabs,
       LoadingText,
     },
@@ -433,6 +422,7 @@
         }
       },
       confirmCancel() {
+        this.showUnsavedDialog = false;
         if (this.isNew) {
           if (this.channelSet && this.channelSet.id) {
             return this.deleteChannelSet(this.channelSet).then(this.close);

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -217,12 +217,12 @@ describe('ChannelSetModal', () => {
       });
 
       it('should prompt user if there are unsaved changes', async () => {
-        expect(getUnsavedDialog(wrapper).attributes('data-test-visible')).toBeFalsy();
+        expect(getUnsavedDialog(wrapper).exists()).toBeFalsy();
 
         await getCollectionNameInput(wrapper).setValue('My collection');
         await getCloseButton(wrapper).trigger('click');
 
-        expect(getUnsavedDialog(wrapper).attributes('data-test-visible')).toBeTruthy();
+        expect(getUnsavedDialog(wrapper).exists()).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
## Summary

Replaced **Vuetify's** `MessageDialog` component with **Kolibri Design System's** `KModal` for the unsaved changes dialog in the Collections modal.

### Changes Made
- Replaced `MessageDialog` with `KModal` in `ChannelSetModal.vue`
- Updated modal props to use `KModal`'s API (`title`, `submitText`, `cancelText`)
- Maintained all existing functionality and event handlers
- updated all the neccary tests

### How Verified
1. Logged in as `user@a.com` with password `a`
2. Navigated to **Channels > Collections**
3. Clicked **"New collection"** button
4. Added text to **Collection name** input
5. Clicked close button in the top bar
6. Verified unsaved changes modal appears with `KModal` styling
7. Tested both **"Exit without saving"** and **"Save and close"** buttons
8. Confirmed all functionality works as expected

### References
- Fixes **#5299**
