### PR TITLE
fix/page-not-found

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/errors/PageNotFoundError.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/errors/PageNotFoundError.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <AppError>
+  <StudioAppError>
     <template #header>
       {{ $tr('pageNotFoundHeader') }}
     </template>
@@ -8,27 +8,28 @@
       {{ $tr('pageNotFoundDetails') }}
     </template>
     <template #actions>
-      <VBtn
+      <KRouterLink
         v-bind="backHomeLink"
-        color="primary"
+        appearance="raised-button"
+        primary
       >
         {{ $tr('backToHomeAction') }}
-      </VBtn>
+      </KRouterLink>
     </template>
-  </AppError>
+  </StudioAppError>
 
 </template>
 
 
 <script>
 
-  import AppError from './AppError';
   import { routerMixin } from 'shared/mixins';
+  import StudioAppError from './StudioAppError.vue';
 
   export default {
     name: 'PageNotFoundError',
     components: {
-      AppError,
+      StudioAppError,
     },
     mixins: [routerMixin],
     props: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR replaces Vuetify components with Kolibri Design System components in the ‘Page not found’ error page, specifically:
	•	Replaced `AppError` with `StudioAppError` (created in issue #5235)
	•	Replaced `VBtn` with `KRouterLink` using `appearance="raised-button"` and `primary` props

Manual verification performed:
	•	Temporarily modified `ChannelListIndex.vue` to force display PAGE_NOT_FOUND error
	•	Tested error page rendering, button functionality, and mobile responsiveness
	•	Verified RTL compliance


Screenshots:
After changes-
<img width="1512" height="982" alt="pageNotFound" src="https://github.com/user-attachments/assets/860530f9-41fa-47f8-8977-f43321ecc71b" />



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
•	Closes: #5296
•	Parent issue: #5060 



## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test these changes:
	1.	Temporarily modify `ChannelListIndex.vue` condition to: `v-if="true"` and `:error="{ errorType: 'PAGE_NOT_FOUND' }"`
	2.	Login with `user@a.com` / `a`
	3.	Navigate to Channels page
	5.	Test mobile view and RTL 
	6.	Remember to revert testing changes in `ChannelListIndex.vue`

