### PR TITLE
Fix image export in QTI exercise publishing

### DIFF
--- a/contentcuration/contentcuration/utils/assessment/perseus.py
+++ b/contentcuration/contentcuration/utils/assessment/perseus.py
@@ -119,7 +119,7 @@ class PerseusExerciseGenerator(ExerciseArchiveGenerator):
         return "images"
 
     def get_image_ref_prefix(self):
-        return f"${exercises.IMG_PLACEHOLDER}/"
+        return f"${exercises.IMG_PLACEHOLDER}/images"
 
     def handle_before_assessment_items(self):
         exercise_context = {

--- a/contentcuration/contentcuration/utils/assessment/qti/archive.py
+++ b/contentcuration/contentcuration/utils/assessment/qti/archive.py
@@ -64,6 +64,8 @@ class QTIExerciseGenerator(ExerciseArchiveGenerator):
 
     file_format = "zip"
     preset = format_presets.QTI_ZIP
+    # Our markdown parser does not handle width/height in image refs
+    RETAIN_IMAGE_DIMENSIONS = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -72,6 +74,13 @@ class QTIExerciseGenerator(ExerciseArchiveGenerator):
     def get_image_file_path(self) -> str:
         """Get the file path for QTI assessment items."""
         return "items/images"
+
+    def get_image_ref_prefix(self):
+        """
+        Because we put items in a subdirectory, we need to prefix the image paths
+        with the relative path to the images directory.
+        """
+        return "images"
 
     def _create_html_content_from_text(self, text: str) -> FlowContentList:
         """Convert text content to QTI HTML flow content."""


### PR DESCRIPTION
## Summary
Images in QTI exercises weren't working for two reasons:
* First the markdown wasn't being parsed because the image resize directives in our markdown was not being handled by the Python markdown library we are using
* Second, I had failed to make the substituted image paths relative to the items in the zip file (the items are in `items` but I was including `items` in the image path)
* Fixes the first by just removing the image dimensions from the markdown in QTI - I thought about trying to parse it and set them as width and height on the `img`, but it seemed like a lot of complexity to capture the ~1% max difference in image sizes that our image resizing allows
* Fixes the second issue by ensuring the image paths inserted in QTI are not prefixed with `items/`
* Adds tests for QTI image resizing and generation which I had previously omitted because I thought the Perseus test coverage was sufficient. WRONG!

## References
Fixes https://github.com/learningequality/studio/issues/5247

## Reviewer guidance
Resulting question in Kolibri:

<img width="1917" height="712" alt="Screenshot from 2025-08-21 15-28-27" src="https://github.com/user-attachments/assets/6b42f919-cdfe-48c6-b973-41b8dc253c45" />

To check this, create a survey with a free response question, and add an image to one of the questions. Publish the channel, import to Kolibri and interact with the survey. Ensure that the image is properly displayed.