### PR TITLE
Remove resource selection snackbar from import modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -131,36 +131,25 @@
         </Uploader>
       </VCard>
       <BottomBar v-if="!loading && !loadError && !showFileUploadDefault">
-        <VLayout
-          row
-          align-center
-          fill-height
-          class="px-2"
+        <FileStorage
+          v-if="showStorage"
+          class="mx-2"
+        />
+        <VSpacer />
+        <div
+          v-if="online"
+          class="mt-1 py-3"
         >
-          <VFlex
-            v-if="showStorage"
-            shrink
+          <SavingIndicator :nodeIds="nodeIds" />
+        </div>
+        <div>
+          <VBtn
+            color="primary"
+            @click="handleClose()"
           >
-            <FileStorage />
-          </VFlex>
-          <VSpacer />
-          <VFlex
-            v-if="online"
-            shrink
-          >
-            <div class="mt-1 py-3">
-              <SavingIndicator :nodeIds="nodeIds" />
-            </div>
-          </VFlex>
-          <VFlex shrink>
-            <VBtn
-              color="primary"
-              @click="handleClose()"
-            >
-              {{ $tr('finishButton') }}
-            </VBtn>
-          </VFlex>
-        </VLayout>
+            {{ $tr('finishButton') }}
+          </VBtn>
+        </div>
       </BottomBar>
       <InheritAncestorMetadataModal
         ref="inheritModal"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -131,7 +131,6 @@
     data() {
       return {
         previewNode: null,
-        showSnackbar: true,
       };
     },
     provide: {
@@ -190,13 +189,6 @@
         return this.selected.some(node => node.id === this.previewNode.id);
       },
     },
-    watch: {
-      selectedResourcesCount(newVal, oldVal) {
-        if (this.showSnackbar) {
-          this.showResourcesSnackbar(newVal, oldVal);
-        }
-      },
-    },
     beforeRouteUpdate(to, from, next) {
       this.$store.dispatch('clearSnackbar');
       next();
@@ -213,18 +205,6 @@
       }),
       handlePreview(previewNode) {
         this.previewNode = previewNode;
-      },
-      showResourcesSnackbar(newLength, oldLength) {
-        const latestDelta = newLength - oldLength;
-        const textFromDelta = delta => {
-          const params = { count: Math.abs(delta) };
-          return delta >= 0
-            ? this.$tr('resourcesAddedSnackbar', params)
-            : this.$tr('resourcesRemovedSnackbar', params);
-        };
-        this.$store.dispatch('showSnackbar', {
-          text: textFromDelta(latestDelta),
-        });
       },
       handleClickReview() {
         this.$router.push({
@@ -246,8 +226,6 @@
         }).then(nodes => {
           this.handleRecommendationInteractionEvent();
 
-          // When exiting, do not show snackbar when clearing selections
-          this.showSnackbar = false;
           this.$store.commit('importFromChannels/CLEAR_NODES');
           this.$router.push({
             name: RouteNames.TREE_VIEW,
@@ -292,10 +270,6 @@
       },
     },
     $trs: {
-      resourcesAddedSnackbar:
-        '{count, number} {count, plural, one {resource selected} other {resources selected}}',
-      resourcesRemovedSnackbar:
-        '{count, number} {count, plural, one {resource removed} other {resources removed}}',
       importTitle: 'Import from other channels',
       reviewTitle: 'Resource selection',
       resourcesSelected:

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ImportFromChannelsModal.vue
@@ -70,7 +70,7 @@
       </template>
     </ResourceDrawer>
     <template #bottom>
-      <div class="mx-4 subheading">
+      <div class="mx-2 subheading">
         {{ $tr('resourcesSelected', { count: selectedResourcesCount }) }}
       </div>
       <VSpacer />

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -84,62 +84,47 @@
         data-test="toolbar"
         :appearanceOverrides="{ height: $vuetify.breakpoint.xsOnly ? '72px' : '56px' }"
       >
-        <VLayout
-          row
-          wrap
-          align-center
-        >
-          <VFlex
-            xs12
-            sm4
-            class="pb-1"
+        <div class="mx-2">
+          {{ $tr('channelSelectionCount', { count: selectedCount }) }}
+        </div>
+        <VSpacer />
+        <div>
+          <VBtn
+            flat
+            data-test="cancel"
+            class="ma-0"
+            @click="setSelection(false)"
           >
-            {{ $tr('channelSelectionCount', { count: selectedCount }) }}
-          </VFlex>
-          <VFlex
-            xs12
-            sm8
-          >
-            <VLayout row>
-              <VSpacer />
-              <VBtn
-                flat
-                data-test="cancel"
-                class="ma-0"
-                @click="setSelection(false)"
-              >
-                {{ $tr('cancelButton') }}
-              </VBtn>
-              <BaseMenu top>
-                <template #activator="{ on }">
-                  <VBtn
-                    color="primary"
-                    class="ma-0 mx-2"
-                    v-on="on"
-                  >
-                    {{ $tr('downloadButton') }}
-                    <Icon
-                      class="ml-1"
-                      icon="dropup"
-                      :color="$themeTokens.textInverted"
-                    />
-                  </VBtn>
-                </template>
-                <VList>
-                  <VListTile @click="downloadPDF">
-                    <VListTileTitle>{{ $tr('downloadPDF') }}</VListTileTitle>
-                  </VListTile>
-                  <VListTile
-                    data-test="download-csv"
-                    @click="downloadCSV"
-                  >
-                    <VListTileTitle>{{ $tr('downloadCSV') }}</VListTileTitle>
-                  </VListTile>
-                </VList>
-              </BaseMenu>
-            </VLayout>
-          </VFlex>
-        </VLayout>
+            {{ $tr('cancelButton') }}
+          </VBtn>
+        </div>
+        <BaseMenu top>
+          <template #activator="{ on }">
+            <VBtn
+              color="primary"
+              class="ma-0 mx-2"
+              v-on="on"
+            >
+              {{ $tr('downloadButton') }}
+              <Icon
+                class="ml-1"
+                icon="dropup"
+                :color="$themeTokens.textInverted"
+              />
+            </VBtn>
+          </template>
+          <VList>
+            <VListTile @click="downloadPDF">
+              <VListTileTitle>{{ $tr('downloadPDF') }}</VListTileTitle>
+            </VListTile>
+            <VListTile
+              data-test="download-csv"
+              @click="downloadCSV"
+            >
+              <VListTileTitle>{{ $tr('downloadCSV') }}</VListTileTitle>
+            </VListTile>
+          </VList>
+        </BaseMenu>
       </BottomBar>
     </VContainer>
   </div>

--- a/contentcuration/contentcuration/frontend/shared/views/BottomBar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/BottomBar.vue
@@ -33,6 +33,7 @@
     left: 0;
     z-index: 3;
     display: flex;
+    align-items: center;
     width: 100%;
     height: 64px;
     background-color: #ffffff;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Removes snackbar that would announce whenever you selected or deselected an item for import
- Defaults the bottom bar component to align items vertically and simplifies usages of it by removing redundant flex styling

| Bottom bar | Screenshot |
| --- | --- |
| Import modal (before) | <img width="1477" height="171" alt="image" src="https://github.com/user-attachments/assets/2b8001b3-b1ba-42a6-a45f-ef079b790fd7" /> |
| Import modal (after) | <img width="1477" height="171" alt="image" src="https://github.com/user-attachments/assets/5f8ee6f6-7558-44c6-a96c-f2e8377acbb3" /> |
| Edit modal (before) | <img width="1477" height="171" alt="image" src="https://github.com/user-attachments/assets/b6a01d48-4cec-44ea-8734-1e0adc82a243" /> |
| Edit modal (after) | <img width="1477" height="171" alt="image" src="https://github.com/user-attachments/assets/eab096f4-4c11-4e30-b4ef-249c1c0500dc" /> |


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes https://github.com/learningequality/studio/issues/5267


