### PR TITLE
Add keyboard navigation links and scrolling for jumping in import modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/BrowsingCard.vue
@@ -1,6 +1,7 @@
 <template>
 
   <VCard
+    ref="card"
     hover
     @click="handleClick"
   >
@@ -187,6 +188,12 @@
         } else {
           this.$emit('preview');
         }
+      },
+      /**
+       * @public
+       */
+      focus() {
+        this.$refs.card.$el.focus();
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelInfoCard.vue
@@ -1,6 +1,7 @@
 <template>
 
   <VCard
+    ref="card"
     hover
     :to="channelRoute"
   >
@@ -104,6 +105,14 @@
           },
           query: this.$route.query,
         };
+      },
+    },
+    methods: {
+      /**
+       * @public
+       */
+      focus() {
+        this.$refs.card.$el.focus();
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ChannelList.vue
@@ -44,6 +44,7 @@
     <div v-else>
       <ChannelInfoCard
         v-for="channel in channels"
+        :ref="setFirstChannelCardRef"
         :key="channel.id"
         :channel="channel"
         class="mb-3"
@@ -87,6 +88,7 @@
         channels: [],
         pageCount: 0,
         loading: false,
+        firstChannelCardRef: null,
       };
     },
     computed: {
@@ -131,6 +133,7 @@
       ...mapActions('importFromChannels', ['loadChannels']),
       loadPage() {
         this.loading = true;
+        this.firstChannelCardRef = null;
         this.loadChannels({
           languages: this.languageFilter,
           [this.channelFilter]: true,
@@ -143,6 +146,19 @@
           this.channels = page.results;
           this.loading = false;
         });
+      },
+      setFirstChannelCardRef(ref) {
+        if (!this.firstChannelCardRef) {
+          this.firstChannelCardRef = ref;
+        }
+      },
+      /**
+       * @public
+       */
+      focus() {
+        if (this.firstChannelCardRef) {
+          this.firstChannelCardRef.focus();
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -36,6 +36,7 @@
         <VFlex shrink>
           <Checkbox
             :key="`checkbox-${node.id}`"
+            :ref="setFirstCardCheckboxRef"
             :inputValue="isSelected(node)"
             :disabled="ancestorIsSelected"
             @input="toggleSelected(node)"
@@ -108,6 +109,7 @@
         loading: false,
         more: null,
         moreLoading: false,
+        firstCardCheckboxRef: null,
       };
     },
     computed: {
@@ -184,6 +186,7 @@
       ...mapActions('contentNode', ['loadChildren', 'loadAncestors', 'loadContentNodes']),
       loadData() {
         this.loading = true;
+        this.firstCardCheckboxRef = null;
         const params = {
           complete: true,
         };
@@ -225,6 +228,19 @@
             this.more = response.more || null;
             this.moreLoading = false;
           });
+        }
+      },
+      setFirstCardCheckboxRef(ref) {
+        if (!this.firstCardCheckboxRef) {
+          this.firstCardCheckboxRef = ref;
+        }
+      },
+      /**
+       * @public
+       */
+      focus() {
+        if (this.firstCardCheckboxRef) {
+          this.firstCardCheckboxRef.focus();
         }
       },
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/ContentTreeList.vue
@@ -204,6 +204,8 @@
           this.loadAncestors({ id: this.topicId }),
         ]).then(() => {
           this.loading = false;
+          // scroll to top via focus
+          this.$nextTick(() => this.focus());
         });
       },
       /**

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchFilterBar.vue
@@ -1,7 +1,7 @@
 <template>
 
   <VContainer
-    class="pt-3 px-2"
+    class="pt-2 px-2"
     fluid
   >
     <VChip

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -58,20 +58,26 @@
             </VTextField>
           </VForm>
 
-          <div
-            v-if="!isBrowsing"
-            class="my-2 px-2"
-          >
+          <div class="my-2">
             <ActionLink
-              class="mb-3"
+              v-if="!isBrowsing"
               :text="$tr('savedSearchesLabel')"
               :disabled="!savedSearchesExist"
               @click="showSavedSearches = true"
             />
+            <ActionLink
+              v-if="shouldShowRecommendations"
+              :class="{ 'keyboard-visibility': true, 'mx-3': !isBrowsing }"
+              :text="$tr('jumpToRecommendations')"
+              :style="keyboardVisibilityStyle"
+              @click="handleJumpToRecommendations"
+            />
           </div>
+
           <!-- Search or Topics Browsing -->
           <ChannelList
             v-if="isBrowsing && !$route.params.channelId"
+            ref="channelList"
             @update-language="updateLanguageQuery"
           />
           <ContentTreeList
@@ -86,11 +92,20 @@
           />
           <SearchResultsList
             v-else
+            ref="searchResultList"
             :selected.sync="selected"
             @preview="preview($event)"
             @change_selected="handleChangeSelected"
             @copy_to_clipboard="handleCopyToClipboard"
           />
+          <div style="text-align: center">
+            <ActionLink
+              :text="$tr('jumpToTop')"
+              class="keyboard-visibility"
+              :style="keyboardVisibilityStyle"
+              @click="handleJumpToSearch"
+            />
+          </div>
         </KGridItem>
 
         <!-- Recommended resources panel >= 400px -->
@@ -105,8 +120,14 @@
           </h3>
           <div class="my-3 px-2">
             <ActionLink
+              class="mr-3"
               :text="aboutRecommendationsText$()"
               @click="handleAboutRecommendations"
+            />
+            <ActionLink
+              :text="isBrowsing ? $tr('jumpToSearch') : $tr('jumpToSearchResults')"
+              :style="keyboardVisibilityStyle"
+              @click="handleJumpToSearch"
             />
           </div>
 
@@ -115,6 +136,7 @@
               <RecommendedResourceCard
                 v-for="recommendation in displayedRecommendations"
                 :key="recommendation.id"
+                :ref="setFirstRecommendationRef"
                 :node="recommendation"
                 @change_selected="handleChangeSelected"
                 @preview="
@@ -160,6 +182,13 @@
                 @click="handleViewMoreRecommendations"
               />
             </div>
+          </div>
+          <div class="px-2">
+            <ActionLink
+              :text="$tr('jumpToTop')"
+              :style="keyboardVisibilityStyle"
+              @click="handleJumpToRecommendations"
+            />
           </div>
         </KGridItem>
       </KGrid>
@@ -361,6 +390,7 @@
         importedNodeIds: [],
         rejectedNode: null,
         showFeedbackErrorMessage: false,
+        firstRecommendationRef: null,
       };
     },
     computed: {
@@ -389,6 +419,11 @@
           (this.searchTerm || '').trim().length > 0 &&
           this.searchTerm.trim() !== this.$route.params.searchTerm
         );
+      },
+      keyboardVisibilityStyle() {
+        return {
+          opacity: this.$inputModality === 'keyboard' ? '1' : '0',
+        };
       },
       shouldShowRecommendations() {
         if (!this.isAIFeatureEnabled) {
@@ -613,6 +648,27 @@
       handleBackToBrowse() {
         this.$router.push(this.backToBrowseRoute);
       },
+      handleJumpToRecommendations() {
+        if (this.firstRecommendationRef) {
+          this.firstRecommendationRef.focus();
+        }
+      },
+      handleJumpToSearch() {
+        if (this.isBrowsing) {
+          if (this.$route.params.channelId) {
+            this.$refs.contentTreeList.focus();
+          } else {
+            this.$refs.channelList.focus();
+          }
+        } else {
+          this.$refs.searchResultList.focus();
+        }
+      },
+      setFirstRecommendationRef(ref) {
+        if (!this.firstRecommendationRef) {
+          this.firstRecommendationRef = ref;
+        }
+      },
       updateLanguageQuery(language) {
         this.languageFromChannelList = language;
       },
@@ -712,6 +768,8 @@
         }
       },
       async loadRecommendations(belowThreshold) {
+        this.firstRecommendationRef = null;
+
         if (this.shouldShowRecommendations) {
           this.recommendationsLoading = true;
           this.recommendationsLoadingError = false;
@@ -918,6 +976,10 @@
       searchLabel: 'Search for resources…',
       searchAction: 'Search',
       savedSearchesLabel: 'View saved searches',
+      jumpToRecommendations: 'Jump to recommendations',
+      jumpToSearch: 'Jump to search',
+      jumpToSearchResults: 'Jump to search results',
+      jumpToTop: 'Jump to top',
 
       // Copy strings
       // undo: 'Undo',
@@ -964,6 +1026,14 @@
     padding: 16px;
     margin: 16px 0;
     border-radius: 4px;
+  }
+
+  .keyboard-visibility {
+    cursor: default;
+
+    &:focus {
+      opacity: 1 !important;
+    }
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -76,7 +76,7 @@
 
           <!-- Search or Topics Browsing -->
           <ChannelList
-            v-if="isBrowsing && !$route.params.channelId"
+            v-if="isBrowsing && !browseChannelId"
             ref="channelList"
             @update-language="updateLanguageQuery"
           />
@@ -402,6 +402,9 @@
       isBrowsing() {
         return this.$route.name === RouteNames.IMPORT_FROM_CHANNELS_BROWSE;
       },
+      browseChannelId() {
+        return this.$route.params.channelId;
+      },
       backToBrowseRoute() {
         const query = {
           channel_list: this.$route.query.channel_list,
@@ -609,6 +612,18 @@
         return this.isAnyFeedbackReasonSelected && this.isOtherFeedbackValid;
       },
     },
+    watch: {
+      isBrowsing(before, after) {
+        if (before !== after) {
+          this.$nextTick(() => this.handleJumpToSearch());
+        }
+      },
+      browseChannelId(before, after) {
+        if (before !== after) {
+          this.$nextTick(() => this.handleJumpToSearch());
+        }
+      },
+    },
     beforeRouteEnter(to, from, next) {
       next(vm => {
         vm.searchTerm = to.params.searchTerm || '';
@@ -655,7 +670,7 @@
       },
       handleJumpToSearch() {
         if (this.isBrowsing) {
-          if (this.$route.params.channelId) {
+          if (this.browseChannelId) {
             this.$refs.contentTreeList.focus();
           } else {
             this.$refs.channelList.focus();

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -73,6 +73,7 @@
               >
                 <Checkbox
                   :key="`checkbox-${node.id}`"
+                  :ref="setFirstCardCheckboxRef"
                   :inputValue="isSelected(node)"
                   class="mt-0 pt-0"
                   @input="toggleSelected(node)"
@@ -147,6 +148,7 @@
         nodeIds: [],
         pageCount: 0,
         totalCount: 0,
+        firstCardCheckboxRef: null,
       };
     },
     computed: {
@@ -217,6 +219,7 @@
       fetch() {
         this.loading = true;
         this.loadFailed = false;
+        this.firstCardCheckboxRef = null;
         this.fetchResultsDebounced();
         this.loadSavedSearches();
       },
@@ -250,6 +253,19 @@
       },
       toggleSelected(node) {
         this.$emit('change_selected', { nodes: [node], isSelected: !this.isSelected(node) });
+      },
+      setFirstCardCheckboxRef(ref) {
+        if (!this.firstCardCheckboxRef) {
+          this.firstCardCheckboxRef = ref;
+        }
+      },
+      /**
+       * @public
+       */
+      focus() {
+        if (this.firstCardCheckboxRef) {
+          this.firstCardCheckboxRef.focus();
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchResultsList.vue
@@ -22,7 +22,10 @@
           v-else
           class="mx-0 px-1"
         >
-          <LoadingText v-if="loading" />
+          <LoadingText
+            v-if="loading"
+            ref="loading"
+          />
           <VLayout
             v-else
             row
@@ -59,7 +62,7 @@
               </span>
             </VFlex>
           </VLayout>
-          <div>
+          <div v-if="!loading">
             <VLayout
               v-for="node in nodes"
               :key="node.id"
@@ -145,6 +148,7 @@
       return {
         loading: false,
         loadFailed: false,
+        hasLoaded: false,
         nodeIds: [],
         pageCount: 0,
         totalCount: 0,
@@ -222,6 +226,12 @@
         this.firstCardCheckboxRef = null;
         this.fetchResultsDebounced();
         this.loadSavedSearches();
+        // Ensure loading spinner is in view after initial load
+        if (this.hasLoaded) {
+          this.$nextTick(() => {
+            this.$refs.loading.$el.scrollIntoView();
+          });
+        }
       },
       fetchResultsDebounced: debounce(
         function () {
@@ -237,6 +247,8 @@
               this.nodeIds = page.results.map(n => n.id);
               this.pageCount = page.total_pages;
               this.totalCount = page.count;
+              this.hasLoaded = true;
+              this.$nextTick(() => this.focus());
             })
             .catch(e => {
               this.loadFailed = true;

--- a/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
@@ -1,6 +1,7 @@
 <template>
 
   <KCard
+    ref="card"
     :title="node.title"
     :headingLevel="2"
     thumbnailScaleType="contain"
@@ -85,6 +86,11 @@
         required: true,
       },
     },
+    data() {
+      return {
+        ignorePreview: false,
+      };
+    },
     computed: {
       ...mapState('importFromChannels', ['selected']),
       learningActivities() {
@@ -116,13 +122,31 @@
         this.$emit('change_selected', { nodes: [node], isSelected: !this.isSelected(node) });
       },
       onClick() {
-        this.$emit('preview', this.node);
+        if (!this.ignorePreview) {
+          this.$emit('preview', this.node);
+        }
+        this.ignorePreview = false;
       },
       goToLocation() {
         window.open(this.goToLocationUrl, '_blank');
       },
       markNotRelevant() {
         this.$emit('irrelevant', this.node);
+      },
+      /**
+       * @public
+       */
+      focus() {
+        // KCard doesn't have a focus method
+        const cardTitle = this.$refs.card.$el.querySelector('.k-title');
+        if (cardTitle) {
+          // HACK: focusing the title seems to trigger its onEnter handler, when this focus method
+          // is called from keyboard navigation. when KCard handles this behavior internally, this
+          // hack can be removed
+          this.ignorePreview = true;
+          cardTitle.focus();
+          setTimeout(() => (this.ignorePreview = false), 1000);
+        }
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/shared/views/form/Checkbox.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/form/Checkbox.vue
@@ -1,6 +1,7 @@
 <template>
 
   <KCheckbox
+    ref="checkbox"
     :value="value"
     :label="label"
     :showLabel="showLabel"
@@ -143,6 +144,12 @@
       },
       updateInputValue(newValue) {
         this.$emit('input', newValue);
+      },
+      /**
+       * @public
+       */
+      focus() {
+        this.$refs.checkbox.focus();
       },
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Adds keyboard navigation links that support jumping between sections of the import modal screens, that are only visible when navigating by keyboard. Also leverages the focus behavior to scroll top into view.
- Adds 'Jump to recommendations' link that appears in keyboard navigation after search box
- Adds 'Jump to search' and 'Jump to search results' that appears at the top of the recommendations box
- Adds 'Jump to top' that appears at the bottom of both search results and the recommendations links
- Scrolls to top when opening a channel for browsing, changing a browsing topic, or switching search pages

Out of scope: the 'Channels' select box causes KDS modality tracking to lose its keyboard state

<img width="2470" height="669" alt="image" src="https://github.com/user-attachments/assets/9e6a6d8c-4a96-42bd-9444-928e3a0bcf23" />
<img width="1649" height="441" alt="image" src="https://github.com/user-attachments/assets/d47f6eee-45cb-47b2-bf20-0e6200cb872a" />
<img width="951" height="590" alt="image" src="https://github.com/user-attachments/assets/a35215b0-2029-462f-ba5b-82e40f45f469" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes https://github.com/learningequality/studio/issues/5268
fixes https://github.com/learningequality/studio/issues/5332

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Does tabbing after focus in the search box immediately show the link?
- Does either section's jump link work regardless of whether you're on the default channel list, browsing a channel, or performed a search?
- Does using 'Jump to top' work on either section?