### PR TITLE
Override top-level vuetify dialog z-index

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/styles/main.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.scss
@@ -52,6 +52,10 @@ body {
   .v-btn:focus-visible {
     outline: 2px solid var(--v-secondary-base) !important;
   }
+
+  > .v-dialog__content {
+    z-index: 16 !important;
+  }
 }
 
 /* RTL-related rules */


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Adds global css that overrides the z-index, set as an element style, when using Vuetify's `VDialog`. No issues were observed across studio after this change.

<img width="849" height="340" alt="image" src="https://github.com/user-attachments/assets/ad277e5d-3a26-44dd-bfa8-e768cc281fa5" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes https://github.com/learningequality/studio/issues/5266

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Do other Studio pages and modals have issues after this change?
