### PR TITLE
Fix blank page when reloading import modal after a search

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -13,6 +13,22 @@ import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
 import ChannelModal from 'shared/views/channel/ChannelModal';
 import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
 
+const importBeforeEnter = function (to, from, next) {
+  const promises = [
+    // search recommendations require ancestors to be loaded
+    store.dispatch('contentNode/loadAncestors', { id: to.params.destNodeId }),
+  ];
+
+  if (!store.getters['currentChannel/currentChannel']) {
+    // ensure the current channel is loaded, in case of hard refresh on this route.
+    // alternatively, the page could be reactive to this getter's value, although that doesn't
+    // seem to work properly
+    promises.push(store.dispatch('currentChannel/loadChannel'));
+  }
+
+  return Promise.all(promises).then(() => next());
+};
+
 const router = new VueRouter({
   routes: [
     {
@@ -38,27 +54,14 @@ const router = new VueRouter({
       path: '/import/:destNodeId/browse/:channelId?/:nodeId?',
       component: SearchOrBrowseWindow,
       props: true,
-      beforeEnter: (to, from, next) => {
-        const promises = [
-          // search recommendations require ancestors to be loaded
-          store.dispatch('contentNode/loadAncestors', { id: to.params.destNodeId }),
-        ];
-
-        if (!store.getters['currentChannel/currentChannel']) {
-          // ensure the current channel is loaded, in case of hard refresh on this route.
-          // alternatively, the page could be reactive to this getter's value, although that doesn't
-          // seem to work properly
-          promises.push(store.dispatch('currentChannel/loadChannel'));
-        }
-
-        return Promise.all(promises).then(() => next());
-      },
+      beforeEnter: importBeforeEnter,
     },
     {
       name: RouteNames.IMPORT_FROM_CHANNELS_SEARCH,
       path: '/import/:destNodeId/search/:searchTerm',
       component: SearchOrBrowseWindow,
       props: true,
+      beforeEnter: importBeforeEnter,
     },
     {
       name: RouteNames.IMPORT_FROM_CHANNELS_REVIEW,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -476,7 +476,12 @@
         });
       },
       embedTopicRequest() {
-        if (!this.importDestinationFolder) {
+        // Ensure destination folder is loaded, and it and its ancestors have titles
+        if (
+          !this.importDestinationFolder ||
+          !this.importDestinationFolder.title ||
+          this.topicAncestors.some(n => !n.title)
+        ) {
           return null;
         }
         return {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -395,6 +395,10 @@
           return false;
         }
 
+        if (this.embedTopicRequest === null) {
+          return false;
+        }
+
         if (!validateEmbedTopicRequest(this.embedTopicRequest)) {
           // log to sentry-- this is unexpected, since we use the channel's language as a fallback
           // and channels are required to have a language
@@ -472,6 +476,9 @@
         });
       },
       embedTopicRequest() {
+        if (!this.importDestinationFolder) {
+          return null;
+        }
         return {
           topics: [
             {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/__tests__/SearchOrBrowseWindow.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/__tests__/SearchOrBrowseWindow.spec.js
@@ -78,7 +78,7 @@ describe('SearchOrBrowseWindow', () => {
       'currentChannel/currentChannel': () => ({ language: 'en' }),
       'importFromChannels/savedSearchesExist': () => true,
       isAIFeatureEnabled: () => true,
-      'contentNode/getContentNodeAncestors': () => () => [{ id: 'node-1' }],
+      'contentNode/getContentNodeAncestors': () => () => [{ id: 'node-1', title: 'Test folder' }],
     };
 
     store = new Store({

--- a/contentcuration/contentcuration/frontend/shared/styles/main.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.scss
@@ -53,7 +53,8 @@ body {
     outline: 2px solid var(--v-secondary-base) !important;
   }
 
-  > .v-dialog__content {
+  > .v-dialog__content,
+  > .v-overlay {
     z-index: 16 !important;
   }
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds route handler to the import search route, to ensure channel and import destination folder ancestors are loaded prior to rendering the import modal. Also adds more defensive logic to prevent possibility of blank pages.
- Prevents showing recommendations when folder or ancestor folder is missing a title (ref: (2) in https://github.com/learningequality/studio/issues/5329)
- Fixes small regression with overlay z-index:
<img width="1320" height="806" alt="Screenshot from 2025-08-27 10-43-10" src="https://github.com/user-attachments/assets/e3aefc84-d73a-4271-a04f-f2a61542978f" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
fixes https://github.com/learningequality/studio/issues/5326


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- https://github.com/learningequality/studio/issues/5326 : This specific issue only occurred if you searched for something in the modal first
- z-index regression: add a new folder but don't give it a title, then attempt to exit the edit modal
