### PR TITLE
Reinstate .styl noop replacement for production webpack builds

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/styles/modulePlaceholder.js
+++ b/contentcuration/contentcuration/frontend/shared/styles/modulePlaceholder.js
@@ -1,0 +1,7 @@
+// This file is used as a placeholder, following the same pattern established in
+// jest_config/globalMocks/fileMock.js
+
+// It is used to help use properly overwrite the vuetify stylus files using webpack
+// (see also webpack.config.js > webpack.NormalModuleReplacementPlugin())
+
+'module-file-stub';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const process = require('node:process');
 const fs = require('node:fs');
 const { execSync } = require('node:child_process');
 
+const { NormalModuleReplacementPlugin } = require('webpack');
 const baseConfig = require('kolibri-tools/lib/webpack.config.base');
 const { merge } = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -40,6 +41,7 @@ function getWSLIP() {
 const djangoProjectDir = path.resolve('contentcuration');
 const staticFilesDir = path.resolve(djangoProjectDir, 'contentcuration', 'static');
 const srcDir = path.resolve(djangoProjectDir, 'contentcuration', 'frontend');
+const dummyModule = path.resolve(srcDir, 'shared', 'styles', 'modulePlaceholder.js')
 
 const bundleOutputDir = path.resolve(staticFilesDir, 'studio');
 
@@ -186,6 +188,13 @@ module.exports = (env = {}) => {
   });
   if (dev) {
     config.entry.editorDev = './editorDev/index.js';
+  } else {
+    config.plugins.push(
+      new NormalModuleReplacementPlugin(
+        /styl$/,
+        dummyModule
+      ),
+    )
   }
   return config;
 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Re-adds module replacement in the webpack config for Vuetify's stylus files, but more specifically only targeting `.styl` files. Without this specificity, other resolution failures occur for `mini-css-extract-plugin/dist/hmr/hotModuleReplacement.js`, which was the original cause for removal during the pnpm transition. 

<img width="1799" height="1742" alt="image" src="https://github.com/user-attachments/assets/c27a5f9a-d487-46ea-b026-aea027b5fd61" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
source https://github.com/learningequality/studio/pull/4106
closes https://github.com/learningequality/studio/issues/5342

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Edit the webpack config to always use the devserver output path
2. Run `npx webpack serve --env prod --config webpack.config.js --progress` and `pnpm run runserver`
3. Check studio UI
