### PR TITLE
Fixes the KLogo display in preview window

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -4,131 +4,142 @@
     :key="fileId"
     :class="{ fullscreen }"
   >
-    <KLogo
-      v-if="loading"
-      altText=""
-      :animate="true"
-      :size="300"
-    />
-    <VCard
-      v-if="!file"
-      flat
-      class="message-card"
-    >
-      <VLayout
-        align-center
-        justify-center
-        fill-height
-      >
-        {{ $tr('noFileText') }}
-      </VLayout>
-    </VCard>
-    <VCard
-      v-else-if="file.uploading || file.error"
-      flat
-      class="message-card"
-    >
-      <VLayout
-        align-center
-        justify-center
-        fill-height
-        data-test="progress"
-      >
-        <FileStatus
-          :fileId="file.id"
-          large
-        />
-      </VLayout>
-    </VCard>
-    <VFlex v-else-if="isVideo">
-      <video
-        controls
-        preload="metadata"
-        controlsList="nodownload"
-        crossOrigin
-        @loadeddata="loading = false"
-      >
-        <source
-          :src="src"
-          :type="file.mimetype"
-        >
-        <track
-          v-for="subtitle in subtitles"
-          :key="subtitle.id"
-          :src="subtitle.url"
-          kind="subtitles"
-          :srclang="subtitle.language.id"
-          :label="subtitle.language.native_name"
-        >
-      </video>
-    </VFlex>
-    <VCard
-      v-else-if="isAudio"
-      flat
-    >
-      <VLayout
-        align-center
-        justify-center
-        fill-height
-      >
-        <audio
-          controls
-          :src="src"
-          :type="file.mimetype"
-          @loadeddata="loading = false"
-        ></audio>
-      </VLayout>
-    </VCard>
-    <iframe
-      v-else-if="isHTML"
-      :src="htmlPath"
-      sandbox="allow-scripts"
-      @load="loading = false"
-    ></iframe>
-    <embed
-      v-else-if="isPDF"
-      :src="src"
-      :type="file.mimetype"
-      @load="loading = false"
-    >
     <div
-      v-else-if="isEpub"
-      class="epub"
+      class="renderer"
+      :aria-busy="loading"
     >
-      <EpubRenderer
-        :src="src"
-        @load="loading = false"
-      />
-    </div>
-
-    <VCard
-      v-else
-      class="message-card"
-      flat
-    >
-      <VLayout
-        align-center
-        justify-center
-        fill-height
-        data-test="not-supported"
+      <div
+        v-show="loading"
+        class="overlay"
+        :style="{ background: $themePalette.white }"
       >
-        <VTooltip
-          bottom
-          lazy
+        <KLogo
+          altText=""
+          :animate="true"
+          :size="300"
+        />
+      </div>
+
+      <VCard
+        v-if="!file"
+        flat
+        class="message-card"
+      >
+        <VLayout
+          align-center
+          justify-center
+          fill-height
         >
-          <template #activator="{ on }">
-            <VIconWrapper
-              color="grey lighten-2"
-              large
-              v-on="on"
-            >
-              visibility_off
-            </VIconWrapper>
-          </template>
-          <span>{{ $tr('previewNotSupported') }}</span>
-        </VTooltip>
-      </VLayout>
-    </VCard>
+          {{ $tr('noFileText') }}
+        </VLayout>
+      </VCard>
+      <VCard
+        v-else-if="file.uploading || file.error"
+        flat
+        class="message-card"
+      >
+        <VLayout
+          align-center
+          justify-center
+          fill-height
+          data-test="progress"
+        >
+          <FileStatus
+            :fileId="file.id"
+            large
+          />
+        </VLayout>
+      </VCard>
+      <VFlex v-else-if="isVideo">
+        <video
+          controls
+          preload="metadata"
+          controlsList="nodownload"
+          crossOrigin
+          @loadeddata="loading = false"
+        >
+          <source
+            :src="src"
+            :type="file.mimetype"
+          >
+          <track
+            v-for="subtitle in subtitles"
+            :key="subtitle.id"
+            :src="subtitle.url"
+            kind="subtitles"
+            :srclang="subtitle.language.id"
+            :label="subtitle.language.native_name"
+          >
+        </video>
+      </VFlex>
+      <VCard
+        v-else-if="isAudio"
+        flat
+      >
+        <VLayout
+          align-center
+          justify-center
+          fill-height
+        >
+          <audio
+            controls
+            :src="src"
+            :type="file.mimetype"
+            @loadeddata="loading = false"
+          ></audio>
+        </VLayout>
+      </VCard>
+      <iframe
+        v-else-if="isHTML"
+        :src="htmlPath"
+        sandbox="allow-scripts"
+        @load="loading = false"
+      ></iframe>
+      <embed
+        v-else-if="isPDF"
+        :src="src"
+        :type="file.mimetype"
+        @load="loading = false"
+      >
+      <div
+        v-else-if="isEpub"
+        class="epub"
+      >
+        <EpubRenderer
+          :src="src"
+          @load="loading = false"
+        />
+      </div>
+
+      <VCard
+        v-else
+        class="message-card"
+        flat
+      >
+        <VLayout
+          align-center
+          justify-center
+          fill-height
+          data-test="not-supported"
+        >
+          <VTooltip
+            bottom
+            lazy
+          >
+            <template #activator="{ on }">
+              <VIconWrapper
+                color="grey lighten-2"
+                large
+                v-on="on"
+              >
+                visibility_off
+              </VIconWrapper>
+            </template>
+            <span>{{ $tr('previewNotSupported') }}</span>
+          </VTooltip>
+        </VLayout>
+      </VCard>
+    </div>
   </VLayout>
 
 </template>
@@ -230,6 +241,21 @@
 <style lang="scss" scoped>
 
   $max-height: calc(100vh - 96px);
+
+  .renderer {
+    position: relative;
+    width: 100%;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
 
   .v-card,
   video,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the `KLogo` display in the resource preview window during loading of resources

**Before**

https://github.com/user-attachments/assets/49667c6b-e9c1-4680-a741-2d481d54a9b1

**After**
<img width="605" height="963" alt="Screenshot 2025-09-02 at 15 59 50" src="https://github.com/user-attachments/assets/475cd624-3931-48cc-8fa5-d7474eb3e840" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5327

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Sign in to Hotfixes with an account with enabled search recommendations
- Go to a channel with resources and try to preview a resource
- Attempt to import a resource from other channels and preview it
