### PR TITLE
Fix css override troubles

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -179,9 +179,9 @@
 
     <NewTopicModal
       v-if="showNewTopicModal"
-      v-model="showNewTopicModal"
       data-test="newtopicmodal"
       @createTopic="createTopic"
+      @cancelCreateTopic="showNewTopicModal = false"
     />
   </FullscreenModal>
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/NewTopicModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/NewTopicModal.vue
@@ -1,83 +1,50 @@
 <template>
 
-  <MessageDialog
-    v-model="dialog"
-    :header="$tr('createTopic')"
+  <KModal
+    :title="$tr('createTopic')"
+    :cancelText="$tr('cancel')"
+    :submitText="$tr('create')"
+    data-test="newtopicmodal"
+    @cancel="cancel"
+    @submit="create"
   >
-    <VForm
-      ref="form"
-      lazy-validation
-      @submit.prevent="create"
-    >
-      <VTextField
-        v-model="title"
-        maxlength="200"
-        counter
-        :label="$tr('topicTitle')"
-        box
-        :rules="titleRules"
-        required
-      />
-    </VForm>
-    <template #buttons="{ close }">
-      <VBtn
-        flat
-        data-test="close"
-        @click="close"
-      >
-        {{ $tr('cancel') }}
-      </VBtn>
-      <VBtn
-        color="primary"
-        data-test="create"
-        @click="create"
-      >
-        {{ $tr('create') }}
-      </VBtn>
-    </template>
-  </MessageDialog>
+    <KTextbox
+      ref="title"
+      v-model="title"
+      :label="$tr('topicTitle')"
+      :maxlength="200"
+      :invalid="showErrorText"
+      :invalidText="titleError"
+      :showInvalidText="showErrorText"
+    />
+  </KModal>
 
 </template>
 
 
 <script>
 
-  import MessageDialog from 'shared/views/MessageDialog';
-
   export default {
     name: 'NewTopicModal',
-    components: {
-      MessageDialog,
-    },
-    props: {
-      value: {
-        type: Boolean,
-        default: false,
-      },
-    },
     data() {
       return {
         title: '',
+        titleError: null,
+        showErrorText: false,
       };
-    },
-    computed: {
-      dialog: {
-        get() {
-          return this.value;
-        },
-        set(value) {
-          this.$emit('input', value);
-        },
-      },
-      titleRules() {
-        return [v => !!v || this.$tr('topicTitleRequired')];
-      },
     },
     methods: {
       create() {
-        if (this.$refs.form.validate()) {
+        if (!this.title) {
+          this.titleError = this.$tr('topicTitleRequired');
+          this.showErrorText = true;
+          this.$refs.title.focus();
+        } else {
           this.$emit('createTopic', this.title);
         }
+      },
+      cancel() {
+        this.$emit('cancelCreateTopic');
       },
     },
     $trs: {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/__tests__/moveModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/__tests__/moveModal.spec.js
@@ -50,6 +50,10 @@ function makeWrapper(selected) {
       Breadcrumbs: true,
       ResourceDrawer: true,
       OfflineText: true,
+      NewTopicModal: {
+        name: 'NewTopicModal',
+        template: '<div data-test="newtopicmodal"></div>',
+      },
     },
   });
 }

--- a/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/ImportFromChannels/SearchOrBrowseWindow.vue
@@ -219,7 +219,7 @@
         <p
           v-if="showFeedbackErrorMessage"
           class="feedback-form-error"
-          :style="{ color: $themeTokens.error, backgroundColor: $themePalette.red.v_100 }"
+          :style="{ color: $themeTokens.error, backgroundColor: $themePalette.pink.v_100 }"
         >
           <KLabeledIcon
             icon="error"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -1,181 +1,173 @@
 <template>
 
-  <FullscreenModal
-    v-model="dialog"
-    :header="$tr('trashModalTitle')"
-  >
-    <LoadingText
-      v-if="loading"
-      data-test="loading"
-    />
-    <VContainer
-      v-else-if="!items.length"
-      fluid
-      data-test="empty"
+  <div>
+    <FullscreenModal
+      v-if="!moveModalOpen"
+      v-model="dialog"
+      :header="$tr('trashModalTitle')"
     >
-      <h1 class="font-weight-bold headline mt-4 pt-4 text-xs-center">
-        {{ $tr('trashEmptyText') }}
-      </h1>
-      <p class="mt-3 subheading text-xs-center">
-        {{ $tr('trashEmptySubtext') }}
-      </p>
-    </VContainer>
-    <VContent v-else>
-      <VContainer
-        fluid
-        class="pa-4"
-        data-test="list"
-        style="max-height: calc(100vh - 128px); overflow-y: auto"
-      >
-        <VCard
-          style="width: 100%; max-width: 900px; margin: 0 auto"
-          flat
-          class="pa-2"
-        >
-          <VDataTable
-            :headers="headers"
-            :items="items"
-            hide-actions
-            must-sort
-          >
-            <template #headerCell="props">
-              <VLayout
-                v-if="props.header.selectAll"
-                row
-                align-center
-              >
-                <VFlex shrink>
-                  <Checkbox
-                    :inputValue="selected.length === items.length"
-                    :indeterminate="!!selected.length && selected.length !== items.length"
-                    data-test="selectall"
-                    @input="toggleSelectAll"
-                  />
-                </VFlex>
-                <VFlex>
-                  {{ props.header.text }}
-                </VFlex>
-              </VLayout>
-              <span v-else>
-                {{ props.header.text }}
-              </span>
-            </template>
-            <template #items="{ item }">
-              <tr
-                :key="item.id"
-                :style="{ backgroundColor: getItemBackground(item.id) }"
-              >
-                <td>
-                  <VLayout
-                    row
-                    align-center
-                  >
-                    <VFlex shrink>
-                      <Checkbox
-                        v-model="selected"
-                        :value="item.id"
-                        data-test="checkbox"
-                      />
-                    </VFlex>
-                    <VFlex
-                      shrink
-                      class="mx-3"
-                    >
-                      <ContentNodeIcon :kind="item.kind" />
-                    </VFlex>
-                    <VFlex
-                      :class="getTitleClass(item)"
-                      grow
-                    >
-                      <ActionLink
-                        :text="getTitle(item)"
-                        data-test="item"
-                        @click="previewNodeId = item.id"
-                      />
-                    </VFlex>
-                  </VLayout>
-                </td>
-                <td class="text-xs-right">
-                  {{ $formatRelative(item.modified, { now: new Date() }) }}
-                </td>
-              </tr>
-            </template>
-          </VDataTable>
-          <div class="show-more-button-container">
-            <KButton
-              v-if="more"
-              :disabled="moreLoading"
-              @click="loadMore"
-            >
-              {{ showMoreLabel }}
-            </KButton>
-          </div>
-        </VCard>
-      </VContainer>
-      <ResourceDrawer
-        style="margin-top: 64px"
-        :nodeId="previewNodeId"
-        :channelId="currentChannel.id"
-        app
-        @close="previewNodeId = null"
+      <LoadingText
+        v-if="loading"
+        data-test="loading"
       />
-    </VContent>
-    <template #bottom>
-      <span
-        v-if="selected.length"
-        class="mr-4 subheading"
+      <VContainer
+        v-else-if="!items.length"
+        fluid
+        data-test="empty"
       >
-        {{ getSelectedTopicAndResourceCountText(selected) }}
-      </span>
-      <VSpacer />
-      <VBtn
-        flat
-        :disabled="!selected.length"
-        data-test="restore"
-        @click="moveModalOpen = true"
-      >
-        {{ $tr('restoreButton') }}
-      </VBtn>
-      <VBtn
-        color="primary"
-        :disabled="!selected.length"
-        data-test="delete"
-        @click="showConfirmationDialog = true"
-      >
-        {{ $tr('deleteButton') }}
-      </VBtn>
-    </template>
-    <MessageDialog
-      v-model="showConfirmationDialog"
-      :header="$tr('deleteConfirmationHeader', counts)"
-      :text="$tr('deleteConfirmationText')"
-    >
-      <template #buttons="{ close }">
+        <h1 class="font-weight-bold headline mt-4 pt-4 text-xs-center">
+          {{ $tr('trashEmptyText') }}
+        </h1>
+        <p class="mt-3 subheading text-xs-center">
+          {{ $tr('trashEmptySubtext') }}
+        </p>
+      </VContainer>
+      <VContent v-else>
+        <VContainer
+          fluid
+          class="pa-4"
+          data-test="list"
+          style="max-height: calc(100vh - 128px); overflow-y: auto"
+        >
+          <VCard
+            style="width: 100%; max-width: 900px; margin: 0 auto"
+            flat
+            class="pa-2"
+          >
+            <VDataTable
+              :headers="headers"
+              :items="items"
+              hide-actions
+              must-sort
+            >
+              <template #headerCell="props">
+                <VLayout
+                  v-if="props.header.selectAll"
+                  row
+                  align-center
+                >
+                  <VFlex shrink>
+                    <Checkbox
+                      :inputValue="selected.length === items.length"
+                      :indeterminate="!!selected.length && selected.length !== items.length"
+                      data-test="selectall"
+                      @input="toggleSelectAll"
+                    />
+                  </VFlex>
+                  <VFlex>
+                    {{ props.header.text }}
+                  </VFlex>
+                </VLayout>
+                <span v-else>
+                  {{ props.header.text }}
+                </span>
+              </template>
+              <template #items="{ item }">
+                <tr
+                  :key="item.id"
+                  :style="{ backgroundColor: getItemBackground(item.id) }"
+                >
+                  <td>
+                    <VLayout
+                      row
+                      align-center
+                    >
+                      <VFlex shrink>
+                        <Checkbox
+                          v-model="selected"
+                          :value="item.id"
+                          data-test="checkbox"
+                        />
+                      </VFlex>
+                      <VFlex
+                        shrink
+                        class="mx-3"
+                      >
+                        <ContentNodeIcon :kind="item.kind" />
+                      </VFlex>
+                      <VFlex
+                        :class="getTitleClass(item)"
+                        grow
+                      >
+                        <ActionLink
+                          :text="getTitle(item)"
+                          data-test="item"
+                          @click="previewNodeId = item.id"
+                        />
+                      </VFlex>
+                    </VLayout>
+                  </td>
+                  <td class="text-xs-right">
+                    {{ $formatRelative(item.modified, { now: new Date() }) }}
+                  </td>
+                </tr>
+              </template>
+            </VDataTable>
+            <div class="show-more-button-container">
+              <KButton
+                v-if="more"
+                :disabled="moreLoading"
+                @click="loadMore"
+              >
+                {{ showMoreLabel }}
+              </KButton>
+            </div>
+          </VCard>
+        </VContainer>
+        <ResourceDrawer
+          style="margin-top: 64px"
+          :nodeId="previewNodeId"
+          :channelId="currentChannel.id"
+          app
+          @close="previewNodeId = null"
+        />
+      </VContent>
+      <template #bottom>
+        <span
+          v-if="selected.length"
+          class="mr-4 subheading"
+        >
+          {{ getSelectedTopicAndResourceCountText(selected) }}
+        </span>
+        <VSpacer />
         <VBtn
           flat
-          data-test="closeconfirm"
-          @click="close"
+          :disabled="!selected.length"
+          data-test="restore"
+          @click="moveModalOpen = true"
         >
-          {{ $tr('deleteConfirmationCancelButton') }}
+          {{ $tr('restoreButton') }}
         </VBtn>
         <VBtn
           color="primary"
-          data-test="deleteconfirm"
-          @click="deleteNodes"
+          :disabled="!selected.length"
+          data-test="delete"
+          @click="showConfirmationDialog = true"
         >
-          {{ $tr('deleteConfirmationDeleteButton') }}
+          {{ $tr('deleteButton') }}
         </VBtn>
       </template>
-    </MessageDialog>
+      <KModal
+        v-if="showConfirmationDialog"
+        :title="$tr('deleteConfirmationHeader', counts)"
+        :cancelText="$tr('deleteConfirmationCancelButton')"
+        :submitText="$tr('deleteConfirmationDeleteButton')"
+        data-test="deleteconfirm"
+        @cancel="showConfirmationDialog = false"
+        @submit="deleteNodes"
+      >
+        <p>{{ $tr('deleteConfirmationText') }}</p>
+      </KModal>
+    </FullscreenModal>
     <MoveModal
-      v-if="moveModalOpen"
+      v-else
       ref="moveModal"
       v-model="moveModalOpen"
       :moveNodeIds="selected"
       :movingFromTrash="true"
       @target="moveNodes"
     />
-  </FullscreenModal>
+  </div>
 
 </template>
 
@@ -190,7 +182,6 @@
   import { RouteNames } from '../../constants';
   import ContentNodeIcon from 'shared/views/ContentNodeIcon';
   import Checkbox from 'shared/views/form/Checkbox';
-  import MessageDialog from 'shared/views/MessageDialog';
   import LoadingText from 'shared/views/LoadingText';
   import FullscreenModal from 'shared/views/FullscreenModal';
   import { titleMixin, routerMixin } from 'shared/mixins';
@@ -204,7 +195,6 @@
       ContentNodeIcon,
       ResourceDrawer,
       Checkbox,
-      MessageDialog,
       LoadingText,
       FullscreenModal,
       MoveModal,

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -134,7 +134,7 @@ describe('trashModal', () => {
 
     it('clicking CLOSE on delete confirmation dialog should close the dialog', async () => {
       await wrapper.setData({ showConfirmationDialog: true });
-      await wrapper.findComponent('[data-test="closeconfirm"]').trigger('click');
+      await wrapper.findComponent('[data-test="deleteconfirm"]').vm.$emit('cancel');
       expect(wrapper.vm.showConfirmationDialog).toBe(false);
     });
 
@@ -143,7 +143,7 @@ describe('trashModal', () => {
       const deleteContentNodes = jest.spyOn(wrapper.vm, 'deleteContentNodes');
       deleteContentNodes.mockImplementation(() => Promise.resolve());
       await wrapper.setData({ selected, showConfirmationDialog: true });
-      await wrapper.findComponent('[data-test="deleteconfirm"]').trigger('click');
+      await wrapper.findComponent('[data-test="deleteconfirm"]').vm.$emit('submit');
       expect(deleteContentNodes).toHaveBeenCalledWith(selected);
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/styles/main.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.scss
@@ -52,11 +52,6 @@ body {
   .v-btn:focus-visible {
     outline: 2px solid var(--v-secondary-base) !important;
   }
-
-  > .v-dialog__content,
-  > .v-overlay {
-    z-index: 16 !important;
-  }
 }
 
 /* RTL-related rules */

--- a/contentcuration/contentcuration/frontend/shared/styles/main.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.scss
@@ -52,6 +52,11 @@ body {
   .v-btn:focus-visible {
     outline: 2px solid var(--v-secondary-base) !important;
   }
+
+  > .v-dialog__content,
+  > .v-overlay {
+    z-index: 16 !important;
+  }
 }
 
 /* RTL-related rules */

--- a/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
@@ -39,15 +39,31 @@
       <KFixedGrid :numCols="2">
         <KFixedGridItem alignment="right">
           <KIconButton
+            ref="goToLocation"
             icon="openNewTab"
-            :tooltip="$tr('goToLocationTooltip')"
             @click.stop="goToLocation"
           />
+          <KTooltip
+            reference="goToLocation"
+            :refs="$refs"
+            appendToOverlay
+            :appearanceOverrides="{ zIndex: 202 }"
+          >
+            {{ $tr('goToLocationTooltip') }}
+          </KTooltip>
           <KIconButton
+            ref="markNotRelevant"
             icon="thumbDown"
-            :tooltip="$tr('markNotRelevantTooltip')"
             @click.stop="markNotRelevant"
           />
+          <KTooltip
+            reference="markNotRelevant"
+            :refs="$refs"
+            appendToOverlay
+            :appearanceOverrides="{ zIndex: 202 }"
+          >
+            {{ $tr('markNotRelevantTooltip') }}
+          </KTooltip>
         </KFixedGridItem>
       </KFixedGrid>
     </template>

--- a/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
@@ -39,31 +39,17 @@
       <KFixedGrid :numCols="2">
         <KFixedGridItem alignment="right">
           <KIconButton
-            ref="goToLocation"
             icon="openNewTab"
+            :tooltip="$tr('goToLocationTooltip')"
+            :aria-label="$tr('goToLocationTooltip')"
             @click.stop="goToLocation"
           />
-          <KTooltip
-            reference="goToLocation"
-            :refs="$refs"
-            appendToOverlay
-            :appearanceOverrides="{ zIndex: 202 }"
-          >
-            {{ $tr('goToLocationTooltip') }}
-          </KTooltip>
           <KIconButton
-            ref="markNotRelevant"
             icon="thumbDown"
+            :tooltip="$tr('markNotRelevantTooltip')"
+            :aria-label="$tr('markNotRelevantTooltip')"
             @click.stop="markNotRelevant"
           />
-          <KTooltip
-            reference="markNotRelevant"
-            :refs="$refs"
-            appendToOverlay
-            :appearanceOverrides="{ zIndex: 202 }"
-          >
-            {{ $tr('markNotRelevantTooltip') }}
-          </KTooltip>
         </KFixedGridItem>
       </KFixedGrid>
     </template>

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "jszip": "^3.10.1",
     "kolibri-constants": "^0.2.12",
-    "kolibri-design-system": "5.2.1",
+    "kolibri-design-system": "5.3.0",
     "lodash": "^4.17.21",
     "lowlight": "^3.3.0",
     "material-icons": "0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       kolibri-design-system:
-        specifier: 5.2.1
-        version: 5.2.1
+        specifier: 5.3.0
+        version: 5.3.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4869,8 +4869,8 @@ packages:
   kolibri-design-system@5.0.1:
     resolution: {integrity: sha512-oz5gEFUj7NYZbrqr89gPjSfRFVuuilSqILA4bbWqLWwkI9ay/uVMdsh8cY2Xajhtzccjwqa1c/NxUETr5kMfHQ==}
 
-  kolibri-design-system@5.2.1:
-    resolution: {integrity: sha512-KGZmhnqTBSetkrqc71BzlvWEiH4Hi8FQjqy0pYzpxdnRjb4Xx9l5Bp6w7WnAECQm10pEfbxUcfTBXUic0ecFmQ==}
+  kolibri-design-system@5.3.0:
+    resolution: {integrity: sha512-vqlqNaI200yWZOq6gwADZf79e+7Hq3wKz7l2idwNLt6UsihT/dRlodBN68aU4w5Wq3zqK/9bctnDLCcXVJx/rw==}
 
   kolibri-format@1.0.1:
     resolution: {integrity: sha512-yGQpsJkBAzmRueAq6MG1UOuDl9pbhEtMWNxq9ObG5pPVkG8uhWJAS1L71GCuNAeaV1XG2IWo2565Ov4yXnudeA==}
@@ -13140,7 +13140,7 @@ snapshots:
       vue2-teleport: 1.1.4
       xstate: 4.38.3
 
-  kolibri-design-system@5.2.1:
+  kolibri-design-system@5.3.0:
     dependencies:
       aphrodite: https://codeload.github.com/learningequality/aphrodite/tar.gz/fdc8d7be8912a5cf17f74ff10f124013c52c3e32
       autosize: 3.0.21


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes unresponsiveness of the trash page **Restore** button and **Add New Folder** button in the move resource page caused by the css overriding done when fixing https://github.com/learningequality/studio/pull/5322. To fix the issue, a new prop `appearanceOverrides` has been added to the `KTooltip` component so its appearance can be better manipulated, particularly the `z-index` in this case. 

**Note:** Testing this pr is dependent on merging and releasing https://github.com/learningequality/kolibri-design-system/pull/1112

**Before:**

Restore button

https://github.com/user-attachments/assets/c6d50705-febf-4ddb-869c-a8b872dc5c37

Add New Folder button

https://github.com/user-attachments/assets/88e77270-fdf9-45a9-9e8e-49d4a30cda68

**After:**
The tooltips still work as before

https://github.com/user-attachments/assets/24c1617e-e0d0-4fa6-9ea0-41426036c871

Restore button

https://github.com/user-attachments/assets/978c88e3-60aa-4032-a332-46de68b3fa9a

Add New Folder button

https://github.com/user-attachments/assets/7a693624-81c2-4b95-8f21-cc0df9fed644

**Note:**
Please note that this [a11y contrast issue](https://learningequality.slack.com/archives/C0LK8QS9J/p1757090717058289?thread_ts=1757088246.421979&cid=C0LK8QS9J) has been fixed as part of this pr.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5350
Fixes #5349

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Go to a channel and **move** or **delete** a folder or a resource. 
- Do one of the following depending on the above;
  - Select the "Open trash" option from the ellipsis button and attempt to restore the deleted folder or resource.
  - For the move option, Click the "Add new folder" to create a folder to move the resource or folder.
- Both operations should work as expected.
