### PR TITLE
Fix Edit language modal not closing immediately

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/QuickEditModal/EditLanguageModal.vue
@@ -178,7 +178,7 @@
           }),
         );
         /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
-        await this.showSnackbarSimple(commonStrings.$tr('changesSaved'));
+        this.showSnackbarSimple(commonStrings.$tr('changesSaved'));
         this.close(this.changed);
       },
       showSnackbarSimple(message) {


### PR DESCRIPTION
## Summary
Fixes the 'Edit language' modal not closing immediately after saving the changes.

## References
closes #5348 

## Reviewer guidance
- Go to a channel and select a folder or a resource
- Click the Edit language icon
- Select a language and click the Save button
- The modal now closes immediately! 