### PR TITLE
Fixes additional resource preview Klogo loading issues

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -6,10 +6,10 @@
   >
     <div
       class="renderer"
-      :aria-busy="loading"
+      :aria-busy="isSupported && loading"
     >
       <div
-        v-show="loading"
+        v-show="isSupported && loading"
         class="overlay"
         :style="{ background: $themePalette.white }"
       >
@@ -215,6 +215,9 @@
       },
       isEpub() {
         return this.file.file_format === 'epub';
+      },
+      isSupported() {
+        return this.isVideo || this.isAudio || this.isHTML || this.isPDF || this.isEpub;
       },
       htmlPath() {
         const entry = get(this.contentNode, ['extra_fields', 'options', 'entry'], 'index.html');


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr prevents the `KLogo` from loading endlessly when `bloompub`, `bloomd`, `h5p`, and `kpub` file types are loaded.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5327

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Sign in to Hotfixes with an account with enabled search recommendations
- Go to a channel with resources and try to preview a resource
- Attempt to import a resource from other channels and preview it
