### PR TITLE
[Remove Vuetify from Studio] Buttons / links on account created / deleted pages

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/accountDeleted/AccountDeleted.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/accountDeleted/AccountDeleted.vue
@@ -2,13 +2,12 @@
 
   <MessageLayout :header="$tr('accountDeletedTitle')">
     <template #back>
-      <VBtn
-        color="primary"
-        :to="{ name: 'Main' }"
-        large
-      >
-        {{ $tr('backToLogin') }}
-      </VBtn>
+      <KButton
+        appearance="raised-button"
+        :primary="true"
+        :text="$tr('backToLogin')"
+        @click="$router.push({ name: 'Main' })"
+      />
     </template>
   </MessageLayout>
 

--- a/contentcuration/contentcuration/frontend/accounts/pages/accountDeleted/AccountDeleted.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/accountDeleted/AccountDeleted.vue
@@ -2,11 +2,11 @@
 
   <MessageLayout :header="$tr('accountDeletedTitle')">
     <template #back>
-      <KButton
-        appearance="raised-button"
-        :primary="true"
+      <KRouterLink
+        :to="{ name: 'Main' }"
         :text="$tr('backToLogin')"
-        @click="$router.push({ name: 'Main' })"
+        :primary="true"
+        appearance="raised-button"
       />
     </template>
   </MessageLayout>

--- a/contentcuration/contentcuration/frontend/accounts/pages/activateAccount/AccountCreated.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/activateAccount/AccountCreated.vue
@@ -2,13 +2,12 @@
 
   <MessageLayout :header="$tr('accountCreatedTitle')">
     <template #back>
-      <VBtn
-        color="primary"
-        :to="{ name: 'Main' }"
-        large
-      >
-        {{ $tr('backToLogin') }}
-      </VBtn>
+      <KButton
+        appearance="raised-button"
+        :primary="true"
+        :text="$tr('backToLogin')"
+        @click="$router.push({ name: 'Main' })"
+      />
     </template>
   </MessageLayout>
 

--- a/contentcuration/contentcuration/frontend/accounts/pages/activateAccount/AccountCreated.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/activateAccount/AccountCreated.vue
@@ -2,11 +2,11 @@
 
   <MessageLayout :header="$tr('accountCreatedTitle')">
     <template #back>
-      <KButton
-        appearance="raised-button"
-        :primary="true"
+      <KRouterLink
+        :to="{ name: 'Main' }"
         :text="$tr('backToLogin')"
-        @click="$router.push({ name: 'Main' })"
+        :primary="true"
+        appearance="raised-button"
       />
     </template>
   </MessageLayout>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->


## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Updated VBtn to Kbutton in Account Delete and Account Created pages

<img width="1512" height="713" alt="Screenshot 2025-09-06 at 8 45 26 PM" src="https://github.com/user-attachments/assets/8fa11327-62cd-4d5d-967f-d83a8516bf1b" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes [5353](https://github.com/learningequality/studio/issues/5353)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Test Kbuttons in Account Deleted and Account created pages.
