### PR TITLE
Updated VBtn to KButton in upload files #5379

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -81,10 +81,10 @@
                     {{ $tr('addTopic') }}
                   </VBtn>
                   <KButton
-                  v-else-if="uploadMode"
-                  :text="$tr('uploadButton')"
-                  :disabled="creatingNodes"
-                  @click="openFileDialog"
+                    v-else-if="uploadMode"
+                    :text="$tr('uploadButton')"
+                    :disabled="creatingNodes"
+                    @click="openFileDialog"
                   />
                 </ToolBar>
                 <div ref="list">

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadDefault.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FileUploadDefault.vue
@@ -35,14 +35,12 @@
                   {{ $tr('dropHereText') }}
                 </p>
                 <KButton
-                :text="$tr('chooseFilesButton')"
-                :primary="true"
-                data-test="upload"
-                @click="openFileDialog"
-
+                  :text="$tr('chooseFilesButton')"
+                  :primary="true"
+                  data-test="upload"
+                  @click="openFileDialog"
                 />
 
-                
                 <p class="grey--text mt-2 small text-center">
                   {{ $tr('acceptsHelp', { extensions: acceptedFiles }) }}
                 </p>


### PR DESCRIPTION
Fixes #5379 
## Summary
Updated VBtn to KButton in upload files.
AFTER IMAGES
<img width="1365" height="680" alt="Screenshot From 2025-09-11 03-00-21" src="https://github.com/user-attachments/assets/391059d9-dda1-476a-924c-b8bc8faf9081" />
<img width="1369" height="674" alt="Screenshot From 2025-09-11 03-01-42" src="https://github.com/user-attachments/assets/b98505bc-3230-46fe-9eed-92713403c1dc" />





## References
• Parent issue: https://github.com/learningequality/studio/issues/5060
## Reviewer guidance
Login as a@a.com with password a.
Go to Channels > Published Channel.
Click Add then go to Upload files option.(the upload files page will be opened).
Use select files option.(the edit files page will be opened).

