### PR TITLE
fix(texteditor): compute accepted images extensions from mimes

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditorStrings.js
@@ -224,7 +224,7 @@ const MESSAGES = {
     context: 'Accessibility label for the button that opens the file picker.',
   },
   supportedFileTypes: {
-    message: 'Supported file types: ',
+    message: 'Supported file types: { extensions }',
     context: 'A list of supported image file formats.',
   },
   removeImage: {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditorStrings.js
@@ -224,7 +224,7 @@ const MESSAGES = {
     context: 'Accessibility label for the button that opens the file picker.',
   },
   supportedFileTypes: {
-    message: 'Supported file types: png, jpg, jpeg, svg, webp',
+    message: 'Supported file types: ',
     context: 'A list of supported image file formats.',
   },
   removeImage: {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/image/ImageUploadModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/image/ImageUploadModal.vue
@@ -216,7 +216,7 @@
         const extensions = ACCEPTED_MIME_TYPES.map(type =>
           type.replace('image/', '').replace('svg+xml', 'svg'),
         );
-        return supportedFileTypes$() + extensions.join(', ');
+        return supportedFileTypes$({ extensions: extensions.join(', ') });
       });
 
       const instance = getCurrentInstance();

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/image/ImageUploadModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/image/ImageUploadModal.vue
@@ -105,7 +105,7 @@
           >
             {{ selectFile$() }}
           </button>
-          <p class="drop-zone-text">{{ supportedFileTypes$() }}</p>
+          <p class="drop-zone-text">{{ supportedFileTypesText }}</p>
         </ImageDropZone>
       </div>
     </div>
@@ -212,6 +212,13 @@
       const imageProcessor = inject('imageProcessor', {});
       const { processFile, ACCEPTED_MIME_TYPES } = imageProcessor;
 
+      const supportedFileTypesText = computed(() => {
+        const extensions = ACCEPTED_MIME_TYPES.map(type =>
+          type.replace('image/', '').replace('svg+xml', 'svg'),
+        );
+        return supportedFileTypes$() + extensions.join(', ');
+      });
+
       const instance = getCurrentInstance();
       const store = instance.proxy.$store;
 
@@ -285,6 +292,7 @@
         isEditMode,
         canInsert,
         ACCEPTED_MIME_TYPES,
+        supportedFileTypesText,
         triggerFileInput,
         onFileSelect,
         onInsert,
@@ -311,7 +319,6 @@
         altTextDescription$,
         imageDropZoneText$,
         selectFileToUpload$,
-        supportedFileTypes$,
         removeImage$,
         remove$,
         saveChanges$,


### PR DESCRIPTION
## Summary
Instead of hard coding the accepted extension types for image uploading, I now compute them from the `ACCEPTED_MIME_TYPES` provided by the image upload service. 
Also I stopped translating them. I noticed this because I saw a mismatch that we didn't notice in the image upload modal.

---

## Reviewer guidance
1. Go to the exercise editor
2. Click the add image button
3. See the accepted extension types at the bottom of the open modal