### PR TITLE
Add regression test for and fix use of accent property for mo tag.

### DIFF
--- a/contentcuration/contentcuration/tests/utils/test_markdown.py
+++ b/contentcuration/contentcuration/tests/utils/test_markdown.py
@@ -166,6 +166,21 @@ class TexMathTestMixin:
 
         self._assert_conversion(markdown_text, expected)
 
+    def test_mo_accented(self):
+        """Regression test for missed experimental property on mo tags"""
+
+        markdown_text = "$$a_b+\\overrightarrow{abc}+\\overleftarrow{abc}\\div\\surd\\overline{abc}$$"
+        expected = (
+            '<math display="block">'
+            "<semantics><mrow><msub><mi>a</mi><mi>b</mi></msub><mo>+</mo><mover><mrow><mi>a</mi><mi>b</mi><mi>c</mi></mrow><mo>→</mo></mover><mo>+</mo>"
+            '<mover><mrow><mi>a</mi><mi>b</mi><mi>c</mi></mrow><mo>←</mo></mover><mi>÷</mi><mo stretchy="false">√</mo><mover><mrow><mi>a</mi><mi>b</mi>'
+            '<mi>c</mi></mrow><mo accent="true">―</mo></mover></mrow>'
+            '<annotation encoding="application/x-tex">a_b+\\overrightarrow{abc}+\\overleftarrow{abc}\\div\\surd\\overline{abc}</annotation></semantics>'
+            "</math>"
+        )
+
+        self._assert_conversion(markdown_text, expected)
+
 
 class TestTexMathPlugin(TexMathTestMixin, unittest.TestCase):
     """Test direct markdown conversion: markdown → HTML+MathML"""

--- a/contentcuration/contentcuration/utils/assessment/qti/mathml/core.py
+++ b/contentcuration/contentcuration/utils/assessment/qti/mathml/core.py
@@ -45,6 +45,7 @@ class Mn(MathMLTokenElement):
 
 
 class Mo(MathMLTokenElement):
+    accent: Optional[bool] = None
     fence: Optional[bool] = None
     form: Optional[MathMLForm] = None
     largeop: Optional[bool] = None


### PR DESCRIPTION
## Summary
The pydantic implementation of the mo element I had previously done was missing the non-standard `accent` property. This was causing errors during publish for one of Peter's test channels.

I took the LaTeX from that specific exercise to make a regression test, and confirmed that adding the accent property to the pydantic class resolved the issue.

## References
Fixes this error I saw when running publish in an interactive shell in a disposable pod on hotfixes:
```
ValidationError: 1 validation error for Mo
accent
  Extra inputs are not permitted [type=extra_forbidden, input_value='true', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
```

## Reviewer guidance
Cross check with the MDN page: https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mo#accent

I also asked Claude Code to do a follow up scan of all the MathML and HTML classes and compare them to the spec to see if anything else might be missing. It said nothing was, although I don't take that as proof positive! But at least, there's some validation that we have complete coverage now.

I think this would be fairly low risk to go into the search recommendations release - but it is probably simpler to reserve this for an immediate follow up patch release.