### PR TITLE
add focus trapping to resource preview side panel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourceDrawer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourceDrawer.vue
@@ -16,6 +16,7 @@
       @scroll="$emit('scroll', $event)"
     >
       <div
+        ref="rootEl"
         class="pa-4"
         style="margin-bottom: 64px"
       >
@@ -43,14 +44,25 @@
 
 <script>
 
+  import { ref } from 'vue';
   import ResourcePanel from './ResourcePanel';
   import ResizableNavigationDrawer from 'shared/views/ResizableNavigationDrawer';
+  import { useFocusTrap } from 'shared/views/TipTapEditor/TipTapEditor/composables/useFocusTrap';
 
   export default {
     name: 'ResourceDrawer',
     components: {
       ResizableNavigationDrawer,
       ResourcePanel,
+    },
+    setup() {
+      const rootEl = ref(null);
+
+      useFocusTrap(rootEl);
+
+      return {
+        rootEl,
+      };
     },
     props: {
       // key for sessionStorage to store width data at


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds focus trapping to the resource preview side panel displayed when importing resources from other channels. It uses the [`useFocusTrap`](https://github.com/learningequality/studio/blob/01e8feef3af5d97cd9f9be6874216a6b2b6117e0/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useFocusTrap.js) composable (implemened by @habibayman, Thank you! 🙂).

**Note:** This seems like best way to resolve the bug for now, however, ultimately, we'll want to migrate the side panel from Vuetify so we can take advantage of the `KFocusTrap` component, which won't work out of the box with the current side panel implementation.

**Before**
<img width="1432" height="669" alt="Image" src="https://github.com/user-attachments/assets/ef98231b-2544-4dc9-965d-b0e85d1a9dfb" />

**After**

https://github.com/user-attachments/assets/96a027a2-2cd9-4878-abd6-e30252beb9fb

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5269

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Import resource from other channels
- Select a particular resource
- Use the Tab key to navigate the side panel
- observe the behaviour
