### PR TITLE
Always remove image dimensions from markdown during image processing

### DIFF
--- a/contentcuration/contentcuration/tests/utils/test_exercise_creation.py
+++ b/contentcuration/contentcuration/tests/utils/test_exercise_creation.py
@@ -984,6 +984,15 @@ class TestPerseusExerciseCreation(StudioTestCase):
             "Different sized images should have different file sizes",
         )
 
+        # Verify that the dimensions have been stripped from the markdown
+        for file_name in unique_image_files:
+            # Because we can't predict the set ordering, just confirm that
+            # neither dimension descriptor is applied.
+            first_file = f"{file_name} =200x150"
+            self.assertNotIn(first_file, content)
+            second_file = f"{file_name} =100x75"
+            self.assertNotIn(second_file, content)
+
     def test_image_resizing_in_question(self):
         """Test image resizing functionality in question content"""
         self._test_image_resizing_in_field("question")

--- a/contentcuration/contentcuration/utils/assessment/qti/archive.py
+++ b/contentcuration/contentcuration/utils/assessment/qti/archive.py
@@ -64,8 +64,6 @@ class QTIExerciseGenerator(ExerciseArchiveGenerator):
 
     file_format = "zip"
     preset = format_presets.QTI_ZIP
-    # Our markdown parser does not handle width/height in image refs
-    RETAIN_IMAGE_DIMENSIONS = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
* I mistakenly believed that Perseus' markdown processing handled the image dimension addition we had made to the markdown, whereas in fact this only gets used in our backend and nowhere else.
* Fixes this by adding a regression test that this is always removed, and simplifying our image replacement behaviour to always do this (and not just for QTI export, as my previous fix had done: https://github.com/learningequality/studio/pull/5316)
* Cleans up the previous special casing for this, and simplifies our image replacement flow to just do a single pass using re.sub.

## References
Fixes [#5398](https://github.com/learningequality/studio/issues/5398)

## Reviewer guidance
Do the changes make sense, is the existing test coverage adequate to guard against regressions, is the regression coverage added in this PR adequate to prevent this in future?
