### PR TITLE
Updated VBtn to KButton (Buttons in Add previous / next step) #5376

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AddRelatedResourcesModal.vue
@@ -62,24 +62,23 @@
 
             <template v-if="displayActionsButtons(childNode)">
               <VListTileAction>
-                <VBtn
-                  flat
+                <KButton
+                  :text="$tr('previewStepBtnLabel')"
                   class="font-weight-bold"
+                  appearance="flat-button"
                   @click.stop.prevent="onPreviewStepClick(childNode.id)"
-                >
-                  {{ $tr('previewStepBtnLabel') }}
-                </VBtn>
+                />
               </VListTileAction>
 
               <VListTileAction v-if="!isNodePreviewOpen">
-                <VBtn
-                  flat
-                  color="primary"
+                <KButton
+            
+                  :text="$tr('addStepBtnLabel')"
+                  :primary="true"
                   class="font-weight-bold"
+                  appearance="flat-button"
                   @click.stop.prevent="onAddStepClick(childNode.id)"
-                >
-                  {{ $tr('addStepBtnLabel') }}
-                </VBtn>
+                />
               </VListTileAction>
             </template>
           </VListTile>
@@ -97,14 +96,14 @@
         v-if="displayActionsButtons"
         #actions
       >
-        <VBtn
-          flat
-          color="primary"
+        <KButton
+            
+          :text="$tr('addStepBtnLabel')"
           class="font-weight-bold"
+          :primary="true"
+          appearance="flat-button"
           @click.stop.prevent="onAddStepClick(previewNodeId)"
-        >
-          {{ $tr('addStepBtnLabel') }}
-        </VBtn>
+        />
       </template>
     </ResourceDrawer>
   </FullscreenModal>


### PR DESCRIPTION
Fixes #5376

## Summary
Updated VBtn to KButton (Buttons in Add previous / next step) 
AFTER IMAGES

ADD PREVIOUS STEP
<img width="1363" height="649" alt="Screenshot From 2025-09-13 02-47-59" src="https://github.com/user-attachments/assets/51ac682e-46fb-4a6d-8d4c-85ea65e5cf39" />

<img width="1363" height="649" alt="Screenshot From 2025-09-13 02-46-19" src="https://github.com/user-attachments/assets/efbb7490-be25-4816-910d-e5984bad4ec3" />

ADD NEXT STEP
<img width="1363" height="649" alt="Screenshot From 2025-09-13 02-45-36" src="https://github.com/user-attachments/assets/2ca1bafe-7fa3-4940-9b62-c336998977cd" />
<img width="1363" height="649" alt="Screenshot From 2025-09-13 02-45-06" src="https://github.com/user-attachments/assets/7c92db5f-c8ea-4dfd-aff7-91a6312d78b6" />


## References
• Parent issue: https://github.com/learningequality/studio/issues/5060
## Reviewer guidance
Login as a@a.com with password a
Go to Channels > Published Channel
Select Sample video
Click Edit
Go to Related tab
Click Add previous / next step
Click Preview
