### PR TITLE
Ensure free response questions can be answered

### DIFF
--- a/contentcuration/contentcuration/tests/utils/test_exercise_creation.py
+++ b/contentcuration/contentcuration/tests/utils/test_exercise_creation.py
@@ -1517,6 +1517,52 @@ class TestQTIExerciseCreation(StudioTestCase):
             self._normalize_xml(actual_item_xml),
         )
 
+    def test_free_response_question_no_answers(self):
+        assessment_id = "fedcba0987654321fedcba0987654321"
+        item = self._create_assessment_item(
+            exercises.FREE_RESPONSE,
+            "What is the capital of France?",
+            [],
+            assessment_id=assessment_id,
+        )
+
+        exercise_data = {
+            "mastery_model": exercises.M_OF_N,
+            "randomize": True,
+            "n": 1,
+            "m": 1,
+            "all_assessment_items": [item.assessment_id],
+            "assessment_mapping": {item.assessment_id: exercises.FREE_RESPONSE},
+        }
+
+        self._create_qti_zip(exercise_data)
+        exercise_file = self.exercise_node.files.get(preset_id=format_presets.QTI_ZIP)
+        zip_file = self._validate_qti_zip_structure(exercise_file)
+
+        # Check the QTI XML for text entry specifics
+        expected_item_file = "items/K_ty6CYdlQyH-3LoJh2VDIQ.xml"
+        actual_item_xml = zip_file.read(expected_item_file).decode("utf-8")
+
+        # Expected QTI item XML content for text entry
+        expected_item_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0p1_v1p0.xsd" identifier="K_ty6CYdlQyH-3LoJh2VDIQ" title="Test QTI Exercise 1" adaptive="false" time-dependent="false" language="en-US" tool-name="kolibri" tool-version="0.1">
+    <qti-response-declaration identifier="RESPONSE" cardinality="single" base-type="string" />
+    <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float" />
+    <qti-item-body>
+        <div>
+            <p>What is the capital of France?</p>
+            <p><qti-text-entry-interaction response-identifier="RESPONSE" expected-length="50" placeholder-text="Enter your answer here" /></p>
+        </div>
+    </qti-item-body>
+    <qti-response-processing template="https://purl.imsglobal.org/spec/qti/v3p0/rptemplates/match_correct" />
+</qti-assessment-item>"""
+
+        # Compare normalized XML
+        self.assertEqual(
+            self._normalize_xml(expected_item_xml),
+            self._normalize_xml(actual_item_xml),
+        )
+
     def test_free_response_question_with_maths(self):
         assessment_id = "fedcba0987654321fedcba0987654321"
         item = self._create_assessment_item(

--- a/contentcuration/contentcuration/utils/assessment/qti/archive.py
+++ b/contentcuration/contentcuration/utils/assessment/qti/archive.py
@@ -152,15 +152,17 @@ class QTIExerciseGenerator(ExerciseArchiveGenerator):
         prompt.append(interaction_element)
         interaction = Div(children=prompt)
 
-        float_answer = True
         correct_values = []
+        values_float = []
         for answer in processed_data["answers"]:
             if answer["correct"]:
                 correct_values.append(Value(value=str(answer["answer"])))
-                try:
-                    float(answer["answer"])
-                except ValueError:
-                    float_answer = False
+            try:
+                float(answer["answer"])
+                values_float.append(True)
+            except ValueError:
+                values_float.append(False)
+        float_answer = bool(values_float) and all(values_float)
 
         response_declaration = ResponseDeclaration(
             identifier="RESPONSE",


### PR DESCRIPTION
## Summary
* Fixes issue where free response questions with no set answers (i.e. all of them) would get set as having a float value in the QTI.
* Adds regression test and defaults to string value when no answers are given
* Update to check all candidate answers, so that users are free to input specified incorrect answers

## References
Fixes the Studio aspect of https://github.com/learningequality/kolibri/issues/13754

## Reviewer guidance
Create a survey in your local Studio. Add a free response question.
Import it into Kolibri using code from this PR: https://github.com/learningequality/kolibri/pull/13791

Ensure that you can enter text responses and submit.

Screenshot of a successfully submitted survey response in the report:

<img width="1910" height="590" alt="Screenshot from 2025-09-26 15-44-35" src="https://github.com/user-attachments/assets/24cc117d-12df-4677-82b3-a888ff1a6d59" />
