### PR TITLE
[Remove Vuetify from Studio] Buttons in Move modal #5355

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -31,13 +31,12 @@
         </template>
       </Breadcrumbs>
       <VSpacer />
-      <VBtn
-        color="grey lighten-4"
+      <KButton
+    
+        :text="$tr('addTopic')"
         data-test="newtopic"
         @click="showNewTopicModal = true"
-      >
-        {{ $tr('addTopic') }}
-      </VBtn>
+      />
     </ToolBar>
     <!-- list of children content -->
     <LoadingText
@@ -159,22 +158,22 @@
         v-if="moveHereButtonDisabled && moveNodesInProgress"
         :size="20"
       />
-      <VBtn
-        flat
-        exact
-        data-test="cancel"
-        @click="dialog = false"
-      >
-        {{ $tr('cancel') }}
-      </VBtn>
-      <VBtn
-        color="primary"
-        data-test="move"
-        :disabled="moveHereButtonDisabled"
-        @click="moveNodes"
-      >
-        {{ $tr('moveHere') }}
-      </VBtn>
+      <KButtonGroup>
+        <KButton
+          appearance="flat-button"
+          :text="$tr('cancel')"
+          data-test="cancel"
+          @click="dialog = false"
+        />
+        <KButton
+          :primary="true"
+          :text="$tr('moveHere')"
+          :disabled="moveHereButtonDisabled"
+          data-test="move"
+          @click="moveNodes"
+        />
+      </KButtonGroup>
+      
     </template>
 
     <NewTopicModal

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -433,8 +433,9 @@
     width: 100%;
     margin-bottom: 10px;
   }
+
   .add-topic-btn {
-  flex-shrink: 0;
-}
+    flex-shrink: 0;
+  }
 
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/move/MoveModal.vue
@@ -32,7 +32,7 @@
       </Breadcrumbs>
       <VSpacer />
       <KButton
-    
+        class="add-topic-btn"
         :text="$tr('addTopic')"
         data-test="newtopic"
         @click="showNewTopicModal = true"
@@ -434,5 +434,8 @@
     width: 100%;
     margin-bottom: 10px;
   }
+  .add-topic-btn {
+  flex-shrink: 0;
+}
 
 </style>


### PR DESCRIPTION
Fixes #5355 

## Summary
Updated Buttons from Vbtn to KButton in Move modal
Used KButtonGroup for the bottom right Buttons for 8px spacing.


IMAGES
<img width="1368" height="680" alt="Screenshot From 2025-09-29 00-07-59" src="https://github.com/user-attachments/assets/6ac8ba28-6411-4cc8-b672-b082ddb03fcb" />


## References
• Parent issue: https://github.com/learningequality/studio/issues/5060


## Reviewer guidance

Login as a@a.com with password a
Go to Channels > Published Channel
Check topic or resource
Click "Move" icon



