### PR TITLE
[Remove Vuetify from Studio] Deactivate and delete confirmation dialogs in admin user actions #5411

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserActionsDropdown.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserActionsDropdown.vue
@@ -1,25 +1,33 @@
 <template>
 
   <div>
-    <ConfirmationDialog
-      v-model="deleteDialog"
-      title="Delete user"
-      :text="`Are you sure you want to permanently delete ${user.name}'s account?`"
-      confirmButtonText="Delete"
+    <KModal
+      v-if="deleteDialog"
+      :title="$tr('deleteUserTitle')"
+      :submitText="$tr('deleteAction')"
+      :cancelText="$tr('cancelAction')"
       data-test="confirm-delete"
-      @confirm="deleteHandler"
-    />
-    <ConfirmationDialog
-      v-model="deactivateDialog"
-      title="Deactivate user"
-      :text="
-        `Deactivating ${user.name}'s account will block them from ` +
-          `accessing their account. Are you sure you want to continue?`
-      "
-      confirmButtonText="Deactivate"
+      @submit="deleteHandler"
+      @cancel="deleteDialog = false"
+    >
+      <div class="kmodal-confirmation-content">
+        <p>{{ $tr('deleteUserMessage', { name: user.name }) }}</p>
+      </div>
+    </KModal>
+
+    <KModal
+      v-if="deactivateDialog"
+      :title="$tr('deactivateUserTitle')"
+      :submitText="$tr('deactivateAction')"
+      :cancelText="$tr('cancelAction')"
       data-test="confirm-deactivate"
-      @confirm="deactivateHandler"
-    />
+      @submit="deactivateHandler"
+      @cancel="deactivateDialog = false"
+    >
+      <div class="kmodal-confirmation-content">
+        <p>{{ $tr('deactivateUserMessage', { name: user.name }) }}</p>
+      </div>
+    </KModal>
     <UserPrivilegeModal
       v-model="addAdminPrivilegeDialog"
       header="Add admin privileges"
@@ -106,14 +114,14 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
-  import ConfirmationDialog from '../../components/ConfirmationDialog';
+  
   import EmailUsersDialog from './EmailUsersDialog';
   import UserPrivilegeModal from './UserPrivilegeModal';
 
   export default {
     name: 'UserActionsDropdown',
     components: {
-      ConfirmationDialog,
+    
       EmailUsersDialog,
       UserPrivilegeModal,
     },
@@ -174,9 +182,32 @@
         });
       },
     },
+    $trs: {
+      deleteUserTitle: 'Delete user',
+      deleteAction: 'Delete',
+      deleteUserMessage: "Are you sure you want to permanently delete {name}'s account?",
+      deactivateUserTitle: 'Deactivate user',
+      deactivateAction: 'Deactivate',
+      deactivateUserMessage: "Deactivating {name}'s account will block them from accessing their account. Are you sure you want to continue?",
+      cancelAction: 'Cancel',
+    },
   };
 
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+.kmodal-confirmation-content {
+  color: #212121;
+  white-space: normal;
+  text-align: left;
+}
+
+::v-deep .title {
+  color: #212121;
+  text-align: left;
+  font-weight: bold;
+}
+
+</style>

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userActionsDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userActionsDropdown.spec.js
@@ -71,8 +71,8 @@ describe('userActionsDropdown', () => {
     });
 
     it('confirm delete user should call deleteUser', async () => {
-      wrapper.find('[data-test="confirm-delete"]').vm.$emit('confirm');
-      await wrapper.vm.$nextTick();
+      await wrapper.findComponent('[data-test="delete"]').trigger('click');
+      wrapper.findComponent('[data-test="confirm-delete"]').vm.$emit('submit');
       expect(mocks.deleteUser).toHaveBeenCalledWith(userId);
     });
 
@@ -93,8 +93,8 @@ describe('userActionsDropdown', () => {
     });
 
     it('confirm deactivate should call updateUser with is_active = false', async () => {
-      wrapper.findComponent('[data-test="confirm-deactivate"]').vm.$emit('confirm');
-      await wrapper.vm.$nextTick();
+      await wrapper.findComponent('[data-test="deactivate"]').trigger('click');
+      wrapper.findComponent('[data-test="confirm-deactivate"]').vm.$emit('submit');
       expect(mocks.updateUser).toHaveBeenCalledWith({ id: userId, is_active: false });
     });
 


### PR DESCRIPTION
Fixes #5411 

## Summary
Migrated 2  user action confirmation dialogs from Vuetify to KDS KModal.
## After images for Desktop users:
<img width="1353" height="675" alt="Screenshot From 2025-10-02 21-59-02" src="https://github.com/user-attachments/assets/93403c45-16db-4335-a466-67150b1b4d9d" />
<img width="1353" height="675" alt="Screenshot From 2025-10-02 21-59-21" src="https://github.com/user-attachments/assets/36a6aae7-faee-4529-8bf1-0c0615baa4c5" />


## After images for Mobile users:
<img width="339" height="589" alt="Screenshot From 2025-10-01 18-38-14" src="https://github.com/user-attachments/assets/81abf9fa-fb45-4e8e-b21e-548a48aa1ca8" />


<img width="330" height="589" alt="Screenshot From 2025-10-01 18-38-31" src="https://github.com/user-attachments/assets/39f9129e-fc2b-46cf-af2a-34794d1c3448" />

## References

• Parent issue: https://github.com/learningequality/studio/issues/5060



## Reviewer guidance

Login as a@a.com with password a
Go to Administration > Users
Click Actions dropdown in the last column of the table
Click Deactivate
Click Delete
