### PR TITLE
When creating exercises, default randomize to true as data.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/DetailsTabView.vue
@@ -694,7 +694,7 @@
       /* FORM FIELDS */
       title: generateGetterSetter('title'),
       description: generateGetterSetter('description'),
-      randomizeOrder: generateExtraFieldsGetterSetter('randomize', true),
+      randomizeOrder: generateExtraFieldsGetterSetter('randomize'),
       author: generateGetterSetter('author'),
       provider: generateGetterSetter('provider'),
       aggregator: generateGetterSetter('aggregator'),

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js
@@ -220,6 +220,10 @@ export function createContentNode(context, { parent, kind, ...payload }) {
     ...payload,
   };
 
+  if (kind === ContentKindsNames.EXERCISE) {
+    contentNodeData.extra_fields.randomize = true;
+  }
+
   contentNodeData.complete = isNodeComplete({
     nodeDetails: contentNodeData,
     assessmentItems: [],


### PR DESCRIPTION
## Summary
Previously, we only defaulted the UI to show randomize as true for exercises. Somehow, because extra_fields was empty, this meant that we bypassed any validation at all, even though randomize used to be 'required'. In the most recent update, we made the validation more strict, and now it fails because it was not being set on initial exercise creation.

This resolves that by instead of just having a default displayed in the UI, the frontend sets randomize for any exercise node as true by default.

## References
Fixes https://github.com/learningequality/studio/issues/5419

## Reviewer guidance
Ensure you can create a new exercise and the creation change for it is successfully synced and applied on the backend.
