### PR TITLE
[Remove Vuetify from Studio] Buttons in New folder and Trash 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -73,13 +73,11 @@
                   class="add-wrapper"
                   :color="$themeTokens.textInverted"
                 >
-                  <VBtn
+                  <KButton
                     v-if="addTopicsMode"
-                    color="greyBackground"
+                    :text="$tr('addTopic')"
                     @click="createTopic"
-                  >
-                    {{ $tr('addTopic') }}
-                  </VBtn>
+                  />
                   <KButton
                     v-else-if="uploadMode"
                     :text="$tr('uploadButton')"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -128,22 +128,20 @@
         {{ getSelectedTopicAndResourceCountText(selected) }}
       </span>
       <VSpacer />
-      <VBtn
-        flat
+      <KButton
+        appearance="flat-button"
+        :text="$tr('restoreButton')"
         :disabled="!selected.length"
         data-test="restore"
         @click="moveModalOpen = true"
-      >
-        {{ $tr('restoreButton') }}
-      </VBtn>
-      <VBtn
-        color="primary"
+      />
+      <KButton
+        :primary="true"
+        :text="$tr('deleteButton')"
         :disabled="!selected.length"
         data-test="delete"
         @click="showConfirmationDialog = true"
-      >
-        {{ $tr('deleteButton') }}
-      </VBtn>
+      />
     </template>
     <MessageDialog
       v-model="showConfirmationDialog"

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -375,4 +375,8 @@
     width: 100%;
   }
 
+  .button-group {
+    white-space: nowrap;
+  }
+
 </style>

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -128,20 +128,22 @@
         {{ getSelectedTopicAndResourceCountText(selected) }}
       </span>
       <VSpacer />
-      <KButton
-        appearance="flat-button"
-        :text="$tr('restoreButton')"
-        :disabled="!selected.length"
-        data-test="restore"
-        @click="moveModalOpen = true"
-      />
-      <KButton
-        :primary="true"
-        :text="$tr('deleteButton')"
-        :disabled="!selected.length"
-        data-test="delete"
-        @click="showConfirmationDialog = true"
-      />
+      <KButtonGroup>
+        <KButton
+          appearance="flat-button"
+          :text="$tr('restoreButton')"
+          :disabled="!selected.length"
+          data-test="restore"
+          @click="moveModalOpen = true"
+        />
+        <KButton
+          :primary="true"
+          :text="$tr('deleteButton')"
+          :disabled="!selected.length"
+          data-test="delete"
+          @click="showConfirmationDialog = true"
+        />
+      </KButtonGroup>
     </template>
     <MessageDialog
       v-model="showConfirmationDialog"


### PR DESCRIPTION
Fixes #5421 
## Summary
Replaced Vuetify VBtn elements with Kolibri Design System KButton elements in trash and folder creation modals. Added KButtonGroup containers to maintain proper element spacing and applied CSS to prevent button element wrapping on mobile screens.

## Desktop Users
Successfully replaced Vuetify VBtn elements with Kolibri Design System KButton elements in trash and folder creation modals. Added KButtonGroup containers to maintain proper element spacing and applied CSS to prevent button element wrapping on mobile screens
<img width="1363" height="682" alt="Screenshot From 2025-10-03 14-58-06" src="https://github.com/user-attachments/assets/5bf5ae10-105d-40df-bd21-14211be5f01a" />
<img width="1366" height="680" alt="Screenshot From 2025-10-03 15-09-49" src="https://github.com/user-attachments/assets/fb79c0be-c18f-4ac8-804a-f6598468cbd9" />
<img width="1127" height="683" alt="image" src="https://github.com/user-attachments/assets/ce1b6dbf-6c64-417b-8c32-fd90503d8c34" />


## Mobile Users
<img width="331" height="578" alt="Screenshot From 2025-10-03 15-17-39" src="https://github.com/user-attachments/assets/40a79a60-11a6-4c2c-9c93-8a8a9b6df0fd" />
<img width="330" height="583" alt="Screenshot From 2025-10-03 14-57-33" src="https://github.com/user-attachments/assets/12f980db-840a-4fa9-97f7-e5ff2c933c4b" />







## References

• Parent issue: https://github.com/learningequality/studio/issues/5060

## Reviewer guidance

Login as a@a.com with password a
Go to Channels > Published Channel
Click Add > New folder and create the folder
Go back to the channel page
Select the folder
Click Remove
Open trash from the ... dropdown at the top of the page