### PR TITLE
[Remove Vuetify from Studio] 'Unsaved changes' modal in Channels - New collection

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -154,29 +154,18 @@
         </VContainer>
       </VWindowItem>
     </VWindow>
-    <MessageDialog
-      v-model="showUnsavedDialog"
-      :header="$tr('unsavedChangesHeader')"
-      :text="$tr('unsavedChangesText')"
+    <KModal
+      v-if="showUnsavedDialog"
+      :title="$tr('unsavedChangesHeader')"
+      :submitText="$tr('saveButton')"
+      :cancelText="$tr('closeButton')"
       data-test="dialog-unsaved"
       :data-test-visible="showUnsavedDialog"
+      @submit="save"
+      @cancel="confirmCancel"
     >
-      <template #buttons>
-        <VSpacer />
-        <VBtn
-          flat
-          @click="confirmCancel"
-        >
-          {{ $tr('closeButton') }}
-        </VBtn>
-        <VBtn
-          color="primary"
-          @click="save"
-        >
-          {{ $tr('saveButton') }}
-        </VBtn>
-      </template>
-    </MessageDialog>
+      {{ $tr('unsavedChangesText') }}
+    </KModal>
     <template #bottom>
       <div class="mx-4 subheading">
         {{ $tr('channelSelectedCountText', { channelCount: channels.length }) }}
@@ -215,7 +204,6 @@
   import { ChannelListTypes, ErrorTypes } from 'shared/constants';
   import { constantsTranslationMixin, routerMixin } from 'shared/mixins';
   import CopyToken from 'shared/views/CopyToken';
-  import MessageDialog from 'shared/views/MessageDialog';
   import FullscreenModal from 'shared/views/FullscreenModal';
   import Tabs from 'shared/views/Tabs';
   import LoadingText from 'shared/views/LoadingText';
@@ -225,7 +213,6 @@
     components: {
       CopyToken,
       ChannelSelectionList,
-      MessageDialog,
       ChannelItem,
       FullscreenModal,
       Tabs,

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -217,12 +217,12 @@ describe('ChannelSetModal', () => {
       });
 
       it('should prompt user if there are unsaved changes', async () => {
-        expect(getUnsavedDialog(wrapper).attributes('data-test-visible')).toBeFalsy();
+        expect(getUnsavedDialog(wrapper).exists()).toBeFalsy();
 
         await getCollectionNameInput(wrapper).setValue('My collection');
         await getCloseButton(wrapper).trigger('click');
 
-        expect(getUnsavedDialog(wrapper).attributes('data-test-visible')).toBeTruthy();
+        expect(getUnsavedDialog(wrapper).exists()).toBeTruthy();
       });
     });
 


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Replaced Vuetify's MessageDialog component with Kolibri Design System's KModal for the unsaved changes dialog in the Collections modal.

- Replaced MessageDialog with KModal in ChannelSetModal.vue
- Updated modal props to use KModal's API (title, submitText, cancelText)
- Maintained all existing functionality and event handlers


**Manual verification:**

1. Logged in as user@a.com with password a
2. Navigated to Channels > Collections
3. Clicked "New collection" button
4. Added text to Collection name input
5. Clicked close button in the top bar
6. Verified unsaved changes modal appears with KModal styling
7. Tested both "Exit without saving" and "Save and close" buttons
8. All functionality works as expected

After Changes Screenshot:
<img width="1512" height="982" alt="Screenshot 2025-10-07 at 11 43 43 AM" src="https://github.com/user-attachments/assets/2130cb34-5b7c-4a51-89cd-4577a1d8446b" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- Fixes: #5299 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
**Test these changes by:**

Login as user@a.com with password a

1. Go to Channels > Collections
2. Click "New collection" button
3. Add text to Collection name input
4. Click the close button in the top bar
5. Verify the unsaved changes modal appears and functions correctly
6. Test both cancel and save actions

**Areas to focus on:**

- Modal properly blocks navigation when unsaved changes exist
- Both RTL and LTR layouts work correctly
- All 19 tests in channelSetModal.spec.js pass


