### PR TITLE
[Remove Vuetify from Studio] View/Exit fullscreen buttons/links in file preview

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/FilePreview.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/FilePreview.vue
@@ -26,13 +26,13 @@
       >
         {{ $tr('fullscreenModeText') }}
         <VSpacer />
-        <VBtn
+        <KButton
           data-test="closefullscreen"
-          flat
+          appearance="flat-button"
+          :primary="false"
+          :text="$tr('exitFullscreen')"
           @click="fullscreen = false"
-        >
-          {{ $tr('exitFullscreen') }}
-        </VBtn>
+        />
       </VToolbar>
       <ContentRenderer
         :nodeId="nodeId"
@@ -43,9 +43,11 @@
         v-if="!fullscreen"
         class="mt-2"
       >
-        <ActionLink
+        <KButton
           v-if="showFullscreenOption"
           data-test="openfullscreen"
+          appearance="basic-link"
+          :primary="true"
           :text="$tr('viewFullscreen')"
           @click="fullscreen = true"
         />


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Replaced Vuetify usages in FilePreview with Kolibri Design System components: swapped VBtn for KButton and replaced the ActionLink usage with a KDS link-styled KButton, preserving the original behavior and i18n strings while keeping all other code intact .
Added :fullscreen CSS rules scoped to the preview container to hide non-essential UI (e.g., thumbnail/logo pane) and expand the renderer when in fullscreen to match expected UX, without altering fullscreen logic or event handling .
**Manual verification:**

- Opened Published Channel > Topic 1, selected “Sample Video,” and used the side panel “View fullscreen” entry point to enter fullscreen .

- Verified fullscreen top bars, video playback area, and “Exit fullscreen,” ensuring only the renderer is visible in fullscreen and that exiting restores prior layout .

**Screenshots after changes:**
<img width="1512" height="982" alt="Screenshot 2025-10-09 at 11 14 07 PM" src="https://github.com/user-attachments/assets/688fdc71-66db-494b-80b0-967f14377c0e" />
<img width="1512" height="982" alt="Screenshot 2025-10-09 at 11 14 00 PM" src="https://github.com/user-attachments/assets/04f3ed89-7a4b-4cdf-bf1d-a87f028f3c49" />




## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Issue fixes: #5442

- KDS Buttons and links guidance for choosing KButton and link-like appearances .


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Focus on FilePreview: verify the “View fullscreen” link (now a KDS link-styled KButton) and the “Exit fullscreen” control behave identically and remain fully keyboard accessible and translated .

- In fullscreen, confirm non-essential UI is hidden via :fullscreen CSS and the content renderer occupies available space; confirm Escape and button both exit cleanly with no layout regressions on return 

