### PR TITLE
Adds defensive check when generating language text in the language dropdown

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/LanguageDropdown.vue
@@ -113,8 +113,7 @@
     },
     methods: {
       languageText(item) {
-        const nativeName = item?.native_name || '';
-        const firstNativeName = nativeName.split(',')[0].trim();
+        const firstNativeName = item.native_name.split(',')[0].trim();
         return this.$tr('languageItemText', { language: firstNativeName, code: item.id });
       },
     },

--- a/contentcuration/contentcuration/frontend/shared/views/__tests__/languageDropdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/__tests__/languageDropdown.spec.js
@@ -81,14 +81,4 @@ describe('languageDropdown', () => {
     const item = { native_name: '', id: 'de' };
     expect(wrapper.vm.languageText(item)).toBe(' (de)');
   });
-
-  it('returns formatted language text when native_name is missing', () => {
-    const wrapper = shallowMount(LanguageDropdown, {
-      mocks: {
-        $tr: (key, params) => `${params.language} (${params.code})`,
-      },
-    });
-    const item = { id: 'fr' };
-    expect(wrapper.vm.languageText(item)).toBe(' (fr)');
-  });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds a defensive on the code for the error reported in sentry as detailed [here](https://github.com/learningequality/studio/issues/5434). The bug is triggered when trying to edit multiple resources with differing languages.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5434

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Use any of the LanguageDropdowns in any of the pages in studio
- Ensure no regressions in behavior
- Check logs to ensure above logs are not reported
- Regression tests have also been added, so should pass.
