### PR TITLE
[Remove Vuetify from Studio] Permanently delete resource confirmation dialog

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/TrashModal.vue
@@ -1,170 +1,173 @@
 <template>
 
-  <FullscreenModal
-    v-model="dialog"
-    :header="$tr('trashModalTitle')"
-  >
-    <LoadingText
-      v-if="loading"
-      data-test="loading"
-    />
-    <VContainer
-      v-else-if="!items.length"
-      fluid
-      data-test="empty"
+  <div>
+    <FullscreenModal
+      v-if="!moveModalOpen"
+      v-model="dialog"
+      :header="$tr('trashModalTitle')"
     >
-      <h1 class="font-weight-bold headline mt-4 pt-4 text-xs-center">
-        {{ $tr('trashEmptyText') }}
-      </h1>
-      <p class="mt-3 subheading text-xs-center">
-        {{ $tr('trashEmptySubtext') }}
-      </p>
-    </VContainer>
-    <VContent v-else>
-      <VContainer
-        fluid
-        class="pa-4"
-        data-test="list"
-        style="max-height: calc(100vh - 128px); overflow-y: auto"
-      >
-        <VCard
-          style="width: 100%; max-width: 900px; margin: 0 auto"
-          flat
-          class="pa-2"
-        >
-          <VDataTable
-            :headers="headers"
-            :items="items"
-            hide-actions
-            must-sort
-          >
-            <template #headerCell="props">
-              <VLayout
-                v-if="props.header.selectAll"
-                row
-                align-center
-              >
-                <VFlex shrink>
-                  <Checkbox
-                    :inputValue="selected.length === items.length"
-                    :indeterminate="!!selected.length && selected.length !== items.length"
-                    data-test="selectall"
-                    @input="toggleSelectAll"
-                  />
-                </VFlex>
-                <VFlex>
-                  {{ props.header.text }}
-                </VFlex>
-              </VLayout>
-              <span v-else>
-                {{ props.header.text }}
-              </span>
-            </template>
-            <template #items="{ item }">
-              <tr
-                :key="item.id"
-                :style="{ backgroundColor: getItemBackground(item.id) }"
-              >
-                <td>
-                  <VLayout
-                    row
-                    align-center
-                  >
-                    <VFlex shrink>
-                      <Checkbox
-                        v-model="selected"
-                        :value="item.id"
-                        data-test="checkbox"
-                      />
-                    </VFlex>
-                    <VFlex
-                      shrink
-                      class="mx-3"
-                    >
-                      <ContentNodeIcon :kind="item.kind" />
-                    </VFlex>
-                    <VFlex
-                      :class="getTitleClass(item)"
-                      grow
-                    >
-                      <ActionLink
-                        :text="getTitle(item)"
-                        data-test="item"
-                        @click="previewNodeId = item.id"
-                      />
-                    </VFlex>
-                  </VLayout>
-                </td>
-                <td class="text-xs-right">
-                  {{ $formatRelative(item.modified, { now: new Date() }) }}
-                </td>
-              </tr>
-            </template>
-          </VDataTable>
-          <div class="show-more-button-container">
-            <KButton
-              v-if="more"
-              :disabled="moreLoading"
-              @click="loadMore"
-            >
-              {{ showMoreLabel }}
-            </KButton>
-          </div>
-        </VCard>
-      </VContainer>
-      <ResourceDrawer
-        style="margin-top: 64px"
-        :nodeId="previewNodeId"
-        :channelId="currentChannel.id"
-        app
-        @close="previewNodeId = null"
+      <LoadingText
+        v-if="loading"
+        data-test="loading"
       />
-    </VContent>
-    <template #bottom>
-      <span
-        v-if="selected.length"
-        class="mr-4 subheading"
+      <VContainer
+        v-else-if="!items.length"
+        fluid
+        data-test="empty"
       >
-        {{ getSelectedTopicAndResourceCountText(selected) }}
-      </span>
-      <VSpacer />
-      <KButtonGroup>
-        <KButton
-          appearance="flat-button"
-          :text="$tr('restoreButton')"
-          :disabled="!selected.length"
-          data-test="restore"
-          @click="moveModalOpen = true"
+        <h1 class="font-weight-bold headline mt-4 pt-4 text-xs-center">
+          {{ $tr('trashEmptyText') }}
+        </h1>
+        <p class="mt-3 subheading text-xs-center">
+          {{ $tr('trashEmptySubtext') }}
+        </p>
+      </VContainer>
+      <VContent v-else>
+        <VContainer
+          fluid
+          class="pa-4"
+          data-test="list"
+          style="max-height: calc(100vh - 128px); overflow-y: auto"
+        >
+          <VCard
+            style="width: 100%; max-width: 900px; margin: 0 auto"
+            flat
+            class="pa-2"
+          >
+            <VDataTable
+              :headers="headers"
+              :items="items"
+              hide-actions
+              must-sort
+            >
+              <template #headerCell="props">
+                <VLayout
+                  v-if="props.header.selectAll"
+                  row
+                  align-center
+                >
+                  <VFlex shrink>
+                    <Checkbox
+                      :inputValue="selected.length === items.length"
+                      :indeterminate="!!selected.length && selected.length !== items.length"
+                      data-test="selectall"
+                      @input="toggleSelectAll"
+                    />
+                  </VFlex>
+                  <VFlex>
+                    {{ props.header.text }}
+                  </VFlex>
+                </VLayout>
+                <span v-else>
+                  {{ props.header.text }}
+                </span>
+              </template>
+              <template #items="{ item }">
+                <tr
+                  :key="item.id"
+                  :style="{ backgroundColor: getItemBackground(item.id) }"
+                >
+                  <td>
+                    <VLayout
+                      row
+                      align-center
+                    >
+                      <VFlex shrink>
+                        <Checkbox
+                          v-model="selected"
+                          :value="item.id"
+                          data-test="checkbox"
+                        />
+                      </VFlex>
+                      <VFlex
+                        shrink
+                        class="mx-3"
+                      >
+                        <ContentNodeIcon :kind="item.kind" />
+                      </VFlex>
+                      <VFlex
+                        :class="getTitleClass(item)"
+                        grow
+                      >
+                        <ActionLink
+                          :text="getTitle(item)"
+                          data-test="item"
+                          @click="previewNodeId = item.id"
+                        />
+                      </VFlex>
+                    </VLayout>
+                  </td>
+                  <td class="text-xs-right">
+                    {{ $formatRelative(item.modified, { now: new Date() }) }}
+                  </td>
+                </tr>
+              </template>
+            </VDataTable>
+            <div class="show-more-button-container">
+              <KButton
+                v-if="more"
+                :disabled="moreLoading"
+                @click="loadMore"
+              >
+                {{ showMoreLabel }}
+              </KButton>
+            </div>
+          </VCard>
+        </VContainer>
+        <ResourceDrawer
+          style="margin-top: 64px"
+          :nodeId="previewNodeId"
+          :channelId="currentChannel.id"
+          app
+          @close="previewNodeId = null"
         />
-        <KButton
-          :primary="true"
-          :text="$tr('deleteButton')"
-          :disabled="!selected.length"
-          data-test="delete"
-          @click="showConfirmationDialog = true"
-        />
-      </KButtonGroup>
-    </template>
-    <KModal
-      v-if="showConfirmationDialog"
-      data-test="deleteconfirm"
-      :title="$tr('deleteConfirmationHeader', counts)"
-      :cancelText="$tr('deleteConfirmationCancelButton')"
-      :submitText="$tr('deleteConfirmationDeleteButton')"
-      @cancel="showConfirmationDialog = false"
-      @submit="deleteNodes"
-    >
-      <p>{{ $tr('deleteConfirmationText') }}</p>
-    </KModal>
+      </VContent>
+      <template #bottom>
+        <span
+          v-if="selected.length"
+          class="mr-4 subheading"
+        >
+          {{ getSelectedTopicAndResourceCountText(selected) }}
+        </span>
+        <VSpacer />
+        <KButtonGroup>
+          <KButton
+            appearance="flat-button"
+            :text="$tr('restoreButton')"
+            :disabled="!selected.length"
+            data-test="restore"
+            @click="moveModalOpen = true"
+          />
+          <KButton
+            :primary="true"
+            :text="$tr('deleteButton')"
+            :disabled="!selected.length"
+            data-test="delete"
+            @click="showConfirmationDialog = true"
+          />
+        </KButtonGroup>
+      </template>
+      <KModal
+        v-if="showConfirmationDialog"
+        :title="$tr('deleteConfirmationHeader', counts)"
+        :cancelText="$tr('deleteConfirmationCancelButton')"
+        :submitText="$tr('deleteConfirmationDeleteButton')"
+        data-test="deleteconfirm"
+        @cancel="showConfirmationDialog = false"
+        @submit="deleteNodes"
+      >
+        <p>{{ $tr('deleteConfirmationText') }}</p>
+      </KModal>
+    </FullscreenModal>
     <MoveModal
-      v-if="moveModalOpen"
+      v-else
       ref="moveModal"
       v-model="moveModalOpen"
       :moveNodeIds="selected"
       :movingFromTrash="true"
       @target="moveNodes"
     />
-  </FullscreenModal>
+  </div>
 
 </template>
 


### PR DESCRIPTION
Fixes https://github.com/learningequality/studio/issues/5443

## Summary
1. Migrated Permanently delete confirmation dialog in Edit channel > Trash > TrashModal form MessageDialogue to KModal. There were some minor UI changes, refer to the screenshots below.

Previous (MessageDialogue)
<img width="1546" height="866" alt="Screenshot 2025-10-14 at 10 21 39 PM" src="https://github.com/user-attachments/assets/54858bf1-1405-4bab-87c8-dee587c6cf40" />

After (KModal)
<img width="1557" height="867" alt="Screenshot 2025-10-14 at 10 29 19 PM" src="https://github.com/user-attachments/assets/a681a4ca-db88-4a98-a26d-13033546da38" />

2. Updated the unit test suite accordingly, passing all tests.
<img width="531" height="144" alt="Screenshot 2025-10-15 at 2 56 02 PM" src="https://github.com/user-attachments/assets/fc1eafce-c65f-4299-91d0-7dea9d561267" />

