### PR TITLE
[Remove Vuetify from Studio] Finish button and Incomplete resource modal

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/edit/EditModal.vue
@@ -139,12 +139,11 @@
           <SavingIndicator :nodeIds="nodeIds" />
         </div>
         <div>
-          <VBtn
-            color="primary"
+          <KButton
+            :primary="true"
+            :text="$tr('finishButton')"
             @click="handleClose()"
-          >
-            {{ $tr('finishButton') }}
-          </VBtn>
+          />
         </div>
       </BottomBar>
       <InheritAncestorMetadataModal
@@ -156,28 +155,16 @@
     </VDialog>
 
     <!-- Dialog for catching unsaved changes -->
-    <MessageDialog
-      v-model="promptInvalid"
-      :header="$tr('invalidNodesFound', { count: invalidNodes.length })"
-      :text="$tr('invalidNodesFoundText')"
+    <KModal
+      v-if="promptInvalid"
+      :title="$tr('invalidNodesFound', { count: invalidNodes.length })"
+      :submitText="$tr('saveAnywaysButton')"
+      :cancelText="$tr('keepEditingButton')"
+      @submit="closeModal(true)"
+      @cancel="promptInvalid = false"
     >
-      <template #buttons="{ close }">
-        <VBtn
-          flat
-          data-test="saveanyways"
-          color="primary"
-          @click="closeModal(true)"
-        >
-          {{ $tr('saveAnywaysButton') }}
-        </VBtn>
-        <VBtn
-          color="primary"
-          @click="close"
-        >
-          {{ $tr('keepEditingButton') }}
-        </VBtn>
-      </template>
-    </MessageDialog>
+      <p>{{ $tr('invalidNodesFoundText') }}</p>
+    </KModal>
 
     <!-- Dialog for catching in-progress file uploads -->
     <KModal
@@ -219,7 +206,6 @@
   import { ContentKindLearningActivityDefaults } from 'shared/leUtils/ContentKinds';
   import { fileSizeMixin, routerMixin } from 'shared/mixins';
   import FileStorage from 'shared/views/files/FileStorage';
-  import MessageDialog from 'shared/views/MessageDialog';
   import ResizableNavigationDrawer from 'shared/views/ResizableNavigationDrawer';
   import Uploader from 'shared/views/files/Uploader';
   import LoadingText from 'shared/views/LoadingText';
@@ -244,7 +230,6 @@
       FileStorage,
       FileUploadDefault,
       LoadingText,
-      MessageDialog,
       OfflineText,
       FileDropzone,
       SavingIndicator,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
Fixes #5378 
## Summary
Replaced Vuetify's VBtn with Kolibri Design System's KButton for the Finish button
Replaced Vuetify-based MessageDialog with KDS KModal for the incomplete resource modal
## Desktop Images
<img width="1201" height="956" alt="Screenshot From 2025-10-21 13-33-26" src="https://github.com/user-attachments/assets/2cdba506-aa3c-4ce2-ab5a-d9e93932fe29" />
<img width="1201" height="956" alt="Screenshot From 2025-10-21 13-33-34" src="https://github.com/user-attachments/assets/b8ebc8ba-04a5-41d5-97af-0bb4e62e9fd0" />

## Mobile Images:
<img width="683" height="757" alt="Screenshot From 2025-10-21 13-27-55" src="https://github.com/user-attachments/assets/ce98a353-457d-4dde-afc8-433c32d4ab4c" />
<img width="683" height="757" alt="Screenshot From 2025-10-21 13-28-04" src="https://github.com/user-attachments/assets/b03aac8f-a766-4af0-958e-ba1ae060cbb6" />


## References
Sub-issue of https://github.com/learningequality/studio/issues/5060.


## Reviewer guidance
Login as a@a.com with password a
Go to Channels > Published Channel
Select Sample video
Click Edit
Remove information from a required field, e.g. Learning Activity
Click Finish