### PR TITLE
Restore EPUB renderer height

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/ContentRenderer.vue
@@ -1,12 +1,12 @@
 <template>
 
-  <VLayout
-    :key="fileId"
-    :class="{ fullscreen }"
+  <div
+    class="renderer"
+    :aria-busy="isSupported && loading"
   >
-    <div
-      class="renderer"
-      :aria-busy="isSupported && loading"
+    <VLayout
+      :key="fileId"
+      :class="{ fullscreen }"
     >
       <div
         v-show="isSupported && loading"
@@ -139,8 +139,8 @@
           </VTooltip>
         </VLayout>
       </VCard>
-    </div>
-  </VLayout>
+    </VLayout>
+  </div>
 
 </template>
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Upon inspecting the EPUB renderer, it was clear the height styling was not functioning as it was originally intended. This was abundantly clear based off the positioning of the left/right buttons, not being centered. The issue appeared to originate from some alterations to the flexbox structure upwards in the DOM. By relocating a newer div wrapper used for applying a relative style, this removed the interference causing the malfunction, and restored the intended styling.

This does not address the `tagName` error linked in the issue as it's wholly unrelated to the render issue, and possibly benign.

<img width="1081" height="518" alt="image" src="https://github.com/user-attachments/assets/438e10c6-c309-4351-893d-7760fe722a11" />
<img width="1081" height="518" alt="image" src="https://github.com/user-attachments/assets/07215568-9e04-448b-87c8-47a019df6b6a" />
<img width="2543" height="1053" alt="image" src="https://github.com/user-attachments/assets/91d6b652-d24a-43c2-baf9-c6e6a92d3e41" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
fixes https://github.com/learningequality/studio/issues/5424
related to https://github.com/learningequality/studio/pull/5351

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Download one of the EPUBs from the channel linked in the issue
2. Upload it to your local Studio
3. Observe the EPUB preview properly renders
