### PR TITLE
Update KDS from 5.3.0 to 5.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "jszip": "^3.10.1",
     "kolibri-constants": "^0.2.12",
-    "kolibri-design-system": "5.3.0",
+    "kolibri-design-system": "5.4.1",
     "lodash": "^4.17.21",
     "lowlight": "^3.3.0",
     "marked": "^16.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       kolibri-design-system:
-        specifier: 5.3.0
-        version: 5.3.0
+        specifier: 5.4.1
+        version: 5.4.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4880,8 +4880,8 @@ packages:
   kolibri-design-system@5.0.1:
     resolution: {integrity: sha512-oz5gEFUj7NYZbrqr89gPjSfRFVuuilSqILA4bbWqLWwkI9ay/uVMdsh8cY2Xajhtzccjwqa1c/NxUETr5kMfHQ==}
 
-  kolibri-design-system@5.3.0:
-    resolution: {integrity: sha512-vqlqNaI200yWZOq6gwADZf79e+7Hq3wKz7l2idwNLt6UsihT/dRlodBN68aU4w5Wq3zqK/9bctnDLCcXVJx/rw==}
+  kolibri-design-system@5.4.1:
+    resolution: {integrity: sha512-XTSTDqhNz1BDKXLq99rK87hdy7vHlhhXBGm7OEjTJQUvlmcpJgR0lrGZhX7KusyNcInmonNQtU/p7059u9ISfA==}
 
   kolibri-format@1.0.1:
     resolution: {integrity: sha512-yGQpsJkBAzmRueAq6MG1UOuDl9pbhEtMWNxq9ObG5pPVkG8uhWJAS1L71GCuNAeaV1XG2IWo2565Ov4yXnudeA==}
@@ -13165,7 +13165,7 @@ snapshots:
       vue2-teleport: 1.1.4
       xstate: 4.38.3
 
-  kolibri-design-system@5.3.0:
+  kolibri-design-system@5.4.1:
     dependencies:
       aphrodite: https://codeload.github.com/learningequality/aphrodite/tar.gz/fdc8d7be8912a5cf17f74ff10f124013c52c3e32
       autosize: 3.0.21


### PR DESCRIPTION
## Summary

Update KDS from 5.3.0 to 5.4.1

Related release notes:
- https://github.com/learningequality/kolibri-design-system/releases/tag/v5.4.0
- https://github.com/learningequality/kolibri-design-system/releases/tag/v5.4.1

No changes needed in Studio.

Didn't notice any issues on localhost.