### PR TITLE
[Remove Vuetify from Studio] Collection channels loader in Channels - New collection

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -72,9 +72,7 @@
               </p>
 
               <!-- Channel list section -->
-              <VCardText v-if="loadingChannels">
-                <StudioLargeLoader />
-              </VCardText>
+              <StudioLargeLoader v-if="show('collections', loadingChannels, 500)" />
               <div
                 v-else
                 fluid
@@ -197,6 +195,7 @@
 
   import { set } from 'vue';
   import { mapGetters, mapActions } from 'vuex';
+  import useKShow from 'kolibri-design-system/lib/composables/useKShow';
   import difference from 'lodash/difference';
   import { RouteNames } from '../../constants';
   import ChannelItem from './ChannelItem';
@@ -226,6 +225,10 @@
       StudioLargeLoader,
     },
     mixins: [formMixin, constantsTranslationMixin, routerMixin],
+    setup() {
+      const { show } = useKShow();
+      return { show };
+    },
     props: {
       channelSetId: {
         type: String,

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -11,6 +11,13 @@ import ChannelSetModal from '../ChannelSetModal';
 import channel from 'shared/vuex/channel';
 import storeFactory from 'shared/vuex/baseStore';
 
+jest.mock('kolibri-design-system/lib/composables/useKShow', () => ({
+  __esModule: true,
+  default: () => ({
+    show: () => false, // skip loading state
+  }),
+}));
+
 const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(VueRouter);

--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/index.vue
@@ -13,8 +13,13 @@
       }}
     </div>
 
+    <!-- Set minHeight to prevent from content shifting after loaded -->
+    <StudioLargeLoader
+      v-if="show('storageUse', !storageUseByKind, 500)"
+      :style="{ minHeight: '370px' }"
+    />
     <KFixedGrid
-      v-if="storageUseByKind !== null"
+      v-else
       numCols="8"
       gutter="10"
     >
@@ -47,7 +52,6 @@
         </KFixedGridItem>
       </template>
     </KFixedGrid>
-    <StudioLargeLoader v-else />
 
     <div class="storage-request">
       <h2 ref="requestheader">
@@ -106,6 +110,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
+  import useKShow from 'kolibri-design-system/lib/composables/useKShow';
   import RequestForm from './RequestForm';
   import { fileSizeMixin, constantsTranslationMixin } from 'shared/mixins';
   import { ContentKindsList, ContentKindsNames } from 'shared/leUtils/ContentKinds';
@@ -119,6 +124,10 @@
       StudioLargeLoader,
     },
     mixins: [fileSizeMixin, constantsTranslationMixin],
+    setup() {
+      const { show } = useKShow();
+      return { show };
+    },
     data() {
       return {
         showRequestForm: false,

--- a/contentcuration/contentcuration/frontend/shared/views/StudioLargeLoader.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/StudioLargeLoader.vue
@@ -19,6 +19,10 @@
 <style lang="scss" scoped>
 
   .large-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
     padding: 24px;
   }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
Fixes #5244 

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR replaces Vuetify-dependent loading components with a new StudioLargeLoader component that uses KDS components instead. The changes ensure visual consistency while removing Vuetify dependencies as part of the Vuetify removal project  in channelSet Modal.

## Images
<img width="791" height="911" alt="Screenshot From 2025-10-22 20-13-42" src="https://github.com/user-attachments/assets/f5ee14ad-1c68-4b98-bded-cb79f371e0e9" />


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Sub-issue of https://github.com/learningequality/studio/issues/5060.

## Reviewer guidance

In code, temporarily modify template condition loadingChannels to truthy
Login as user@a.com with password a
Go to Channels > Collections
Click New collection button
