### PR TITLE
[Remove Vuetify from Studio] Buttons in disk space popup in Administration - Users

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserStorage.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserStorage.vue
@@ -41,17 +41,17 @@
         </template>
       </DropdownWrapper>
     </VLayout>
-    <KButtonGroup :style="{ 'white-space': 'nowrap' }">
+    <KButtonGroup>
       <KButton
         v-if="showCancel"
         appearance="flat-button"
-        :text="$tr('cancelButton')"
+        text="Cancel"
         data-test="cancel"
         @click="cancel"
       />
       <KButton
         :primary="true"
-        :text="$tr('saveChangesButton')"
+        text="Save changes"
         type="submit"
         data-test="submit"
       />
@@ -147,10 +147,6 @@
         this.space = this.value / units[this.unit];
         this.$emit('close');
       },
-    },
-    $trs: {
-      cancelButton: 'Cancel',
-      saveChangesButton: 'Save changes',
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
Fixes #5354 


## Summary
This PR replaces Vuetify buttons in the Administration > Users > Edit disk space popup with Kolibri Design System (KDS) button components. The migration maintains all existing functionality while removing Vuetify dependencies as part of the Vuetify removal project.

## IMAGES
<img width="1843" height="917" alt="Screenshot From 2025-10-22 23-59-19" src="https://github.com/user-attachments/assets/868a39e9-dbac-4cb2-bdfc-67f2c64c1b00" />

<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Sub-issue of https://github.com/learningequality/studio/issues/5060.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Login as a@a.com with password a
Go to Administration > Users
Click the edit icon in the Disk space colum of users table