### PR TITLE
Add focus trapping to resource preview side panel

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -75,7 +75,7 @@
       >
         <VTab
           href="#questions"
-          class="pa-1 px-2"
+          class="pa-1"
           exact
           @change="tab = 'questions'"
         >
@@ -88,7 +88,7 @@
         </VTab>
         <VTab
           href="#details"
-          class="pa-1 px-2"
+          class="pa-1"
           exact
           @change="tab = 'details'"
         >
@@ -923,10 +923,6 @@
 
     /* stylelint-disable-next-line custom-property-pattern */
     border: 1px solid var(--v-greyBackground-base) !important;
-  }
-
-  .pa-1 {
-    padding: 4px !important;
   }
 
 </style>


### PR DESCRIPTION


## Summary
This PR fixes focus trapping to resource preview side panel
### Before 
https://private-user-images.githubusercontent.com/79847249/492744591-c9be29f9-42e2-4824-bb91-2dfc15bc149c.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjEyNDYxMTgsIm5iZiI6MTc2MTI0NTgxOCwicGF0aCI6Ii83OTg0NzI0OS80OTI3NDQ1OTEtYzliZTI5ZjktNDJlMi00ODI0LWJiOTEtMmRmYzE1YmMxNDljLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEwMjMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMDIzVDE4NTY1OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTY2MWFkMGQ3ZmZhOTExYjEyOWJhMjJjNzJkYTU1MGUwY2I1NTgxOTRkMDMwNWUwMGVlYzE1ZDE4ZGUwNzVhN2ImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.S7imaDoagPuZTR79pogC0CZ2AHi9V-TTPM_XgWRQol0
### After

https://github.com/user-attachments/assets/f893e91c-cb43-4b76-ad38-1cd5c5a23bc6




## References
[#5406](https://github.com/learningequality/studio/issues/5406)

## Reviewer guidance

- Sign in to Hotfixes with an account with enabled search recommendations
- Go to a channel and try to import resources from other channels
- Open the side panel for a selected resource