### PR TITLE
[Remove Vuetify from Studio] Remove temporary ::v-deep override from external links on licenses modal

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/Storage/RequestForm.vue
@@ -523,11 +523,6 @@
     font-size: 14px;
   }
 
-  /* fixes unintended margin caused by KDS styles */
-  .license-link ::v-deep span {
-    margin-left: 0 !important;
-  }
-
   .license-description {
     margin-bottom: 8px;
     line-height: 1.5;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Removes temporary `::v-deep` CSS override for `.license-link` that was added in PR #5107 to fix KExternalLink's incorrect margin. 

This override is no longer needed since the root cause has been fixed in KDS PR #1125 (merged) and Studio now has the latest KDS version.

**Changes:**
- Removed `::v-deep span { margin-left: 0 !important; }` override from RequestForm.vue

**Verification:**
- Checked "Learn More" links in Settings > Storage > Request More Space form display correctly with proper spacing
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
- Fixes #5127
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Settings > Storage > Request More Space
2. Expand the "About Licenses" section
3. Verify "Learn More" links have correct spacing and alignment
4. Test in both LTR and RTL languages if possible

…
