### PR TITLE
[DO NOT MERGE UNTIL JUST BEFORE RELEASE] Add file duration setting as migration task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ migrate:
 # 4) Remove the management command from this `deploy-migrate` recipe
 # 5) Repeat!
 deploy-migrate:
-	echo "Nothing to do here!"
+	python contentcuration/manage.py set_file_duration
 
 contentnodegc:
 	python contentcuration/manage.py garbage_collect


### PR DESCRIPTION
## Summary
Adds our file duration setting management command back as a deployment task

## References
Fixes some issues that I caused by using the ricecooker RemoteFile class - duration was not set on Khan Academy videos created in this way.

## Reviewer guidance
Have I properly followed the instructions in the make file comments?