### PR TITLE
[Remove Vuetify from Studio] Changing question type confirmation dialog in Questions

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/AssessmentTab/AssessmentTab.vue
@@ -26,8 +26,8 @@
     <KModal
       v-if="dialog.open"
       :title="dialog.title"
-      :cancelText="$tr('dialogCancelBtnLabel')"
-      :submitText="$tr('dialogChangeBtnLabel')"
+      :cancelText="dialog.cancelLabel || $tr('dialogCancelBtnLabel')"
+      :submitText="dialog.submitLabel || $tr('dialogSubmitBtnLabel')"
       @cancel="dialog.onCancel"
       @submit="dialog.onSubmit"
     >
@@ -61,6 +61,8 @@
           open: false,
           title: '',
           message: '',
+          cancelLabel: '',
+          submitLabel: '',
           onCancel: () => {},
           onSubmit: () => {},
         },
@@ -119,11 +121,20 @@
       async onDeleteAssessmentItem(item) {
         await this.deleteAssessmentItem(item);
       },
-      openDialog({ title = '', message = '', onCancel = () => {}, onSubmit = () => {} } = {}) {
+      openDialog({
+        title = '',
+        message = '',
+        cancelLabel = '',
+        submitLabel = '',
+        onCancel = () => {},
+        onSubmit = () => {},
+      } = {}) {
         this.dialog = {
           open: true,
           title,
           message,
+          cancelLabel,
+          submitLabel,
           onCancel: () => {
             if (typeof onCancel === 'function') {
               onCancel();
@@ -153,7 +164,7 @@
     $trs: {
       incompleteItemsCountMessage:
         '{invalidItemsCount} incomplete {invalidItemsCount, plural, one {question} other {questions}}',
-      dialogChangeBtnLabel: 'Change',
+      dialogSubmitBtnLabel: 'Submit',
       dialogCancelBtnLabel: 'Cancel',
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Migrated the `MessageDialog` built with several Vuetify components is currently used to show question type changing confirmation popup with KModal. The particular layer of code was implemented in `AssesmentTab.vue`

### Screenshots
<img width="670" height="235" alt="image" src="https://github.com/user-attachments/assets/9b721984-1f33-461b-b3fa-5aa308cc4d8d" />

The following is a visual of the new dialog built using KModal. The only major UI difference is that the title is not bold - this is the default behavior of KModal. To make it bold, custom CSS styling would need to be implemented within the file. If that’s needed, I’d be happy to make the change
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #5420 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
**How to reach there?**
- Go to Channels > Published Channel
- Select Sample exercise
- Click Edit
- Go to Questions tab
- Change the first question type to True/False