### PR TITLE
Pin pip due to pip-tools incompatibility.

### DIFF
--- a/.github/workflows/deploytest.yml
+++ b/.github/workflows/deploytest.yml
@@ -61,7 +61,9 @@ jobs:
           ${{ runner.os }}-pyprod-
     - name: Install pip-tools and python dependencies
       run: |
-        python -m pip install --upgrade pip
+        # Pin pip to 25.2 to avoid incompatibility with pip-tools and 25.3
+        # see https://github.com/jazzband/pip-tools/issues/2252
+        python -m pip install pip==25.2
         pip install pip-tools
         pip-sync requirements.txt
     - name: Use pnpm

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -82,7 +82,9 @@ jobs:
           ${{ runner.os }}-pytest-
     - name: Install pip-tools and python dependencies
       run: |
-        python -m pip install --upgrade pip
+        # Pin pip to 25.2 to avoid incompatibility with pip-tools and 25.3
+        # see https://github.com/jazzband/pip-tools/issues/2252
+        python -m pip install pip==25.2
         pip install pip-tools
         pip-sync requirements.txt requirements-dev.txt
     - name: Test pytest


### PR DESCRIPTION
Recent changes to pip have broken compatibility with pip-tools https://github.com/jazzband/pip-tools/issues/2252 so pinning pip in github actions to deal with this for now.