### PR TITLE
Configure Celery for graceful shutdown during K8s deployments

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -348,6 +348,11 @@ CELERY = {
     "result_serializer": "json",
     "result_extended": True,
     "worker_send_task_events": True,
+    # Graceful shutdown: allow 28 seconds for tasks to complete before forced termination
+    # This is 2 seconds less than Kubernetes terminationGracePeriodSeconds (30s)
+    "worker_soft_shutdown_timeout": int(
+        os.getenv("CELERY_WORKER_SOFT_SHUTDOWN_TIMEOUT", "28")
+    ),
 }
 
 # When cleaning up orphan nodes, only clean up any that have been last modified

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ x-studio-environment:
     CELERY_BROKER_ENDPOINT: redis
     CELERY_RESULT_BACKEND_ENDPOINT: redis
     CELERY_REDIS_PASSWORD: ""
+    REMAP_SIGTERM: "SIGQUIT"
     PROBER_STUDIO_BASE_URL: http://studio-app:8080/{path}
 
 x-studio-worker:


### PR DESCRIPTION
## Summary
- Add worker_soft_shutdown_timeout (reading from CELERY_WORKER_SOFT_SHUTDOWN_TIMEOUT env var, defaulting to 28s) to Celery config in settings.py
- Add REMAP_SIGTERM=SIGQUIT to docker compose env vars to trigger soft shutdown

When K8s sends SIGTERM during pod termination, workers will now:
1. Stop accepting new tasks
2. Continue processing current task for up to 28 seconds
3. Exit cleanly if task completes, or timeout after 28s
4. Allow K8s 2s buffer before 30s grace period expires

:exclamation: 🤖 Generated with [Claude Code](https://claude.com/claude-code) :exclamation: 

## References
Fixes https://github.com/learningequality/studio/issues/5000

## Reviewer guidance

Does this match the spec outlined by @bjester in the issue above? I think it does - noting that we have already upgraded to a compatible version of celery https://github.com/learningequality/studio/blob/hotfixes/requirements.txt#L31

Lastly - for manual testing - what happens when a long running publish is interrupted by this? Does it get properly rerun? I think it should because the "change event" should still be marked as unapplied, and not errored, but would be good to check. It will be a bit of a bummer that it will start from the beginning again, but it's better than not happening at all!