### PR TITLE
[Remove Vuetify from Studio] Buttons in edit channel details

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/channel/ChannelModal.vue
@@ -148,7 +148,6 @@
   import ChannelThumbnail from './ChannelThumbnail';
   import ChannelSharing from './ChannelSharing';
   import { ErrorTypes } from 'shared/constants';
-  import MessageDialog from 'shared/views/MessageDialog';
   import LanguageDropdown from 'shared/views/LanguageDropdown';
   import ContentDefaults from 'shared/views/form/ContentDefaults';
   import FullscreenModal from 'shared/views/FullscreenModal';
@@ -164,7 +163,6 @@
       ContentDefaults,
       ChannelThumbnail,
       ChannelSharing,
-      MessageDialog,
       FullscreenModal,
       Banner,
       Tabs,


### PR DESCRIPTION
Fixes #5485 

## Summary
Migrated the  following buttons and confirmation dialog in Channels > Edit channel details/New channel:
- Replaced `MessageDialog` by `KModal`
- Replaced `VBtn` with the most suitable `KButton`

1. `Unsaved changes` dialogue box:
(Before when using `MessageDialog`)
<img   alt="Screenshot 2025-10-21 at 2 22 37 PM" src="https://github.com/user-attachments/assets/54bb526b-2ead-4286-9992-76dab34b7923" />

(After when using `KModal`)
<img  alt="Screenshot 2025-10-21 at 2 28 10 PM" src="https://github.com/user-attachments/assets/b553fad0-4127-4b5c-b812-d63ae73804cd" />

2. Editing already existing channel (No changes)
<img width="1347" height="371" alt="Screenshot 2025-10-21 at 2 48 53 PM" src="https://github.com/user-attachments/assets/da91bbb1-b408-4344-b124-28e2349fe733" />

3. Creating new channel (No changes)
<img width="998" height="339" alt="Screenshot 2025-10-21 at 2 51 06 PM" src="https://github.com/user-attachments/assets/d50c0dcb-9029-47df-ac3e-540e0178898a" />

