### PR TITLE
fix: Added UI improvements to collections pages link.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetList.vue
@@ -1,6 +1,16 @@
 <template>
-  <VContainer class="list-items" fluid>
-    <VLayout row wrap align-center justify-space-between class="pb-2">
+
+  <VContainer
+    class="list-items"
+    fluid
+  >
+    <VLayout
+      row
+      wrap
+      align-center
+      justify-space-between
+      class="pb-2"
+    >
       <VFlex class="text-xs-left">
         <KButton
           v-if="!loading && channelSets && channelSets.length"
@@ -11,7 +21,10 @@
         />
       </VFlex>
 
-      <VFlex class="text-xs-right" shrink="0">
+      <VFlex
+        class="text-xs-right"
+        shrink="0"
+      >
         <KButton
           v-if="!loading"
           appearance="raised-button"
@@ -23,14 +36,18 @@
       </VFlex>
     </VLayout>
 
-    <VLayout row justify-center class="pt-2">
+    <VLayout
+      row
+      justify-center
+      class="pt-2"
+    >
       <VFlex xs12>
         <template v-if="loading">
           <LoadingText />
         </template>
 
         <template v-else-if="channelSets && !channelSets.length">
-          <div class="text-xs-center mt-4 p-2">
+          <div class="mt-4 p-2 text-xs-center">
             <p class="mb-0">{{ $tr('noChannelSetsFound') }}</p>
             <KButton
               :text="$tr('aboutChannelSetsLink')"
@@ -42,7 +59,11 @@
         </template>
 
         <template v-else>
-          <VDataTable :headers="headers" :items="sortedChannelSets" hide-actions>
+          <VDataTable
+            :headers="headers"
+            :items="sortedChannelSets"
+            hide-actions
+          >
             <template #items="{ item }">
               <ChannelSetItem :channelSetId="item.id" />
             </template>
@@ -66,82 +87,89 @@
       </div>
     </KModal>
   </VContainer>
+
 </template>
 
-<script>
-import sortBy from 'lodash/sortBy';
-import { mapGetters, mapActions } from 'vuex';
-import { RouteNames } from '../../constants';
-import ChannelSetItem from './ChannelSetItem.vue';
-import LoadingText from 'shared/views/LoadingText';
 
-export default {
-  name: 'ChannelSetList',
-  components: { ChannelSetItem, LoadingText },
-  data() {
-    return { loading: true, infoDialog: false };
-  },
-  computed: {
-    ...mapGetters('channelSet', ['channelSets']),
-    headers() {
-      return [
-        { text: this.$tr('title'), sortable: false, value: 'name' },
-        { text: this.$tr('token'), sortable: false, value: 'secret_token', width: '224px' },
-        { text: this.$tr('channelNumber'), sortable: false, align: 'right', width: '50px' },
-        { text: this.$tr('options'), sortable: false, align: 'center', width: '100px' },
-      ];
+<script>
+
+  import sortBy from 'lodash/sortBy';
+  import { mapGetters, mapActions } from 'vuex';
+  import { RouteNames } from '../../constants';
+  import ChannelSetItem from './ChannelSetItem.vue';
+  import LoadingText from 'shared/views/LoadingText';
+
+  export default {
+    name: 'ChannelSetList',
+    components: { ChannelSetItem, LoadingText },
+    data() {
+      return { loading: true, infoDialog: false };
     },
-    channelSetsDisclamerStyle() {
-      return { color: this.$themePalette.red.v_500 };
+    computed: {
+      ...mapGetters('channelSet', ['channelSets']),
+      headers() {
+        return [
+          { text: this.$tr('title'), sortable: false, value: 'name' },
+          { text: this.$tr('token'), sortable: false, value: 'secret_token', width: '224px' },
+          { text: this.$tr('channelNumber'), sortable: false, align: 'right', width: '50px' },
+          { text: this.$tr('options'), sortable: false, align: 'center', width: '100px' },
+        ];
+      },
+      channelSetsDisclamerStyle() {
+        return { color: this.$themePalette.red.v_500 };
+      },
+      sortedChannelSets() {
+        return sortBy(this.channelSets || [], s => (s.name || '').toLowerCase());
+      },
     },
-    sortedChannelSets() {
-      return sortBy(this.channelSets || [], s => (s.name || '').toLowerCase());
+    async mounted() {
+      try {
+        await this.loadChannelSetList();
+      } finally {
+        this.loading = false;
+      }
     },
-  },
-  async mounted() {
-    try {
-      await this.loadChannelSetList();
-    } finally {
-      this.loading = false;
-    }
-  },
-  methods: {
-    ...mapActions('channelSet', ['loadChannelSetList']),
-    newChannelSet() {
-      this.$router.push({ name: RouteNames.NEW_CHANNEL_SET });
+    methods: {
+      ...mapActions('channelSet', ['loadChannelSetList']),
+      newChannelSet() {
+        this.$router.push({ name: RouteNames.NEW_CHANNEL_SET });
+      },
     },
-  },
-  $trs: {
-    cancelButtonLabel: 'Close',
-    noChannelSetsFound:
-      'You can package together multiple channels to create a collection. The entire collection can then be imported to Kolibri at once by using a collection token.',
-    addChannelSetTitle: 'New collection',
-    aboutChannelSets: 'About collections',
-    aboutChannelSetsLink: 'Learn more about collections',
-    channelSetsDescriptionText:
-      'A collection contains multiple Kolibri Studio channels that can be imported at one time to Kolibri with a single collection token.',
-    channelSetsInstructionsText:
-      'You can make a collection by selecting the channels you want to be imported together.',
-    channelSetsDisclaimer:
-      'You will need Kolibri version 0.12.0 or higher to import channel collections',
-    title: 'Collection name',
-    token: 'Token ID',
-    channelNumber: 'Number of channels',
-    options: 'Options',
-  },
-};
+    $trs: {
+      cancelButtonLabel: 'Close',
+      noChannelSetsFound:
+        'You can package together multiple channels to create a collection. The entire collection can then be imported to Kolibri at once by using a collection token.',
+      addChannelSetTitle: 'New collection',
+      aboutChannelSets: 'About collections',
+      aboutChannelSetsLink: 'Learn more about collections',
+      channelSetsDescriptionText:
+        'A collection contains multiple Kolibri Studio channels that can be imported at one time to Kolibri with a single collection token.',
+      channelSetsInstructionsText:
+        'You can make a collection by selecting the channels you want to be imported together.',
+      channelSetsDisclaimer:
+        'You will need Kolibri version 0.12.0 or higher to import channel collections',
+      title: 'Collection name',
+      token: 'Token ID',
+      channelNumber: 'Number of channels',
+      options: 'Options',
+    },
+  };
+
 </script>
 
+
 <style lang="scss" scoped>
-.list-items {
-  margin: 0 auto;
-}
 
-.link-btn {
-  margin: 0 8px;
-}
+  .list-items {
+    margin: 0 auto;
+  }
 
-::v-deep .v-datatable {
-  background-color: transparent !important;
-}
+  .link-btn {
+    margin: 0 8px;
+  }
+
+  ::v-deep .v-datatable {
+    background-color: transparent !important;
+  }
+
 </style>


### PR DESCRIPTION
## Summary
- Changed the link from "learn about collections" to "learn more about collections".
- Aligned it after the description text.
- Still aligned to the right if collections are available.
- added vertical spacing between button and text.

<img width="1916" height="883" alt="image" src="https://github.com/user-attachments/assets/86382b38-e9c7-4e12-ae06-df3db0dab224" />

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Slack Conversation Link:
https://learningequality.slack.com/archives/C03S2EN192A/p1761950793197879
