### PR TITLE
[Remove Vuetify from Studio] Convert Sign In page unit tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
@@ -16,7 +16,11 @@ const createRouter = () => {
       { path: '/', name: 'Main', component: { template: '<div />' } },
       { path: '/forgot-password', name: 'ForgotPassword', component: { template: '<div />' } },
       { path: '/create', name: 'Create', component: { template: '<div />' } },
-      { path: '/account-not-active', name: 'AccountNotActivated', component: { template: '<div />' } },
+      {
+        path: '/account-not-active',
+        name: 'AccountNotActivated',
+        component: { template: '<div />' },
+      },
     ],
   });
 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Converted AccountsMain (Sign In page) unit tests from Vue Test Utils to Vue Testing Library, focusing on user-observable behavior instead of implementation details.

**Changes:**
- Replaced `mount()` with `render()` and Vue Testing Library queries
- Simplified Vuex mocking: Using `mocks: { $store }` instead of `createLocalVue` (component only uses dispatch/state)
- Minimal stubs: Only `PolicyModals` stub kept
- 8 comprehensive tests covering all major user workflows

**Test Coverage:**
- Form rendering and display
- Form validation (empty submission)
- Login failures with error messaging
- Successful login and redirect flow
- Protected page access with `?next=` parameter
- Inactive account detection
- Offline state handling

All tests use semantic queries (`getByRole`, `getByLabelText`, `getByText`) and test only user-visible behavior.


…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- **Issue**: #5534 (Convert AccountsMain tests to VTL)
- **Related**: #5536 (CatalogList conversion)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
**Testing:**

- Run the test suite
- pnpm run test -- [accountsMain.spec.js](http://_vscodecontentref_/0)
-  All 8 tests should pass

…
