### PR TITLE
Prevent and handle IntegrityErrors during user creation

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -213,9 +213,10 @@
         <KButton
           primary
           class="mt-5"
-          :disabled="offline"
+          :disabled="offline || submitting"
           :text="$tr('finishButton')"
           type="submit"
+          data-test="submit-button"
         />
       </VForm>
     </VLayout>
@@ -260,6 +261,7 @@
       return {
         valid: true,
         registrationFailed: false,
+        submitting: false,
         form: {
           first_name: '',
           last_name: '',
@@ -482,6 +484,12 @@
         // We need to check the "acceptedAgreement" here explicitly because it is not a
         // Vuetify form field and does not trigger the form validation.
         if (this.$refs.form.validate() && this.acceptedAgreement) {
+          // Prevent double submission
+          if (this.submitting) {
+            return Promise.resolve();
+          }
+
+          this.submitting = true;
           const cleanedData = this.clean(this.form);
           return this.register(cleanedData)
             .then(() => {
@@ -517,6 +525,9 @@
                 this.registrationFailed = true;
                 this.valid = false;
               }
+            })
+            .finally(() => {
+              this.submitting = false;
             });
         } else if (this.$refs.top.scrollIntoView) {
           this.$refs.top.scrollIntoView({ behavior: 'smooth' });

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/create.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/create.spec.js
@@ -179,4 +179,19 @@ describe('create', () => {
       expect(wrapper.vm.registrationFailed).toBe(true);
     });
   });
+  describe('double-submit prevention', () => {
+    it('should prevent multiple API calls on rapid clicks', async () => {
+      const [wrapper, mocks] = await makeWrapper();
+
+      // Click submit multiple times
+      const p1 = wrapper.vm.submit();
+      const p2 = wrapper.vm.submit();
+      const p3 = wrapper.vm.submit();
+
+      await Promise.all([p1, p2, p3]);
+
+      // Only 1 API call should be made
+      expect(mocks.register).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Adds extra handling for potential IntegrityError when attempting to create a user
Adds frontend submission blocking
Adds a backend test and frontend test for each behaviour
Fixed a typo in the backend tests for user registration (`pasword` instead of `password`)

## References
Fixes [#4779](https://github.com/learningequality/studio/issues/4779)

## Reviewer guidance

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 

Manual tests:
Load the account creation page
Turn network throttling on in the Network tab of the browser
Create an account and try to click the submit button multiple times

To make absolutely sure of the backend fix you can also disable the 'submission prevention' code in the frontend, then do the same just to test the backend - I was not able to replicate the 500 from the Sentry error doing this, even without the fixes, but I suspect this may be because of the single threaded devserver environment.
