### PR TITLE
Update KDS to 5.5.0

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/styles/main.scss
+++ b/contentcuration/contentcuration/frontend/shared/styles/main.scss
@@ -1,4 +1,5 @@
 @import '~material-icons/iconfont/material-icons.css';
+@import '~kolibri-design-system/lib/styles/common';
 
 @font-face {
   font-family: 'Noto Sans';

--- a/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/RecommendedResourceCard.vue
@@ -159,19 +159,3 @@
   };
 
 </script>
-
-
-<style>
-
-  .visuallyhidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    border: 0;
-  }
-
-</style>

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "jszip": "^3.10.1",
     "kolibri-constants": "^0.2.12",
-    "kolibri-design-system": "5.4.1",
+    "kolibri-design-system": "5.5.0",
     "lodash": "^4.17.21",
     "lowlight": "^3.3.0",
     "marked": "^16.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       kolibri-design-system:
-        specifier: 5.4.1
-        version: 5.4.1
+        specifier: 5.5.0
+        version: 5.5.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4879,8 +4879,8 @@ packages:
   kolibri-design-system@5.0.1:
     resolution: {integrity: sha512-oz5gEFUj7NYZbrqr89gPjSfRFVuuilSqILA4bbWqLWwkI9ay/uVMdsh8cY2Xajhtzccjwqa1c/NxUETr5kMfHQ==}
 
-  kolibri-design-system@5.4.1:
-    resolution: {integrity: sha512-XTSTDqhNz1BDKXLq99rK87hdy7vHlhhXBGm7OEjTJQUvlmcpJgR0lrGZhX7KusyNcInmonNQtU/p7059u9ISfA==}
+  kolibri-design-system@5.5.0:
+    resolution: {integrity: sha512-ykLARvIFy6FHoIPfRXk3XHUzmvn2RstDaT2ck8vc7XEawXcZkzt2w9JUVtpnNKdCEnvgg7ufL4cqr0B4Yej0mA==}
 
   kolibri-format@1.0.1:
     resolution: {integrity: sha512-yGQpsJkBAzmRueAq6MG1UOuDl9pbhEtMWNxq9ObG5pPVkG8uhWJAS1L71GCuNAeaV1XG2IWo2565Ov4yXnudeA==}
@@ -13176,7 +13176,7 @@ snapshots:
       vue2-teleport: 1.1.4
       xstate: 4.38.3
 
-  kolibri-design-system@5.4.1:
+  kolibri-design-system@5.5.0:
     dependencies:
       aphrodite: https://codeload.github.com/learningequality/aphrodite/tar.gz/fdc8d7be8912a5cf17f74ff10f124013c52c3e32
       autosize: 3.0.21


### PR DESCRIPTION
## Summary

Update KDS to 5.5.0

- Related release notes:
  - https://github.com/learningequality/kolibri-design-system/releases/tag/v5.4.2
  - https://github.com/learningequality/kolibri-design-system/releases/tag/v5.5.0

- No breaking changes
- Installs the new KDS stylesheet, and removes `visuallyhidden` styles that are not longer needed since the class is provided by KDS (card manually previewed - no regressions noticed).