### PR TITLE
chore: update dependabot to monthly schedule with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,19 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
+      interval: "monthly"
       time: "00:00"
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for Javascript
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
+      interval: "monthly"
       time: "00:00"
+    cooldown:
+      default-days: 7
     groups:
       babel:
         patterns:
@@ -33,9 +35,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
+      interval: "monthly"
       time: "00:00"
+    cooldown:
+      default-days: 7
     groups:
       github:
         patterns:


### PR DESCRIPTION
- Changed schedule interval from weekly to monthly for all package ecosystems
- Removed day specification (monthly runs on 1st of month)
- Added cooldown of 7 days to avoid freshly released versions

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 