### PR TITLE
Fix Language foreign key column lengths

### DIFF
--- a/contentcuration/contentcuration/migrations/0155_fix_language_foreign_key_length.py
+++ b/contentcuration/contentcuration/migrations/0155_fix_language_foreign_key_length.py
@@ -1,31 +1,19 @@
-# Generated manually to fix Language foreign key column lengths
+# Generated manually to fix Language foreign key column length in M2M junction table
 # See https://github.com/learningequality/studio/issues/5618
 #
 # When Language.id was changed from max_length=7 to max_length=14 in migration
-# 0081, Django 1.9 did not cascade the primary key column size change to
-# foreign key and many-to-many junction table columns. This migration fixes
-# those columns for databases that were created before the migration squash.
+# 0081, Django 1.9 did not cascade the primary key column size change to the
+# many-to-many junction table column. This migration fixes that column for
+# databases that were created before the migration squash.
 #
-# This migration is idempotent - it only alters columns that are still varchar(7).
+# This migration is idempotent - it only alters the column if it is still varchar(7).
 from django.db import migrations
 
 
-# SQL to fix each column, checking if it needs to be altered first
+# SQL to fix the column, checking if it needs to be altered first
 FORWARD_SQL = """
 DO $$
 BEGIN
-    -- Fix contentcuration_channel.language_id
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = 'contentcuration_channel'
-        AND column_name = 'language_id'
-        AND character_maximum_length = 7
-    ) THEN
-        ALTER TABLE contentcuration_channel
-            ALTER COLUMN language_id TYPE varchar(14);
-    END IF;
-
     -- Fix contentcuration_channel_included_languages.language_id (M2M junction table)
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
@@ -35,30 +23,6 @@ BEGIN
         AND character_maximum_length = 7
     ) THEN
         ALTER TABLE contentcuration_channel_included_languages
-            ALTER COLUMN language_id TYPE varchar(14);
-    END IF;
-
-    -- Fix contentcuration_contentnode.language_id
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = 'contentcuration_contentnode'
-        AND column_name = 'language_id'
-        AND character_maximum_length = 7
-    ) THEN
-        ALTER TABLE contentcuration_contentnode
-            ALTER COLUMN language_id TYPE varchar(14);
-    END IF;
-
-    -- Fix contentcuration_file.language_id
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = 'public'
-        AND table_name = 'contentcuration_file'
-        AND column_name = 'language_id'
-        AND character_maximum_length = 7
-    ) THEN
-        ALTER TABLE contentcuration_file
             ALTER COLUMN language_id TYPE varchar(14);
     END IF;
 END $$;


### PR DESCRIPTION
## Summary
When Language.id was changed from max_length=7 to max_length=14 in migration 0081, Django 1.9 did not cascade the primary key column size change to many-to-many junction table columns.

This migration fixes the included_languages through table language_id column for databases that were created before the migration squash. It is idempotent - columns that are already varchar(14) are not modified.

Fixes: contentcuration_channel_included_languages.language_id

Adds migration test that deliberately corrupts the DB columns then runs the migration and confirms the fix.

## References
Fixes #5618

## Reviewer guidance
Because of our migration squashing, the bug is not extant on development machines, so coercing the database column length manually and then running the migration to ensure the change in the migration test was the best I could do here.

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and made updates before making it ready for review :robot: 
