### PR TITLE
[Remove Vuetify from Studio] Convert 'Reset password' unit tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/resetPassword.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/resetPassword.spec.js
@@ -51,7 +51,7 @@ describe('ResetPassword', () => {
 
     expect(setPasswordMock).not.toHaveBeenCalled();
 
-    await screen.findByText("Password should be at least 8 characters long");
+    await screen.findByText('Password should be at least 8 characters long');
     await screen.findByText("Passwords don't match");
   });
 


### PR DESCRIPTION
Fixes https://github.com/learningequality/studio/issues/5637

Migrates test suite to Vue Testing Library to focus on user behavior rather than implementation details.

- Replaced brittle wrapper manipulation with screen queries
- Added validation and successful submission scenarios
- Verified correct payload dispatch to Vuex with query params

<img width="1388" height="576" alt="image" src="https://github.com/user-attachments/assets/cf3a2734-6e8d-4583-8f59-43d6fcbdbd45" />

