### PR TITLE
Temporarily hide draft button.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -227,6 +227,7 @@
             </VBtn>
 
             <VBtn
+              v-if="false"
               color="primary"
               data-test="display-publish-draft-dialog-btn"
               @click="displayPublishDraftDialog = true"


### PR DESCRIPTION
## Summary
Temporarily hides the publish draft button to reduce confusion while the feature is unavailable on Kolibri

## Reviewer guidance

| Before | After |
|--------|--------|
| <img width="2876" height="1604" alt="Screenshot From 2026-01-19 17-03-30" src="https://github.com/user-attachments/assets/637672a2-f83c-4343-a7ec-08f09d430e6c" /> | <img width="2876" height="1604" alt="Screenshot From 2026-01-19 17-03-02" src="https://github.com/user-attachments/assets/0d754cb6-03e7-4ec0-996f-bda52bc7794e" /> | 