### PR TITLE
Fix prop type check on 'New collection' page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSetModal.vue
@@ -42,7 +42,7 @@
                 <KTextbox
                   v-model="name"
                   :label="$tr('titleLabel')"
-                  maxlength="200"
+                  :maxlength="200"
                   :invalid="errors.name"
                   :invalidText="$tr('titleRequiredText')"
                   showInvalidText


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
<img width="1806" height="816" alt="Screenshot From 2026-01-20 15-48-28" src="https://github.com/user-attachments/assets/02b3a3e8-1ada-4952-ae99-dbae62a6e5bc" />

Fixed a prop type validation warning in the New Collection page where the maxlength prop was receiving a string value "200" instead of the expected number 200
## References
Fixes #5648 

## Reviewer guidance
How to Get There
 -  Navigate to /channels/#/collections/new URL