### PR TITLE
Fix admin privilege dialog not opening from actions menu

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserActionsDropdown.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserActionsDropdown.vue
@@ -67,7 +67,7 @@
             <VListTile
               v-if="user.is_admin"
               data-test="removeadmin"
-              @mousedown.stop
+              @click.stop
               @click="removeAdminPrivilegeDialog = true"
             >
               <VListTileTitle>Remove admin privileges</VListTileTitle>
@@ -75,7 +75,7 @@
             <VListTile
               v-else
               data-test="addadmin"
-              @mousedown.stop
+              @click.stop
               @click="addAdminPrivilegeDialog = true"
             >
               <VListTileTitle>Add admin privileges</VListTileTitle>


### PR DESCRIPTION
Description

This PR fixes an issue where the `Add / Remove admin privileges` dialog did not open upon clicking the `Add admin privileges` action inside the Users tab.

## What was changed

- Adjusted click handling so the menu interaction no longer blocks dialog rendering

- Preserved existing behavior and API of UserActionsDropdown and UserPrivilegeModal

## Why this works

The dialog state is now set at the correct time in Vue’s render cycle

Prevents the menu component from swallowing or cancelling the dialog trigger

Matches the expected UX: clicking the `Add admin privilages` reliably opens the confirmation dialog


## Testing

Manually verified:
- Add admin privileges dialog opens correctly
- Remove admin privileges dialog opens correctly
Email / Deactivate / Delete actions still behave as expected

https://github.com/user-attachments/assets/7bfdfaa3-2443-47ef-af18-2e065379f000

## Related issue
Fixes #5645 