### PR TITLE
Fix semantic structure of 'Create an account' page

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/Create.vue
@@ -17,7 +17,7 @@
       class="mb-4 primary--text text-xs-center"
     >
       {{ $tr('createAnAccountTitle') }}
-  </h1>
+    </h1>
     <VLayout
       justify-center
       class="px-3"
@@ -639,7 +639,9 @@
   .align-items {
     display: block;
   }
-  h1{
+
+  h1 {
     font-size: 21px;
   }
+
 </style>


### PR DESCRIPTION
Fixes https://github.com/learningequality/studio/issues/5647

Summary
This PR fixes the heading hierarchy on the Create Account page by swapping the h1 and h2 tags. The main page title “Create an account” is now inside an h1 tag instead of h2. All section headings (Basic information, Usage, Location, Source) are now inside h2 instead of h1. The visual design remains the same: Section headings still look identical because the subheading and font-weight-bold classes control their size and style. The only required visual adjustment is for the “Create an account” heading, which should remain 24px after moving it to h1.

Manual verification
S1) Open the Create Account page.

S2) Confirm that all headings look exactly the same as before.

S3) Check that only the HTML heading levels have changed.

current semantic
![Screenshot 2026-01-10 000212](https://github.com/user-attachments/assets/2e1565e5-21d3-4455-ac9c-7c64719fc9ee)

updated semantic
![Screenshot 2026-01-10](https://github.com/user-attachments/assets/94a23582-8795-4023-85e2-6b79204a0c03)
