### PR TITLE
[ESoCC] Command to create channel versions

### DIFF
--- a/contentcuration/contentcuration/management/commands/create_channel_versions.py
+++ b/contentcuration/contentcuration/management/commands/create_channel_versions.py
@@ -142,7 +142,7 @@ def validate_published_data(data, channel):
 
 
 class Command(BaseCommand):
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: C901
         logging.info("Creating channel versions")
 
         channels = Channel.objects.filter(version__gt=0)
@@ -168,15 +168,17 @@ class Command(BaseCommand):
                         )
 
                     # Can't have nulls in these lists!
-                    pub_data["included_languages"] = [
-                        lang
-                        for lang in pub_data["included_languages"]
-                        if lang is not None
-                    ]
+                    if pub_data.get("included_languages"):
+                        pub_data["included_languages"] = [
+                            lang
+                            for lang in pub_data["included_languages"]
+                            if lang is not None
+                        ]
 
-                    pub_data["included_categories"] = [
-                        c for c in pub_data["included_categories"] if c is not None
-                    ]
+                    if pub_data.get("included_categories"):
+                        pub_data["included_categories"] = [
+                            c for c in pub_data["included_categories"] if c is not None
+                        ]
 
                     # Create or update channel version
                     channel_version, _ = ChannelVersion.objects.update_or_create(

--- a/contentcuration/contentcuration/tests/utils/test_create_channel_versions.py
+++ b/contentcuration/contentcuration/tests/utils/test_create_channel_versions.py
@@ -172,16 +172,6 @@ class TestValidatePublishedData(StudioTestCase):
 
         self.assertEqual(data["included_categories"], existing_categories)
 
-    def test_works_with_null_category(self):
-        """Should preserve existing included_categories in data."""
-        existing_categories = ["history", "art", None]
-        fixed_existing_categories = ["history", "art"]
-        input_data = {"included_categories": existing_categories}
-
-        data, _ = validate_published_data(input_data, self.channel)
-
-        self.assertEqual(data["included_categories"], fixed_existing_categories)
-
     def test_computes_kind_count(self):
         """Should compute kind_count from published nodes."""
         video_kind = ContentKind.objects.get(kind=content_kinds.VIDEO)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

Adds a create_channel_versions command that uses the published_data dict on Channels to create new ChannelVersion instances.

I worked out the initial approach and some simple tests myself and asked Claude to help extrapolate the tests I made to include checks for things like the Audited license models and such. 

## References
<!--
 * references to related issues and PRs
-->

Closes #5593 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Have I missed anything?
