### PR TITLE
Create Composite backend for non-prod curriculum API testing

### DIFF
--- a/contentcuration/automation/utils/appnexus/base.py
+++ b/contentcuration/automation/utils/appnexus/base.py
@@ -191,29 +191,32 @@ class BackendFactory(ABC):
 
 
 class CompositeBackend:
-    def __init__(self, backends):
-        self.backends = backends
-        self.active_backend = None
+    def __init__(self, backend, prefixes):
+        self.backend = backend
+        self.prefixes = prefixes
+        self._connected = False
 
     def connect(self, **kwargs):
         """
-        Loops through a list of backends in order to establish
-        which should be the active backend.
+        Loops through a list of prefixes in order to establish
+        which backend is available to connect.
 
         """
-        prefixes = [b.url_prefix for b in self.backends]
-        for backend in self.backends:
-            if backend.connect(**kwargs):
-                self.active_backend = backend
+        for prefix in self.prefixes:
+            self.backend.url_prefix = prefix
+            if self.backend.connect():
+                self._connected = True
                 return True
-        raise AssertionError(f"Could not connect to any backend in list: {prefixes}")
+        raise AssertionError(
+            f"Could not connect to any backend in list: {self.prefixes}"
+        )
 
     def make_request(self, request):
-        if self.active_backend:
-            return self.active_backend.make_request(request)
+        if self._connected:
+            return self.backend.make_request(request)
         else:
             self.connect()
-            return self.active_backend.make_request(request)
+            return self.backend.make_request(request)
 
 
 class Adapter:

--- a/contentcuration/contentcuration/utils/recommendations.py
+++ b/contentcuration/contentcuration/utils/recommendations.py
@@ -16,6 +16,7 @@ from automation.utils.appnexus.base import Backend
 from automation.utils.appnexus.base import BackendFactory
 from automation.utils.appnexus.base import BackendRequest
 from automation.utils.appnexus.base import BackendResponse
+from automation.utils.appnexus.base import CompositeBackend
 from django.conf import settings
 from django.db.models import Exists
 from django.db.models import F
@@ -108,10 +109,17 @@ class RecommendationsBackendFactory(BackendFactory):
         )
 
     def create_backend(self) -> Backend:
-        backend = Recommendations()
-        backend.base_url = self._prepare_url(settings.CURRICULUM_AUTOMATION_API_URL)
-        backend.connect_endpoint = "/connect"
-        return backend
+        if settings.SITE_ID == settings.PRODUCTION_SITE_ID:
+            backend = Recommendations()
+            backend.base_url = self._prepare_url(settings.CURRICULUM_AUTOMATION_API_URL)
+            backend.connect_endpoint = "/connect"
+            return backend
+        else:
+            backend = Recommendations()
+            backend.base_url = self._prepare_url(settings.CURRICULUM_AUTOMATION_API_URL)
+            backend.connect_endpoint = "/connect"
+
+            return CompositeBackend(backend, ["unstable", "stable"])
 
 
 class RecommendationsAdapter(Adapter):


### PR DESCRIPTION
## Summary

This PR introduces a `CompositeBackend` that accepts a `backend` and a list of `url_prefix`es to manage optional unstable backend connections in non-production settings. 

It also adds a test, and updates some existing tests that are testing prod-only scenarios to clarify that they are production only and do not use the composite backend.

## References
Fixes #5584

## Reviewer guidance

I leaned heavily on Claude to understand this area of the code base but used it more as a tool to investigate and orient myself, as well as practice some of the patterns. I wrote the code myself (although it did point out more than one error in my python syntax 😁 ), with the exception of updating the existing tests in test_recommendations.py (which I didn't think to do on my own).

I do have some questions about my approach, so I opened this as a draft PR to have a reference for what I was wondering about.  I've intentionally left two separate commits so they can be compared.

In the first commit, I have an initial implementation of `CompositeBackend` that: 
> accepts a list of backends in its constructor

I continued from there, but after writing tests for the first time, I realized (after reviewing the error message with Claude) that I wasn't able to create multiple backend instances. 

In the second commit, you will see a different approach, which passes one backend, and a list of prefixes and the rest of my changes. It seems to still meet the same goals of the acceptance criteria. Is this second option better? 

I did a bit of brainstorming with Claude about other possibilities and googled a bit about the "singleton pattern" (new to me!) but moving away from that seemed like there could potentially be other unforeseen consequences. And I don't feel confident in my ability to know what those might be :) 

Look forward to thoughts!
