### PR TITLE
[Remove Vuetify from Studio] Buttons, dropdowns, and dialog in channel editor root page 

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue
@@ -72,33 +72,19 @@
           </span>
         </template>
       </Breadcrumbs>
-      <BaseMenu
+      <KIconButton
         v-if="!loadingAncestors"
-        class="pa-1"
+        icon="list"
+        :tooltip="$tr('viewModeTooltip')"
       >
-        <template #activator="{ on }">
-          <IconButton
-            icon="list"
-            :text="$tr('viewModeTooltip')"
-            v-on="on"
+        <template #menu>
+          <KDropdownMenu
+            :options="viewModeOptions"
+            :hasIcons="true"
+            @select="handleViewModeSelect"
           />
         </template>
-        <VList>
-          <VListTile
-            v-for="mode in viewModes"
-            :key="mode"
-            @click="(setViewMode(mode), trackViewMode(mode))"
-          >
-            <VListTileAction style="min-width: 32px">
-              <Icon
-                v-if="mode === viewMode"
-                icon="check"
-              />
-            </VListTileAction>
-            <VListTileTitle>{{ $tr(mode) }}</VListTileTitle>
-          </VListTile>
-        </VList>
-      </BaseMenu>
+      </KIconButton>
     </VToolbar>
 
     <!-- Topic actions -->
@@ -164,42 +150,21 @@
       />
       <VSpacer v-if="!selected.length" />
       <VToolbarItems v-if="!loadingAncestors">
-        <BaseMenu v-if="canEdit">
-          <template #activator="{ on }">
-            <VBtn
-              color="primary"
-              class="ml-2"
-              style="height: 32px"
-              v-on="on"
-            >
-              {{ $tr('addButton') }}
-              <Icon
-                icon="dropdown"
-                :color="$themeTokens.textInverted"
-              />
-            </VBtn>
+        <KButton
+          v-if="canEdit"
+          :primary="true"
+          :text="$tr('addButton')"
+          hasDropdown
+          class="ml-2"
+          style="height: 32px"
+        >
+          <template #menu>
+            <KDropdownMenu
+              :options="addMenuOptions"
+              @select="handleAddMenuSelect"
+            />
           </template>
-          <VList>
-            <VListTile @click="newTopicNode">
-              <VListTileTitle>{{ $tr('addTopic') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              :to="uploadFilesLink"
-              @click="trackClickEvent('Upload files')"
-            >
-              <VListTileTitle>{{ $tr('uploadFiles') }}</VListTileTitle>
-            </VListTile>
-            <VListTile @click="newExerciseNode">
-              <VListTileTitle>{{ $tr('addExercise') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              :to="importFromChannelsRoute"
-              @click="trackClickEvent('Import from other channels')"
-            >
-              <VListTileTitle>{{ $tr('importFromChannels') }}</VListTileTitle>
-            </VListTile>
-          </VList>
-        </BaseMenu>
+        </KButton>
       </VToolbarItems>
     </ToolBar>
 
@@ -324,6 +289,13 @@
   import DraggableRegion from 'shared/views/draggable/DraggableRegion';
   import { searchRecommendationsStrings } from 'shared/strings/searchRecommendationsStrings';
   import AiRecommendationsBanner from 'shared/views/AiRecommendationsBanner';
+
+  const AddMenuOptions = {
+    ADD_TOPIC: 'add-topic',
+    UPLOAD_FILES: 'upload-files',
+    ADD_EXERCISE: 'add-exercise',
+    IMPORT_FROM_CHANNELS: 'import-from-channels',
+  };
 
   export default {
     name: 'CurrentTopicView',
@@ -566,6 +538,13 @@
       viewModes() {
         return Object.values(viewModes);
       },
+      viewModeOptions() {
+        return this.viewModes.map(mode => ({
+          label: this.$tr(mode),
+          value: mode,
+          icon: mode === this.viewMode ? 'check' : undefined,
+        }));
+      },
       importFromChannelsRoute() {
         return {
           name: RouteNames.IMPORT_FROM_CHANNELS_BROWSE,
@@ -573,6 +552,14 @@
             destNodeId: this.$route.params.nodeId,
           },
         };
+      },
+      addMenuOptions() {
+        return [
+          { label: this.$tr('addTopic'), value: AddMenuOptions.ADD_TOPIC },
+          { label: this.$tr('uploadFiles'), value: AddMenuOptions.UPLOAD_FILES },
+          { label: this.$tr('addExercise'), value: AddMenuOptions.ADD_EXERCISE },
+          { label: this.$tr('importFromChannels'), value: AddMenuOptions.IMPORT_FROM_CHANNELS },
+        ];
       },
       selectionText() {
         return this.getSelectedTopicAndResourceCountText(this.selected);
@@ -1014,6 +1001,28 @@
       },
       trackViewMode(mode) {
         this.$analytics.trackAction('general', mode);
+      },
+      handleViewModeSelect(option) {
+        this.setViewMode(option.value);
+        this.trackViewMode(option.value);
+      },
+      handleAddMenuSelect(option) {
+        switch (option.value) {
+          case AddMenuOptions.ADD_TOPIC:
+            this.newTopicNode();
+            break;
+          case AddMenuOptions.UPLOAD_FILES:
+            this.trackClickEvent('Upload files');
+            this.$router.push(this.uploadFilesLink);
+            break;
+          case AddMenuOptions.ADD_EXERCISE:
+            this.newExerciseNode();
+            break;
+          case AddMenuOptions.IMPORT_FROM_CHANNELS:
+            this.trackClickEvent('Import from other channels');
+            this.$router.push(this.importFromChannelsRoute);
+            break;
+        }
       },
       showTitleDescriptionModal(nodeId) {
         this.editTitleDescriptionModal = {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -130,7 +130,7 @@
       </template>
       <VToolbarItems>
         <KIconButton
-          v-if="channelMenuOptions.length"
+          v-if="!loading && channelMenuOptions.length"
           class="toolbar-icon-btn"
           icon="optionsHorizontal"
           :tooltip="$tr('moreOptions')"
@@ -501,6 +501,12 @@
               label: this.$tr('publishButton'),
               value: ChannelMenuOptions.PUBLISH,
               disabled: this.disablePublish,
+            });
+          }
+          if (this.currentChannel && this.currentChannel.draft_token) {
+            options.push({
+              label: this.getDraftTokenAction$(),
+              value: ChannelMenuOptions.PREVIEW_DRAFT,
             });
           }
           options.push({

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -677,7 +677,7 @@
         // Handle channel-specific options
         switch (option.value) {
           case ChannelMenuOptions.PUBLISH:
-            this.showPublishSidePanel = true;
+            this.publishChannel();
             break;
           case ChannelMenuOptions.VIEW_DETAILS:
             this.$router.push(this.viewChannelDetailsLink);

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -138,6 +138,7 @@
           <template #menu>
             <KDropdownMenu
               :options="channelMenuOptions"
+              :hasIcons="true"
               @select="handleChannelMenuSelect"
             />
           </template>
@@ -410,6 +411,9 @@
         }
         return this.canManage && this.isPublished && !this.currentChannel.public;
       },
+      canShareChannel() {
+        return this.canManage || this.isPublished;
+      },
       viewChannelDetailsLink() {
         return {
           name: ChannelRouteNames.CHANNEL_DETAILS,
@@ -466,6 +470,7 @@
         return DropEffect.COPY;
       },
       shareMenuOptions() {
+        if (!this.canShareChannel) return [];
         const options = [];
         if (this.canSubmitToCommunityLibrary) {
           options.push({
@@ -503,32 +508,32 @@
             value: ChannelMenuOptions.VIEW_DETAILS,
           });
           if (this.canEdit) {
-            let label = this.$tr('editChannel');
+            const editOption = {
+              label: this.$tr('editChannel'),
+              value: ChannelMenuOptions.EDIT_CHANNEL,
+            };
             if (!this.currentChannel.language) {
-              label = `${label} ⚠️`;
+              editOption.icon = 'warningIncomplete';
             }
-            options.push({
-              label,
-              value: 'edit-channel',
-            });
+            options.push(editOption);
           }
 
           if (this.canSubmitToCommunityLibrary) {
             options.push({
               label: this.$tr('submitToCommunityLibrary'),
-              value: 'submit-to-library',
+              value: ShareMenuOptions.SUBMIT_TO_LIBRARY,
             });
           }
           if (this.canManage) {
             options.push({
               label: this.$tr('inviteCollaborators'),
-              value: 'invite-collaborators',
+              value: ShareMenuOptions.INVITE_COLLABORATORS,
             });
           }
           if (this.isPublished) {
             options.push({
               label: this.$tr('shareToken'),
-              value: 'share-token',
+              value: ShareMenuOptions.SHARE_TOKEN,
             });
           }
         } else {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -17,7 +17,7 @@
         {{ currentChannel.name }}
       </VToolbarTitle>
       <VToolbarItems
-        v-if="$vuetify.breakpoint.smAndUp"
+        v-if="!windowIsSmall"
         class="ml-4"
       >
         <KRouterLink
@@ -60,89 +60,67 @@
         v-if="errorsInChannel && canEdit"
         class="mx-1"
       >
-        <VTooltip
-          bottom
-          lazy
+        <div
+          ref="errorCount"
+          class="amber--text title"
+          style="width: max-content"
         >
-          <template #activator="{ on }">
-            <div
-              class="amber--text title"
-              style="width: max-content"
-              v-on="on"
-            >
-              {{ $formatNumber(errorsInChannel) }}
-              <KIcon icon="warningIncomplete" />
-            </div>
-          </template>
+          {{ $formatNumber(errorsInChannel) }}
+          <KIcon icon="warningIncomplete" />
+        </div>
+        <KTooltip
+          reference="errorCount"
+          :refs="$refs"
+          placement="bottom"
+        >
           <span>{{ $tr('incompleteDescendantsText', { count: errorsInChannel }) }}</span>
-        </VTooltip>
+        </KTooltip>
       </div>
-      <template v-if="$vuetify.breakpoint.smAndUp">
+      <template v-if="!windowIsSmall">
         <span
           v-if="canManage && isRicecooker"
           class="font-weight-bold grey--text subheading"
         >
           {{ $tr('apiGenerated') }}
         </span>
-        <BaseMenu v-if="canShareChannel">
-          <template #activator="{ on }">
-            <KButton
-              hasDropdown
-              class="share-button"
-              v-on="on"
-            >
-              {{ $tr('shareMenuButton') }}
-            </KButton>
-          </template>
-          <VList>
-            <VListTile
-              v-if="canSubmitToCommunityLibrary"
-              @click="showSubmitToCommunityLibrarySidePanel = true"
-            >
-              <VListTileTitle>{{ $tr('submitToCommunityLibrary') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="canManage"
-              :to="shareChannelLink"
-              @click="trackClickEvent('Share channel')"
-            >
-              <VListTileTitle>{{ $tr('inviteCollaborators') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="isPublished"
-              @click="showTokenModal = true"
-            >
-              <VListTileTitle>{{ $tr('shareToken') }}</VListTileTitle>
-            </VListTile>
-          </VList>
-        </BaseMenu>
-        <VTooltip
-          v-if="!loading && canManage"
-          bottom
-          attach="body"
-          lazy
+        <KButton
+          v-if="shareMenuOptions.length"
+          :text="$tr('shareMenuButton')"
+          hasDropdown
+          class="share-button"
         >
-          <template #activator="{ on }">
-            <!-- Need to wrap in div to enable tooltip when button is disabled -->
-            <div
-              style="height: 100%"
-              v-on="on"
-            >
-              <VBtn
-                color="primary"
-                flat
-                class="ma-0"
-                :class="{ disabled: disablePublish }"
-                :disabled="disablePublish"
-                style="height: inherit"
-                @click.stop="publishChannel"
-              >
-                {{ $tr('publishButton') }}
-              </VBtn>
-            </div>
+          <template #menu>
+            <KDropdownMenu
+              :options="shareMenuOptions"
+              @select="handleShareMenuSelect"
+            />
           </template>
+        </KButton>
+        <!-- Need to wrap in div to enable tooltip when button is disabled -->
+        <div
+          v-if="!loading && canManage"
+          ref="publishButton"
+          style="height: 100%"
+        >
+          <KButton
+            :text="$tr('publishButton')"
+            :primary="true"
+            appearance="flat-button"
+            class="ma-0"
+            :class="{ disabled: disablePublish }"
+            :disabled="disablePublish"
+            style="height: inherit"
+            @click="publishChannel"
+          />
+        </div>
+        <KTooltip
+          v-if="!loading && canManage"
+          reference="publishButton"
+          :refs="$refs"
+          placement="bottom"
+        >
           <span>{{ publishButtonTooltip }}</span>
-        </VTooltip>
+        </KTooltip>
         <span
           v-else-if="!loading"
           class="font-weight-bold grey--text subheading"
@@ -151,89 +129,19 @@
         </span>
       </template>
       <VToolbarItems>
-        <BaseMenu v-if="showChannelMenu">
-          <template #activator="{ on }">
-            <VBtn
-              flat
-              icon
-              v-on="on"
-            >
-              <Icon
-                icon="optionsHorizontal"
-                style="font-size: 25px"
-              />
-            </VBtn>
+        <KIconButton
+          v-if="channelMenuOptions.length"
+          class="toolbar-icon-btn"
+          icon="optionsHorizontal"
+          :tooltip="$tr('moreOptions')"
+        >
+          <template #menu>
+            <KDropdownMenu
+              :options="channelMenuOptions"
+              @select="handleChannelMenuSelect"
+            />
           </template>
-          <VList>
-            <template v-if="$vuetify.breakpoint.xsOnly">
-              <VListTile
-                v-if="canManage"
-                :disabled="disablePublish"
-                @click="showPublishModal = true"
-              >
-                <VListTileTitle>{{ $tr('publishButton') }}</VListTileTitle>
-              </VListTile>
-              <VListTile :to="viewChannelDetailsLink">
-                <VListTileTitle>{{ $tr('channelDetails') }}</VListTileTitle>
-              </VListTile>
-              <VListTile
-                v-if="canEdit"
-                :to="editChannelLink"
-              >
-                <VListTileTitle>
-                  {{ $tr('editChannel') }}
-                  <Icon
-                    v-if="!currentChannel.language"
-                    class="mx-1"
-                    color="red"
-                    icon="error"
-                    style="vertical-align: baseline"
-                  />
-                </VListTileTitle>
-              </VListTile>
-            </template>
-            <VListTile
-              v-if="currentChannel && currentChannel.draft_token"
-              @click="showPreviewDraftModal = true"
-            >
-              <VListTileTitle>{{ getDraftTokenAction$() }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="isPublished"
-              @click="showTokenModal = true"
-            >
-              <VListTileTitle>{{ $tr('getToken') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="canManage"
-              :to="shareChannelLink"
-              @click="trackClickEvent('Share channel')"
-            >
-              <VListTileTitle>{{ $tr('shareChannel') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="canEdit"
-              @click="syncChannel"
-            >
-              <VListTileTitle>{{ $tr('syncChannel') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="canEdit"
-              :to="trashLink"
-              @click="trackClickEvent('Trash')"
-            >
-              <VListTileTitle>{{ $tr('openTrash') }}</VListTileTitle>
-            </VListTile>
-            <VListTile
-              v-if="canEdit"
-              @click="deleteChannelModal"
-            >
-              <VListTileTitle class="red--text">
-                {{ $tr('deleteChannel') }}
-              </VListTileTitle>
-            </VListTile>
-          </VList>
-        </BaseMenu>
+        </KIconButton>
       </VToolbarItems>
       <template #extension>
         <slot name="extension"></slot>
@@ -351,6 +259,7 @@
 <script>
 
   import { mapActions, mapGetters, mapState } from 'vuex';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import PreviewDraftChannelModal from '../../components/modals/PreviewDraftChannelModal.vue';
   import Clipboard from '../../components/Clipboard';
   import SyncResourcesModal from '../sync/SyncResourcesModal';
@@ -376,6 +285,25 @@
   import { communityChannelsStrings } from 'shared/strings/communityChannelsStrings';
   import { commonStrings } from 'shared/strings/commonStrings';
 
+  // Menu option constants
+  const ShareMenuOptions = {
+    SUBMIT_TO_LIBRARY: 'submit-to-library',
+    INVITE_COLLABORATORS: 'invite-collaborators',
+    SHARE_TOKEN: 'share-token',
+  };
+
+  const ChannelMenuOptions = {
+    PUBLISH: 'publish',
+    VIEW_DETAILS: 'view-details',
+    EDIT_CHANNEL: 'edit-channel',
+    PREVIEW_DRAFT: 'preview-draft',
+    GET_TOKEN: 'get-token',
+    SHARE_CHANNEL: 'share-channel',
+    SYNC: 'sync',
+    TRASH: 'trash',
+    DELETE: 'delete',
+  };
+
   export default {
     name: 'TreeViewBase',
     components: {
@@ -399,8 +327,10 @@
     },
     mixins: [titleMixin],
     setup() {
+      const { windowIsSmall } = useKResponsiveWindow();
       const { getDraftTokenAction$ } = communityChannelsStrings;
       return {
+        windowIsSmall,
         getDraftTokenAction$,
       };
     },
@@ -474,14 +404,6 @@
           return this.$tr('noChangesText');
         }
       },
-      showChannelMenu() {
-        return (
-          !this.loading && (this.$vuetify.breakpoint.xsOnly || this.canManage || this.isPublished)
-        );
-      },
-      canShareChannel() {
-        return this.canManage || this.isPublished;
-      },
       canSubmitToCommunityLibrary() {
         if (!this.currentChannel) {
           return false;
@@ -542,6 +464,111 @@
       },
       dropEffect() {
         return DropEffect.COPY;
+      },
+      shareMenuOptions() {
+        const options = [];
+        if (this.canSubmitToCommunityLibrary) {
+          options.push({
+            label: this.$tr('submitToCommunityLibrary'),
+            value: ShareMenuOptions.SUBMIT_TO_LIBRARY,
+          });
+        }
+        if (this.canManage) {
+          options.push({
+            label: this.$tr('inviteCollaborators'),
+            value: ShareMenuOptions.INVITE_COLLABORATORS,
+          });
+        }
+        if (this.isPublished) {
+          options.push({
+            label: this.$tr('shareToken'),
+            value: ShareMenuOptions.SHARE_TOKEN,
+          });
+        }
+        return options;
+      },
+      channelMenuOptions() {
+        const options = [];
+
+        if (this.windowIsSmall) {
+          if (this.canManage) {
+            options.push({
+              label: this.$tr('publishButton'),
+              value: ChannelMenuOptions.PUBLISH,
+              disabled: this.disablePublish,
+            });
+          }
+          options.push({
+            label: this.$tr('channelDetails'),
+            value: ChannelMenuOptions.VIEW_DETAILS,
+          });
+          if (this.canEdit) {
+            let label = this.$tr('editChannel');
+            if (!this.currentChannel.language) {
+              label = `${label} ⚠️`;
+            }
+            options.push({
+              label,
+              value: 'edit-channel',
+            });
+          }
+
+          if (this.canSubmitToCommunityLibrary) {
+            options.push({
+              label: this.$tr('submitToCommunityLibrary'),
+              value: 'submit-to-library',
+            });
+          }
+          if (this.canManage) {
+            options.push({
+              label: this.$tr('inviteCollaborators'),
+              value: 'invite-collaborators',
+            });
+          }
+          if (this.isPublished) {
+            options.push({
+              label: this.$tr('shareToken'),
+              value: 'share-token',
+            });
+          }
+        } else {
+          // Desktop view - show different options
+          if (this.currentChannel && this.currentChannel.draft_token) {
+            options.push({
+              label: this.getDraftTokenAction$(),
+              value: ChannelMenuOptions.PREVIEW_DRAFT,
+            });
+          }
+          if (this.isPublished) {
+            options.push({
+              label: this.$tr('getToken'),
+              value: ChannelMenuOptions.GET_TOKEN,
+            });
+          }
+          if (this.canManage) {
+            options.push({
+              label: this.$tr('shareChannel'),
+              value: ChannelMenuOptions.SHARE_CHANNEL,
+            });
+          }
+        }
+
+        if (this.canEdit) {
+          options.push({
+            label: this.$tr('syncChannel'),
+            value: ChannelMenuOptions.SYNC,
+          });
+          options.push({
+            label: this.$tr('openTrash'),
+            value: ChannelMenuOptions.TRASH,
+          });
+          options.push({
+            label: this.$tr('deleteChannel'),
+            value: ChannelMenuOptions.DELETE,
+          });
+        }
+
+        return options;
       },
     },
     watch: {
@@ -611,6 +638,64 @@
       trackClickEvent(eventLabel) {
         this.$analytics.trackClick('channel_editor_toolbar', eventLabel);
       },
+      // Shared handler for common menu options that appear in both Share and Channel menus
+      handleCommonShareOption(value) {
+        switch (value) {
+          case ShareMenuOptions.SUBMIT_TO_LIBRARY:
+            this.showSubmitToCommunityLibrarySidePanel = true;
+            break;
+          case ShareMenuOptions.INVITE_COLLABORATORS:
+            this.trackClickEvent('Share channel');
+            this.$router.push(this.shareChannelLink);
+            break;
+          case ShareMenuOptions.SHARE_TOKEN:
+            this.showTokenModal = true;
+            break;
+        }
+      },
+      handleShareMenuSelect(option) {
+        this.handleCommonShareOption(option.value);
+      },
+      handleChannelMenuSelect(option) {
+        // Check if it's a common share option first
+        if (Object.values(ShareMenuOptions).includes(option.value)) {
+          this.handleCommonShareOption(option.value);
+          return;
+        }
+
+        // Handle channel-specific options
+        switch (option.value) {
+          case ChannelMenuOptions.PUBLISH:
+            this.showPublishSidePanel = true;
+            break;
+          case ChannelMenuOptions.VIEW_DETAILS:
+            this.$router.push(this.viewChannelDetailsLink);
+            break;
+          case ChannelMenuOptions.EDIT_CHANNEL:
+            this.$router.push(this.editChannelLink);
+            break;
+          case ChannelMenuOptions.PREVIEW_DRAFT:
+            this.showPreviewDraftModal = true;
+            break;
+          case ChannelMenuOptions.GET_TOKEN:
+            this.showTokenModal = true;
+            break;
+          case ChannelMenuOptions.SHARE_CHANNEL:
+            this.trackClickEvent('Share channel');
+            this.$router.push(this.shareChannelLink);
+            break;
+          case ChannelMenuOptions.SYNC:
+            this.syncChannel();
+            break;
+          case ChannelMenuOptions.TRASH:
+            this.trackClickEvent('Trash');
+            this.$router.push(this.trashLink);
+            break;
+          case ChannelMenuOptions.DELETE:
+            this.deleteChannelModal();
+            break;
+        }
+      },
     },
     $trs: {
       channelDetails: 'View channel details',
@@ -635,6 +720,9 @@
       submitToCommunityLibrary: 'Submit to Community Library',
       inviteCollaborators: 'Invite collaborators',
       shareToken: 'Share token',
+
+      // More options menu
+      moreOptions: 'More options',
 
       channelDeletedSnackbar: 'Channel deleted',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -495,18 +495,13 @@
       channelMenuOptions() {
         const options = [];
 
+        // On small screens, prepend the actions that are hidden from the toolbar
         if (this.windowIsSmall) {
           if (this.canManage) {
             options.push({
               label: this.$tr('publishButton'),
               value: ChannelMenuOptions.PUBLISH,
               disabled: this.disablePublish,
-            });
-          }
-          if (this.currentChannel && this.currentChannel.draft_token) {
-            options.push({
-              label: this.getDraftTokenAction$(),
-              value: ChannelMenuOptions.PREVIEW_DRAFT,
             });
           }
           options.push({
@@ -523,47 +518,27 @@
             }
             options.push(editOption);
           }
-
-          if (this.canSubmitToCommunityLibrary) {
-            options.push({
-              label: this.$tr('submitToCommunityLibrary'),
-              value: ShareMenuOptions.SUBMIT_TO_LIBRARY,
-            });
-          }
-          if (this.canManage) {
-            options.push({
-              label: this.$tr('inviteCollaborators'),
-              value: ShareMenuOptions.INVITE_COLLABORATORS,
-            });
-          }
-          if (this.isPublished) {
-            options.push({
-              label: this.$tr('shareToken'),
-              value: ShareMenuOptions.SHARE_TOKEN,
-            });
-          }
-        } else {
-          // Desktop view - show different options
-          if (this.currentChannel && this.currentChannel.draft_token) {
-            options.push({
-              label: this.getDraftTokenAction$(),
-              value: ChannelMenuOptions.PREVIEW_DRAFT,
-            });
-          }
-          if (this.isPublished) {
-            options.push({
-              label: this.$tr('getToken'),
-              value: ChannelMenuOptions.GET_TOKEN,
-            });
-          }
-          if (this.canManage) {
-            options.push({
-              label: this.$tr('shareChannel'),
-              value: ChannelMenuOptions.SHARE_CHANNEL,
-            });
-          }
         }
 
+        // Common options shown on all screen sizes
+        if (this.currentChannel && this.currentChannel.draft_token) {
+          options.push({
+            label: this.getDraftTokenAction$(),
+            value: ChannelMenuOptions.PREVIEW_DRAFT,
+          });
+        }
+        if (this.isPublished) {
+          options.push({
+            label: this.$tr('getToken'),
+            value: ChannelMenuOptions.GET_TOKEN,
+          });
+        }
+        if (this.canManage) {
+          options.push({
+            label: this.$tr('shareChannel'),
+            value: ChannelMenuOptions.SHARE_CHANNEL,
+          });
+        }
         if (this.canEdit) {
           options.push({
             label: this.$tr('syncChannel'),

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/TreeViewBase.vue
@@ -518,6 +518,12 @@
             }
             options.push(editOption);
           }
+          if (this.canSubmitToCommunityLibrary) {
+            options.push({
+              label: this.$tr('submitToCommunityLibrary'),
+              value: ShareMenuOptions.SUBMIT_TO_LIBRARY,
+            });
+          }
         }
 
         // Common options shown on all screen sizes

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/__tests__/TreeViewBase.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/__tests__/TreeViewBase.spec.js
@@ -9,6 +9,15 @@ import storeFactory from 'shared/vuex/baseStore';
 import DraggablePlugin from 'shared/vuex/draggablePlugin';
 import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
 
+// Mock useKResponsiveWindow composable
+jest.mock('kolibri-design-system/lib/composables/useKResponsiveWindow', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const useKResponsiveWindow =
+  require('kolibri-design-system/lib/composables/useKResponsiveWindow').default;
+
 const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(VueRouter);
@@ -55,8 +64,18 @@ const initWrapper = ({
   getters = GETTERS,
   actions = ACTIONS,
   channelOverrides = {},
-  breakpoint = { smAndUp: true },
+  windowIsSmall = false,
 } = {}) => {
+  // Mock the responsive window composable - return plain values
+  useKResponsiveWindow.mockReturnValue({
+    windowIsSmall,
+    windowIsMedium: false,
+    windowIsLarge: !windowIsSmall,
+    windowHeight: 768,
+    windowWidth: windowIsSmall ? 360 : 1024,
+    windowBreakpoint: windowIsSmall ? 0 : 4,
+  });
+
   const router = new VueRouter({
     routes: [
       {
@@ -113,13 +132,6 @@ const initWrapper = ({
     propsData: {
       loading: false,
     },
-    mocks: {
-      $vuetify: {
-        breakpoint: {
-          smAndUp: breakpoint.smAndUp,
-        },
-      },
-    },
     stubs: {
       ToolBar: {
         template: '<div><slot /><slot name="extension" /></div>',
@@ -127,46 +139,23 @@ const initWrapper = ({
       MainNavigationDrawer: true,
       PublishSidePanel: true,
       SubmitToCommunityLibrarySidePanel: true,
+      ResubmitToCommunityLibraryModal: true,
       ProgressModal: true,
       ChannelTokenModal: true,
+      RemoveChannelModal: true,
       SyncResourcesModal: true,
       Clipboard: true,
       OfflineText: true,
       ContentNodeIcon: true,
       DraggablePlaceholder: true,
-      MessageDialog: true,
       SavingIndicator: true,
       QuickEditModal: true,
-      BaseMenu: {
-        name: 'BaseMenu',
-        template:
-          '<div><slot name="activator" :on="{}" /><div class="menu-content"><slot /></div></div>',
-      },
     },
   });
 };
 
 const getShareButton = wrapper => {
-  const allBaseMenus = wrapper.findAllComponents({ name: 'BaseMenu' });
-  for (let i = 0; i < allBaseMenus.length; i++) {
-    const baseMenu = allBaseMenus.at(i);
-    const shareButton = baseMenu.find('.share-button');
-    if (shareButton.exists()) {
-      return shareButton;
-    }
-  }
-  return { exists: () => false };
-};
-const getShareMenuItems = wrapper => {
-  const allBaseMenus = wrapper.findAllComponents({ name: 'BaseMenu' });
-  for (let i = 0; i < allBaseMenus.length; i++) {
-    const baseMenu = allBaseMenus.at(i);
-    const shareButton = baseMenu.find('.share-button');
-    if (shareButton.exists()) {
-      return baseMenu.findAll('.v-list__tile');
-    }
-  }
-  return { length: 0, wrappers: [] };
+  return wrapper.find('.share-button');
 };
 
 describe('TreeViewBase', () => {
@@ -292,7 +281,7 @@ describe('TreeViewBase', () => {
       getters.currentChannel.canManage = () => true;
       getters.currentChannel.currentChannel = () => createChannel({ published: true });
 
-      const wrapper = initWrapper({ getters, breakpoint: { smAndUp: false } });
+      const wrapper = initWrapper({ getters, windowIsSmall: true });
       expect(getShareButton(wrapper).exists()).toBe(false);
     });
   });
@@ -305,11 +294,10 @@ describe('TreeViewBase', () => {
         createChannel({ published: true, public: false });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const submitItem = menuItems.wrappers.find(item =>
-        item.text().includes('Submit to Community Library'),
-      );
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const submitItem = menuOptions.find(item => item.value === 'submit-to-library');
       expect(submitItem).toBeDefined();
+      expect(submitItem.label).toContain('Submit to Community Library');
     });
 
     it('hides submit to community library when user cannot submit', () => {
@@ -319,10 +307,8 @@ describe('TreeViewBase', () => {
         createChannel({ published: true, public: false });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const submitItem = menuItems.wrappers.find(item =>
-        item.text().includes('Submit to Community Library'),
-      );
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const submitItem = menuOptions.find(item => item.value === 'submit-to-library');
       expect(submitItem).toBeUndefined();
     });
 
@@ -333,10 +319,8 @@ describe('TreeViewBase', () => {
         createChannel({ published: true, public: true });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const submitItem = menuItems.wrappers.find(item =>
-        item.text().includes('Submit to Community Library'),
-      );
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const submitItem = menuOptions.find(item => item.value === 'submit-to-library');
       expect(submitItem).toBeUndefined();
     });
 
@@ -346,11 +330,10 @@ describe('TreeViewBase', () => {
       getters.currentChannel.currentChannel = () => createChannel({ published: false });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const inviteItem = menuItems.wrappers.find(item =>
-        item.text().includes('Invite collaborators'),
-      );
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const inviteItem = menuOptions.find(item => item.value === 'invite-collaborators');
       expect(inviteItem).toBeDefined();
+      expect(inviteItem.label).toContain('Invite collaborators');
     });
 
     it('hides invite collaborators when user cannot manage', () => {
@@ -359,10 +342,8 @@ describe('TreeViewBase', () => {
       getters.currentChannel.currentChannel = () => createChannel({ published: true });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const inviteItem = menuItems.wrappers.find(item =>
-        item.text().includes('Invite collaborators'),
-      );
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const inviteItem = menuOptions.find(item => item.value === 'invite-collaborators');
       expect(inviteItem).toBeUndefined();
     });
 
@@ -372,9 +353,10 @@ describe('TreeViewBase', () => {
       getters.currentChannel.currentChannel = () => createChannel({ published: true });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const tokenItem = menuItems.wrappers.find(item => item.text().includes('Share token'));
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const tokenItem = menuOptions.find(item => item.value === 'share-token');
       expect(tokenItem).toBeDefined();
+      expect(tokenItem.label).toContain('Share token');
     });
 
     it('hides share token when channel is not published', () => {
@@ -383,8 +365,8 @@ describe('TreeViewBase', () => {
       getters.currentChannel.currentChannel = () => createChannel({ published: false });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      const tokenItem = menuItems.wrappers.find(item => item.text().includes('Share token'));
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      const tokenItem = menuOptions.find(item => item.value === 'share-token');
       expect(tokenItem).toBeUndefined();
     });
 
@@ -395,15 +377,11 @@ describe('TreeViewBase', () => {
         createChannel({ published: true, public: false });
 
       const wrapper = initWrapper({ getters });
-      const menuItems = getShareMenuItems(wrapper);
-      expect(menuItems.length).toBe(3);
-      expect(
-        menuItems.wrappers.some(item => item.text().includes('Submit to Community Library')),
-      ).toBe(true);
-      expect(menuItems.wrappers.some(item => item.text().includes('Invite collaborators'))).toBe(
-        true,
-      );
-      expect(menuItems.wrappers.some(item => item.text().includes('Share token'))).toBe(true);
+      const menuOptions = wrapper.vm.shareMenuOptions;
+      expect(menuOptions.length).toBe(3);
+      expect(menuOptions.some(item => item.value === 'submit-to-library')).toBe(true);
+      expect(menuOptions.some(item => item.value === 'invite-collaborators')).toBe(true);
+      expect(menuOptions.some(item => item.value === 'share-token')).toBe(true);
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/__tests__/TreeViewBase.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/__tests__/TreeViewBase.spec.js
@@ -384,4 +384,109 @@ describe('TreeViewBase', () => {
       expect(menuOptions.some(item => item.value === 'share-token')).toBe(true);
     });
   });
+
+  describe('channelMenuOptions computed property', () => {
+    it('includes publish, view details, and edit channel on small screens', () => {
+      const getters = cloneDeep(GETTERS);
+      getters.currentChannel.canManage = () => true;
+      getters.currentChannel.canEdit = () => true;
+
+      const wrapper = initWrapper({ getters, windowIsSmall: true });
+      const values = wrapper.vm.channelMenuOptions.map(item => item.value);
+      expect(values).toContain('publish');
+      expect(values).toContain('view-details');
+      expect(values).toContain('edit-channel');
+    });
+
+    it('omits publish, view details, and edit channel on large screens', () => {
+      const getters = cloneDeep(GETTERS);
+      getters.currentChannel.canManage = () => true;
+      getters.currentChannel.canEdit = () => true;
+
+      const wrapper = initWrapper({ getters, windowIsSmall: false });
+      const values = wrapper.vm.channelMenuOptions.map(item => item.value);
+      expect(values).not.toContain('publish');
+      expect(values).not.toContain('view-details');
+      expect(values).not.toContain('edit-channel');
+    });
+
+    it('marks the edit channel option with a warning icon when language is missing', () => {
+      const getters = cloneDeep(GETTERS);
+      getters.currentChannel.canEdit = () => true;
+      getters.currentChannel.currentChannel = () => createChannel({ language: null });
+
+      const wrapper = initWrapper({ getters, windowIsSmall: true });
+      const editOption = wrapper.vm.channelMenuOptions.find(item => item.value === 'edit-channel');
+      expect(editOption.icon).toBe('warningIncomplete');
+    });
+
+    it('includes submit to community library on small screens when the user can submit', () => {
+      const getters = cloneDeep(GETTERS);
+      getters.currentChannel.canManage = () => true;
+      getters.currentChannel.currentChannel = () =>
+        createChannel({ published: true, public: false });
+
+      const wrapper = initWrapper({ getters, windowIsSmall: true });
+      const values = wrapper.vm.channelMenuOptions.map(item => item.value);
+      expect(values).toContain('submit-to-library');
+    });
+
+    it('omits submit to community library on large screens', () => {
+      const getters = cloneDeep(GETTERS);
+      getters.currentChannel.canManage = () => true;
+      getters.currentChannel.currentChannel = () =>
+        createChannel({ published: true, public: false });
+
+      const wrapper = initWrapper({ getters, windowIsSmall: false });
+      const values = wrapper.vm.channelMenuOptions.map(item => item.value);
+      expect(values).not.toContain('submit-to-library');
+    });
+  });
+
+  describe('handleChannelMenuSelect method', () => {
+    it('opens the publish side panel for the publish option', () => {
+      const wrapper = initWrapper();
+      wrapper.vm.handleChannelMenuSelect({ value: 'publish' });
+      expect(wrapper.vm.showPublishSidePanel).toBe(true);
+    });
+
+    it('opens the delete modal for the delete option', () => {
+      const wrapper = initWrapper();
+      wrapper.vm.handleChannelMenuSelect({ value: 'delete' });
+      expect(wrapper.vm.showDeleteModal).toBe(true);
+    });
+
+    it('opens the sync modal for the sync option', () => {
+      const wrapper = initWrapper();
+      wrapper.vm.handleChannelMenuSelect({ value: 'sync' });
+      expect(wrapper.vm.showSyncModal).toBe(true);
+    });
+
+    it('navigates to the edit channel page for the edit channel option', () => {
+      const wrapper = initWrapper();
+      const push = jest.spyOn(wrapper.vm.$router, 'push').mockImplementation(() => {});
+      wrapper.vm.handleChannelMenuSelect({ value: 'edit-channel' });
+      expect(push).toHaveBeenCalledWith(wrapper.vm.editChannelLink);
+    });
+
+    it('opens the submit to community library panel for the shared submit option', () => {
+      const wrapper = initWrapper();
+      wrapper.vm.handleChannelMenuSelect({ value: 'submit-to-library' });
+      expect(wrapper.vm.showSubmitToCommunityLibrarySidePanel).toBe(true);
+    });
+  });
+
+  describe('handleShareMenuSelect method', () => {
+    it('opens the token modal for the share token option', () => {
+      const wrapper = initWrapper();
+      wrapper.vm.handleShareMenuSelect({ value: 'share-token' });
+      expect(wrapper.vm.showTokenModal).toBe(true);
+    });
+
+    it('opens the submit to community library panel for the submit option', () => {
+      const wrapper = initWrapper();
+      wrapper.vm.handleShareMenuSelect({ value: 'submit-to-library' });
+      expect(wrapper.vm.showSubmitToCommunityLibrarySidePanel).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Migrated channel editor toolbar from Vuetify to KDS components, replacing `VTooltip`, `VBtn`, `VList`, and `BaseMenu` with KDS equivalents.

**Changes:**
- Replaced `VTooltip` with `KTooltip` (error count + publish button tooltips)
- Replaced `VBtn` with `KButton` for Publish button
- Replaced `BaseMenu + VList` with `KButton + KDropdownMenu` for Share dropdown
- Replaced `VBtn + BaseMenu + VList` with `KIconButton + KDropdownMenu` for three-dots menu
- Added `shareMenuOptions` and `channelMenuOptions` computed properties
- Added `handleShareMenuSelect` and `handleChannelMenuSelect` methods

**Screenshots:**
<img width="335" height="733" alt="Screenshot 2026-01-28 at 5 56 43 PM" src="https://github.com/user-attachments/assets/df1de013-a664-4ec8-8ffb-7716c614b72e" />
…
<img width="963" height="736" alt="Screenshot 2026-01-28 at 5 55 55 PM" src="https://github.com/user-attachments/assets/e6b2f561-3c64-4fe8-b015-e8cdd21176c8" />
…
<img width="963" height="727" alt="Screenshot 2026-01-28 at 5 55 47 PM" src="https://github.com/user-attachments/assets/71b23b4c-ffb9-4c73-b84a-ea26b58db4ae" />
…
<img width="335" height="491" alt="Screenshot 2026-01-28 at 5 54 45 PM" src="https://github.com/user-attachments/assets/1a3c2c13-c8db-448a-9dd1-d05bd824d839" />
…
<img width="983" height="749" alt="Screenshot 2026-01-28 at 5 55 39 PM" src="https://github.com/user-attachments/assets/681e81e0-aad7-4ad6-9e20-89baa7f1fe89" />
…
<img width="339" height="459" alt="Screenshot 2026-01-28 at 5 54 34 PM" src="https://github.com/user-attachments/assets/a6b0d88d-8edf-4abb-9aa6-7480aaf97cc3" />
…
<img width="984" height="752" alt="Screenshot 2026-01-28 at 5 55 32 PM" src="https://github.com/user-attachments/assets/01b3ed3d-cc7d-4168-ad1b-005db819fe9a" />
…
<img width="336" height="459" alt="Screenshot 2026-01-28 at 5 54 15 PM" src="https://github.com/user-attachments/assets/b8666fb8-774d-4dda-a397-fee60e1699e6" />
…
<img width="337" height="490" alt="Screenshot 2026-01-28 at 5 54 52 PM" src="https://github.com/user-attachments/assets/a65622e8-8269-4569-806f-d1d9e66349c3" />


…

## References
<!--
 * references to related issues and PRs
-->

Closes #5597
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Login as `a@a.com` / `a`
2. Go to Channels > Published Channel > Edit (to enter channel editor)
3. Test Share dropdown (desktop view)
4. Test Publish button
5. Test three-dots menu
6. Test responsive behavior (resize browser to mobile width ~375px)




…
