### PR TITLE
Fix misaligned links on About Studio page

### DIFF
--- a/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
+++ b/contentcuration/contentcuration/frontend/settings/pages/UsingStudio/index.vue
@@ -154,5 +154,4 @@
     margin-top: 32px;
   }
 
-
 </style>


### PR DESCRIPTION
## Summary

Fixes the vertical alignment of external links on the `Settings` > `About Studio` page to ensure they are visually consistent with other links and surrounding text.

## Manual Verification

<img width="2880" height="1630" alt="Untitled design" src="https://github.com/user-attachments/assets/63c78f6a-29f5-41a8-a670-a3bd74268c0a" />

## References
Fixes #5671 

