### PR TITLE
[Remove Vuetify from Studio] Convert 'Activation failed' unit tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/requestNewActivationLink.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/requestNewActivationLink.spec.js
@@ -29,12 +29,10 @@ function renderComponent() {
       {
         path: '/main',
         name: 'Main',
-        // component: { render: h => h('div') }, // dummy
       },
       {
         path: '/activation-link-resent',
         name: 'ActivationLinkReSent',
-        // component: { render: h => h('div') }, // dummy
       },
     ],
   });


### PR DESCRIPTION
## Summary
Refactored `accounts/pages/__tests__/requestNewActivationLink.spec.js `  to use Vue Testing Library, rewriting test suite to use Vue Testing Library (VTL) and in a way that reflects how a user interacts with the application.

Manual verification


<img width="1220" height="188" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/e8234b33-f759-426b-9720-933641e57638" />


Ran:

pnpm test accounts/pages/__tests__/requestNewActivationLink.spec.js  (from frontend)

## References
Closes : #5636 

