### PR TITLE
Improve alert banner

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/StudioBanner.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/StudioBanner.vue
@@ -5,9 +5,13 @@
     data-testid="studio-banner"
     :style="{
       backgroundColor: error ? $themePalette.red.v_100 : '',
-      color: error ? $themeTokens.error : '',
     }"
   >
+    <KIcon
+      v-if="error"
+      class="icon"
+      icon="error"
+    />
     <slot>
       {{ text }}
     </slot>
@@ -34,7 +38,16 @@
 <style lang="scss" scoped>
 
   .banner {
-    padding: 16px;
+    display: flex;
+    gap: 16px;
+    padding: 12px 16px;
+  }
+
+  .icon {
+    position: relative;
+    top: -1px;
+    flex-shrink: 0;
+    font-size: 18px;
   }
 
 </style>


### PR DESCRIPTION
## Summary

Studio uses multiple styles for error banners (with black text, with red text, ...). We've discussed with @tomiwaoLE which one to choose for `StudioBanner` component that gradually replaces Vuetify-based banners and will ultimately become the only alert component. This PR aligns `StudioBanner` with the decisions taken and [this design](https://www.figma.com/design/p7aOP2MBv0SED1uhaPwqEd/Kolibri-Design-System?node-id=426-7997&t=PRH2sqoMQs73debW-0):


<img width="500" height="auto" alt="" src="https://github.com/user-attachments/assets/382a25bf-56cc-49b0-a2ea-5d21e6235fd0" />

As of now, changes affect these places:

| | Before | After |
| --- | --- | --- |
| 'Make public' dialog in channels administration | <img width="922" height="567" alt="Screenshot from 2026-02-03 20-11-56" src="https://github.com/user-attachments/assets/2d11c391-606f-4420-a920-f2fbe3f74e5c" /> | <img width="922" height="567" alt="Screenshot from 2026-02-03 20-10-58" src="https://github.com/user-attachments/assets/c2bb671a-22c3-4dd8-9664-36bcb6060485" /> |
| Storage form request in settings | <img width="876" height="567" alt="Screenshot from 2026-02-03 20-12-40" src="https://github.com/user-attachments/assets/80e48d2e-406f-4cf5-b8f5-d65aa14d6994" /> | <img width="876" height="567" alt="Screenshot from 2026-02-03 20-13-00" src="https://github.com/user-attachments/assets/f488bc8a-dad9-46ae-a620-501d20ace6c8" /> |

but will gradually take effect in the whole Studio.