### PR TITLE
[Remove Vuetify from Studio] Convert collection modal tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/vue';
-import { configure } from '@testing-library/dom';
+import { render, screen, waitFor, configure } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';


### PR DESCRIPTION
## Summary
Refactored channelSetModal.spec.js to use Vue Testing Library and focus on user-facing behavior instead of component internals. 


### Ran
pnpm test -- channelList/views/ChannelSet/__tests__/channelSetModal.spec.js


Ref:
<img width="1037" height="230" alt="Screenshot 2026-02-08 at 5 21 16 PM" src="https://github.com/user-attachments/assets/1f969b11-61dc-468d-bb9f-58b49fc77d3c" />


Closes : #5686
