### PR TITLE
Replace hardcoded toolbar breakpoints with KListWithOverflow

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue
@@ -183,12 +183,11 @@
       };
 
       onMounted(() => {
-        // capture
-        document.addEventListener('click', handleClickOutside, true);
+        document.addEventListener('click', handleClickOutside);
       });
 
       onUnmounted(() => {
-        document.removeEventListener('click', handleClickOutside, true);
+        document.removeEventListener('click', handleClickOutside);
       });
 
       const getMarkdownContent = () => {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -36,7 +36,7 @@
 
     <!-- Collapsible toolbar groups -->
     <KListWithOverflow
-      :items="toolbarGroups"
+      :items="toolbarGroupsWithDividers"
       class="overflow-list"
     >
       <template #item="{ item }">
@@ -67,7 +67,9 @@
       </template>
 
       <template #divider>
-        <ToolbarDivider />
+        <div class="list-with-overflow-divider">
+          <ToolbarDivider />
+        </div>
       </template>
 
       <template #more="{ overflowItems }">
@@ -266,6 +268,10 @@
         });
 
         for (const group of overflowItems) {
+          if (group.type === 'divider') {
+            options.push(group);
+            continue;
+          }
           for (const action of group.groupActions) {
             if (action.dropdownActions) {
               for (const dropdownAction of action.dropdownActions) {
@@ -280,6 +286,17 @@
         return options;
       };
 
+      const toolbarGroupsWithDividers = computed(() => {
+        const groups = [];
+        toolbarGroups.value.forEach((group, index) => {
+          groups.push(group);
+          if (index < toolbarGroups.value.length - 1) {
+            groups.push({ type: 'divider' });
+          }
+        });
+        return groups;
+      });
+
       const onOverflowSelect = (option, event) => {
         event.stopPropagation();
         option.handler(event, { fromOverflow: true });
@@ -287,7 +304,7 @@
 
       return {
         toolbarRef,
-        toolbarGroups,
+        toolbarGroupsWithDividers,
         flatOverflowOptions,
         historyActions,
         minimizeAction,
@@ -387,6 +404,10 @@
       color: #3730a3;
       background-color: #e0e7ff;
     }
+  }
+
+  .list-with-overflow-divider {
+    padding: 0 6px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -32,7 +32,7 @@
     <!-- Format dropdown -->
     <div
       role="group"
-      class="toolbar-group"
+      class="formatting-group toolbar-group"
       :aria-label="textFormattingOptions$()"
     >
       <FormatDropdown />
@@ -366,11 +366,6 @@
     border-radius: 8px 8px 0 0;
   }
 
-  .minimize-button {
-    /* Push the minimize button to the far right. */
-    margin-left: auto;
-  }
-
   .overflow-list {
     flex: 1;
     min-width: 0;
@@ -380,6 +375,12 @@
     display: flex;
     gap: 2px;
     align-items: center;
+  }
+
+  .formatting-group {
+    /* Let it shrink if possible */
+    flex: 1;
+    flex-grow: 0;
   }
 
   .dropdown-item-icon {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -4,11 +4,16 @@
     ref="toolbarRef"
     class="toolbar"
     role="toolbar"
+    :style="{
+      backgroundColor: $themePalette.grey.v_50,
+      borderBottom: `1px solid ${$themeTokens.fineLine}`,
+    }"
     :aria-label="textFormattingToolbar$()"
   >
     <!-- History buttons -->
     <div
       role="group"
+      class="toolbar-group"
       :aria-label="historyActions$()"
     >
       <ToolbarButton
@@ -27,6 +32,7 @@
     <!-- Format dropdown -->
     <div
       role="group"
+      class="toolbar-group"
       :aria-label="textFormattingOptions$()"
     >
       <FormatDropdown />
@@ -73,7 +79,17 @@
       </template>
 
       <template #more="{ overflowItems }">
-        <button class="more-button">
+        <button
+          class="more-button"
+          :class="
+            $computedClass({
+              ':is([aria-expanded=\'true\'])': {
+                color: $themePalette.blue.v_600,
+                background: $themePalette.blue.v_100,
+              },
+            })
+          "
+        >
           <span>{{ moreButtonText$() }}</span>
           <img
             :src="require('../../assets/icon-chevron-down.svg')"
@@ -87,7 +103,14 @@
             <template #option="{ option }">
               <div
                 class="overflow-item"
-                :class="{ active: option.isActive }"
+                :style="
+                  option.isActive
+                    ? {
+                      color: $themePalette.blue.v_600,
+                      backgroundColor: $themePalette.blue.v_100,
+                    }
+                    : null
+                "
               >
                 <img
                   :src="option.icon"
@@ -103,6 +126,7 @@
     </KListWithOverflow>
 
     <ToolbarButton
+      class="minimize-button"
       :title="minimizeAction.title"
       :icon="minimizeAction.icon"
       @click="minimizeAction.handler"
@@ -114,8 +138,7 @@
 
 <script>
 
-  import { defineComponent, ref, computed } from 'vue';
-  import KListWithOverflow from 'kolibri-design-system/lib/KListWithOverflow.vue';
+  import { ref, computed } from 'vue';
   import { useToolbarActions } from '../composables/useToolbarActions';
   import { getTipTapEditorStrings } from '../TipTapEditorStrings';
   import { useDropdowns } from '../composables/useDropdowns';
@@ -124,10 +147,9 @@
   import PasteDropdown from './toolbar/PasteDropdown.vue';
   import ToolbarDivider from './toolbar/ToolbarDivider.vue';
 
-  export default defineComponent({
+  export default {
     name: 'EditorToolbar',
     components: {
-      KListWithOverflow,
       ToolbarButton,
       FormatDropdown,
       PasteDropdown,
@@ -165,7 +187,7 @@
         moreButtonText$,
       } = getTipTapEditorStrings();
 
-      const onToolClick = (tool, event, { fromOverflow } = {}) => {
+      const onInsertToolClick = (tool, event, { fromOverflow } = {}) => {
         const target = fromOverflow ? null : event.currentTarget;
         if (tool.name === 'image') {
           emit('insert-image', target);
@@ -180,15 +202,13 @@
 
       // Toolbar groups in visual order (left-to-right).
       // KListWithOverflow will collapse items from the end first.
-      // Note: Don't include dividers here - KListWithOverflow renders
-      // them automatically via #divider slot.
-      //
+      // Note: Don't include dividers here - this will be the source of truth.
+
       // Each group describes its actions via `groupActions`. A `label` makes
       // the wrapper a role="group"; omitting it renders a plain div (for
       // single-action groups that don't need grouping semantics).
       // Actions with a `component` key render that component instead of a
-      // ToolbarButton (e.g. PasteDropdown). Actions with an `onClick` key
-      // receive the click event; otherwise `handler()` is called.
+      // ToolbarButton (e.g. PasteDropdown).
       const toolbarGroups = computed(() => [
         {
           name: 'textFormat',
@@ -254,7 +274,7 @@
           label: insertTools$(),
           groupActions: insertTools.value.map(tool => ({
             ...tool,
-            handler: (e, { fromOverflow } = {}) => onToolClick(tool, e, { fromOverflow }),
+            handler: (e, { fromOverflow } = {}) => onInsertToolClick(tool, e, { fromOverflow }),
           })),
         },
       ]);
@@ -290,6 +310,11 @@
         return options;
       };
 
+      /**
+       * Place a divider element between toolbar groups in the overflow menu.
+       * This is necessary to tell KListWithOverflow where to render dividers
+       * between groups.
+       */
       const toolbarGroupsWithDividers = computed(() => {
         const groups = [];
         toolbarGroups.value.forEach((group, index) => {
@@ -305,6 +330,9 @@
       });
 
       const onOverflowSelect = (option, event) => {
+        // Stop propagation to avoid triggering RTE on outside click handler that
+        // minimizes the editor because KDropdownMenu is attached to an overlay layer,
+        // i.e. not a descendant of the editor.
         event.stopPropagation();
         option.handler(event, { fromOverflow: true });
       };
@@ -322,7 +350,7 @@
         moreButtonText$,
       };
     },
-  });
+  };
 
 </script>
 
@@ -335,19 +363,12 @@
     gap: 6px;
     align-items: center;
     padding: 8px;
-    background: #f8f9fa;
-    border-bottom: 1px solid #e1e5e9;
     border-radius: 8px 8px 0 0;
   }
 
-  .toolbar > :last-child {
+  .minimize-button {
+    /* Push the minimize button to the far right. */
     margin-left: auto;
-  }
-
-  [role='group'] {
-    display: flex;
-    gap: 2px;
-    align-items: center;
   }
 
   .overflow-list {
@@ -383,11 +404,6 @@
     outline: 2px solid #0097f2;
   }
 
-  .more-button[aria-expanded='true'] {
-    color: #4368f5;
-    background: #d9e1fd;
-  }
-
   .more-button-icon {
     width: 16px;
     height: 16px;
@@ -406,11 +422,6 @@
     padding: 8px 12px;
     font-size: 1.2rem;
     line-height: 140%;
-
-    &.active {
-      color: #3730a3;
-      background-color: #e0e7ff;
-    }
   }
 
   .list-with-overflow-divider {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -71,193 +71,32 @@
       </template>
 
       <template #more="{ overflowItems }">
-        <div
-          ref="moreDropdownContainer"
-          class="more-dropdown-container"
-          role="group"
-          :aria-label="'More options'"
-        >
-          <button
-            ref="moreButton"
-            class="more-button"
-            :title="'More options'"
-            :class="{ active: isMoreDropdownOpen }"
-            :aria-expanded="isMoreDropdownOpen"
-            aria-haspopup="menu"
-            aria-controls="more-options-menu"
-            @click="toggleMoreDropdown"
+        <button class="more-button">
+          <span>{{ moreButtonText$() }}</span>
+          <img
+            :src="require('../../assets/icon-chevron-down.svg')"
+            aria-hidden="true"
+            class="more-button-icon"
           >
-            <span>{{ moreButtonText$() }}</span>
-            <img
-              :src="require('../../assets/icon-chevron-down.svg')"
-              aria-hidden="true"
-              class="more-button-icon"
-              :class="{ rotated: isMoreDropdownOpen }"
-            >
-          </button>
-
-          <div
-            v-show="isMoreDropdownOpen"
-            id="more-options-menu"
-            ref="moreDropdown"
-            class="more-dropdown"
-            role="menu"
-            :aria-label="'Additional formatting options'"
-            @click.stop="isMoreDropdownOpen = false"
-            @keydown="handleMenuKeydown"
+          <KDropdownMenu
+            :options="flatOverflowOptions(overflowItems)"
+            @select="onOverflowSelect"
           >
-            <!-- Overflow Text Formatting -->
-            <template v-if="overflowItems.some(i => i.name === 'textFormat')">
-              <button
-                v-for="action in textActions"
-                :key="action.name"
-                class="dropdown-item"
-                :class="{ active: action.isActive }"
-                role="menuitem"
-                @click="action.handler"
-              >
-                <img
-                  :src="action.icon"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ action.title }}</span>
-              </button>
-            </template>
-
-            <!-- Overflow Clipboard -->
-            <template v-if="overflowItems.some(i => i.name === 'clipboard')">
-              <button
-                class="dropdown-item"
-                role="menuitem"
-                @click="handleCopy"
-              >
-                <img
-                  :src="require('../../assets/icon-copy.svg')"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ copy$() }}</span>
-              </button>
-              <button
-                v-for="option in pasteOptions"
-                :key="option.name"
-                class="dropdown-item"
-                role="menuitem"
-                @click="option.handler"
+            <template #option="{ option }">
+              <div
+                class="overflow-item"
+                :class="{ active: option.isActive }"
               >
                 <img
                   :src="option.icon"
                   class="dropdown-item-icon"
-                  alt=""
                   aria-hidden="true"
                 >
-                <span class="dropdown-item-text">{{ option.title }}</span>
-              </button>
+                <span>{{ option.label }}</span>
+              </div>
             </template>
-
-            <!-- Overflow Text Alignment -->
-            <template v-if="overflowItems.some(i => i.name === 'align')">
-              <button
-                class="dropdown-item"
-                :class="{ active: alignAction.isActive }"
-                role="menuitem"
-                :disabled="!alignAction.isAvailable"
-                @click="alignAction.handler"
-              >
-                <img
-                  :src="alignAction.icon"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ alignAction.title }}</span>
-              </button>
-            </template>
-
-            <!-- Overflow Clear Format -->
-            <template v-if="overflowItems.some(i => i.name === 'clearFormat')">
-              <button
-                class="dropdown-item"
-                role="menuitem"
-                :disabled="!canClearFormat"
-                @click="handleClearFormat"
-              >
-                <img
-                  :src="require('../../assets/icon-clearFormat.svg')"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ clearFormatting$() }}</span>
-              </button>
-            </template>
-
-            <!-- Overflow Lists -->
-            <template v-if="overflowItems.some(i => i.name === 'lists')">
-              <button
-                v-for="list in listActions"
-                :key="list.name"
-                class="dropdown-item"
-                role="menuitem"
-                :class="{ active: list.isActive }"
-                :aria-pressed="list.isActive"
-                @click="list.handler"
-              >
-                <img
-                  :src="list.icon"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ list.title }}</span>
-              </button>
-            </template>
-
-            <!-- Overflow Script -->
-            <template v-if="overflowItems.some(i => i.name === 'script')">
-              <button
-                v-for="script in scriptActions"
-                :key="script.name"
-                class="dropdown-item"
-                role="menuitem"
-                :class="{ active: script.isActive }"
-                :aria-pressed="script.isActive"
-                @click="script.handler"
-              >
-                <img
-                  :src="script.icon"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ script.title }}</span>
-              </button>
-            </template>
-
-            <!-- Overflow Insert Tools -->
-            <template v-if="overflowItems.some(i => i.name === 'insert')">
-              <button
-                v-for="tool in insertTools"
-                :key="tool.name"
-                class="dropdown-item"
-                role="menuitem"
-                :class="{ active: tool.isActive }"
-                @click="onToolClick(tool, $event)"
-              >
-                <img
-                  :src="tool.icon"
-                  class="dropdown-item-icon"
-                  alt=""
-                  aria-hidden="true"
-                >
-                <span class="dropdown-item-text">{{ tool.title }}</span>
-              </button>
-            </template>
-          </div>
-        </div>
+          </KDropdownMenu>
+        </button>
       </template>
     </KListWithOverflow>
 
@@ -273,7 +112,7 @@
 
 <script>
 
-  import { defineComponent, ref, computed, onMounted, onUnmounted, nextTick } from 'vue';
+  import { defineComponent, ref, computed } from 'vue';
   import KListWithOverflow from 'kolibri-design-system/lib/KListWithOverflow.vue';
   import { useToolbarActions } from '../composables/useToolbarActions';
   import { getTipTapEditorStrings } from '../TipTapEditorStrings';
@@ -294,10 +133,6 @@
     },
     setup(props, { emit }) {
       const toolbarRef = ref(null);
-      const moreButton = ref(null);
-      const moreDropdown = ref(null);
-      const moreDropdownContainer = ref(null);
-      const isMoreDropdownOpen = ref(false);
 
       const {
         handleCopy,
@@ -305,9 +140,7 @@
         canClearFormat,
         historyActions,
         textActions,
-        alignAction,
         listActions,
-        scriptActions,
         insertTools,
         minimizeAction,
       } = useToolbarActions(emit);
@@ -328,14 +161,8 @@
         moreButtonText$,
       } = getTipTapEditorStrings();
 
-      const onToolClick = (tool, event) => {
-        isMoreDropdownOpen.value = false;
-        let target = event.currentTarget;
-
-        // If the tool is in the overflow menu (clicked from dropdown), center the modal
-        const isFromOverflow = moreDropdown.value?.contains(event.target);
-        if (isFromOverflow) target = null;
-
+      const onToolClick = (tool, event, { fromOverflow } = {}) => {
+        const target = fromOverflow ? null : event.currentTarget;
         if (tool.name === 'image') {
           emit('insert-image', target);
         } else if (tool.name === 'link') {
@@ -343,7 +170,6 @@
         } else if (tool.name === 'math') {
           emit('insert-math', target);
         } else {
-          // For all other buttons, call their original handler
           tool.handler();
         }
       };
@@ -380,6 +206,7 @@
             {
               name: 'pasteDropdown',
               component: PasteDropdown,
+              dropdownActions: pasteOptions.value,
             },
           ],
         },
@@ -421,81 +248,53 @@
           label: insertTools$(),
           groupActions: insertTools.value.map(tool => ({
             ...tool,
-            handler: e => onToolClick(tool, e),
+            handler: (e, { fromOverflow } = {}) => onToolClick(tool, e, { fromOverflow }),
           })),
         },
       ]);
 
-      const toggleMoreDropdown = () => {
-        isMoreDropdownOpen.value = !isMoreDropdownOpen.value;
-      };
+      // Flattens the visible overflow groups into a KDropdownMenu-compatible
+      // options array. Maps `title` → `label` and `isAvailable` → `disabled`.
+      // Actions with `dropdownActions` (e.g. PasteDropdown) are expanded into
+      // their constituent items; other component-only actions are skipped.
+      const flatOverflowOptions = overflowItems => {
+        const options = [];
+        const toOption = a => ({
+          ...a,
+          label: a.title,
+          disabled: a.isAvailable !== undefined ? !a.isAvailable : false,
+        });
 
-      // Handle keyboard navigation in dropdown menu
-      const handleMenuKeydown = async event => {
-        if (event.key === 'Escape') {
-          isMoreDropdownOpen.value = false;
-          // Return focus to the more button
-          await nextTick();
-          moreButton.value?.focus();
-        } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-          event.preventDefault();
-          const menuItems = Array.from(
-            moreDropdown.value?.querySelectorAll('[role="menuitem"]:not(:disabled)') || [],
-          );
-          const currentIndex = menuItems.indexOf(document.activeElement);
-
-          let nextIndex;
-          if (event.key === 'ArrowDown') {
-            nextIndex = currentIndex < menuItems.length - 1 ? currentIndex + 1 : 0;
-          } else {
-            nextIndex = currentIndex > 0 ? currentIndex - 1 : menuItems.length - 1;
+        for (const group of overflowItems) {
+          for (const action of group.groupActions) {
+            if (action.dropdownActions) {
+              for (const dropdownAction of action.dropdownActions) {
+                options.push(toOption(dropdownAction));
+              }
+            } else {
+              options.push(toOption(action));
+            }
           }
-
-          menuItems[nextIndex]?.focus();
         }
+
+        return options;
       };
 
-      // Close dropdown when clicking outside
-      const handleClickOutside = event => {
-        if (moreDropdownContainer.value && !moreDropdownContainer.value.contains(event.target)) {
-          isMoreDropdownOpen.value = false;
-        }
+      const onOverflowSelect = (option, event) => {
+        event.stopPropagation();
+        option.handler(event, { fromOverflow: true });
       };
-
-      onMounted(() => {
-        document.addEventListener('mousedown', handleClickOutside, { passive: true });
-      });
-
-      onUnmounted(() => {
-        document.removeEventListener('mousedown', handleClickOutside);
-      });
 
       return {
         toolbarRef,
-        moreButton,
-        moreDropdown,
-        moreDropdownContainer,
-        isMoreDropdownOpen,
         toolbarGroups,
-        handleCopy,
-        handleClearFormat,
-        onToolClick,
-        toggleMoreDropdown,
-        handleMenuKeydown,
-        canClearFormat,
+        flatOverflowOptions,
         historyActions,
-        textActions,
-        alignAction,
-        listActions,
-        scriptActions,
-        insertTools,
         minimizeAction,
-        pasteOptions,
-        copy$,
+        onOverflowSelect,
         textFormattingToolbar$,
         historyActions$,
         textFormattingOptions$,
-        clearFormatting$,
         moreButtonText$,
       };
     },
@@ -504,7 +303,7 @@
 </script>
 
 
-<style scoped>
+<style lang="scss" scoped>
 
   .toolbar {
     position: relative;
@@ -532,79 +331,16 @@
     min-width: 0;
   }
 
-  /* Temporary workaround: clip the brief wrap-flicker in KListWithOverflow
-     during resize recalculation. Remove this block (and stop reaching into
-     KDS internals via ::v-deep) once learningequality/kolibri-design-system#1246
-     is released and the KDS version pinned in package.json is bumped. */
-  .overflow-list ::v-deep .list {
-    overflow: hidden;
-  }
-
   .toolbar-group {
     display: flex;
     gap: 2px;
     align-items: center;
   }
 
-  .more-dropdown-container {
-    position: relative;
-  }
-
-  .more-dropdown {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    z-index: 1000;
-    min-width: 220px;
-    max-height: 400px;
-    padding: 4px 0;
-    margin-top: 4px;
-    overflow-y: auto;
-    background: white;
-    border: 1px solid #e1e5e9;
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  }
-
-  .dropdown-item {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    padding: 8px 12px;
-    font-size: 1.2rem;
-    color: #374151;
-    text-align: left;
-    cursor: pointer;
-    background: none;
-    border: 0;
-    transition: background-color 0.15s ease;
-  }
-
-  .dropdown-item:hover,
-  .dropdown-item:focus {
-    background-color: #f3f4f6;
-    outline: none;
-  }
-
-  .dropdown-item.active {
-    color: #3730a3;
-    background-color: #e0e7ff;
-  }
-
   .dropdown-item-icon {
     flex-shrink: 0;
     width: 20px;
     height: 20px;
-    margin-right: 12px;
-  }
-
-  .dropdown-item:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-  }
-
-  .dropdown-item:disabled:hover {
-    background-color: transparent;
   }
 
   .more-button {
@@ -623,7 +359,7 @@
     outline: 2px solid #0097f2;
   }
 
-  .more-button.active {
+  .more-button[aria-expanded='true'] {
     color: #4368f5;
     background: #d9e1fd;
   }
@@ -635,15 +371,21 @@
     transition: transform 0.15s ease;
   }
 
-  .more-button-icon.rotated {
+  .more-button[aria-expanded='true'] .more-button-icon {
     transform: rotate(180deg);
   }
 
-  /* Ensure dropdown stays on screen */
-  @media (max-width: 300px) {
-    .more-dropdown {
-      right: auto;
-      left: 0;
+  .overflow-item {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 12px;
+    font-size: 1.2rem;
+    line-height: 140%;
+
+    &.active {
+      color: #3730a3;
+      background-color: #e0e7ff;
     }
   }
 

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -40,117 +40,29 @@
       class="overflow-list"
     >
       <template #item="{ item }">
-        <!-- Text formatting -->
         <div
-          v-if="item.name === 'textFormat'"
-          role="group"
-          :aria-label="item.ariaLabel"
+          :role="item.role"
+          :aria-label="item.label"
           class="toolbar-group"
         >
-          <ToolbarButton
-            v-for="action in textActions"
-            :key="action.name"
-            :title="action.title"
-            :icon="action.icon"
-            :is-active="action.isActive"
-            @click="action.handler"
-          />
-        </div>
-
-        <!-- Copy/Paste -->
-        <div
-          v-else-if="item.name === 'clipboard'"
-          role="group"
-          :aria-label="item.ariaLabel"
-          class="toolbar-group"
-        >
-          <ToolbarButton
-            :title="copy$()"
-            :icon="require('../../assets/icon-copy.svg')"
-            @click="handleCopy"
-          />
-          <PasteDropdown />
-        </div>
-
-        <!-- Text Alignment -->
-        <div
-          v-else-if="item.name === 'align'"
-          class="toolbar-group"
-        >
-          <ToolbarButton
-            :title="alignAction.title"
-            :icon="alignAction.icon"
-            :is-active="alignAction.isActive"
-            :is-available="alignAction.isAvailable"
-            @click="alignAction.handler"
-          />
-        </div>
-
-        <!-- Clear Format -->
-        <div
-          v-else-if="item.name === 'clearFormat'"
-          class="toolbar-group"
-        >
-          <ToolbarButton
-            :title="clearFormatting$()"
-            :icon="require('../../assets/icon-clearFormat.svg')"
-            :is-available="canClearFormat"
-            @click="handleClearFormat"
-          />
-        </div>
-
-        <!-- Lists -->
-        <div
-          v-else-if="item.name === 'lists'"
-          role="group"
-          :aria-label="item.ariaLabel"
-          class="toolbar-group"
-        >
-          <ToolbarButton
-            v-for="list in listActions"
-            :key="list.name"
-            :title="list.title"
-            :icon="list.icon"
-            :rtl-icon="list.rtlIcon"
-            :should-flip-in-rtl="list.name === 'bulletList'"
-            :is-active="list.isActive"
-            @click="list.handler"
-          />
-        </div>
-
-        <!-- Script formatting -->
-        <div
-          v-else-if="item.name === 'script'"
-          role="group"
-          :aria-label="item.ariaLabel"
-          class="toolbar-group"
-        >
-          <ToolbarButton
-            v-for="script in scriptActions"
-            :key="script.name"
-            :title="script.title"
-            :icon="script.icon"
-            :rtl-icon="script.rtlIcon"
-            :is-active="script.isActive"
-            @click="script.handler"
-          />
-        </div>
-
-        <!-- Insert tools -->
-        <div
-          v-else-if="item.name === 'insert'"
-          role="group"
-          :aria-label="item.ariaLabel"
-          class="toolbar-group"
-        >
-          <ToolbarButton
-            v-for="tool in insertTools"
-            :key="tool.name"
-            :title="tool.title"
-            :icon="tool.icon"
-            :is-active="tool.isActive"
-            @click="onToolClick(tool, $event)"
-          />
+          <template v-for="action in item.groupActions">
+            <component
+              :is="action.component"
+              v-if="action.component"
+              :key="`component-${action.name}`"
+            />
+            <ToolbarButton
+              v-else
+              :key="`button-${action.name}`"
+              :title="action.title"
+              :icon="action.icon"
+              :is-active="action.isActive"
+              :isAvailable="action.isAvailable"
+              :rtlIcon="action.rtlIcon"
+              :shouldFlipInRtl="action.shouldFlipInRtl"
+              @click="action.handler"
+            />
+          </template>
         </div>
       </template>
 
@@ -410,29 +322,11 @@
         textStyleFormatting$,
         copyAndPasteActions$,
         listFormatting$,
-        scriptFormatting$,
+        // scriptFormatting$,
         insertTools$,
         clearFormatting$,
         moreButtonText$,
       } = getTipTapEditorStrings();
-
-      // Toolbar groups in visual order (left-to-right).
-      // KListWithOverflow will collapse items from the end first.
-      // Note: Don't include dividers here - KListWithOverflow renders
-      // them automatically via #divider slot.
-      const toolbarGroups = computed(() => [
-        { name: 'textFormat', ariaLabel: textStyleFormatting$() },
-        { name: 'clipboard', ariaLabel: copyAndPasteActions$() },
-        // Perseus flavoured markdown does not support alignment,
-        // so we disable this for now until we stop using markdown as the primary target
-        // { name: 'align' },
-        { name: 'clearFormat' },
-        { name: 'lists', ariaLabel: listFormatting$() },
-        // Perseus flavoured markdown does not support super and sub script,
-        // so we disable this for now until we stop using markdown as the primary target
-        { name: 'script', ariaLabel: scriptFormatting$() },
-        { name: 'insert', ariaLabel: insertTools$() },
-      ]);
 
       const onToolClick = (tool, event) => {
         isMoreDropdownOpen.value = false;
@@ -453,6 +347,84 @@
           tool.handler();
         }
       };
+
+      // Toolbar groups in visual order (left-to-right).
+      // KListWithOverflow will collapse items from the end first.
+      // Note: Don't include dividers here - KListWithOverflow renders
+      // them automatically via #divider slot.
+      //
+      // Each group describes its actions via `groupActions`. A `label` makes
+      // the wrapper a role="group"; omitting it renders a plain div (for
+      // single-action groups that don't need grouping semantics).
+      // Actions with a `component` key render that component instead of a
+      // ToolbarButton (e.g. PasteDropdown). Actions with an `onClick` key
+      // receive the click event; otherwise `handler()` is called.
+      const toolbarGroups = computed(() => [
+        {
+          name: 'textFormat',
+          role: 'group',
+          label: textStyleFormatting$(),
+          groupActions: textActions.value,
+        },
+        {
+          name: 'clipboard',
+          role: 'group',
+          label: copyAndPasteActions$(),
+          groupActions: [
+            {
+              name: 'copy',
+              title: copy$(),
+              icon: require('../../assets/icon-copy.svg'),
+              handler: handleCopy,
+            },
+            {
+              name: 'pasteDropdown',
+              component: PasteDropdown,
+            },
+          ],
+        },
+        // Perseus flavoured markdown does not support alignment,
+        // so we disable this for now until we stop using markdown as the primary target
+        // {
+        //   name: 'align',
+        //   groupActions: [alignAction.value]
+        // },
+        {
+          name: 'clearFormat',
+          groupActions: [
+            {
+              name: 'clearFormat',
+              title: clearFormatting$(),
+              icon: require('../../assets/icon-clearFormat.svg'),
+              isAvailable: canClearFormat.value,
+              handler: handleClearFormat,
+            },
+          ],
+        },
+        {
+          name: 'lists',
+          role: 'group',
+          label: listFormatting$(),
+          groupActions: listActions.value,
+        },
+        // Perseus flavoured markdown does not support super and sub script,
+        // so we disable this for now until we stop using markdown as the primary target
+        // {
+        //   name: 'script',
+        //   role: 'group',
+        //   label: scriptFormatting$(),
+        //   groupActions: scriptActions.value
+        // },
+        {
+          name: 'insert',
+          role: 'group',
+          label: insertTools$(),
+          groupActions: insertTools.value.map(tool => ({
+            ...tool,
+            handler: e => onToolClick(tool, e),
+          })),
+        },
+      ]);
 
       const toggleMoreDropdown = () => {
         isMoreDropdownOpen.value = !isMoreDropdownOpen.value;

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -141,10 +141,12 @@
         handleClearFormat,
         canClearFormat,
         historyActions,
+        alignAction,
         textActions,
         listActions,
         insertTools,
         minimizeAction,
+        scriptActions,
       } = useToolbarActions(emit);
 
       const { pasteOptions } = useDropdowns();
@@ -157,7 +159,7 @@
         textStyleFormatting$,
         copyAndPasteActions$,
         listFormatting$,
-        // scriptFormatting$,
+        scriptFormatting$,
         insertTools$,
         clearFormatting$,
         moreButtonText$,
@@ -212,12 +214,13 @@
             },
           ],
         },
-        // Perseus flavoured markdown does not support alignment,
-        // so we disable this for now until we stop using markdown as the primary target
-        // {
-        //   name: 'align',
-        //   groupActions: [alignAction.value]
-        // },
+        {
+          name: 'align',
+          groupActions: [alignAction.value],
+          // Perseus flavoured markdown does not support alignment,
+          // so we disable this for now until we stop using markdown as the primary target
+          hide: true,
+        },
         {
           name: 'clearFormat',
           groupActions: [
@@ -236,14 +239,15 @@
           label: listFormatting$(),
           groupActions: listActions.value,
         },
-        // Perseus flavoured markdown does not support super and sub script,
-        // so we disable this for now until we stop using markdown as the primary target
-        // {
-        //   name: 'script',
-        //   role: 'group',
-        //   label: scriptFormatting$(),
-        //   groupActions: scriptActions.value
-        // },
+        {
+          name: 'script',
+          role: 'group',
+          label: scriptFormatting$(),
+          groupActions: scriptActions.value,
+          // Perseus flavoured markdown does not support super and sub script,
+          // so we disable this for now until we stop using markdown as the primary target
+          hide: true,
+        },
         {
           name: 'insert',
           role: 'group',
@@ -289,6 +293,9 @@
       const toolbarGroupsWithDividers = computed(() => {
         const groups = [];
         toolbarGroups.value.forEach((group, index) => {
+          if (group.hide) {
+            return;
+          }
           groups.push(group);
           if (index < toolbarGroups.value.length - 1) {
             groups.push({ type: 'divider' });

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -34,307 +34,321 @@
 
     <ToolbarDivider />
 
-    <!-- Text formatting -->
-    <div
-      v-if="visibleCategories.includes('textFormat')"
-      role="group"
-      :aria-label="textStyleFormatting$()"
+    <!-- Collapsible toolbar groups -->
+    <KListWithOverflow
+      :items="toolbarGroups"
+      class="overflow-list"
     >
-      <ToolbarButton
-        v-for="action in textActions"
-        :key="action.name"
-        :title="action.title"
-        :icon="action.icon"
-        :is-active="action.isActive"
-        @click="action.handler"
-      />
-    </div>
-
-    <ToolbarDivider v-if="visibleCategories.includes('textFormat')" />
-
-    <!-- Copy/Paste -->
-    <div
-      v-if="visibleCategories.includes('clipboard')"
-      role="group"
-      :aria-label="copyAndPasteActions$()"
-    >
-      <ToolbarButton
-        :title="copy$()"
-        :icon="require('../../assets/icon-copy.svg')"
-        @click="handleCopy"
-      />
-      <PasteDropdown />
-    </div>
-
-    <ToolbarDivider v-if="visibleCategories.includes('clipboard')" />
-
-    <!-- Text Alignment -->
-    <ToolbarButton
-      v-if="visibleCategories.includes('align')"
-      :title="alignAction.title"
-      :icon="alignAction.icon"
-      :is-active="alignAction.isActive"
-      :is-available="alignAction.isAvailable"
-      @click="alignAction.handler"
-    />
-
-    <ToolbarDivider v-if="visibleCategories.includes('align')" />
-
-    <!-- Clear Formatting -->
-
-    <ToolbarButton
-      v-if="visibleCategories.includes('clearFormat')"
-      :title="clearFormatting$()"
-      :icon="require('../../assets/icon-clearFormat.svg')"
-      :is-available="canClearFormat"
-      @click="handleClearFormat"
-    />
-
-    <ToolbarDivider v-if="visibleCategories.includes('clearFormat')" />
-
-    <!-- Lists -->
-    <div
-      v-if="visibleCategories.includes('lists')"
-      role="group"
-      :aria-label="listFormatting$()"
-    >
-      <ToolbarButton
-        v-for="list in listActions"
-        :key="list.name"
-        :title="list.title"
-        :icon="list.icon"
-        :rtl-icon="list.rtlIcon"
-        :should-flip-in-rtl="list.name === 'bulletList'"
-        :is-active="list.isActive"
-        @click="list.handler"
-      />
-    </div>
-
-    <ToolbarDivider v-if="visibleCategories.includes('lists')" />
-
-    <!-- Script formatting -->
-    <div
-      v-if="visibleCategories.includes('script')"
-      role="group"
-      :aria-label="scriptFormatting$()"
-    >
-      <ToolbarButton
-        v-for="script in scriptActions"
-        :key="script.name"
-        :title="script.title"
-        :icon="script.icon"
-        :rtl-icon="script.rtlIcon"
-        :is-active="script.isActive"
-        @click="script.handler"
-      />
-    </div>
-
-    <ToolbarDivider v-if="visibleCategories.includes('script')" />
-
-    <!-- Insert tools -->
-    <div
-      v-if="visibleCategories.includes('insert')"
-      role="group"
-      :aria-label="insertTools$()"
-    >
-      <ToolbarButton
-        v-for="tool in insertTools"
-        :key="tool.name"
-        :title="tool.title"
-        :icon="tool.icon"
-        :is-active="tool.isActive"
-        @click="onToolClick(tool, $event)"
-      />
-    </div>
-
-    <!-- More dropdown - only visible when there are overflow categories -->
-    <div
-      v-if="overflowCategories.length > 0"
-      ref="moreDropdownContainer"
-      class="more-dropdown-container"
-      role="group"
-      :aria-label="'More options'"
-    >
-      <button
-        ref="moreButton"
-        class="more-button"
-        :title="'More options'"
-        :class="{ active: isMoreDropdownOpen }"
-        :aria-expanded="isMoreDropdownOpen"
-        aria-haspopup="menu"
-        aria-controls="more-options-menu"
-        @click="toggleMoreDropdown"
-      >
-        <span>{{ moreButtonText$() }}</span>
-        <img
-          :src="require('../../assets/icon-chevron-down.svg')"
-          aria-hidden="true"
-          class="more-button-icon"
-          :class="{ rotated: isMoreDropdownOpen }"
+      <template #item="{ item }">
+        <!-- Text formatting -->
+        <div
+          v-if="item.name === 'textFormat'"
+          role="group"
+          :aria-label="item.ariaLabel"
+          class="toolbar-group"
         >
-      </button>
-
-      <div
-        v-show="isMoreDropdownOpen"
-        id="more-options-menu"
-        ref="moreDropdown"
-        class="more-dropdown"
-        role="menu"
-        :aria-label="'Additional formatting options'"
-        @click.stop="isMoreDropdownOpen = false"
-        @keydown="handleMenuKeydown"
-      >
-        <!-- Overflow Text Formatting -->
-        <template v-if="overflowCategories.includes('textFormat')">
-          <button
+          <ToolbarButton
             v-for="action in textActions"
             :key="action.name"
-            class="dropdown-item"
-            :class="{ active: action.isActive }"
-            role="menuitem"
+            :title="action.title"
+            :icon="action.icon"
+            :is-active="action.isActive"
             @click="action.handler"
-          >
-            <img
-              :src="action.icon"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ action.title }}</span>
-          </button>
-        </template>
-        <!-- Overflow Clipboard -->
-        <template v-if="overflowCategories.includes('clipboard')">
-          <button
-            class="dropdown-item"
-            role="menuitem"
+          />
+        </div>
+
+        <!-- Copy/Paste -->
+        <div
+          v-else-if="item.name === 'clipboard'"
+          role="group"
+          :aria-label="item.ariaLabel"
+          class="toolbar-group"
+        >
+          <ToolbarButton
+            :title="copy$()"
+            :icon="require('../../assets/icon-copy.svg')"
             @click="handleCopy"
-          >
-            <img
-              :src="require('../../assets/icon-copy.svg')"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ copy$() }}</span>
-          </button>
-          <button
-            v-for="option in pasteOptions"
-            :key="option.name"
-            class="dropdown-item"
-            role="menuitem"
-            @click="option.handler"
-          >
-            <img
-              :src="option.icon"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ option.title }}</span>
-          </button>
-        </template>
+          />
+          <PasteDropdown />
+        </div>
 
-        <!-- Overflow Text Alignment -->
-        <template v-if="overflowCategories.includes('align')">
-          <button
-            class="dropdown-item"
-            :class="{ active: alignAction.isActive }"
-            role="menuitem"
-            :disabled="!alignAction.isAvailable"
+        <!-- Text Alignment -->
+        <div
+          v-else-if="item.name === 'align'"
+          class="toolbar-group"
+        >
+          <ToolbarButton
+            :title="alignAction.title"
+            :icon="alignAction.icon"
+            :is-active="alignAction.isActive"
+            :is-available="alignAction.isAvailable"
             @click="alignAction.handler"
-          >
-            <img
-              :src="alignAction.icon"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ alignAction.title }}</span>
-          </button>
-        </template>
+          />
+        </div>
 
-        <!-- Overflow Clear Format -->
-        <template v-if="overflowCategories.includes('clearFormat')">
-          <button
-            class="dropdown-item"
-            role="menuitem"
-            :disabled="!canClearFormat"
+        <!-- Clear Format -->
+        <div
+          v-else-if="item.name === 'clearFormat'"
+          class="toolbar-group"
+        >
+          <ToolbarButton
+            :title="clearFormatting$()"
+            :icon="require('../../assets/icon-clearFormat.svg')"
+            :is-available="canClearFormat"
             @click="handleClearFormat"
-          >
-            <img
-              :src="require('../../assets/icon-clearFormat.svg')"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ clearFormatting$() }}</span>
-          </button>
-        </template>
+          />
+        </div>
 
-        <!-- Overflow Lists -->
-        <template v-if="overflowCategories.includes('lists')">
-          <button
+        <!-- Lists -->
+        <div
+          v-else-if="item.name === 'lists'"
+          role="group"
+          :aria-label="item.ariaLabel"
+          class="toolbar-group"
+        >
+          <ToolbarButton
             v-for="list in listActions"
             :key="list.name"
-            class="dropdown-item"
-            role="menuitem"
-            :class="{ active: list.isActive }"
-            :aria-pressed="list.isActive"
+            :title="list.title"
+            :icon="list.icon"
+            :rtl-icon="list.rtlIcon"
+            :should-flip-in-rtl="list.name === 'bulletList'"
+            :is-active="list.isActive"
             @click="list.handler"
-          >
-            <img
-              :src="list.icon"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ list.title }}</span>
-          </button>
-        </template>
+          />
+        </div>
 
-        <!-- Overflow Script -->
-        <template v-if="overflowCategories.includes('script')">
-          <button
+        <!-- Script formatting -->
+        <div
+          v-else-if="item.name === 'script'"
+          role="group"
+          :aria-label="item.ariaLabel"
+          class="toolbar-group"
+        >
+          <ToolbarButton
             v-for="script in scriptActions"
             :key="script.name"
-            class="dropdown-item"
-            role="menuitem"
-            :class="{ active: script.isActive }"
-            :aria-pressed="script.isActive"
+            :title="script.title"
+            :icon="script.icon"
+            :rtl-icon="script.rtlIcon"
+            :is-active="script.isActive"
             @click="script.handler"
-          >
-            <img
-              :src="script.icon"
-              class="dropdown-item-icon"
-              alt=""
-              aria-hidden="true"
-            >
-            <span class="dropdown-item-text">{{ script.title }}</span>
-          </button>
-        </template>
+          />
+        </div>
 
-        <!-- Overflow Insert Tools -->
-        <template v-if="overflowCategories.includes('insert')">
-          <button
+        <!-- Insert tools -->
+        <div
+          v-else-if="item.name === 'insert'"
+          role="group"
+          :aria-label="item.ariaLabel"
+          class="toolbar-group"
+        >
+          <ToolbarButton
             v-for="tool in insertTools"
             :key="tool.name"
-            class="dropdown-item"
-            role="menuitem"
-            :class="{ active: tool.isActive }"
+            :title="tool.title"
+            :icon="tool.icon"
+            :is-active="tool.isActive"
             @click="onToolClick(tool, $event)"
+          />
+        </div>
+      </template>
+
+      <template #divider>
+        <ToolbarDivider />
+      </template>
+
+      <template #more="{ overflowItems }">
+        <div
+          ref="moreDropdownContainer"
+          class="more-dropdown-container"
+          role="group"
+          :aria-label="'More options'"
+        >
+          <button
+            ref="moreButton"
+            class="more-button"
+            :title="'More options'"
+            :class="{ active: isMoreDropdownOpen }"
+            :aria-expanded="isMoreDropdownOpen"
+            aria-haspopup="menu"
+            aria-controls="more-options-menu"
+            @click="toggleMoreDropdown"
           >
+            <span>{{ moreButtonText$() }}</span>
             <img
-              :src="tool.icon"
-              class="dropdown-item-icon"
-              alt=""
+              :src="require('../../assets/icon-chevron-down.svg')"
               aria-hidden="true"
+              class="more-button-icon"
+              :class="{ rotated: isMoreDropdownOpen }"
             >
-            <span class="dropdown-item-text">{{ tool.title }}</span>
           </button>
-        </template>
-      </div>
-    </div>
+
+          <div
+            v-show="isMoreDropdownOpen"
+            id="more-options-menu"
+            ref="moreDropdown"
+            class="more-dropdown"
+            role="menu"
+            :aria-label="'Additional formatting options'"
+            @click.stop="isMoreDropdownOpen = false"
+            @keydown="handleMenuKeydown"
+          >
+            <!-- Overflow Text Formatting -->
+            <template v-if="overflowItems.some(i => i.name === 'textFormat')">
+              <button
+                v-for="action in textActions"
+                :key="action.name"
+                class="dropdown-item"
+                :class="{ active: action.isActive }"
+                role="menuitem"
+                @click="action.handler"
+              >
+                <img
+                  :src="action.icon"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ action.title }}</span>
+              </button>
+            </template>
+
+            <!-- Overflow Clipboard -->
+            <template v-if="overflowItems.some(i => i.name === 'clipboard')">
+              <button
+                class="dropdown-item"
+                role="menuitem"
+                @click="handleCopy"
+              >
+                <img
+                  :src="require('../../assets/icon-copy.svg')"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ copy$() }}</span>
+              </button>
+              <button
+                v-for="option in pasteOptions"
+                :key="option.name"
+                class="dropdown-item"
+                role="menuitem"
+                @click="option.handler"
+              >
+                <img
+                  :src="option.icon"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ option.title }}</span>
+              </button>
+            </template>
+
+            <!-- Overflow Text Alignment -->
+            <template v-if="overflowItems.some(i => i.name === 'align')">
+              <button
+                class="dropdown-item"
+                :class="{ active: alignAction.isActive }"
+                role="menuitem"
+                :disabled="!alignAction.isAvailable"
+                @click="alignAction.handler"
+              >
+                <img
+                  :src="alignAction.icon"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ alignAction.title }}</span>
+              </button>
+            </template>
+
+            <!-- Overflow Clear Format -->
+            <template v-if="overflowItems.some(i => i.name === 'clearFormat')">
+              <button
+                class="dropdown-item"
+                role="menuitem"
+                :disabled="!canClearFormat"
+                @click="handleClearFormat"
+              >
+                <img
+                  :src="require('../../assets/icon-clearFormat.svg')"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ clearFormatting$() }}</span>
+              </button>
+            </template>
+
+            <!-- Overflow Lists -->
+            <template v-if="overflowItems.some(i => i.name === 'lists')">
+              <button
+                v-for="list in listActions"
+                :key="list.name"
+                class="dropdown-item"
+                role="menuitem"
+                :class="{ active: list.isActive }"
+                :aria-pressed="list.isActive"
+                @click="list.handler"
+              >
+                <img
+                  :src="list.icon"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ list.title }}</span>
+              </button>
+            </template>
+
+            <!-- Overflow Script -->
+            <template v-if="overflowItems.some(i => i.name === 'script')">
+              <button
+                v-for="script in scriptActions"
+                :key="script.name"
+                class="dropdown-item"
+                role="menuitem"
+                :class="{ active: script.isActive }"
+                :aria-pressed="script.isActive"
+                @click="script.handler"
+              >
+                <img
+                  :src="script.icon"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ script.title }}</span>
+              </button>
+            </template>
+
+            <!-- Overflow Insert Tools -->
+            <template v-if="overflowItems.some(i => i.name === 'insert')">
+              <button
+                v-for="tool in insertTools"
+                :key="tool.name"
+                class="dropdown-item"
+                role="menuitem"
+                :class="{ active: tool.isActive }"
+                @click="onToolClick(tool, $event)"
+              >
+                <img
+                  :src="tool.icon"
+                  class="dropdown-item-icon"
+                  alt=""
+                  aria-hidden="true"
+                >
+                <span class="dropdown-item-text">{{ tool.title }}</span>
+              </button>
+            </template>
+          </div>
+        </div>
+      </template>
+    </KListWithOverflow>
+
     <ToolbarButton
       :title="minimizeAction.title"
       :icon="minimizeAction.icon"
@@ -348,6 +362,7 @@
 <script>
 
   import { defineComponent, ref, computed, onMounted, onUnmounted, nextTick } from 'vue';
+  import KListWithOverflow from 'kolibri-design-system/lib/KListWithOverflow.vue';
   import { useToolbarActions } from '../composables/useToolbarActions';
   import { getTipTapEditorStrings } from '../TipTapEditorStrings';
   import { useDropdowns } from '../composables/useDropdowns';
@@ -359,6 +374,7 @@
   export default defineComponent({
     name: 'EditorToolbar',
     components: {
+      KListWithOverflow,
       ToolbarButton,
       FormatDropdown,
       PasteDropdown,
@@ -370,33 +386,6 @@
       const moreDropdown = ref(null);
       const moreDropdownContainer = ref(null);
       const isMoreDropdownOpen = ref(false);
-      const toolbarWidth = ref(0);
-
-      // TODO: Maybe these shouldnt be hardcoded?
-      const OVERFLOW_BREAKPOINTS = {
-        insert: 760,
-        script: 710,
-        lists: 650,
-        clearFormat: 560,
-        align: 530,
-        clipboard: 500,
-        textFormat: 400,
-      };
-
-      // Categories that can overflow (in order of overflow priority)
-      const OVERFLOW_CATEGORIES = [
-        'insert',
-        // Perseus flavoured markdown does not support super and sub script,
-        // so we disable this for now until we stop using markdown as the primary target
-        // 'script',
-        'lists',
-        'clearFormat',
-        // Perseus flavoured markdown does not support alignment,
-        // so we disable this for now until we stop using markdown as the primary target
-        // 'align',
-        'clipboard',
-        'textFormat',
-      ];
 
       const {
         handleCopy,
@@ -427,48 +416,31 @@
         moreButtonText$,
       } = getTipTapEditorStrings();
 
-      // Compute which categories should be visible vs in overflow
-      const visibleCategories = computed(() => {
-        return OVERFLOW_CATEGORIES.filter(
-          category => toolbarWidth.value >= OVERFLOW_BREAKPOINTS[category],
-        );
-      });
-
-      const overflowCategories = computed(() => {
-        return OVERFLOW_CATEGORIES.filter(category => !visibleCategories.value.includes(category));
-      });
-
-      // Handle resize observer
-      let resizeObserver = null;
-
-      const updateToolbarWidth = () => {
-        if (toolbarRef.value) {
-          // Batch layout reads in next frame
-          requestAnimationFrame(() => {
-            toolbarWidth.value = toolbarRef.value.offsetWidth;
-          });
-        }
-      };
-
-      const handleResize = entries => {
-        // Use ResizeObserver data directly - no DOM reading
-        requestAnimationFrame(() => {
-          for (const entry of entries) {
-            toolbarWidth.value = entry.contentRect.width;
-          }
-        });
-      };
-
-      const handleWindowResize = () => {
-        requestAnimationFrame(updateToolbarWidth);
-      };
+      // Toolbar groups in visual order (left-to-right).
+      // KListWithOverflow will collapse items from the end first.
+      // Note: Don't include dividers here - KListWithOverflow renders
+      // them automatically via #divider slot.
+      const toolbarGroups = computed(() => [
+        { name: 'textFormat', ariaLabel: textStyleFormatting$() },
+        { name: 'clipboard', ariaLabel: copyAndPasteActions$() },
+        // Perseus flavoured markdown does not support alignment,
+        // so we disable this for now until we stop using markdown as the primary target
+        // { name: 'align' },
+        { name: 'clearFormat' },
+        { name: 'lists', ariaLabel: listFormatting$() },
+        // Perseus flavoured markdown does not support super and sub script,
+        // so we disable this for now until we stop using markdown as the primary target
+        { name: 'script', ariaLabel: scriptFormatting$() },
+        { name: 'insert', ariaLabel: insertTools$() },
+      ]);
 
       const onToolClick = (tool, event) => {
         isMoreDropdownOpen.value = false;
         let target = event.currentTarget;
 
-        // If the tool is in the overflow menu, we center the modal
-        if (!visibleCategories.value.includes('insert')) target = null;
+        // If the tool is in the overflow menu (clicked from dropdown), center the modal
+        const isFromOverflow = moreDropdown.value?.contains(event.target);
+        if (isFromOverflow) target = null;
 
         if (tool.name === 'image') {
           emit('insert-image', target);
@@ -492,7 +464,7 @@
           isMoreDropdownOpen.value = false;
           // Return focus to the more button
           await nextTick();
-          moreButton.value?.$el?.focus();
+          moreButton.value?.focus();
         } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
           event.preventDefault();
           const menuItems = Array.from(
@@ -518,32 +490,11 @@
         }
       };
 
-      onMounted(async () => {
-        await nextTick();
-
-        // Initial width measurement in next frame
-        requestAnimationFrame(() => {
-          updateToolbarWidth();
-        });
-
-        // Set up resize observer
-        if (toolbarRef.value && window.ResizeObserver) {
-          resizeObserver = new ResizeObserver(handleResize);
-          resizeObserver.observe(toolbarRef.value);
-        } else {
-          // Fallback to window resize listener with passive flag
-          window.addEventListener('resize', handleWindowResize, { passive: true });
-        }
-
+      onMounted(() => {
         document.addEventListener('mousedown', handleClickOutside, { passive: true });
       });
 
       onUnmounted(() => {
-        if (resizeObserver) {
-          resizeObserver.disconnect();
-        } else {
-          window.removeEventListener('resize', handleWindowResize);
-        }
         document.removeEventListener('mousedown', handleClickOutside);
       });
 
@@ -553,8 +504,7 @@
         moreDropdown,
         moreDropdownContainer,
         isMoreDropdownOpen,
-        visibleCategories,
-        overflowCategories,
+        toolbarGroups,
         handleCopy,
         handleClearFormat,
         onToolClick,
@@ -573,11 +523,6 @@
         textFormattingToolbar$,
         historyActions$,
         textFormattingOptions$,
-        textStyleFormatting$,
-        copyAndPasteActions$,
-        listFormatting$,
-        scriptFormatting$,
-        insertTools$,
         clearFormatting$,
         moreButtonText$,
       };
@@ -605,6 +550,25 @@
   }
 
   [role='group'] {
+    display: flex;
+    gap: 2px;
+    align-items: center;
+  }
+
+  .overflow-list {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Temporary workaround: clip the brief wrap-flicker in KListWithOverflow
+     during resize recalculation. Remove this block (and stop reaching into
+     KDS internals via ::v-deep) once learningequality/kolibri-design-system#1246
+     is released and the KDS version pinned in package.json is bumped. */
+  .overflow-list ::v-deep .list {
+    overflow: hidden;
+  }
+
+  .toolbar-group {
     display: flex;
     gap: 2px;
     align-items: center;

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/FormatDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/FormatDropdown.vue
@@ -258,13 +258,6 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   }
 
-  @media screen and (max-width: 600px) {
-    .format-dropdown {
-      width: 80px;
-      min-width: 0;
-    }
-  }
-
   .dropdown-item {
     display: flex;
     gap: 8px;
@@ -277,7 +270,6 @@
       'Segoe UI',
       sans-serif;
     font-size: 14px;
-    line-height: 140%;
     color: #000000;
     cursor: pointer;
   }

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useToolbarActions.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useToolbarActions.js
@@ -383,6 +383,7 @@ export function useToolbarActions(emit) {
       icon: require('../../assets/icon-bulletList.svg'),
       handler: handleBulletList,
       isActive: isMarkActive('bulletList'),
+      shouldFlipInRtl: true,
     },
     {
       name: 'numberList',

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jspdf": "https://github.com/parallax/jsPDF.git#b7a1d8239c596292ce86dafa77f05987bcfa2e6e",
     "jszip": "^3.10.1",
     "kolibri-constants": "^0.2.12",
-    "kolibri-design-system": "5.7.0",
+    "kolibri-design-system": "5.8.0",
     "lodash": "^4.18.1",
     "lowlight": "^3.3.0",
     "marked": "^16.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       kolibri-design-system:
-        specifier: 5.7.0
-        version: 5.7.0
+        specifier: 5.8.0
+        version: 5.8.0
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -5124,8 +5124,8 @@ packages:
   kolibri-constants@0.2.12:
     resolution: {integrity: sha512-ApVc/KLwEaDJohqKhQTdao4UdWmoyq2pQ5lk8ra+1rDpJvsFWsAOGVC4RTv4YEDlAYJzj2/QZlJQ91u5yUURSQ==}
 
-  kolibri-design-system@5.7.0:
-    resolution: {integrity: sha512-+ol8VBIfTbSbLGmSvtGehZUhEFejWJDAzGNujRL62DHs9NhDjpmjBGehvk/y7BV13FwxFR4tOFhW9RxnYx7eBg==}
+  kolibri-design-system@5.8.0:
+    resolution: {integrity: sha512-BbVYDTwSuX9V1NOMDGxWLmuR7k5tR/HOagTAzdZ+JhWXZxQuOPoqznmsy9dtqpkThDlqfuiX/BOIrUMwvvAAkg==}
 
   kolibri-format@1.0.1:
     resolution: {integrity: sha512-yGQpsJkBAzmRueAq6MG1UOuDl9pbhEtMWNxq9ObG5pPVkG8uhWJAS1L71GCuNAeaV1XG2IWo2565Ov4yXnudeA==}
@@ -13825,7 +13825,7 @@ snapshots:
 
   kolibri-constants@0.2.12: {}
 
-  kolibri-design-system@5.7.0:
+  kolibri-design-system@5.8.0:
     dependencies:
       aphrodite: https://codeload.github.com/learningequality/aphrodite/tar.gz/fdc8d7be8912a5cf17f74ff10f124013c52c3e32
       autosize: 3.0.21


### PR DESCRIPTION
> :robot: **AI usage:** Claude Code (Opus 4.7) made the original ``KListWithOverflow`` integration and authored most of the code at my direction. After review, Claude (this session) also rebased the branch onto current ``unstable``, re-integrated the alignment-button work that landed in #5677 while this PR was idle, and traced the two root-cause bugs in KDS that Marcella's review surfaced. I personally verified the post-rebase toolbar at the failing widths and during fast resize, and authored review responses.

## Summary

Replace hardcoded pixel breakpoints in the RTE toolbar with KDS's `KListWithOverflow`. The toolbar now automatically collapses items into a "More" dropdown based on available space rather than fixed breakpoints, so future button additions don't require recomputing breakpoints.

**Closes:** #5258

## Status (review-cycle 2)

This branch was rebased onto current ``unstable`` to bring in:
- The alignment-button work merged via #5677 (re-integrated as a ``toolbarGroups`` entry between ``clipboard`` and ``clearFormat``).
- Other ``unstable`` updates accumulated since the original PR.

**Paired KDS PR:** [learningequality/kolibri-design-system#1246](https://github.com/learningequality/kolibri-design-system/pull/1246) addresses the two upstream bugs Marcella identified ([review thread](https://github.com/learningequality/studio/pull/5707#pullrequestreview-3098620812)):
1. The 850–950px overlap (restored items kept ``position: absolute``).
2. The wrap-flicker on resize (``.list`` had ``flex-wrap: wrap`` + ``overflow: visible``).

The ``::v-deep .list { overflow: hidden }`` workaround on lines 559–565 of ``EditorToolbar.vue`` is kept *for now* with a comment pointing at KDS#1246. **Once that PR is released and the KDS version pinned in ``package.json`` is bumped, the workaround block can be deleted** — both the flicker it patched and the overlap it didn't will be fixed upstream.

## :warning: TEMP review-only commit on this branch

The top commit (`f7fd4b318`, **`TEMP: pin kolibri-design-system to KDS#1246 fork branch for review`**) adds a `pnpm.overrides` entry pointing `kolibri-design-system` at the fork branch backing [KDS#1246](https://github.com/learningequality/kolibri-design-system/pull/1246), so reviewers can verify the fix end-to-end with one `pnpm install` instead of needing a local `pnpm link`.

**To test:**
```sh
git fetch origin pull/5707/head:pr-5707 && git checkout pr-5707
pnpm install
# start dev server as usual — toolbar will use the KDS PR fixes via the override
```

**Before merge,** drop this top commit, bump `kolibri-design-system` to whatever KDS release contains #1246, and re-run `pnpm install`. The commit message has the exact removal steps.

## Screenshots

The most informative screenshots are the before/after pair at 900px viewport (the previously-failing range Marcella reported), captured against the same Studio build with KDS swapped between the buggy ``develop`` HEAD and the [paired KDS PR fix](https://github.com/learningequality/kolibri-design-system/pull/1246):

| Viewport | Without KDS#1246 (current ``develop``) | With KDS#1246 + this PR |
|----------|----------------------------------------|-------------------------|
| 900px | Marcella's overlap reproduces — see [KDS#1246 description](https://github.com/learningequality/kolibri-design-system/pull/1246) for the side-by-side. | ![900px clean](https://i.imgur.com/leSaibt.png) |
| 940px | Same overlap pattern | ![940px clean](https://i.imgur.com/cqoBjnB.png) |

The remaining behavior (full toolbar at 1280px, More button below ~750px, dropdown at narrow widths) is unchanged from the original PR's screenshots:

| Viewport | Description | Original screenshot |
|----------|-------------|-------------|
| 1280px | Full width - all toolbar items visible | <img width="1280" height="720" alt="toolbar_full_1280px" src="https://github.com/user-attachments/assets/072d65ce-3da3-4465-9c21-9a5be82d9ce8" /> |
| 700px | Narrow - items collapse, "More" button appears | <img width="700" height="720" alt="toolbar_narrow_700px" src="https://github.com/user-attachments/assets/4009dc19-d1d7-4759-993b-a0ed31197441" /> |
| 500px | Mobile with "More" dropdown open | <img width="500" height="720" alt="toolbar_mobile_500px_dropdown" src="https://github.com/user-attachments/assets/1a7e644b-6c15-4a11-be0b-319e48bb86ec" /> |

> Note: the original 1280/700/500 screenshots predate the alignment-button work (#5677). They illustrate overflow behavior correctly; the alignment button is now an additional group in the toolbar but its visual position doesn't change the overflow story.

## Reviewer notes — addressing prior review feedback

- **`::v-deep .list` (rtibbles, MisRob, marcellamaki):** the upstream cause of the flicker is fixed in [KDS#1246](https://github.com/learningequality/kolibri-design-system/pull/1246). The block here is kept temporarily with a comment; will be removed once KDS#1246 is released and the dependency bumped in this PR.
- **850–950px overlap (marcellamaki):** root-caused to a missing ``position: 'unset'`` reset in ``KListWithOverflow.setOverflowItems()``'s restoration branch (introduced in [KDS#612](https://github.com/learningequality/kolibri-design-system/pull/612)). Fixed in [KDS#1246](https://github.com/learningequality/kolibri-design-system/pull/1246) with one line.
- **Hardcoded English aria-labels (rtibbles):** ``'More options'`` and ``'Additional formatting options'`` in ``EditorToolbar.vue`` are pre-existing from before this PR. Pending decision: include i18n in this PR vs. file follow-up issue. (habibayman volunteered to file 2026-03-05.)

## Test Plan

### Studio RTE toolbar (this PR's primary surface)

- [x] Verify toolbar displays all items at wide viewports (1200px+)
- [x] Verify "More" button appears when viewport narrows (verified at <750px)
- [x] Verify clicking "More" shows dropdown with overflow items
- [x] Verify no flicker/flash when resizing viewport (verified locally with paired KDS#1246)
- [x] Verify overflow items in dropdown are functional (bold, italic, etc.)
- [x] Verify keyboard navigation works in overflow menu (Arrow keys, Escape)
- [x] Verify alignment button is present and functional (post-rebase regression check)
- [ ] Test in RTL mode _(open — please flag if RTL-specific testing is required for re-review)_
- [ ] Final pass after KDS#1246 merges, version bump, and ``::v-deep`` removal

### Cross-consumer regression (because KDS#1246 changes behavior for *all* ``KListWithOverflow`` consumers)

The TEMP override pulls KDS#1246's fix into Studio for the whole branch — so the existing Studio consumer below is *already* exercising the new KDS behavior on this branch. Kolibri and the KDS docs page need separate verification:

- [ ] **Studio — ``CurrentTopicView.vue``** (``contentcuration/contentcuration/frontend/channelEdit/views/CurrentTopicView.vue``, lines 123–156). Tests: open a channel with multiple chips/breadcrumbs in the topic view, resize across the overflow threshold, confirm no overlap and no wrap-flicker.
- [ ] **Kolibri — ``LanguageSwitcherList``** (``packages/kolibri/components/language-switcher/LanguageSwitcherList.vue``). Tests: open language switcher in a Kolibri instance running against the bumped KDS, confirm language pills overflow correctly into "More" and don't visually overlap at threshold widths. Most likely visible from the public-facing footer.
- [ ] **KDS docs demo page** (``docs/pages/klistwithoverflow.vue`` in the kolibri-design-system repo). Sanity-check the docs example still renders correctly after the KDS upgrade — this is the simplest reproduction surface and any visual regression will show up here first.