### PR TITLE
Fix broken disk space popup in admin users table

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
@@ -69,7 +69,7 @@
             <Icon icon="edit" />
           </VBtn>
         </template>
-        <VCard>
+        <VCard style="min-width: 280px">
           <VCardText>
             <UserStorage
               :userId="userId"


### PR DESCRIPTION
## Summary
- Fixes the disk space popup in Administration > Users looking broken (too small, scrollbar, background visible)
- Added `min-width: 280px` to the `VCard` wrapping the `UserStorage` form inside the `BaseMenu` popup, preventing the content from being squeezed by Vuetify's `.v-menu__content` `max-width: 80%` constraint

Fixes #5706

## Test plan
- [ ] Sign in with an Admin user
- [ ] Go to Administration > Users
- [ ] Click the edit icon next to a user's disk space value
- [ ] Verify the popup displays properly without scrollbar or clipped content
- [ ] Verify the Size input, unit dropdown, and Cancel/Save buttons are all visible and usable