### PR TITLE
Downgrade non-urgent _sort_by_order logging error to warning

### DIFF
--- a/contentcuration/contentcuration/utils/assessment/base.py
+++ b/contentcuration/contentcuration/utils/assessment/base.py
@@ -284,10 +284,7 @@ class ExerciseArchiveGenerator(ABC):
         for answer in answer_data:
             if answer["answer"]:
                 if isinstance(answer["answer"], str):
-                    (
-                        answer["answer"],
-                        answer_images,
-                    ) = self._process_content(
+                    (answer["answer"], answer_images,) = self._process_content(
                         answer["answer"],
                     )
                     answer["images"] = answer_images


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Downgrades logging error in `_sort_by_order` to a warning instead, since sort order isn't critical when publishing a channel with pre/post-tests and doesn't need to be a Sentry alert.

## References
<!--
 * references to related issues and PRs
-->

Closes #5661 


