### PR TITLE
Remove channelVersion object and database with version "next" when stale

### DIFF
--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -1141,6 +1141,13 @@ def publish_channel(  # noqa: C901
         else:
             increment_channel_version(channel)
         if not is_draft_version:
+            ccmodels.ChannelVersion.objects.filter(
+                channel=channel, version=None
+            ).delete()
+            draft_db_path = get_content_db_path(channel_id, "next")
+            if storage.exists(draft_db_path):
+                storage.delete(draft_db_path)
+
             sync_contentnode_and_channel_tsvectors(channel_id=channel.id)
             mark_all_nodes_as_published(base_tree)
             fill_published_fields(channel, version_notes)


### PR DESCRIPTION
## Summary
- Clean up stale ChannelVersion objects and database.
- Unit test.

## References
closes #5567 

## Reviewer guidance
- Run pytest

## AI usage
Used Claude for test generation. 