### PR TITLE
Update snackbar to use multiline overflow option

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/GlobalSnackbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/GlobalSnackbar.vue
@@ -5,6 +5,7 @@
     :key="key"
     :timeout="snackbarOptions.duration"
     left
+    multi-line
     :value="snackbarIsVisible"
     @input="visibilityToggled"
   >


### PR DESCRIPTION
## Summary
In French and Portuguese, the "not relevant" recommendations snackbar string was too long to fit in it's container. We can use the Vuetify `multi-lin` prop for VSnackbar to manage this.

## References
Fixes https://github.com/learningequality/studio/issues/5407

## Reviewer guidance
I forced this in the code jankily so I didn't have to do the fully CA local setup to test this fix. I think cross checking the code with the documentation and then asking QA team to confirm is probably easier than dev manual QA on this PR, unless you already have local testing for search recommendations set up.

before:
<img width="791" height="451" alt="Screenshot 2026-03-02 at 7 04 39 PM" src="https://github.com/user-attachments/assets/15a79c6e-2450-4313-bb9d-c75a2d1553d7" />

after:
<img width="1136" height="753" alt="Screenshot 2026-03-02 at 6 59 39 PM" src="https://github.com/user-attachments/assets/e0af6a8c-5765-4280-ba1a-0baca88f0d54" />


## AI usage
I asked Claude the easiest way to fix this and I learned this prop existed! handy!
