### PR TITLE
Add additional completion to exercises that have already had their completion criteria fixed but their complete value is still wrong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ migrate:
 # 4) Remove the management command from this `deploy-migrate` recipe
 # 5) Repeat!
 deploy-migrate:
-	echo "Nothing to do here!"
+	python contentcuration/manage.py fix_exercise_extra_fields
 
 contentnodegc:
 	python contentcuration/manage.py garbage_collect

--- a/contentcuration/contentcuration/management/commands/fix_exercise_extra_fields.py
+++ b/contentcuration/contentcuration/management/commands/fix_exercise_extra_fields.py
@@ -65,6 +65,7 @@ class Command(BaseCommand):
         migrated_complete = 0
         old_style_fixed = 0
         old_style_complete = 0
+        incomplete_fixed = 0
         exercises_checked = 0
 
         for node in queryset.iterator(chunk_size=CHUNKSIZE):
@@ -77,6 +78,8 @@ class Command(BaseCommand):
                 migrated_fixed += 1
                 if complete:
                     migrated_complete += 1
+            elif fix_type == "incomplete" and complete:
+                incomplete_fixed += 1
             exercises_checked += 1
             if exercises_checked % CHUNKSIZE == 0:
                 logging.info(
@@ -92,6 +95,11 @@ class Command(BaseCommand):
                         migrated_complete, migrated_fixed
                     )
                 )
+                logging.info(
+                    "{} marked complete that were previously incomplete".format(
+                        incomplete_fixed
+                    )
+                )
 
         logging.info("{} / {} exercises checked".format(exercises_checked, total))
         logging.info(
@@ -105,17 +113,25 @@ class Command(BaseCommand):
             )
         )
         logging.info(
+            "{} marked complete that were previously incomplete".format(
+                incomplete_fixed
+            )
+        )
+        logging.info(
             "Done in {:.1f}s. Fixed {} migrated exercises, "
-            "migrated {} old-style exercises.{}".format(
+            "migrated {} old-style exercises."
+            "marked {} previously incomplete exercises complete. {}".format(
                 time.time() - start,
                 migrated_fixed,
                 old_style_fixed,
+                incomplete_fixed,
                 " (dry run)" if dry_run else "",
             )
         )
 
     def _process_node(self, node, dry_run):
         ef = node.extra_fields
+        was_complete = node.complete
         if isinstance(ef, str):
             try:
                 ef = json.loads(ef)
@@ -131,6 +147,8 @@ class Command(BaseCommand):
             ef["options"]["completion_criteria"]["threshold"]["m"] = None
             ef["options"]["completion_criteria"]["threshold"]["n"] = None
             fix_type = "m_n_fix"
+        elif not was_complete:
+            fix_type = "incomplete"
         else:
             return None, None
         node.extra_fields = ef

--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -1817,6 +1817,32 @@ class FixExerciseExtraFieldsTestCase(StudioTestCase):
         self.assertEqual(threshold["m"], 0)
         self.assertEqual(threshold["n"], 0)
 
+    def test_incomplete_node_with_valid_fields_gets_marked_complete(self):
+        """An incomplete exercise with valid extra_fields should be marked complete."""
+        node = self._create_exercise(
+            {
+                "options": {
+                    "completion_criteria": {
+                        "threshold": {
+                            "mastery_model": exercises.DO_ALL,
+                            "m": None,
+                            "n": None,
+                        },
+                        "model": completion_criteria.MASTERY,
+                    }
+                },
+            }
+        )
+        # Force incomplete status even though fields are valid
+        node.complete = False
+        node.save()
+
+        command = FixExerciseExtraFieldsCommand()
+        command.handle()
+
+        node.refresh_from_db()
+        self.assertTrue(node.complete)
+
     def test_migrates_string_extra_fields(self):
         """Command should parse and migrate extra_fields stored as a JSON string."""
         node = self._create_exercise(


### PR DESCRIPTION
## Summary
Further fixes to exercise completion. It appears that some are still not getting properly marked as complete, on inspection, it appears that they may already have had their completion criteria migrated by the frontend, but then never remarked as complete.
Fixes this by adding mark complete calls to all incomplete exercises.
Also adds the exercises command to the deploy step in the Makefile

## References
Fixes https://github.com/learningequality/studio/issues/5667

## Reviewer guidance
It is possible that this could mark otherwise "complete" exercises incomplete, should I guard against that? 

## AI usage
I used Claude to write the additional test, all other changes were by hand.