### PR TITLE
Don't show pagination when loading

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -111,8 +111,9 @@
             </KCardGrid>
           </VFlex>
           <VFlex
+            v-if="!loading"
             xs12
-            style="padding-bottom: 72px"
+            class="pagination-container"
           >
             <VLayout justify-center>
               <Pagination
@@ -486,6 +487,11 @@
   .results-text,
   .download-link-wrapper {
     min-height: 30px; // prevent layout shifts when loading state changes
+  }
+
+  .pagination-container {
+    padding-bottom: 72px;
+    margin-top: 32px;
   }
 
 </style>


### PR DESCRIPTION
## Summary

A follow-up to https://github.com/learningequality/studio/pull/5696.

On `unstable` server with more cards than on localhost and pagination visible, I observed

- Lack of space between cards and pagination
- Pagination visible when loading
- 
<img width="600" height="auto" alt="" src="https://github.com/user-attachments/assets/08bc3725-fea0-43df-94dc-754f883075e8" />

This should fix it.