### PR TITLE
remove-vuetify-usage-from-content-library

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilterBar.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogFilterBar.vue
@@ -1,17 +1,16 @@
 <template>
 
-  <VContainer class="pa-4">
-    <div v-if="currentFilters.length">
-      <VChip
+  <div class="filter-bar-container">
+    <div v-if="currentFilters.length" class="filter-bar-content">
+      <StudioChip
         v-for="(filter, index) in currentFilters"
         :key="`catalog-filter-${index}`"
-        close
-        class="ma-1"
+        :class="{ notranslate: filter.notranslate }"
+        :text="filter.text"
+        :close="true"
         :data-test="`filter-chip-${index}`"
-        @input="filter.onclose"
-      >
-        {{ filter.text }}
-      </VChip>
+        @close="filter.onclose"
+      />
       <KButton
         v-if="currentFilters.length"
         class="clear-link"
@@ -21,61 +20,50 @@
         @click="clearFilters"
       />
     </div>
-  </VContainer>
+  </div>
 
 </template>
 
 
 <script>
 
-  import flatten from 'lodash/flatten'; // Tests fail with native Array.flat() method
+  import flatten from 'lodash/flatten';
   import { catalogFilterMixin } from './mixins';
   import { constantsTranslationMixin } from 'shared/mixins';
+  import StudioChip from 'shared/views/StudioChip';
 
-  /**
-   * Returns the expected format for filters
-   * {
-   *   text: string to display for filter
-   *   onclose: action to do if filter is removed
-   * }
-   */
-  function createFilter(value, text, onclose) {
-    return value ? { text, onclose } : false;
+  function createFilter(value, text, onclose, notranslate = false) {
+    return value ? { text, onclose, notranslate } : false;
   }
 
   export default {
     name: 'CatalogFilterBar',
+    components: {
+      StudioChip,
+    },
     mixins: [constantsTranslationMixin, catalogFilterMixin],
     computed: {
       currentFilters() {
         return flatten([
-          // Keywords
           createFilter(
             this.keywords,
             this.$tr('keywords', { text: this.keywords }),
             this.resetKeywords,
+            true
           ),
-
-          // Languages
           this.languages.map(language =>
             createFilter(language, this.translateLanguage(language), () =>
-              this.removeLanguage(language),
-            ),
+              this.removeLanguage(language)
+            )
           ),
-
-          // Licenses
           this.licenses.map(license =>
             createFilter(license, this.translateLicense(license), () =>
-              this.removeLicense(license),
-            ),
+              this.removeLicense(license)
+            )
           ),
-
-          // Kinds
           this.kinds.map(kind =>
-            createFilter(kind, this.translateConstant(kind), () => this.removeKind(kind)),
+            createFilter(kind, this.translateConstant(kind), () => this.removeKind(kind))
           ),
-
-          // Includes
           createFilter(this.bookmark, this.$tr('starred'), this.resetBookmark),
           createFilter(this.coach, this.$tr('coachContent'), this.resetCoach),
           createFilter(this.assessments, this.$tr('assessments'), this.resetAssessments),
@@ -124,22 +112,16 @@
 
 <style lang="scss" scoped>
 
-  h3,
-  p {
-    width: 100%;
-  }
-
-  .container {
+  .filter-bar-container {
     max-width: 1128px;
+    padding: 16px;
     margin: 0 auto;
   }
 
-  .v-card {
-    cursor: pointer;
-
-    &:hover {
-      background-color: var(--v-grey-lighten4);
-    }
+  .filter-bar-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
   }
 
   .clear-link {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilterBar.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogFilterBar.spec.js
@@ -16,7 +16,9 @@ const query = {
 async function closeChipByText(user, text) {
   const chip = await screen.findByText(text);
 
-  const closeButton = chip.closest('[data-test^="filter-chip"]').querySelector('.v-chip__close');
+
+  const chipContainer = chip.closest('[data-test^="filter-chip"]');
+  const closeButton = chipContainer.querySelector('[data-test="remove-chip"]');
 
   expect(closeButton).toBeTruthy();
   await user.click(closeButton);


### PR DESCRIPTION
Summary
This pr removes vuetify from the content library filter bar by replacing vcontainer with a custom flexbox layout and vchip with the studiochip component. the ui and behavior remain unchanged.

Changes:
replaced vcontainer with custom div layout
replaced vchip with studiochip
ensured filter interactions work as before
updated tests using @testing-library/vue

Manual verification:
login with user@a.com / a, go to channels > content library, apply filters, remove chips, and verify clear all works.

Reference:
#5746
AI Usage:
I used an AI agent only to debug and fix a few errors. After applying those fixes, I manually reviewed the code and verified that all filter interactions and tests work correctly to ensure everything functions as expected.

<img width="1855" height="923" alt="Screenshot from 2026-03-09 21-35-12" src="https://github.com/user-attachments/assets/7c990976-f134-41e9-9aba-55934bac290f" />







