### PR TITLE
Fix copy path needing one more /contentcuration

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,24 @@
+services:
+  studio-app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.prod
+    image: learningequality/studio-app-prod
+    ports:
+      - "8080:8081"
+    volumes:
+      - .:/src
+    environment:
+      MPLBACKEND: ps
+      SHELL: /bin/bash
+      AWS_S3_ENDPOINT_URL: http://minio:9000
+      AWS_BUCKET_NAME: content
+      DATA_DB_HOST: postgres
+      DJANGO_SETTINGS_MODULE: contentcuration.settings
+      RUN_MODE: docker-compose
+      CELERY_TIMEZONE: America/Los_Angeles
+      CELERY_REDIS_DB: 0
+      CELERY_BROKER_ENDPOINT: redis
+      CELERY_RESULT_BACKEND_ENDPOINT: redis
+      CELERY_REDIS_PASSWORD: ""
+      REMAP_SIGTERM: "SIGQUIT"

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -7,10 +7,8 @@ RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 COPY . .
 
-# Ensure expected bundles directory exists and run production frontend build
-RUN mkdir -p contentcuration/static/js/bundles \
-    && ln -s /contentcuration/node_modules /contentcuration/contentcuration/node_modules \
-    && pnpm run build
+# The webpack build, creating the frontend assets, later copied to the final image
+RUN pnpm run build
 
 
 FROM ghcr.io/astral-sh/uv:python3.10-trixie-slim
@@ -46,11 +44,11 @@ RUN uv pip sync --system /contentcuration/requirements.txt
 COPY . /contentcuration/
 
 # Copy compiled frontend static output from node-builder
-COPY --from=node-builder /contentcuration/contentcuration/static /contentcuration/contentcuration/static
+COPY --from=node-builder /contentcuration/contentcuration/contentcuration/static /contentcuration/contentcuration/contentcuration/static
 
 ARG COMMIT_SHA
 ENV RELEASE_COMMIT_SHA=$COMMIT_SHA
 
-EXPOSE 8000
+EXPOSE 8081
 
-ENTRYPOINT ["make", "altprodserver"]
+CMD ["make", "altprodserver"]


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- The [refactored Dockerfile](https://github.com/learningequality/studio/pull/5752) copied the wrong directory; both of these exist
  - `/contentcuration/contentcuration/static` -- referenced by old cruft, misled me, but it's where `collectstatic` puts all static files eventually
  - `/contentcuration/contentcuration/contentcuration/static` -- where the frontend assets really live
- We should probably rename the root directory something else like `/app` or `/src` to reduce this confusion, although we would need to coordinate that with infra since k8s configs reference this
- The `ENTRYPOINT` was changed to `CMD` to facilitate easier inspection, allowing you to launch `/bin/bash` in it; this should not affect k8s
- The exposed port was changed to align with `make altprodserver`; k8s uses the same port
- Confusing and unneeded cruft was removed
- Added docker-compose YAML for testing build and startup of the production image

## References
<!--
 * references to related issues and PRs
-->
Fixes https://github.com/learningequality/studio/issues/5754


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. I started up services `make dcservicesup`
2. I edited the `docker-compose.prod.yml` to point to the network created by `make dcservicesup`, e.g.:
```yaml
networks:
  default:
    name: studio_post-uv-frontend-serve_default
    external: true
```
3. I ran `docker compose -f docker-compose.prod.yml up`
4. I accessed http://localhost:8080/
5. While it still wasn't loading all resources (I think this is existing due to config differences), I confirmed that the frontend assets were copied and that it didn't fail to find the `serviceWorker.js` like the Sentry error

<!--
AI USAGE - DEEP guidelines

If AI was used in preparing this PR, please fill in the section below.
Our DEEP guidelines ask that when using AI you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

If AI was not used, delete the section below.
-->

## AI usage
I asked AI to help debug it. Ultimately, it didn't help.