### PR TITLE
Rollback dockerfile to version from hotfixes

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,54 +1,47 @@
-FROM node:20-trixie-slim AS node-builder
-
-WORKDIR /contentcuration
-
-COPY package.json pnpm-lock.yaml ./
-RUN corepack enable pnpm && pnpm install --frozen-lockfile
-
-COPY . .
-
-# The webpack build, creating the frontend assets, later copied to the final image
-RUN pnpm run build
-
-
-FROM ghcr.io/astral-sh/uv:python3.10-trixie-slim
+FROM python:3.10-slim-bookworm
 
 # Set the timezone
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 # Default Python file.open file encoding to UTF-8 instead of ASCII, workaround for le-utils setup.py issue
-ENV LANG=C.UTF-8
+ENV LANG C.UTF-8
+RUN apt-get update && apt-get -y install python3-pip python3-dev gcc libpq-dev libssl-dev libffi-dev make git curl libjpeg-dev ffmpeg
 
+# Pin, Download and install node 18.x
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends \
-        gcc \
-        libpq-dev \
-        libssl-dev \
-        libffi-dev \
-        make \
-        git \
-        curl \
-        gettext \
-        libjpeg-dev \
-        ffmpeg \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "Package: nodejs" >> /etc/apt/preferences.d/preferences \
+    && echo "Pin: origin deb.nodesource.com" >> /etc/apt/preferences.d/preferences \
+    && echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/preferences\
+    && apt-get update \
+    && apt-get install -y nodejs
 
+RUN corepack enable pnpm
+
+COPY ./package.json .
+COPY ./pnpm-lock.yaml .
+RUN pnpm install
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip
+RUN pip install --ignore-installed -r requirements.txt
+
+COPY  . /contentcuration/
 WORKDIR /contentcuration
 
-COPY requirements.txt /contentcuration/
-
-# Install Python dependencies
-RUN uv pip sync --system /contentcuration/requirements.txt
-
-COPY . /contentcuration/
-
-# Copy compiled frontend static output from node-builder
-COPY --from=node-builder /contentcuration/contentcuration/contentcuration/static /contentcuration/contentcuration/contentcuration/static
+# generate the node bundles
+RUN mkdir -p contentcuration/static/js/bundles
+RUN ln -s /node_modules /contentcuration/node_modules
+RUN pnpm run build
 
 ARG COMMIT_SHA
 ENV RELEASE_COMMIT_SHA=$COMMIT_SHA
 
-EXPOSE 8081
+EXPOSE 8000
 
-CMD ["make", "altprodserver"]
+ENTRYPOINT ["make", "altprodserver"]


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Despite [fixing](https://github.com/learningequality/studio/pull/5756) the copying of frontend assets to the final image, the [observed error](https://github.com/learningequality/studio/issues/5754) persists. It isn't clear what's going wrong. Accessing the pods on `unstable` and `hotfixes` showed pretty much identical results in the presence of files and manually running the failing code.

This rolls back the changes to the production dockerfile.

The rest of the changes should be contained to development environments.

## References
<!--
 * references to related issues and PRs
-->
https://github.com/learningequality/studio/pull/5756
https://github.com/learningequality/studio/issues/5754
https://github.com/learningequality/studio/pull/5752


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
The file should be identical to what's in hotfixes and production: https://github.com/learningequality/studio/blob/hotfixes/docker/Dockerfile.prod
