### PR TITLE
Add draft_channels feature flag

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/PublishSidePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/PublishSidePanel.vue
@@ -264,9 +264,7 @@
         return true;
       });
 
-      const showDraftMode = computed(() =>
-        hasFeatureEnabled.value(FeatureFlagKeys.test_dev_feature),
-      );
+      const showDraftMode = computed(() => hasFeatureEnabled.value(FeatureFlagKeys.draft_channels));
 
       const submitText = computed(() => {
         return mode.value === PublishModes.DRAFT ? saveDraft$() : publishAction$();

--- a/contentcuration/contentcuration/static/feature_flags.json
+++ b/contentcuration/contentcuration/static/feature_flags.json
@@ -18,6 +18,11 @@
       "type": "boolean",
       "title":"Test Survey feature",
       "description": "Allow user access to Survey"
+    },
+    "draft_channels": {
+      "type": "boolean",
+      "title": "Draft channels",
+      "description": "Allow users to publish draft channels"
     }
   },
   "examples": [


### PR DESCRIPTION
## Summary

Adds draft_channels feature flag, and uses this flag instead of the `test_dev_feature` feature flag which is excluded from non-dev environments.

## Reviewer guidance
* Check that you can activate this flag for non-admin users.
* Check that if this flag is disabled, non-admin users cannot see the "draft" option on the publish side panel.