### PR TITLE
Prevent syncing from incomplete source node

### DIFF
--- a/contentcuration/contentcuration/tests/test_contentnodes.py
+++ b/contentcuration/contentcuration/tests/test_contentnodes.py
@@ -824,6 +824,27 @@ class SyncNodesOperationTestCase(StudioTestCase):
         )
         self._assert_same_files(orig_video, cloned_video)
 
+    def test_sync_but_incomplete(self):
+        orig_video, cloned_video = self._setup_original_and_deriative_nodes()
+        orig_video.license_id = None
+        orig_video.mark_complete()
+        self.assertFalse(orig_video.complete)
+        orig_video.save()
+
+        self.assertTrue(cloned_video.complete)
+
+        sync_node(
+            cloned_video,
+            sync_titles_and_descriptions=True,
+            sync_resource_details=True,
+            sync_files=True,
+            sync_assessment_items=True,
+        )
+
+        self.assertIsNotNone(cloned_video.license_id)
+        cloned_video.mark_complete()
+        self.assertTrue(cloned_video.complete)
+
     def test_sync_with_subs(self):
         orig_video, cloned_video = self._setup_original_and_deriative_nodes()
         self._add_subs_to_video_node(orig_video, "fr")
@@ -868,6 +889,13 @@ class SyncNodesOperationTestCase(StudioTestCase):
             node_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
         video_node = testdata.node(data, parent=parent)
+        video_node.license_id = 9  # Special Permissions
+        video_node.license_description = "Special permissions for testing"
+        video_node.copyright_holder = "LE"
+        # ensure the node is complete according to our logic
+        video_node.mark_complete()
+        self.assertTrue(video_node.complete)
+        video_node.save()
 
         if withsubs:
             self._add_subs_to_video_node(video_node, "fr")

--- a/contentcuration/contentcuration/utils/sync.py
+++ b/contentcuration/contentcuration/utils/sync.py
@@ -53,11 +53,14 @@ def sync_node(
     sync_assessment_items=False,
 ):
     original_node = node.get_original_node()
+    if not original_node.complete:
+        logging.warning(
+            f"Refusing to sync node {node.pk} from incomplete source node: {original_node.pk}"
+        )
+        return node
     if original_node.node_id != node.node_id:  # Only update if node is not original
         logging.info(
-            "----- Syncing: {} from {}".format(
-                node.title, original_node.get_channel().name
-            )
+            f"----- Syncing: {node.title} from {original_node.get_channel().name}"
         )
         if sync_titles_and_descriptions:
             fields = [


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Adds check to our `sync_node` logic, which synchronizes metadata and content of imported nodes with their sources, to ensure the source is complete. Otherwise, it logs a warning.

## References
<!--
 * references to related issues and PRs
-->
fixes https://github.com/learningequality/studio/issues/5683
related: https://github.com/learningequality/studio/pull/5760

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Follow the reproduce steps in the issue

<!--
AI USAGE - DEEP guidelines

If AI was used in preparing this PR, please fill in the section below.
Our DEEP guidelines ask that when using AI you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

If AI was not used, delete the section below.
-->

## AI usage
None