### PR TITLE
fix(settings): fix some links in the privacy modal

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/policies/PrivacyPolicyModal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/policies/PrivacyPolicyModal.vue
@@ -1,4 +1,5 @@
 <template>
+
   <PoliciesModal
     :policy="policy"
     :title="title"
@@ -310,12 +311,10 @@
           {{ $untranslated('glossaryP3') }}
         </p>
         <p>
-          <b>{{ $untranslated('glossaryP4Comply') }}</b
-          >{{ $untranslated('glossaryP4') }}
+          <b>{{ $untranslated('glossaryP4Comply') }}</b>{{ $untranslated('glossaryP4') }}
         </p>
         <p>
-          <b>{{ $untranslated('glossaryP5ThirdParty') }}</b
-          >{{ $untranslated('glossaryP5') }}
+          <b>{{ $untranslated('glossaryP5ThirdParty') }}</b>{{ $untranslated('glossaryP5') }}
         </p>
         <p>
           <b>{{ $untranslated('glossaryP6') }}</b>
@@ -360,9 +359,12 @@
       </div>
     </div>
   </PoliciesModal>
+
 </template>
 
+
 <script>
+
   import PoliciesModal from './PoliciesModal';
   import { policies } from 'shared/constants';
 
@@ -608,9 +610,12 @@
       updatedPrivacyHeader: 'Updated privacy policy',
     },
   };
+
 </script>
 
+
 <style scoped>
+
   .emphasis {
     font-weight: bold;
     text-transform: uppercase;
@@ -640,4 +645,5 @@
   .toc li {
     margin-bottom: 8px;
   }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Followed Peter's report and replaced the links that were caught broken in the privacy modal and are documented in a screen recording in his issue description [here](https://github.com/learningequality/studio/issues/5755).

1. ~~`http://localhost:8080/en/channels/#/my-channels?showPolicy=community_standards`~~ 
->
 `http://localhost:8080/en/channels/#/my-channels?showPolicy=terms_of_service`

2. ~~`https://learningequality.org/cookies/`~~
->
`https://learningequality.org/cookie-policy/`


---
## References

- fixes #5755 

---

## Reviewer guidance
Navigate to `http://localhost:8080/en/channels/#/my-channels?showPolicy=privacy_policy` and validate the links are working fine.

I am surprised these changes didn't cause any unit tests to fail though! I think we should write some to verify that
