### PR TITLE
chore: replace print() statements with proper logging

### DIFF
--- a/contentcuration/contentcuration/management/commands/set_content_mimetypes.py
+++ b/contentcuration/contentcuration/management/commands/set_content_mimetypes.py
@@ -23,12 +23,12 @@ class Command(BaseCommand):
 
         futures = []
         with concurrent.futures.ThreadPoolExecutor() as e:
-            print("Scheduling all metadata update jobs...")  # noqa: T201
+            self.stdout.write("Scheduling all metadata update jobs...")
             for blob in blobs:
                 future = e.submit(self._update_metadata, blob)
                 futures.append(future)
 
-            print("Waiting for all jobs to finish...")  # noqa: T201
+            self.stdout.write("Waiting for all jobs to finish...")
 
     def _determine_cache_control(self, name):
         _, ext = os.path.splitext(name)

--- a/contentcuration/contentcuration/management/commands/setup.py
+++ b/contentcuration/contentcuration/management/commands/setup.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         email = options["email"]
         password = options["password"]
         if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
-            print("{} is not a valid email".format(email))  # noqa: T201
+            self.stderr.write(self.style.ERROR("{} is not a valid email".format(email)))
             sys.exit()
 
         # create the cache table
@@ -191,9 +191,11 @@ class Command(BaseCommand):
             for legacy_node in legacy_clipboard_nodes:
                 legacy_node.copy_to(target=user1.clipboard_tree)
 
-        print(  # noqa: T201
-            "\n\n\nSETUP DONE: Log in as admin to view data (email: {}, password: {})\n\n\n".format(
-                email, password
+        self.stdout.write(
+            self.style.SUCCESS(
+                "\n\n\nSETUP DONE: Log in as admin to view data (email: {}, password: {})\n\n\n".format(
+                    email, password
+                )
             )
         )
 

--- a/contentcuration/contentcuration/management/commands/setup_perftest_data.py
+++ b/contentcuration/contentcuration/management/commands/setup_perftest_data.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         self.editor.clipboard_tree.get_descendants().delete()
 
         with ContentNode.objects.delay_mptt_updates():
-            print("Creating channel...")  # noqa: T201
+            self.stdout.write("Creating channel...")
             self.generate_random_channels()
 
             # Make sure we have a channel with a lot of root topics to test initial channel load.
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             self.editor.clipboard_tree = TreeBuilder(
                 levels=2, num_children=25, user=self.editor
             ).root
-            print(  # noqa: T201
+            self.stdout.write(
                 "Created clipboard with {} nodes".format(
                     self.editor.clipboard_tree.get_descendants().count()
                 )
@@ -47,7 +47,7 @@ class Command(BaseCommand):
 
             new_channel.main_tree = TreeBuilder(user=self.editor).root
 
-            print(  # noqa: T201
+            self.stdout.write(
                 "Created channel with {} nodes".format(
                     new_channel.main_tree.get_descendants().count()
                 )
@@ -55,4 +55,4 @@ class Command(BaseCommand):
 
             # make sure we have a trash tree so that can be tested with real data as well.
             new_channel.trash_tree = TreeBuilder(user=self.editor).root
-            print("Created channel with id {}".format(new_channel.pk))  # noqa: T201
+            self.stdout.write("Created channel with id {}".format(new_channel.pk))

--- a/contentcuration/contentcuration/management/commands/test_server_perf.py
+++ b/contentcuration/contentcuration/management/commands/test_server_perf.py
@@ -34,24 +34,24 @@ class Command(BaseCommand):
             ] = objects.get_object_creation_stats_mptt_delay(num_objects, num_runs)
             object_types.append("ContentNode-mptt-delay")
 
-            print()
-            print("Test results:")
+            self.stdout.write("")
+            self.stdout.write("Test results:")
             for object_type in object_types:
                 run_stats = stats[object_type]
-                print(
+                self.stdout.write(
                     "Stats for creating {} {} objects over {} runs: {}".format(
                         num_objects, object_type, num_runs, run_stats
                     )
                 )
 
             if options["stress_test"]:
-                print(  # noqa: T201
+                self.stdout.write(
                     "Running stress test simulating creation / cloning of a channel like KA, "
                     "this will take at least several minutes. Please do not interrupt if possible!"
                 )
                 stats = objects.get_large_channel_creation_stats()
                 for stat in stats:
-                    print("{}: {}".format(stat, stats[stat]))
+                    self.stdout.write("{}: {}".format(stat, stats[stat]))
 
         finally:
             if objects:

--- a/contentcuration/contentcuration/perftools/objective.py
+++ b/contentcuration/contentcuration/perftools/objective.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 
@@ -6,6 +7,9 @@ from contentcuration.models import ContentNode
 from contentcuration.models import File
 
 # TODO: Investigate more precise timing libraries
+
+
+logger = logging.getLogger(__name__)
 
 
 def print_progress(text):
@@ -34,7 +38,7 @@ class Objective:
             )
 
     def cleanup(self):
-        print("Performing clean up, please wait...")  # noqa: T201
+        logger.info("Performing clean up, please wait...")
         try:
             if self.root_node:
                 files = File.objects.filter(contentnode=self.root_node)
@@ -45,10 +49,9 @@ class Objective:
                 self.root_node = None
         except Exception:
             if self.root_node:
-                print(  # noqa: T201
-                    "Error in cleanup. Root node with id {} may still exist.".format(
-                        self.root_node.pk
-                    )
+                logger.error(
+                    "Error in cleanup. Root node with id %s may still exist.",
+                    self.root_node.pk,
                 )
             raise
 

--- a/contentcuration/contentcuration/utils/db_tools.py
+++ b/contentcuration/contentcuration/utils/db_tools.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import random
 import string
@@ -31,6 +32,8 @@ from contentcuration.models import License
 from contentcuration.models import User
 from contentcuration.utils.files import duplicate_file
 
+logger = logging.getLogger(__name__)
+
 LICENSE_DESCRIPTION = "Sample text for content with special permissions"
 SORT_ORDER = 0
 
@@ -43,10 +46,10 @@ def create_user(email, password, first_name, last_name, admin=False):
         user.set_password(password)
         user.first_name = first_name
         user.last_name = last_name
-        print(  # noqa: T201
-            "User created (email: {}, password: {}, admin: {})".format(
-                email, password, admin
-            )
+        logger.info(
+            "User created (email: %s, admin: %s)",
+            email,
+            admin,
         )
     user.is_staff = admin
     user.is_admin = admin

--- a/contentcuration/contentcuration/utils/nodes.py
+++ b/contentcuration/contentcuration/utils/nodes.py
@@ -28,6 +28,8 @@ from contentcuration.utils.cache import ResourceSizeCache
 from contentcuration.utils.files import get_thumbnail_encoding
 from contentcuration.utils.sentry import report_exception
 
+logger = logging.getLogger(__name__)
+
 
 def map_files_to_node(user, node, data):  # noqa: C901
     """
@@ -162,7 +164,7 @@ def map_files_to_slideshow_slide_item(user, node, slides, files):
 
         if not matching_slide:
             # TODO(Jacob) Determine proper error type... raise it.
-            print("NO MATCH")  # noqa: T201
+            logger.warning("NO MATCH for checksum %s", checksum)
 
         file_path = generate_object_storage_name(checksum, filename)
         storage = default_storage

--- a/contentcuration/contentcuration/utils/publish.py
+++ b/contentcuration/contentcuration/utils/publish.py
@@ -391,7 +391,7 @@ class TreeMapper:
 
 
 def create_slideshow_manifest(ccnode, user_id=None):
-    print("Creating slideshow manifest...")  # noqa: T201
+    logging.info("Creating slideshow manifest...")
 
     preset = ccmodels.FormatPreset.objects.filter(pk="slideshow_manifest")[0]
     ext = file_formats.JSON


### PR DESCRIPTION
## Summary

This PR replaces remaining `print()` calls in production Python code with proper logging and Django command output (`self.stdout` / `self.stderr`), so output is consistent with project conventions.

While doing this cleanup, I also removed plain-text password logging from user creation logs.

Scope is intentionally small and does not change business logic.

## References

No linked issue; maintenance cleanup.

## Reviewer guidance

- Confirm this is output/logging cleanup only.
- Spot-check command files now use Django output methods.
- Verify no sensitive data is logged.
- Repo search for production `print()` calls now returns no matches.