### PR TITLE
Downgrade grpcio because 1.78.1 was yanked

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -144,7 +144,7 @@ grpc-google-iam-v1==0.12.4
     # via
     #   google-cloud-kms
     #   google-cloud-logging
-grpcio==1.78.1
+grpcio==1.78.0
     # via
     #   google-api-core
     #   google-cloud-appengine-logging


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Eliminates warnings about `grpcio`:
```
warning: `grpcio==1.78.1` is yanked (reason: "Caused major outage with gcloud serveless environments: https://github.com/grpc/grpc/issues/41725")
```

## References
<!--
 * references to related issues and PRs
-->
https://learningequality.slack.com/archives/C0LK8QS9J/p1773768908062049

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Can you run `uv pip sync` and not see any warnings?

<!--
AI USAGE - DEEP guidelines

If AI was used in preparing this PR, please fill in the section below.
Our DEEP guidelines ask that when using AI you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

If AI was not used, delete the section below.
-->

## AI usage
None