### PR TITLE
fix: handle Channel.DoesNotExist in remove_self

### DIFF
--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -333,8 +333,9 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
         if not channel_id:
             return HttpResponseBadRequest("Channel ID is required.")
 
-        channel = Channel.objects.get(id=channel_id)
-        if not channel:
+        try:
+            channel = Channel.objects.get(id=channel_id)
+        except Channel.DoesNotExist:
             return HttpResponseNotFound("Channel not found {}".format(channel_id))
 
         if request.user != user and not request.user.can_edit(channel_id):


### PR DESCRIPTION
## **SUMMARY**

This PR fixes an unhandled `Channel.DoesNotExist` exception in the `remove_self` view that caused a 500 error for invalid `channel_id`. It ensures a proper 404 response is returned instead.
Primary changes are in `contentcuration/contentcuration/viewsets/user.py`.

---

## **FIX**

* **Code (before → after)**

```python
# Before
channel = Channel.objects.get(id=channel_id)

# After
try:
    channel = Channel.objects.get(id=channel_id)
except Channel.DoesNotExist:
    return HttpResponseNotFound(...)
```
---

## **RESULT**

* Invalid `channel_id` now returns **404 Not Found** instead of 500
* Prevents runtime crashes from uncaught exceptions
* Makes the existing error handling path reachable
* No impact on valid request flow

