### PR TITLE
Fix duplicate community library submission

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/composables/useLatestCommunityLibrarySubmission.js
+++ b/contentcuration/contentcuration/frontend/shared/composables/useLatestCommunityLibrarySubmission.js
@@ -6,7 +6,11 @@ export function useLatestCommunityLibrarySubmission({ channelId, admin = false }
 
   function fetchLatestSubmission() {
     // Submissions are ordered by most recent first in the backend
-    return Resource.fetchCollection({ channel: channelId, max_results: 1 }).then(response => {
+    return Resource.fetchCollection({
+      channel: channelId,
+      max_results: 1,
+      ordering: '-date_created',
+    }).then(response => {
       if (response.results.length > 0) {
         return response.results[0];
       }

--- a/contentcuration/contentcuration/viewsets/community_library_submission.py
+++ b/contentcuration/contentcuration/viewsets/community_library_submission.py
@@ -29,6 +29,7 @@ from contentcuration.viewsets.base import ReadOnlyValuesViewset
 from contentcuration.viewsets.base import RESTCreateModelMixin
 from contentcuration.viewsets.base import RESTDestroyModelMixin
 from contentcuration.viewsets.base import RESTUpdateModelMixin
+from contentcuration.viewsets.base import ValuesViewsetOrderingFilter
 from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
 from contentcuration.viewsets.sync.utils import (
     generate_added_to_community_library_event,
@@ -244,11 +245,14 @@ class CommunityLibrarySubmissionViewSetMixin:
         "resolved_by_name": get_resolved_by_name,
         "channel_name": lambda item: item.get("channel__name"),
     }
-    queryset = CommunityLibrarySubmission.objects.all().order_by("-date_updated")
-    filter_backends = [DjangoFilterBackend, SearchFilter]
+    queryset = CommunityLibrarySubmission.objects.all()
+    filter_backends = [DjangoFilterBackend, SearchFilter, ValuesViewsetOrderingFilter]
     filterset_class = CommunityLibrarySubmissionFilterSet
     search_fields = ["channel__name"]
     pagination_class = CommunityLibrarySubmissionPagination
+
+    ordering_fields = ["date_updated", "date_created"]
+    ordering = "-date_updated"
 
     def consolidate(self, items, queryset):
         countries = {}


### PR DESCRIPTION
## Summary

Fixes community library submission ordering when requesting the latest submission. The error occurred because on the submission side panel, we query the latest submission to know if a submission already exists, but the ordering was set to "-updated_date" by default. Therefore, if a previous submission was recently updated, we will get this previous submission, instead of the "newer created submission". Therefore, allowing the user to make the request to create a submission that already exists.

## References
Closes #5766.

## Reviewer guidance
* Create two submissions S1 for version v1, S2 for version v2 for a given channel.
* Aprove S1.
* Without publishing any new versions, go to the submission side panel. You should see that a submission for v2 already exists, and shouldn't allow creating a new submission.
