### PR TITLE
fix: handle invalid UUID in remove_self to prevent 500 and return 400

### DIFF
--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -1,3 +1,4 @@
+import uuid
 from functools import reduce
 
 from django.db import IntegrityError
@@ -43,7 +44,7 @@ from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import VIEWER_M2M
-import uuid
+
 
 class IsAdminUser(BasePermission):
     """

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -43,7 +43,7 @@ from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import VIEWER_M2M
-
+import uuid
 
 class IsAdminUser(BasePermission):
     """
@@ -311,6 +311,10 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
 
         if not channel_id:
             return HttpResponseBadRequest("Channel ID is required.")
+        try:
+            uuid.UUID(channel_id)
+        except ValueError:
+            return HttpResponseBadRequest("Invalid channel ID")
 
         try:
             channel = Channel.objects.get(id=channel_id)

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -316,6 +316,8 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
             channel = Channel.objects.get(id=channel_id)
         except Channel.DoesNotExist:
             return HttpResponseNotFound("Channel not found {}".format(channel_id))
+        except ValueError:
+            return HttpResponseBadRequest("Invalid channel ID: {}".format(channel_id))
 
         if request.user != user and not request.user.can_edit(channel_id):
             return HttpResponseForbidden(


### PR DESCRIPTION
Fixes #5779 
## 1. SUMMARY

This PR fixes an unhandled exception in `ChannelUserViewSet.remove_self` where malformed `channel_id` values could trigger a 500 error. It adds proper validation handling to return a 400 Bad Request instead.

The change is localized to `contentcuration/contentcuration/viewsets/user.py`, aligning error handling with existing patterns in the codebase.

---

## 2. FIX

```python
# Before
try:
    channel = Channel.objects.get(id=channel_id)
except Channel.DoesNotExist:
    return HttpResponseNotFound("Channel not found {}".format(channel_id))

# After
try:
    channel = Channel.objects.get(id=channel_id)
except Channel.DoesNotExist:
    return HttpResponseNotFound("Channel not found {}".format(channel_id))
except ValueError:
    return HttpResponseBadRequest("Invalid channel ID: {}".format(channel_id))
```

---

## 3. VERIFICATION

Sending a request with a malformed `channel_id` (e.g., `not-a-valid-uuid`) now returns a **400 Bad Request** instead of a 500 error. Valid but non existent UUIDs correctly return **404 Not Found**, while valid existing IDs continue to work as expected.

---

## 4. AI Usage

AI was used only to help improve the phrasing of this pull request description.

The issue identification, debugging, and implementation were done manually after reviewing the code and reproducing the behavior locally. The fix was verified to ensure correct handling of malformed, non-existent, and valid UUID inputs.
