### PR TITLE
fix: restrict invitation accept/decline actions to invited user only

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -446,3 +446,27 @@ class CRUDTestCase(StudioAPITestCase):
             ).exists()
         )
         self.assertTrue(models.Change.objects.filter(channel=self.channel).exists())
+
+    def test_accept_invitation_by_non_invitee_is_forbidden(self):
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        # self.user is a channel editor, not the invited user
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("invitation-accept", kwargs={"pk": invitation.id})
+        )
+        self.assertEqual(response.status_code, 403, response.content)
+        invitation.refresh_from_db()
+        self.assertFalse(invitation.accepted)
+
+    def test_decline_invitation_by_non_invitee_is_forbidden(self):
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+
+        # self.user is a channel editor, not the invited user
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse("invitation-decline", kwargs={"pk": invitation.id})
+        )
+        self.assertEqual(response.status_code, 403, response.content)
+        invitation.refresh_from_db()
+        self.assertFalse(invitation.declined)

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -1,8 +1,8 @@
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import FilterSet
 from rest_framework import serializers
-from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -138,14 +138,14 @@ class InvitationViewSet(ValuesViewset):
         instance = serializer.save()
         instance.save()
 
+    def _ensure_invitee(self, request, invitation):
+        if (request.user.email or "").lower() != (invitation.email or "").lower():
+            raise PermissionDenied("Only the invited user may perform this action.")
+
     @action(detail=True, methods=["post"])
     def accept(self, request, pk=None):
         invitation = self.get_object()
-        if request.user.email.lower() != (invitation.email or "").lower():
-            return Response(
-                {"detail": "Only the invited user may accept this invitation."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
+        self._ensure_invitee(request, invitation)
         invitation.accept()
         invitation.accepted = True
         invitation.save()
@@ -164,11 +164,7 @@ class InvitationViewSet(ValuesViewset):
     @action(detail=True, methods=["post"])
     def decline(self, request, pk=None):
         invitation = self.get_object()
-        if request.user.email.lower() != (invitation.email or "").lower():
-            return Response(
-                {"detail": "Only the invited user may decline this invitation."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
+        self._ensure_invitee(request, invitation)
         invitation.declined = True
         invitation.save()
         Change.create_change(

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -1,6 +1,7 @@
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import FilterSet
 from rest_framework import serializers
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -140,6 +141,11 @@ class InvitationViewSet(ValuesViewset):
     @action(detail=True, methods=["post"])
     def accept(self, request, pk=None):
         invitation = self.get_object()
+        if request.user.email.lower() != (invitation.email or "").lower():
+            return Response(
+                {"detail": "Only the invited user may accept this invitation."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         invitation.accept()
         invitation.accepted = True
         invitation.save()
@@ -158,6 +164,11 @@ class InvitationViewSet(ValuesViewset):
     @action(detail=True, methods=["post"])
     def decline(self, request, pk=None):
         invitation = self.get_object()
+        if request.user.email.lower() != (invitation.email or "").lower():
+            return Response(
+                {"detail": "Only the invited user may decline this invitation."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         invitation.declined = True
         invitation.save()
         Change.create_change(


### PR DESCRIPTION
## 1. SUMMARY

This PR enforces invitee-only authorization in the invitation accept and decline endpoints, preventing non-invited users (e.g., channel editors) from modifying invitation state. It ensures only the intended recipient can act on an invitation, avoiding unauthorized acceptance or rejection.

---

## 2. FIX

```python
# Before
invitation = self.get_object()
invitation.accept()

# After
invitation = self.get_object()
if request.user.email.lower() != (invitation.email or "").lower():
    return Response(
        {"detail": "Only the invited user may accept this invitation."},
        status=status.HTTP_403_FORBIDDEN,
    )
invitation.accept()
```

closes https://github.com/learningequality/studio/issues/5781
---

## 3. VERIFICATION

Sending a request as a non invited user to `POST /invitation/<id>/accept/` or `/decline/` now returns **403 FORBIDDEN** instead of modifying the invitation.

The invitation state remains unchanged, while valid requests from the invited user continue to work as expected.

---

## 4, AI Usage

I did not use AI to generate or implement the code changes. The issue was identified by reviewing the existing invitation flow and noticing a missing authorization check, and the fix (including tests) was implemented and validated manually.

AI was only used to help refine the wording and structure of the PR description so that the problem and solution are communicated more clearly. All code changes were implemented and verified manually.
