### PR TITLE
Switch celery to thread runners for dev for the Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # standalone install method
 DOCKER_COMPOSE ?= docker-compose
+CELERY = cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3 --task-events
 
 # support new plugin installation for docker-compose
 ifeq (, $(shell command -v docker-compose 2>/dev/null))
@@ -16,7 +17,7 @@ altprodserver: collectstatic compilemessages
 	cd contentcuration/ && gunicorn contentcuration.wsgi:application --timeout=4000 --error-logfile=/var/log/gunicorn-error.log --workers=${NUM_PROCS} --threads=${NUM_THREADS} --bind=0.0.0.0:8081 --pid=/tmp/contentcuration.pid --log-level=debug || sleep infinity
 
 prodceleryworkers:
-	cd contentcuration/ && celery -A contentcuration worker -l info --concurrency=3 --task-events
+	$(CELERY)
 
 collectstatic:
 	python contentcuration/manage.py collectstatic --noinput
@@ -147,7 +148,7 @@ purge-postgres: .docker/pgpass
 destroy-and-recreate-database: purge-postgres setup
 
 devceleryworkers:
-	$(MAKE) -e DJANGO_SETTINGS_MODULE=contentcuration.dev_settings prodceleryworkers
+	DJANGO_SETTINGS_MODULE=contentcuration.dev_settings $(CELERY) --pool=threads
 
 run-services:
 	$(MAKE) -j 2 dcservicesup devceleryworkers


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Team members are having issues running the celery task workers. Investigation found issues with process forking:
```
On Apple Silicon + macOS 26, billiard's prefork pool is fundamentally unreliable regardless of what's loaded. The grpcio chase was a red herring; the SIGSEGV would likely happen even with a minimal task.

The fix is --pool=solo. Looking at the pnpm run celery script, it already uses -c 1 (single worker), so solo is equivalent in behavior — just without the fork. The simplest thing is to run it directly
```

## References
<!--
 * references to related issues and PRs
-->
https://learningequality.slack.com/archives/C0LK8QS9J/p1774881025194369


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Start up the dev server and celery `make devceleryworkers`
2. Create a channel
3. Add some content to the channel
4. Publish the channel
5. Verify that the task workers ran the tasks
