### PR TITLE
Add minReleaseAge to pnpm settings to reduce likelihood of supply chain compromises

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
       time: "00:00"
     cooldown:
       default-days: 7
+      exclude:
+        - kolibri-constants
+        - kolibri-design-system
+        - kolibri-logging
+        - kolibri-format
+        - kolibri-tools
     groups:
       babel:
         patterns:

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "> 1%",
     "Firefox ESR"
   ],
-  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "volta": {
     "node": "20.19.3",
     "pnpm": "10.12.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# minimum number of minutes
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - kolibri-constants
+  - kolibri-design-system
+  - kolibri-logging
+  - kolibri-format
+  - kolibri-tools


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Using [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) should reduce likelihood of supply chain compromises
- Sets the `minimumReleaseAge` to 1 week to match dependabot
- Upgrades `pnpm` since the feature needs [at least 10.16.0](https://pnpm.io/blog/releases/10.16)

## References
<!--
 * references to related issues and PRs
-->
https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Can you run `pnpm install`?
