### PR TITLE
Update community library page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/router.js
+++ b/contentcuration/contentcuration/frontend/channelList/router.js
@@ -6,7 +6,7 @@ import StudioViewOnlyChannels from './views/Channel/StudioViewOnlyChannels';
 import StudioCollectionsTable from './views/ChannelSet/StudioCollectionsTable';
 import ChannelSetModal from './views/ChannelSet/ChannelSetModal';
 import CatalogList from './views/Channel/CatalogList';
-import CommunityLibraryList from './views/Channel/CommunityLibraryList';
+import CommunityLibraryList from './views/Channel/CommunityLibraryList/index.vue';
 import { RouteNames } from './constants';
 import CatalogFAQ from './views/Channel/CatalogFAQ';
 import SubmissionDetailsModal from 'shared/views/communityLibrary/SubmissionDetailsModal/index.vue';

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CatalogList.vue
@@ -330,10 +330,18 @@
       getDropdownItems(channel) {
         const items = [];
         if (channel.source_url) {
-          items.push({ label: this.$tr('goToWebsite'), icon: 'openNewTab', value: 'source-url' });
+          items.push({
+            label: this.$tr('goToWebsite'),
+            icon: 'openNewTab',
+            value: 'source-url',
+          });
         }
         if (channel.demo_server_url) {
-          items.push({ label: this.$tr('viewContent'), icon: 'openNewTab', value: 'demo-url' });
+          items.push({
+            label: this.$tr('viewContent'),
+            icon: 'openNewTab',
+            value: 'demo-url',
+          });
         }
         return items;
       },
@@ -421,7 +429,7 @@
       },
     },
     $trs: {
-      title: 'Content library',
+      title: 'Kolibri library',
       resultsText: '{count, plural,\n =1 {# result found}\n other {# results found}}',
       selectChannels: 'Download a summary of selected channels',
       cancelButton: 'Cancel',

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/CommunityLibraryFilters.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/CommunityLibraryFilters.vue
@@ -16,6 +16,7 @@
       v-model="countriesFilter"
       :label="countryLabel$()"
       :options="countryOptions"
+      :disabled="disabled || !countryOptions.length"
       multiple
       clearable
     />
@@ -24,6 +25,7 @@
       v-model="languagesFilter"
       :label="languagesLabel$()"
       :options="languageOptions"
+      :disabled="disabled || !languageOptions.length"
       multiple
       clearable
     />
@@ -32,6 +34,7 @@
       v-model="categoriesFilter"
       :label="categoriesLabel$()"
       :options="categoryOptions"
+      :disabled="disabled || !categoryOptions.length"
       multiple
       clearable
     />

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
@@ -203,7 +203,7 @@
 
 <script>
 
-  import { computed, ref, watch } from 'vue';
+  import { computed, onMounted, ref, watch } from 'vue';
   import { useRoute, useRouter } from 'vue-router/composables';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
@@ -214,7 +214,7 @@
   import useCommunityChannelsFilters from './useCommunityChannelsFilters';
   import AboutCommunityLibraryModal from './AboutCommunityLibraryModal.vue';
   import ChannelTokenModal from 'shared/views/channel/ChannelTokenModal';
-  import { listPublicChannels } from 'shared/data/public';
+  import { listPublicChannels, getPublicChannelLabels } from 'shared/data/public';
   import useStore from 'shared/composables/useStore';
   import StudioChip from 'shared/views/StudioChip';
   import Pagination from 'shared/views/Pagination';
@@ -277,6 +277,8 @@
       } = communityChannelsStrings;
       const { copyChannelTokenAction$ } = commonStrings;
 
+      const availableLabels = ref(null);
+
       const {
         countriesFilter,
         categoriesFilter,
@@ -285,9 +287,11 @@
         keywordInput,
         clearSearch,
         removeFilterValue,
-      } = useCommunityChannelsFilters();
+      } = useCommunityChannelsFilters({ availableLabels });
 
-      const loading = ref(false);
+      const loadingChannels = ref(false);
+      const loadingLabels = ref(false);
+      const loading = computed(() => loadingChannels.value || loadingLabels.value);
       const loadError = ref(false);
       const channels = ref([]);
       const showFiltersSidePanel = ref(false);
@@ -328,7 +332,7 @@
       });
 
       async function loadCommunityLibrary() {
-        loading.value = true;
+        loadingChannels.value = true;
         loadError.value = false;
         try {
           const response = await listPublicChannels(fetchQueryParams.value);
@@ -343,7 +347,7 @@
           totalPages.value = 0;
           store.dispatch('errors/handleAxiosError', error);
         } finally {
-          loading.value = false;
+          loadingChannels.value = false;
         }
       }
 
@@ -438,6 +442,18 @@
         },
         { immediate: true, deep: true },
       );
+
+      onMounted(async () => {
+        loadingLabels.value = true;
+        try {
+          availableLabels.value = await getPublicChannelLabels({ public: false });
+        } catch {
+          // Silently ignore: filter options will show all values rather than
+          // restricting to those that have channels.
+        } finally {
+          loadingLabels.value = false;
+        }
+      });
 
       return {
         windowIsSmall,

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
@@ -118,10 +118,10 @@
             />
           </div>
         </div>
-        <div class="list-wrapper">
+        <div>
           <div class="results-header">
             <p
-              v-if="!loading"
+              v-if="!loading && activeFilters.length > 0"
               class="results-text"
             >
               {{ resultsText$({ count }) }}
@@ -543,16 +543,13 @@
   }
 
   .content-container {
+    max-width: 1080px;
     padding: 16px;
+    margin: 0 auto;
 
     p {
       margin: 8px 0;
     }
-  }
-
-  .list-wrapper {
-    max-width: 1080px;
-    margin: 0 auto;
   }
 
   .results-header {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/useCommunityChannelsFilters.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/useCommunityChannelsFilters.js
@@ -1,4 +1,4 @@
-import { computed, inject, provide } from 'vue';
+import { computed, inject, provide, unref } from 'vue';
 import { useFilter } from 'shared/composables/useFilter';
 import { useKeywordSearch } from 'shared/composables/useKeywordSearch';
 import countriesUtil from 'shared/utils/countries';
@@ -19,43 +19,46 @@ const FILTERS_QUERY_PARAMS = Symbol('filtersQueryParams');
 const REMOVE_FILTER_VALUE = Symbol('removeFilterValue');
 const CLEAR_SEARCH = Symbol('clearSearch');
 
-export default function useCommunityChannelsFilters() {
+export default function useCommunityChannelsFilters({ availableLabels } = {}) {
   const countryFilterMap = computed(() => {
     const [lang] = currentLanguage.split('-');
     const allCountries = countriesUtil.getNames(lang);
+    const _availableLabels = unref(availableLabels);
+    const availableCodes = _availableLabels?.countries
+      ? new Set(_availableLabels.countries.map(c => c.code))
+      : null;
     return Object.fromEntries(
-      Object.entries(allCountries).map(([code, name]) => [
-        code,
-        {
-          label: name,
-          params: { countries: code },
-        },
-      ]),
+      Object.entries(allCountries)
+        .filter(([code]) => !availableCodes || availableCodes.has(code))
+        .map(([code, name]) => [code, { label: name, params: { countries: code } }]),
     );
   });
 
   const languageFilterMap = computed(() => {
+    const _availableLabels = unref(availableLabels);
+    const availableIds = _availableLabels?.languages
+      ? new Set(_availableLabels.languages.map(l => l.id))
+      : null;
     return Object.fromEntries(
-      LanguagesList.map(lang => [
-        lang.id,
-        {
-          label: lang.readable_name,
-          params: { languages: lang.id },
-        },
-      ]),
+      LanguagesList.filter(lang => !availableIds || availableIds.has(lang.id))
+        .sort((a, b) => a.readable_name.localeCompare(b.readable_name))
+        .map(lang => [lang.id, { label: lang.readable_name, params: { languages: lang.id } }]),
     );
   });
 
   const categoryFilterMap = computed(() => {
     const sortedCategories = getSortedCategories();
+    const _availableLabels = unref(availableLabels);
+    const availableCategories = _availableLabels?.categories
+      ? new Set(_availableLabels.categories)
+      : null;
     return Object.fromEntries(
-      Object.entries(sortedCategories).map(([value, name]) => [
-        value,
-        {
-          label: translateMetadataString(name),
-          params: { categories: value },
-        },
-      ]),
+      Object.entries(sortedCategories)
+        .filter(([value]) => !availableCategories || availableCategories.has(value))
+        .map(([value, name]) => [
+          value,
+          { label: translateMetadataString(name), params: { categories: value } },
+        ]),
     );
   });
 
@@ -67,14 +70,9 @@ export default function useCommunityChannelsFilters() {
 
   const {
     filter: languagesFilter,
-    options: _languageOptions,
+    options: languageOptions,
     fetchQueryParams: languagesFetchQueryParams,
   } = useFilter({ name: 'languages', filterMap: languageFilterMap, multi: true });
-
-  const languageOptions = computed(() => {
-    // Sort language options alphabetically by label
-    return _languageOptions.value.sort((a, b) => a.label.localeCompare(b.label));
-  });
 
   const {
     filter: categoriesFilter,

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/__tests__/catalogList.spec.js
@@ -126,7 +126,7 @@ describe('CatalogList', () => {
   it('shows the visually hidden title and all channel cards in correct semantic structure', async () => {
     renderComponent();
 
-    const title = await screen.findByRole('heading', { name: /content library/i });
+    const title = await screen.findByRole('heading', { name: /kolibri library/i });
     expect(title).toBeInTheDocument();
     expect(title.tagName).toBe('H1');
     expect(title).toHaveClass('visuallyhidden');

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -251,6 +251,8 @@
           title = this.translateConstant('bookmark');
         } else if (routeName === RouteNames.CHANNELS_EDITABLE) {
           title = this.translateConstant('edit');
+        } else if (routeName === RouteNames.COMMUNITY_LIBRARY_ITEMS) {
+          title = this.communityLibraryLabel$();
         }
         // Title changes for other routes are handled by other components, since
         // we can access $tr messages only from within the component.
@@ -264,7 +266,7 @@
     },
     $trs: {
       channelSets: 'Collections',
-      catalog: 'Content Library',
+      catalog: 'Kolibri Library',
       libraryTitle: 'Kolibri Content Library Catalog',
       frequentlyAskedQuestions: 'Frequently asked questions',
     },

--- a/contentcuration/contentcuration/frontend/shared/data/public.js
+++ b/contentcuration/contentcuration/frontend/shared/data/public.js
@@ -166,6 +166,22 @@ export function listPublicChannels(params = {}) {
 }
 
 /**
+ * Get available filter label options for the public channel list.
+ * Returns an object with available values for each filterable field
+ * (categories, languages, countries).
+ *
+ * @param {Object} params
+ * @return {Promise<{
+ *   categories: string[],
+ *   languages: Array<{id: string, lang_name: string}>,
+ *   countries: Array<{code: string, name: string}>
+ * }>}
+ */
+export function getPublicChannelLabels(params = {}) {
+  return client.get(urls.publicchannel_labels(), { params }).then(response => response.data);
+}
+
+/**
  * Get a content node from the public API
  * @param {String} nodeId
  * @return {Promise<PublicContentNode>}

--- a/contentcuration/contentcuration/frontend/shared/mixins.js
+++ b/contentcuration/contentcuration/frontend/shared/mixins.js
@@ -89,7 +89,7 @@ export const fileStatusMixin = {
 export const constantStrings = createTranslator('ConstantStrings', {
   [ChannelListTypes.EDITABLE]: 'My channels',
   [ChannelListTypes.VIEW_ONLY]: 'View-only',
-  [ChannelListTypes.PUBLIC]: 'Content library',
+  [ChannelListTypes.PUBLIC]: 'Kolibri library',
   [ChannelListTypes.STARRED]: 'Starred',
   do_all: 'Goal: 100% correct',
   num_correct_in_a_row_10: 'Goal: 10 in a row',

--- a/contentcuration/contentcuration/frontend/shared/strings/communityChannelsStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/strings/communityChannelsStrings.js
@@ -195,7 +195,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
       'Description of warning shown in the "Submit to Community Library" panel when the channel is not published',
   },
   publicWarningTitle: {
-    message: 'This channel is currently public in the Content Library.',
+    message: 'This channel is currently public in the Kolibri Library.',
     context:
       'Title of warning shown in the "Submit to Community Library" panel when the channel is public',
   },

--- a/contentcuration/kolibri_public/search.py
+++ b/contentcuration/kolibri_public/search.py
@@ -101,6 +101,58 @@ def _get_available_channels(base_queryset):
     )
 
 
+def _get_available_channel_languages(base_queryset):
+    from contentcuration.models import Language
+
+    return list(
+        Language.objects.filter(public_channels__in=base_queryset)
+        .values("id", lang_name=F("native_name"))
+        .distinct()
+    )
+
+
+def _get_available_countries(base_queryset):
+    from contentcuration.models import Country
+
+    return list(
+        Country.objects.filter(public_channels__in=base_queryset)
+        .values("code", "name")
+        .distinct()
+    )
+
+
+def get_channel_available_metadata_labels(base_queryset):
+    from kolibri_public.models import ChannelMetadata
+
+    content_cache_key = str(
+        ChannelMetadata.objects.all().aggregate(updated=Max("last_updated"))["updated"]
+    )
+    cache_key = "channel-labels:{}:{}".format(
+        content_cache_key,
+        hashlib.md5(str(base_queryset.query).encode("utf8")).hexdigest(),
+    )
+    if cache_key not in cache:
+        base_queryset = base_queryset.order_by()
+        aggregates = {}
+        for field in channelmetadata_bitmask_fieldnames:
+            field_agg = field + "_agg"
+            aggregates[field_agg] = BitOr(field)
+        output = {}
+        if aggregates:
+            agg = base_queryset.aggregate(**aggregates)
+            for field, values in channelmetadata_bitmask_fieldnames.items():
+                bit_value = agg[field + "_agg"]
+                for value in values:
+                    if value["field_name"] not in output:
+                        output[value["field_name"]] = []
+                    if bit_value is not None and bit_value & value["bits"]:
+                        output[value["field_name"]].append(value["label"])
+        output["languages"] = _get_available_channel_languages(base_queryset)
+        output["countries"] = _get_available_countries(base_queryset)
+        cache.set(cache_key, output, timeout=None)
+    return cache.get(cache_key)
+
+
 # Remove the SQLite Bitwise OR definition as not needed.
 
 

--- a/contentcuration/kolibri_public/tests/test_channelmetadata_viewset.py
+++ b/contentcuration/kolibri_public/tests/test_channelmetadata_viewset.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from django.urls import reverse
 from kolibri_public.models import ChannelMetadata
 from kolibri_public.tests.utils.mixer import KolibriPublicMixer
 from le_utils.constants.labels.subjects import SUBJECTSLIST
@@ -293,3 +294,96 @@ class ChannelMetadataLanguageFilterTestCase(StudioAPITestCase):
         ids = [UUID(item["id"]) for item in response.data]
         self.assertIn(UUID(self.channel_en.id), ids)
         self.assertNotIn(UUID(self.channel_multi.id), ids)
+
+
+class ChannelMetadataLabelsActionTestCase(StudioAPITestCase):
+    def setUp(self):
+        super().setUp()
+
+        mixer = KolibriPublicMixer()
+        self.user = testdata.user("labels@user.com")
+
+        self.categories = [SUBJECTSLIST[0], SUBJECTSLIST[1]]
+
+        self.lang_en = Language.objects.get_or_create(
+            id="en", defaults={"lang_code": "en", "readable_name": "English"}
+        )[0]
+        self.lang_fr = Language.objects.get_or_create(
+            id="fr", defaults={"lang_code": "fr", "readable_name": "French"}
+        )[0]
+
+        self.country_us = Country.objects.get_or_create(
+            code="US", defaults={"name": "United States"}
+        )[0]
+        self.country_mx = Country.objects.get_or_create(
+            code="MX", defaults={"name": "Mexico"}
+        )[0]
+        # Country not associated with any channel
+        self.country_br = Country.objects.get_or_create(
+            code="BR", defaults={"name": "Brazil"}
+        )[0]
+
+        self.channel1 = mixer.blend(
+            ChannelMetadata,
+            categories_bitmask_0=1 | 2,  # SUBJECTSLIST[0] and [1]
+            public=False,
+        )
+        self.channel1.included_languages.add(self.lang_en)
+        self.channel1.countries.add(self.country_us)
+
+        self.channel2 = mixer.blend(
+            ChannelMetadata,
+            categories_bitmask_0=2,  # SUBJECTSLIST[1] only
+            public=False,
+        )
+        self.channel2.included_languages.add(self.lang_fr)
+        self.channel2.countries.add(self.country_mx)
+
+    def _labels(self, query=None):
+        self.client.force_authenticate(self.user)
+        url = reverse("publicchannel-labels")
+        return self.client.get(url, query or {})
+
+    def test_labels_returns_200(self):
+        response = self._labels({"public": "false"})
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_labels_returns_available_languages(self):
+        response = self._labels({"public": "false"})
+        language_ids = [lang["id"] for lang in response.data["languages"]]
+        self.assertIn("en", language_ids)
+        self.assertIn("fr", language_ids)
+
+    def test_labels_returns_available_countries(self):
+        response = self._labels({"public": "false"})
+        country_codes = [c["code"] for c in response.data["countries"]]
+        self.assertIn("US", country_codes)
+        self.assertIn("MX", country_codes)
+        # Country not linked to any channel should not appear
+        self.assertNotIn("BR", country_codes)
+
+    def test_labels_returns_available_categories(self):
+        response = self._labels({"public": "false"})
+        categories = response.data.get("categories", [])
+        self.assertIn(self.categories[0], categories)
+        self.assertIn(self.categories[1], categories)
+
+    def test_labels_respects_filter_params(self):
+        # When filtering to only channel1's language, only channel1's country should appear
+        response = self._labels({"public": "false", "languages": "en"})
+        self.assertEqual(response.status_code, 200, response.content)
+        country_codes = [c["code"] for c in response.data["countries"]]
+        self.assertIn("US", country_codes)
+        self.assertNotIn("MX", country_codes)
+
+    def test_labels_country_objects_have_code_and_name(self):
+        response = self._labels({"public": "false"})
+        for country in response.data["countries"]:
+            self.assertIn("code", country)
+            self.assertIn("name", country)
+
+    def test_labels_language_objects_have_id_and_lang_name(self):
+        response = self._labels({"public": "false"})
+        for lang in response.data["languages"]:
+            self.assertIn("id", lang)
+            self.assertIn("lang_name", lang)

--- a/contentcuration/kolibri_public/views.py
+++ b/contentcuration/kolibri_public/views.py
@@ -121,9 +121,7 @@ class ChannelMetadataFilter(FilterSet):
     categories = CharFilter(method=bitmask_contains_and, label="Categories")
     countries = CharInFilter(field_name="countries", label="Countries")
     public = BooleanFilter(field_name="public", label="Public", initial=True)
-    languages = CharInFilter(
-        field_name="included_languages__lang_code", label="Languages"
-    )
+    languages = CharInFilter(field_name="included_languages__id", label="Languages")
 
     class Meta:
         model = models.ChannelMetadata

--- a/contentcuration/kolibri_public/views.py
+++ b/contentcuration/kolibri_public/views.py
@@ -33,10 +33,12 @@ from django_filters.rest_framework import FilterSet
 from django_filters.rest_framework import NumberFilter
 from django_filters.rest_framework import UUIDFilter
 from kolibri_public import models
+from kolibri_public.search import get_channel_available_metadata_labels
 from kolibri_public.search import get_contentnode_available_metadata_labels
 from kolibri_public.stopwords import stopwords_set
 from le_utils.constants import content_kinds
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -254,6 +256,16 @@ class ChannelMetadataViewSet(ReadOnlyValuesViewset):
             item["last_published"] = item["last_updated"]
 
         return items
+
+    @action(detail=False, methods=["get"])
+    def labels(self, request):
+        """
+        Returns available filter option values for the channel list.
+        The response is an object with keys for each filterable field, each
+        containing the set of values present across the filtered queryset.
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        return Response(get_channel_available_metadata_labels(queryset))
 
 
 contentnode_filter_fields = [

--- a/contentcuration/kolibri_public/views.py
+++ b/contentcuration/kolibri_public/views.py
@@ -201,7 +201,7 @@ class ChannelMetadataViewSet(ReadOnlyValuesViewset):
     }
 
     def get_queryset(self):
-        return models.ChannelMetadata.objects.all()
+        return models.ChannelMetadata.objects.all().order_by("name")
 
     def consolidate(self, items, queryset):
         # Only keep a single item for every channel ID, to get rid of possible


### PR DESCRIPTION
## Summary
* Update page title when CommunityChannelList page is visible.
* Adds new `labels` action on the public channel metadata viewset to return available labels for a given queryset.
* Updates frontend filters to show just available channel filter options.
* Remove "N results found" on the CommunityChannelList page when no filters are applied.
* Sets a max width for all nodes of the CommunityChannelList page.
* Sort channels coming from the public channel metadata viewset by name.
* Updates "Content Library" to "Kolibri Library".

### Notes
* We have intentionally chosen to keep the non-autocomplete selects. See https://learningequality.slack.com/archives/C08RCNF1Y0N/p1775075881779779.
* We have decided to keep the mismatch of having the title visible on the Community Library page, but not on the Kolibri Library page. See https://learningequality.slack.com/archives/C08RCNF1Y0N/p1775075881779779.

## References
Closes #5795.

## Reviewer guidance
Check all points described on #5795.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Asked Claude to create a `get_channel_available_metadata_labels` method similar to the current `get_contentnode_available_metadata_labels`, and asked him to write tests for the viewset following the structure of other tests that have tests for the same viewset. Also asked it to update the `useCommunityChannelsFilters` to receive an `availableLabels` ref.