### PR TITLE
[Remove Vuetify from Studio]  Layout and input on the Collection > Select channels page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -13,7 +13,7 @@
       />
       <p
         v-if="!listChannels.length"
-        class="grey--text no-channels-found"
+        class="no-channels-found"
       >
         {{ $tr('noChannelsFound') }}
       </p>
@@ -159,6 +159,7 @@
   .no-channels-found {
     margin-top: 16px;
     margin-bottom: 0;
+    color: v-bind('$themeTokens.annotation');
   }
 
   .selection-card {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -1,24 +1,19 @@
 <template>
 
-  <VContainer
-    fluid
-    class="pa-0 pb-5"
-  >
-    <LoadingText
-      v-if="loading"
-      class="pt-4"
+  <div class="selection-list">
+    <StudioLargeLoader
+      v-if="show(loaderKey, loading, 400)"
+      class="selection-loader"
     />
     <template v-else>
-      <VTextField
+      <KTextbox
         v-model="search"
-        style="max-width: 350px"
-        class="mt-4"
-        box
+        class="search-input"
         :label="$tr('searchText')"
       />
       <p
         v-if="!listChannels.length"
-        class="grey--text mb-0 mt-4"
+        class="grey--text no-channels-found"
       >
         {{ $tr('noChannelsFound') }}
       </p>
@@ -28,29 +23,25 @@
           :key="channel.id"
           flat
           hover
-          class="list-card-hover px-3"
+          class="list-card-hover selection-card"
         >
-          <VLayout
-            align-center
-            row
-          >
-            <Checkbox
-              v-model="selectedChannels"
-              color="primary"
+          <div class="selection-row">
+            <KCheckbox
+              :checked="selectedChannels.includes(channel.id)"
               :data-testid="`checkbox-${channel.id}`"
-              :value="channel.id"
-              class="channel ma-0"
+              class="channel-checkbox"
+              @change="handleSelectChannel(channel.id)"
             />
             <ChannelItem
               :channelId="channel.id"
               :data-testid="`channel-item-${channel.id}`"
               @click="handleSelectChannel"
             />
-          </VLayout>
+          </div>
         </VCard>
       </template>
     </template>
-  </VContainer>
+  </div>
 
 </template>
 
@@ -58,11 +49,11 @@
 <script>
 
   import sortBy from 'lodash/sortBy';
+  import useKShow from 'kolibri-design-system/lib/composables/useKShow';
   import { mapGetters, mapActions } from 'vuex';
   import ChannelItem from './ChannelItem';
   import { ChannelListTypes } from 'shared/constants';
-  import Checkbox from 'shared/views/form/Checkbox';
-  import LoadingText from 'shared/views/LoadingText';
+  import StudioLargeLoader from 'shared/views/StudioLargeLoader';
 
   function listTypeValidator(value) {
     // The value must match one of the ListTypes
@@ -72,9 +63,12 @@
   export default {
     name: 'ChannelSelectionList',
     components: {
-      Checkbox,
       ChannelItem,
-      LoadingText,
+      StudioLargeLoader,
+    },
+    setup() {
+      const { show } = useKShow();
+      return { show };
     },
     props: {
       value: {
@@ -117,6 +111,9 @@
           'name',
         );
       },
+      loaderKey() {
+        return `channel-selection-list-${this.listType}`;
+      },
     },
     mounted() {
       this.loading = true;
@@ -146,12 +143,36 @@
 
 <style lang="scss" scoped>
 
-  .add-channel-button {
-    margin: 0;
+  .selection-list {
+    padding-bottom: 20px;
   }
 
-  .channel /deep/ .k-checkbox {
-    vertical-align: middle;
+  .selection-loader {
+    padding-top: 16px;
+  }
+
+  .search-input {
+    max-width: 350px;
+    margin-top: 16px;
+  }
+
+  .no-channels-found {
+    margin-top: 16px;
+    margin-bottom: 0;
+  }
+
+  .selection-card {
+    padding-inline: 12px;
+  }
+
+  .selection-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .channel-checkbox {
+    margin: 0;
+    padding-inline-end: 4px;
   }
 
   .list-card-hover {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -171,8 +171,8 @@
   }
 
   .channel-checkbox {
-    margin: 0;
     padding-inline-end: 4px;
+    margin: 0;
   }
 
   .list-card-hover {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue
@@ -28,6 +28,8 @@
           <div class="selection-row">
             <KCheckbox
               :checked="selectedChannels.includes(channel.id)"
+              :label="channel.name"
+              :showLabel="false"
               :data-testid="`checkbox-${channel.id}`"
               class="channel-checkbox"
               @change="handleSelectChannel(channel.id)"

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
@@ -5,6 +5,13 @@ import { Store } from 'vuex';
 import ChannelSelectionList from '../ChannelSelectionList';
 import { ChannelListTypes } from 'shared/constants';
 
+jest.mock('kolibri-design-system/lib/composables/useKShow', () => ({
+  __esModule: true,
+  default: () => ({
+    show: (_id, loading) => loading,
+  }),
+}));
+
 const searchWord = 'search test';
 
 const editChannel = {
@@ -82,6 +89,21 @@ describe('ChannelSelectionList', () => {
     expect(screen.getByText(editChannel.name)).toBeInTheDocument();
     expect(screen.getByText(editChannel2.name)).toBeInTheDocument();
     expect(screen.queryByText(publicChannel.name)).not.toBeInTheDocument();
+  });
+
+  it('shows loader while the channel list is loading', async () => {
+    let resolveLoad;
+    const loadingPromise = new Promise(resolve => {
+      resolveLoad = resolve;
+    });
+    mockActions.loadChannelList.mockReturnValueOnce(loadingPromise);
+
+    await renderComponent();
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+
+    resolveLoad();
+    expect(await screen.findByLabelText('Search for a channel')).toBeInTheDocument();
   });
 
   it('filters the channel list when the user types in the search box', async () => {

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js
@@ -17,7 +17,7 @@ const searchWord = 'search test';
 const editChannel = {
   id: 'editchannel',
   name: searchWord,
-  description: '',
+  description: 'A curated collection of math resources',
   edit: true,
   published: true,
 };
@@ -25,7 +25,7 @@ const editChannel = {
 const editChannel2 = {
   id: 'editchannel2',
   name: 'Another Channel',
-  description: '',
+  description: 'Science and nature topics for all ages',
   edit: true,
   published: true,
 };
@@ -86,9 +86,9 @@ describe('ChannelSelectionList', () => {
     // Specific wait avoids wrapping the whole block in waitFor
     expect(await screen.findByLabelText('Search for a channel')).toBeInTheDocument();
 
-    expect(screen.getByText(editChannel.name)).toBeInTheDocument();
-    expect(screen.getByText(editChannel2.name)).toBeInTheDocument();
-    expect(screen.queryByText(publicChannel.name)).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: editChannel.name })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: editChannel2.name })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: publicChannel.name })).not.toBeInTheDocument();
   });
 
   it('shows loader while the channel list is loading', async () => {
@@ -111,23 +111,23 @@ describe('ChannelSelectionList', () => {
     await renderComponent();
 
     // Wait for data load
-    expect(await screen.findByText(editChannel.name)).toBeInTheDocument();
-    expect(screen.getByText(editChannel2.name)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: editChannel.name })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: editChannel2.name })).toBeInTheDocument();
 
     const searchInput = screen.getByLabelText('Search for a channel');
     await user.clear(searchInput);
     await user.type(searchInput, editChannel.name);
 
     // Verify filter happened
-    expect(await screen.findByText(editChannel.name)).toBeInTheDocument();
-    expect(screen.queryByText(editChannel2.name)).not.toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: editChannel.name })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: editChannel2.name })).not.toBeInTheDocument();
   });
 
   it('selects a channel when the user clicks the checkbox', async () => {
     const user = userEvent.setup();
     const { emitted } = await renderComponent();
 
-    await screen.findByText(editChannel.name);
+    await screen.findByRole('heading', { name: editChannel.name });
 
     // Using getByTestId because the component doesn't expose unique
     // accessible roles for individual channel checkboxes
@@ -149,7 +149,7 @@ describe('ChannelSelectionList', () => {
     // Initialize with the channel already selected
     const { emitted } = await renderComponent({ value: [editChannel.id] });
 
-    await screen.findByText(editChannel.name);
+    await screen.findByRole('heading', { name: editChannel.name });
 
     // Using getByTestId because the component doesn't expose unique
     // accessible roles for individual channel checkboxes
@@ -168,7 +168,7 @@ describe('ChannelSelectionList', () => {
     const user = userEvent.setup();
     const { emitted } = await renderComponent();
 
-    await screen.findByText(editChannel.name);
+    await screen.findByRole('heading', { name: editChannel.name });
 
     // Using getByTestId because the component doesn't expose accessible
     // roles for channel cards
@@ -186,7 +186,7 @@ describe('ChannelSelectionList', () => {
     // Initialize with the channel already selected
     const { emitted } = await renderComponent({ value: [editChannel.id] });
 
-    await screen.findByText(editChannel.name);
+    await screen.findByRole('heading', { name: editChannel.name });
 
     // Using getByTestId because the component doesn't expose accessible
     // roles for channel cards
@@ -196,5 +196,14 @@ describe('ChannelSelectionList', () => {
     expect(emitted()).toHaveProperty('input');
     expect(emitted().input).toHaveLength(1);
     expect(emitted().input[0][0]).toEqual([]);
+  });
+
+  it('each checkbox has an accessible name matching its channel name', async () => {
+    await renderComponent();
+
+    // KCheckbox renders a visually-hidden <label for="id"> associated with the input,
+    // so getByRole resolves the accessible name correctly for screen readers
+    expect(await screen.findByRole('checkbox', { name: editChannel.name })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: editChannel2.name })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
This PR removes Vuetify usage from the **layout and input** in the Collection → Select channels selection list, per issue scope.

Changes made:
- Replaced `LoadingText` with `StudioLargeLoader` and `useKShow(..., 400)` for minimum visible loader time.
- Replaced `Checkbox` with `KCheckbox`.
- Replaced `VTextField` with `KTextbox`.
- Replaced local `VContainer` / `VLayout` usage in `ChannelSelectionList` with custom scoped styles and `div` layout.
- Kept channel card refactor out of scope (no card changes).

Behavior preserved:
- Search filtering works as before.
- Selecting/deselecting works via checkbox click.
- Selecting/deselecting works via channel item click.
- Empty-search state still displays “No channels found”.

Tests/verification:
- Updated `channelSelectionList.spec.js` to mock `useKShow`.
- Added loader test for loading state behavior.
- Ran:
  - `pnpm exec eslint contentcuration/contentcuration/frontend/channelList/views/ChannelSet/ChannelSelectionList.vue contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js`
  - `pnpm test -- contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSelectionList.spec.js contentcuration/contentcuration/frontend/channelList/views/ChannelSet/__tests__/channelSetModal.spec.js`
  - `pnpm run build`

Manual verification:
1. Login as `user@a.com` / `a`.
2. Go to `Channels → Collections`.
3. Click `New collection`.
4. Click `Select channels`.
5. Verify loader, search, selection via checkbox, selection via row click, and empty search state.

Screenshots:

| Scenario | Screenshot |
|----------|------------|
| **Select channels — Initial load** | <img width="1124" height="557" alt="Screenshot_20260402_203540" src="https://github.com/user-attachments/assets/b85fb73c-3773-494b-bc5b-5a31292f9b6f" /> |
| **Select channels — Default list** | <img width="1919" height="905" alt="Select channels default list" src="https://github.com/user-attachments/assets/2eed72ac-8731-4e0d-a551-8e2870a54155" /> |
| **Select channels — Filtered / Empty result** | <img width="835" height="576" alt="Select channels filtered empty result" src="https://github.com/user-attachments/assets/1d8b9df2-e18f-4172-9bf5-e2be524c793d" /> |
## References
- Closes #5774
- Part of #5060

## Reviewer guidance
Please verify:
- Loader uses minimum visible time behavior (`useKShow(..., 400)`).
- Checkbox and row click selection interactions still match previous behavior.
- Search and empty-state behavior are unchanged.
- No channel card refactor was introduced.
- No `::v-deep` or `/deep/` selectors were added.

## AI usage
I used Codex (generative AI) to help implement and iterate this change, including component replacement and test updates.

DEEP disclosure:
- **Disclose:** AI was used for implementation support and troubleshooting local setup/build issues.
- **Engage critically:** I reviewed generated code for correctness and scope, ensuring no card refactor or unrelated changes were introduced.
- **Edit:** I refined AI-generated output (including styles and test updates) and removed/avoided out-of-scope changes.
- **Process sharing:** AI was used for drafting code and test scaffolding; final verification was done manually with local UI checks, linting, tests, and build.
