### PR TITLE
Convert trash modal unit tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -232,8 +232,6 @@ describe('TrashModal', () => {
       await user.click(screen.getByTestId('restore'));
       expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
     });
-
-
   });
 
   describe('selection count', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -1,12 +1,10 @@
-import { render, screen, waitFor, configure } from '@testing-library/vue';
+import { render, screen, waitFor, configure, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import VueRouter from 'vue-router';
 
 import { factory } from '../../../store';
 import { RouteNames } from '../../../constants';
 import TrashModal from '../TrashModal';
-
-const store = factory();
 
 const TRASH_ID = 'trash-root-id';
 
@@ -16,19 +14,23 @@ const testChildren = [
   { id: 'test3', title: 'Topic', kind: 'topic', modified: new Date(2020, 1, 1) },
 ];
 
-async function makeWrapper(items = testChildren, isLoading = false) {
+async function makeWrapper(items = testChildren, { isLoading = false, hasMore = false } = {}) {
+  const store = factory();
+
   const loadContentNodesSpy = jest
     .spyOn(TrashModal.methods, 'loadContentNodes')
     .mockResolvedValue({});
   jest.spyOn(TrashModal.methods, 'loadAncestors').mockResolvedValue();
   jest.spyOn(TrashModal.methods, 'removeContentNodes').mockResolvedValue();
+  // loadNodes is not mocked intentionally: we let the real implementation run so that
+  // the loading state and `more` data are exercised through the mocked loadChildren below.
   const loadNodesSpy = jest.spyOn(TrashModal.methods, 'loadNodes');
 
   if (isLoading) {
     jest.spyOn(TrashModal.methods, 'loadChildren').mockReturnValue(new Promise(() => {}));
   } else {
     jest.spyOn(TrashModal.methods, 'loadChildren').mockResolvedValue({
-      more: items === testChildren ? null : { parent: TRASH_ID, page: 2 },
+      more: hasMore ? { parent: TRASH_ID, page: 2 } : null,
       results: [],
     });
   }
@@ -79,7 +81,7 @@ async function makeWrapper(items = testChildren, isLoading = false) {
   }
 
   const user = userEvent.setup();
-  return { ...utils, routerPush, user, loadNodesSpy, loadContentNodesSpy };
+  return { ...utils, routerPush, user, loadNodesSpy, loadContentNodesSpy, store };
 }
 
 describe('TrashModal', () => {
@@ -92,7 +94,7 @@ describe('TrashModal', () => {
 
   describe('on load', () => {
     it('shows a loading indicator while content is loading', async () => {
-      await makeWrapper(testChildren, true);
+      await makeWrapper(testChildren, { isLoading: true });
       expect(screen.getByTestId('loading')).toBeInTheDocument();
     });
 
@@ -114,7 +116,7 @@ describe('TrashModal', () => {
       expect(screen.getByTestId('delete')).toBeDisabled();
       expect(screen.getByTestId('restore')).toBeDisabled();
 
-      await user.click(screen.getAllByRole('checkbox')[1]);
+      await user.click(within(screen.getAllByTestId('checkbox')[0]).getByRole('checkbox'));
 
       await waitFor(() => {
         expect(screen.getByTestId('delete')).toBeEnabled();
@@ -127,12 +129,23 @@ describe('TrashModal', () => {
       await user.click(screen.getByTestId('selectall'));
 
       await waitFor(() => {
-        screen
-          .getAllByRole('checkbox')
-          .slice(1)
-          .forEach(cb => {
-            expect(cb).toBeChecked();
-          });
+        screen.getAllByTestId('checkbox').forEach(container => {
+          expect(within(container).getByRole('checkbox')).toBeChecked();
+        });
+      });
+    });
+
+    it('clicking an item link sets previewNodeId, opening the ResourceDrawer', async () => {
+      const { user } = await makeWrapper();
+
+      const itemLinks = screen.getAllByTestId('item');
+      await user.click(itemLinks[0]);
+
+      await waitFor(() => {
+        expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute(
+          'nodeid',
+          testChildren[0].id,
+        );
       });
     });
   });
@@ -197,9 +210,10 @@ describe('TrashModal', () => {
 
     it('successful deletion triggers snackbar and reloads nodes', async () => {
       jest.spyOn(TrashModal.methods, 'deleteContentNodes').mockResolvedValue();
+
+      const { user, loadNodesSpy, store } = await makeWrapper();
       const dispatchSpy = jest.spyOn(store, 'dispatch').mockImplementation(() => Promise.resolve());
 
-      const { user, loadNodesSpy } = await makeWrapper();
       await user.click(screen.getByTestId('selectall'));
       await user.click(screen.getByTestId('delete'));
       await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
@@ -225,6 +239,32 @@ describe('TrashModal', () => {
       await user.click(screen.getByTestId('restore'));
       expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
     });
+
+    it('successful restore clears selection and previewNodeId, and reloads nodes', async () => {
+      jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
+
+      const { user, loadNodesSpy } = await makeWrapper();
+
+      await user.click(screen.getByTestId('selectall'));
+
+      const itemLinks = screen.getAllByTestId('item');
+      await user.click(itemLinks[0]);
+
+      await user.click(screen.getByTestId('restore'));
+
+      await user.click(await screen.findByRole('button', { name: /Move here/i }));
+
+      await waitFor(() => {
+        expect(loadNodesSpy).toHaveBeenCalled();
+
+        screen.getAllByTestId('checkbox').forEach(container => {
+          expect(within(container).getByRole('checkbox')).not.toBeChecked();
+        });
+
+        const drawer = document.querySelector('resourcedrawer-stub');
+        expect(drawer).not.toHaveAttribute('nodeid');
+      });
+    });
   });
 
   describe('selection count', () => {
@@ -241,18 +281,18 @@ describe('TrashModal', () => {
 
   describe('pagination', () => {
     it('shows a Show more button when there is more paginated content', async () => {
-      await makeWrapper([testChildren[0]]);
+      await makeWrapper([testChildren[0]], { hasMore: true });
       expect(await screen.findByRole('button', { name: /Show more/i })).toBeInTheDocument();
     });
 
     it('clicking Show more calls loadContentNodes with pagination params', async () => {
-      const { user, loadContentNodesSpy } = await makeWrapper([testChildren[0]]);
+      const { user, loadContentNodesSpy } = await makeWrapper([testChildren[0]], { hasMore: true });
       const showMoreBtn = await screen.findByRole('button', { name: /Show more/i });
 
       await user.click(showMoreBtn);
 
       await waitFor(() => {
-        expect(loadContentNodesSpy).toHaveBeenCalledWith({ parent: TRASH_ID, page: 2 });
+        expect(loadContentNodesSpy).toHaveBeenLastCalledWith({ parent: TRASH_ID, page: 2 });
       });
     });
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -1,308 +1,326 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor, configure } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import TrashModal from '../TrashModal';
+import VueRouter from 'vue-router';
+
 import { factory } from '../../../store';
-import router from '../../../router';
 import { RouteNames } from '../../../constants';
+import TrashModal from '../TrashModal';
+
+const store = factory();
+
+const CHANNEL_ID = 'test-channel-id';
+const TRASH_ID = 'trash-root-id';
+const NODE_ID = 'tree-node-id';
 
 const testChildren = [
-  {
-    id: 'test1',
-    title: 'Item1',
-    kind: 'video',
-    modified: new Date(2020, 1, 20),
-  },
-  {
-    id: 'test2',
-    title: 'Item2',
-    kind: 'audio',
-    modified: new Date(2020, 2, 1),
-  },
-  {
-    id: 'test3',
-    title: 'Topic1',
-    kind: 'topic',
-    modified: new Date(2020, 1, 1),
-  },
+  { id: 'test1', title: 'Item', kind: 'video', modified: new Date(2020, 1, 20) },
+  { id: 'test2', title: 'Item', kind: 'audio', modified: new Date(2020, 2, 1) },
+  { id: 'test3', title: 'Topic', kind: 'topic', modified: new Date(2020, 1, 1) },
 ];
 
-const makeWrapper = (items = testChildren, dataOverride = {}) => {
-  const store = factory();
-  
-  // Create spies for methods before rendering
-  const loadContentNodes = jest.spyOn(TrashModal.methods, 'loadContentNodes');
-  loadContentNodes.mockImplementation(() => Promise.resolve());
-  const loadAncestors = jest.spyOn(TrashModal.methods, 'loadAncestors');
-  loadAncestors.mockImplementation(() => Promise.resolve());
-  const loadChildren = jest.spyOn(TrashModal.methods, 'loadChildren');
-  loadChildren.mockImplementation(() => Promise.resolve({ more: null, results: [] }));
-  const removeContentNodes = jest.spyOn(TrashModal.methods, 'removeContentNodes');
-  removeContentNodes.mockImplementation(() => Promise.resolve());
+async function makeWrapper(items = testChildren, isLoading = false, stubOverrides = {}) {
+  const loadContentNodesSpy = jest.spyOn(TrashModal.methods, 'loadContentNodes').mockResolvedValue({});
+  jest.spyOn(TrashModal.methods, 'loadAncestors').mockResolvedValue();
+  jest.spyOn(TrashModal.methods, 'removeContentNodes').mockResolvedValue();
+  const loadNodesSpy = jest.spyOn(TrashModal.methods, 'loadNodes');
 
-  const loadNodes = jest.spyOn(TrashModal.methods, 'loadNodes');
-  // If we want loading: true, we can set dataOverride.
-  loadNodes.mockImplementation(function() {
-    this.loading = dataOverride.loading !== undefined ? dataOverride.loading : false;
-    this.more = null;
-    this.moreLoading = false;
+  if (isLoading) {
+    jest.spyOn(TrashModal.methods, 'loadChildren').mockReturnValue(new Promise(() => {}));
+  } else {
+    jest.spyOn(TrashModal.methods, 'loadChildren').mockResolvedValue({
+      more: items === testChildren ? null : { parent: TRASH_ID, page: 2 },
+      results: [],
+    });
+  }
+
+  const router = new VueRouter({
+    routes: [
+      { name: RouteNames.TRASH, path: '/:nodeId/trash', component: TrashModal },
+      { name: RouteNames.TREE_VIEW, path: '/:nodeId/:detailNodeId?', component: { template: '<div>Tree</div>' } },
+    ],
   });
 
-  const utils = render(TrashModal, {
-    store,
-    router,
-    computed: {
-      currentChannel() {
-        return {
-          id: 'current channel',
-        };
-      },
-      trashId() {
-        return 'trash';
-      },
-      items() {
-        return items;
-      },
-      offline() {
-        return false;
-      },
-      backLink() {
-        return {
-          name: 'TEST_PARENT',
-        };
-      },
-    },
-    stubs: {
-      ResourceDrawer: true,
-      OfflineText: true,
-      MoveModal: {
-        template: '<movemodal-stub></movemodal-stub>',
-        methods: { moveComplete: jest.fn() }
-      },
-    },
-    propsData: {
-      nodeId: 'test',
-    },
-  });
+  router.replace({ name: RouteNames.TRASH, params: { nodeId: NODE_ID } }).catch(() => {});
 
-  return { ...utils, store, loadContentNodes, loadAncestors, loadChildren, loadNodes, removeContentNodes };
-};
+  const routerPush = jest.spyOn(router, 'push').mockResolvedValue();
 
-describe('trashModal', () => {
-  let user;
+  const utils = render(
+    TrashModal,
+    {
+      store,
+      router,
+      computed: {
+        currentChannel: () => ({ id: CHANNEL_ID }),
+        trashId: () => TRASH_ID,
+        items: () => items,
+        offline: () => false,
+        backLink: () => ({ name: RouteNames.TREE_VIEW, params: { nodeId: NODE_ID } }),
+        getSelectedTopicAndResourceCountText: () => ids => `${ids.length} items selected`,
+        counts: () => ({ topicCount: 0, resourceCount: 0 }),
+      },
+      stubs: {
+        MoveModal: true,
+        ResourceDrawer: true,
+        ...stubOverrides,
+        FullscreenModal: {
+          template: `
+            <div>
+              <button data-test="close" @click="$emit('input', false)">Close</button>
+              <slot></slot>
+              <slot name="bottom"></slot>
+            </div>
+          `,
+        },
+        OfflineText: true,
+      },
+    },
+    localVue => {
+      localVue.use(VueRouter);
+    },
+  );
+
+  if (!isLoading) {
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    });
+  }
+
+  const user = userEvent.setup();
+  return { ...utils, routerPush, user, loadNodesSpy, loadContentNodesSpy };
+}
+
+describe('TrashModal', () => {
+  beforeAll(() => configure({ testIdAttribute: 'data-test' }));
+  afterAll(() => configure({ testIdAttribute: 'data-testid' }));
 
   beforeEach(() => {
-    user = userEvent.setup();
-    jest.clearAllMocks();
-    router.replace({ name: RouteNames.TRASH, params: { nodeId: 'test' } }).catch(() => {});
+    jest.restoreAllMocks();
   });
 
   describe('on load', () => {
-    it('should show loading indicator if content is loading', async () => {
-      makeWrapper(testChildren, { loading: true });
-      expect(document.querySelector('[data-test="loading"]')).toBeInTheDocument();
+    it('shows a loading indicator while content is loading', async () => {
+      await makeWrapper(testChildren, true);
+      expect(screen.getByTestId('loading')).toBeInTheDocument();
     });
 
-    it('should show empty text if there are no items', async () => {
-      makeWrapper([]);
-      expect(screen.getByText('Trash is empty')).toBeInTheDocument();
+    it('shows empty text when trash has no items', async () => {
+      await makeWrapper([]);
+      expect(screen.getByTestId('empty')).toBeInTheDocument();
     });
 
-    it('should show items in list', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
-      expect(screen.getByText('Item2')).toBeInTheDocument();
-      expect(screen.getByText('Topic1')).toBeInTheDocument();
+    it('shows the item list when trash has items', async () => {
+      await makeWrapper();
+      expect(screen.getByTestId('list')).toBeInTheDocument();
     });
   });
 
   describe('on topic tree selection', () => {
-    it('clicking item should set previewNodeId', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
+    it('clicking an item opens the resource drawer for that item', async () => {
+      const { user } = await makeWrapper();
 
-      const item1 = screen.getByText('Item1');
-      await user.click(item1);
+      expect(document.querySelector('resourcedrawer-stub')).not.toHaveAttribute('nodeid', testChildren[0].id);
+
+      await user.click(screen.getAllByTestId('item')[0]);
 
       await waitFor(() => {
         const drawer = document.querySelector('resourcedrawer-stub');
-        expect(drawer).toHaveAttribute('nodeid', 'test1');
+        expect(drawer).toBeInTheDocument();
+        expect(drawer).toHaveAttribute('nodeid', testChildren[0].id);
       });
     });
 
-    it('checking item in list should add the item ID to the selected array', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
+    it('checking an item enables the Delete and Restore buttons', async () => {
+      const { user } = await makeWrapper();
+
+      expect(screen.getByTestId('delete')).toBeDisabled();
+      expect(screen.getByTestId('restore')).toBeDisabled();
 
       const checkboxes = screen.getAllByRole('checkbox');
-      const firstItemCheckbox = checkboxes[1];
-      
-      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
-      
-      await user.click(firstItemCheckbox);
-      
+      await user.click(checkboxes[1]);
+
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Delete/i })).toBeEnabled();
+        expect(screen.getByTestId('delete')).toBeEnabled();
+        expect(screen.getByTestId('restore')).toBeEnabled();
       });
     });
 
-    it('checking select all checkbox should check all items', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
-
-      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
-      await user.click(selectAllCheckbox);
+    it('checking the select-all checkbox checks all items', async () => {
+      const { user } = await makeWrapper();
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
 
       await waitFor(() => {
-        const itemCheckboxes = screen.getAllByRole('checkbox').slice(1);
-        itemCheckboxes.forEach(checkbox => {
-          expect(checkbox).toBeChecked();
+        screen.getAllByRole('checkbox').slice(1).forEach(cb => {
+          expect(cb).toBeChecked();
         });
       });
     });
   });
 
   describe('on close', () => {
-    it('clicking close button should go back to parent route', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
+    it('clicking the close button navigates back to the tree view', async () => {
+      const { routerPush, user } = await makeWrapper();
 
-      const closeButton = document.querySelector('[data-test="close"]');
-      await user.click(closeButton);
+      await user.click(screen.getByTestId('close'));
 
       await waitFor(() => {
-        expect(router.currentRoute.name).toBe('TEST_PARENT');
+        expect(routerPush).toHaveBeenCalledWith(
+          expect.objectContaining({ name: RouteNames.TREE_VIEW }),
+        );
       });
     });
   });
 
   describe('on delete', () => {
-    it('DELETE button should be disabled if no items are selected', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
+    it('Delete button is disabled when no items are selected', async () => {
+      await makeWrapper();
+      expect(screen.getByTestId('delete')).toBeDisabled();
     });
 
-    it('clicking DELETE button should open delete confirmation dialog', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
+    it('clicking Delete opens a confirmation dialog', async () => {
+      const { user } = await makeWrapper();
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
+      await user.click(screen.getByTestId('delete'));
 
-      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
-      await user.click(selectAllCheckbox);
-
-      const deleteButton = screen.getByRole('button', { name: /Delete/i });
-      await user.click(deleteButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/You cannot undo this action/i)).toBeInTheDocument();
-      });
+      expect(await screen.findByText(/You cannot undo this action/i)).toBeInTheDocument();
     });
 
-    it('clicking CLOSE on delete confirmation dialog should close the dialog', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
+    it('clicking Cancel in the confirmation dialog closes it', async () => {
+      const { user } = await makeWrapper();
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
+      await user.click(screen.getByTestId('delete'));
+      await screen.findByText(/You cannot undo this action/i);
 
-      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
-      await user.click(selectAllCheckbox);
-
-      const deleteButton = screen.getByRole('button', { name: /Delete/i });
-      await user.click(deleteButton);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
-      });
-
-      const cancelButton = screen.getByRole('button', { name: /Cancel/i });
-      await user.click(cancelButton);
+      await user.click(screen.getByRole('button', { name: /Cancel/i }));
 
       await waitFor(() => {
         expect(screen.queryByText(/You cannot undo this action/i)).not.toBeInTheDocument();
       });
     });
 
-    it('clicking DELETE PERMANENTLY on delete confirmation dialog should trigger deletion', async () => {
-      const deleteContentNodesSpy = jest.spyOn(TrashModal.methods, 'deleteContentNodes');
-      deleteContentNodesSpy.mockImplementation(() => Promise.resolve());
+    it('clicking Delete permanently calls deleteContentNodes with the selected IDs', async () => {
+      const deleteContentNodes = jest
+        .spyOn(TrashModal.methods, 'deleteContentNodes')
+        .mockResolvedValue();
 
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
+      const { user } = await makeWrapper();
 
-      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
-      await user.click(selectAllCheckbox);
-
-      const deleteButton = screen.getByRole('button', { name: /Delete/i });
-      await user.click(deleteButton);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Delete permanently/i })).toBeInTheDocument();
-      });
-
-      const confirmDeleteButton = screen.getByRole('button', { name: /Delete permanently/i });
-      await user.click(confirmDeleteButton);
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
+      await user.click(screen.getByTestId('delete'));
+      await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
 
       await waitFor(() => {
-        expect(deleteContentNodesSpy).toHaveBeenCalledWith(['test1', 'test2', 'test3']);
+        expect(deleteContentNodes).toHaveBeenCalledWith(testChildren.map(c => c.id));
       });
-      deleteContentNodesSpy.mockRestore();
+    });
+
+    it('successful deletion triggers snackbar and reloads nodes', async () => {
+      jest.spyOn(TrashModal.methods, 'deleteContentNodes').mockResolvedValue();
+      const dispatchSpy = jest.spyOn(store, 'dispatch').mockImplementation(() => Promise.resolve());
+
+      const { user, loadNodesSpy } = await makeWrapper();
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
+      await user.click(screen.getByTestId('delete'));
+      await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
+
+      await waitFor(() => {
+        expect(dispatchSpy).toHaveBeenCalledWith('showSnackbar', {
+          text: 'Permanently deleted',
+        });
+        expect(loadNodesSpy).toHaveBeenCalled();
+      });
     });
   });
 
   describe('on restore', () => {
-    it('RESTORE button should be disabled if no items are selected', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Restore/i })).toBeDisabled();
+    it('Restore button is disabled when no items are selected', async () => {
+      await makeWrapper();
+      expect(screen.getByTestId('restore')).toBeDisabled();
     });
 
-    it('RESTORE should set moveModalOpen to true', async () => {
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
-
-      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
-      await user.click(selectAllCheckbox);
-
-      const restoreButton = screen.getByRole('button', { name: /Restore/i });
-      await user.click(restoreButton);
-
-      await waitFor(() => {
-        expect(document.querySelector('.fullscreen-modal-window')).toBeFalsy();
-      });
-    });
-
-    it('moveNodes should clear selected and previewNodeId', async () => {
-      const moveContentNodesSpy = jest.spyOn(TrashModal.methods, 'moveContentNodes');
-      moveContentNodesSpy.mockImplementation(() => Promise.resolve());
-
-      makeWrapper();
-      expect(screen.getByText('Item1')).toBeInTheDocument();
-
-      const itemCheckbox = screen.getAllByRole('checkbox')[1];
-      await user.click(itemCheckbox);
-      
-      const itemText = screen.getByText('Item2');
-      await user.click(itemText);
-
-      await waitFor(() => {
-        expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute('nodeid', 'test2');
-      });
-
-      // Restore action to open MoveModal
-      const restoreButton = screen.getByRole('button', { name: /Restore/i });
-      await user.click(restoreButton);
+    it('clicking Restore opens the MoveModal', async () => {
+      const { user } = await makeWrapper();
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
+      await user.click(screen.getByTestId('restore'));
 
       await waitFor(() => {
         expect(document.querySelector('movemodal-stub')).toBeInTheDocument();
       });
+    });
 
-      const moveModalStub = document.querySelector('movemodal-stub');
-      moveModalStub.__vue__.$emit('target', 'new-parent-id');
+    it('restoring items clears selection and closes the preview', async () => {
+    jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
+    const { user } = await makeWrapper(testChildren, false, {
+      MoveModal: {
+        methods: {
+          moveComplete() {},
+        },
+        template: `
+          <div>
+            <button
+              data-test="move-target"
+              @click="$emit('target', 'target-node-id'); $emit('input', false)"
+            >
+              Confirm move
+            </button>
+          </div>
+        `,
+      },
+    });
+
+    await user.click(screen.getAllByTestId('item')[0]);
+    await waitFor(() => {
+      expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute('nodeid', testChildren[0].id);
+    });
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByTestId('restore'));
+    await user.click(screen.getByTestId('move-target'));
+
+    await waitFor(() => {
+      screen.getAllByRole('checkbox').slice(1).forEach(cb => {
+        expect(cb).not.toBeChecked();
+      });
+      expect(document.querySelector('resourcedrawer-stub')).not.toHaveAttribute('nodeid', testChildren[0].id);
+    });
+  });
+  });
+
+  describe('selection count', () => {
+    it('shows selected item count in the bottom bar', async () => {
+      const { user } = await makeWrapper();
+
+      expect(screen.queryByText(/items selected/i)).not.toBeInTheDocument();
+
+      const [selectAll] = screen.getAllByRole('checkbox');
+      await user.click(selectAll);
+
+      expect(
+        await screen.findByText(`${testChildren.length} items selected`),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('pagination', () => {
+    it('shows a Show more button when there is more paginated content', async () => {
+      await makeWrapper([testChildren[0]]);
+      expect(await screen.findByRole('button', { name: /Show more/i })).toBeInTheDocument();
+    });
+
+    it('clicking Show more calls loadContentNodes with pagination params', async () => {
+      const { user, loadContentNodesSpy } = await makeWrapper([testChildren[0]]);
+      const showMoreBtn = await screen.findByRole('button', { name: /Show more/i });
+
+      await user.click(showMoreBtn);
 
       await waitFor(() => {
-        expect(moveContentNodesSpy).toHaveBeenCalledWith(expect.objectContaining({
-          id__in: expect.any(Array),
-          parent: 'new-parent-id'
-        }));
+        expect(loadContentNodesSpy).toHaveBeenCalledWith({ parent: TRASH_ID, page: 2 });
       });
-      moveContentNodesSpy.mockRestore();
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -1,41 +1,53 @@
-import { mount } from '@vue/test-utils';
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import TrashModal from '../TrashModal';
 import { factory } from '../../../store';
 import router from '../../../router';
 import { RouteNames } from '../../../constants';
 
-const store = factory();
-
 const testChildren = [
   {
     id: 'test1',
-    title: 'Item',
+    title: 'Item1',
     kind: 'video',
     modified: new Date(2020, 1, 20),
   },
   {
     id: 'test2',
-    title: 'Item',
+    title: 'Item2',
     kind: 'audio',
     modified: new Date(2020, 2, 1),
   },
   {
     id: 'test3',
-    title: 'Topic',
+    title: 'Topic1',
     kind: 'topic',
     modified: new Date(2020, 1, 1),
   },
 ];
 
-function makeWrapper(items) {
+const makeWrapper = (items = testChildren, dataOverride = {}) => {
+  const store = factory();
+  
+  // Create spies for methods before rendering
   const loadContentNodes = jest.spyOn(TrashModal.methods, 'loadContentNodes');
   loadContentNodes.mockImplementation(() => Promise.resolve());
   const loadAncestors = jest.spyOn(TrashModal.methods, 'loadAncestors');
   loadAncestors.mockImplementation(() => Promise.resolve());
   const loadChildren = jest.spyOn(TrashModal.methods, 'loadChildren');
   loadChildren.mockImplementation(() => Promise.resolve({ more: null, results: [] }));
+  const removeContentNodes = jest.spyOn(TrashModal.methods, 'removeContentNodes');
+  removeContentNodes.mockImplementation(() => Promise.resolve());
 
-  const wrapper = mount(TrashModal, {
+  const loadNodes = jest.spyOn(TrashModal.methods, 'loadNodes');
+  // If we want loading: true, we can set dataOverride.
+  loadNodes.mockImplementation(function() {
+    this.loading = dataOverride.loading !== undefined ? dataOverride.loading : false;
+    this.more = null;
+    this.moreLoading = false;
+  });
+
+  const utils = render(TrashModal, {
     store,
     router,
     computed: {
@@ -48,7 +60,7 @@ function makeWrapper(items) {
         return 'trash';
       },
       items() {
-        return items || testChildren;
+        return items;
       },
       offline() {
         return false;
@@ -62,110 +74,235 @@ function makeWrapper(items) {
     stubs: {
       ResourceDrawer: true,
       OfflineText: true,
+      MoveModal: {
+        template: '<movemodal-stub></movemodal-stub>',
+        methods: { moveComplete: jest.fn() }
+      },
+    },
+    propsData: {
+      nodeId: 'test',
     },
   });
 
-  return [wrapper, { loadContentNodes, loadAncestors, loadChildren }];
-}
+  return { ...utils, store, loadContentNodes, loadAncestors, loadChildren, loadNodes, removeContentNodes };
+};
 
 describe('trashModal', () => {
-  let wrapper;
+  let user;
 
-  beforeEach(async () => {
-    [wrapper] = makeWrapper();
+  beforeEach(() => {
+    user = userEvent.setup();
+    jest.clearAllMocks();
     router.replace({ name: RouteNames.TRASH, params: { nodeId: 'test' } }).catch(() => {});
-    await wrapper.setData({ loading: false });
   });
 
   describe('on load', () => {
     it('should show loading indicator if content is loading', async () => {
-      await wrapper.setData({ loading: true });
-      expect(wrapper.findComponent('[data-test="loading"]').exists()).toBe(true);
+      makeWrapper(testChildren, { loading: true });
+      expect(document.querySelector('[data-test="loading"]')).toBeInTheDocument();
     });
 
     it('should show empty text if there are no items', async () => {
-      const [emptyWrapper] = makeWrapper([]);
-      await emptyWrapper.setData({ loading: false });
-      expect(emptyWrapper.findComponent('[data-test="empty"]').exists()).toBe(true);
+      makeWrapper([]);
+      expect(screen.getByText('Trash is empty')).toBeInTheDocument();
     });
 
-    it('should show items in list', () => {
-      expect(wrapper.findComponent('[data-test="list"]').exists()).toBe(true);
+    it('should show items in list', async () => {
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+      expect(screen.getByText('Item2')).toBeInTheDocument();
+      expect(screen.getByText('Topic1')).toBeInTheDocument();
     });
   });
 
   describe('on topic tree selection', () => {
     it('clicking item should set previewNodeId', async () => {
-      await wrapper.findComponent('[data-test="item"]').trigger('click');
-      expect(wrapper.vm.previewNodeId).toBe(testChildren[0].id);
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const item1 = screen.getByText('Item1');
+      await user.click(item1);
+
+      await waitFor(() => {
+        const drawer = document.querySelector('resourcedrawer-stub');
+        expect(drawer).toHaveAttribute('nodeid', 'test1');
+      });
     });
 
-    it('checking item in list should add the item ID to the selected array', () => {
-      wrapper
-        .findComponent('[data-test="checkbox"]')
-        .find('input[type="checkbox"]')
-        .element.click();
-      expect(wrapper.vm.selected).toEqual(['test1']);
+    it('checking item in list should add the item ID to the selected array', async () => {
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      const firstItemCheckbox = checkboxes[1];
+      
+      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
+      
+      await user.click(firstItemCheckbox);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Delete/i })).toBeEnabled();
+      });
     });
 
-    it('checking select all checkbox should check all items', () => {
-      wrapper.findComponent('[data-test="selectall"]').vm.$emit('input', true);
-      expect(wrapper.vm.selected).toEqual(testChildren.map(c => c.id));
+    it('checking select all checkbox should check all items', async () => {
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
+      await user.click(selectAllCheckbox);
+
+      await waitFor(() => {
+        const itemCheckboxes = screen.getAllByRole('checkbox').slice(1);
+        itemCheckboxes.forEach(checkbox => {
+          expect(checkbox).toBeChecked();
+        });
+      });
     });
   });
 
   describe('on close', () => {
     it('clicking close button should go back to parent route', async () => {
-      await wrapper.findComponent('[data-test="close"]').trigger('click');
-      expect(wrapper.vm.$route.name).toBe('TEST_PARENT');
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const closeButton = document.querySelector('[data-test="close"]');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(router.currentRoute.name).toBe('TEST_PARENT');
+      });
     });
   });
 
   describe('on delete', () => {
-    it('DELETE button should be disabled if no items are selected', () => {
-      expect(wrapper.findComponent('[data-test="delete"]').vm.disabled).toBe(true);
+    it('DELETE button should be disabled if no items are selected', async () => {
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
     });
 
     it('clicking DELETE button should open delete confirmation dialog', async () => {
-      await wrapper.setData({ selected: testChildren.map(c => c.id) });
-      await wrapper.findComponent('[data-test="delete"]').trigger('click');
-      expect(wrapper.vm.showConfirmationDialog).toBe(true);
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
+      await user.click(selectAllCheckbox);
+
+      const deleteButton = screen.getByRole('button', { name: /Delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/You cannot undo this action/i)).toBeInTheDocument();
+      });
     });
 
     it('clicking CLOSE on delete confirmation dialog should close the dialog', async () => {
-      await wrapper.setData({ showConfirmationDialog: true });
-      await wrapper.findComponent('[data-test="deleteconfirm"]').vm.$emit('cancel');
-      expect(wrapper.vm.showConfirmationDialog).toBe(false);
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
+      await user.click(selectAllCheckbox);
+
+      const deleteButton = screen.getByRole('button', { name: /Delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/You cannot undo this action/i)).not.toBeInTheDocument();
+      });
     });
 
     it('clicking DELETE PERMANENTLY on delete confirmation dialog should trigger deletion', async () => {
-      const selected = testChildren.map(c => c.id);
-      const deleteContentNodes = jest.spyOn(wrapper.vm, 'deleteContentNodes');
-      deleteContentNodes.mockImplementation(() => Promise.resolve());
-      await wrapper.setData({ selected, showConfirmationDialog: true });
-      await wrapper.findComponent('[data-test="deleteconfirm"]').vm.$emit('submit');
-      expect(deleteContentNodes).toHaveBeenCalledWith(selected);
+      const deleteContentNodesSpy = jest.spyOn(TrashModal.methods, 'deleteContentNodes');
+      deleteContentNodesSpy.mockImplementation(() => Promise.resolve());
+
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
+      await user.click(selectAllCheckbox);
+
+      const deleteButton = screen.getByRole('button', { name: /Delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Delete permanently/i })).toBeInTheDocument();
+      });
+
+      const confirmDeleteButton = screen.getByRole('button', { name: /Delete permanently/i });
+      await user.click(confirmDeleteButton);
+
+      await waitFor(() => {
+        expect(deleteContentNodesSpy).toHaveBeenCalledWith(['test1', 'test2', 'test3']);
+      });
+      deleteContentNodesSpy.mockRestore();
     });
   });
 
   describe('on restore', () => {
-    it('RESTORE button should be disabled if no items are selected', () => {
-      expect(wrapper.findComponent('[data-test="restore"]').vm.disabled).toBe(true);
+    it('RESTORE button should be disabled if no items are selected', async () => {
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Restore/i })).toBeDisabled();
     });
 
     it('RESTORE should set moveModalOpen to true', async () => {
-      const selected = testChildren.map(c => c.id);
-      await wrapper.setData({ selected });
-      await wrapper.findComponent('[data-test="restore"]').trigger('click');
-      expect(wrapper.vm.moveModalOpen).toBe(true);
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const selectAllCheckbox = screen.getAllByRole('checkbox')[0];
+      await user.click(selectAllCheckbox);
+
+      const restoreButton = screen.getByRole('button', { name: /Restore/i });
+      await user.click(restoreButton);
+
+      await waitFor(() => {
+        expect(document.querySelector('.fullscreen-modal-window')).toBeFalsy();
+      });
     });
 
-    it('moveNoves should clear selected and previewNodeId', async () => {
-      const moveContentNodes = jest.spyOn(wrapper.vm, 'moveContentNodes');
-      moveContentNodes.mockImplementation(() => Promise.resolve());
-      wrapper.vm.moveNodes();
-      expect(wrapper.vm.selected).toEqual([]);
-      expect(wrapper.vm.previewNodeId).toBe(null);
+    it('moveNodes should clear selected and previewNodeId', async () => {
+      const moveContentNodesSpy = jest.spyOn(TrashModal.methods, 'moveContentNodes');
+      moveContentNodesSpy.mockImplementation(() => Promise.resolve());
+
+      makeWrapper();
+      expect(screen.getByText('Item1')).toBeInTheDocument();
+
+      const itemCheckbox = screen.getAllByRole('checkbox')[1];
+      await user.click(itemCheckbox);
+      
+      const itemText = screen.getByText('Item2');
+      await user.click(itemText);
+
+      await waitFor(() => {
+        expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute('nodeid', 'test2');
+      });
+
+      // Restore action to open MoveModal
+      const restoreButton = screen.getByRole('button', { name: /Restore/i });
+      await user.click(restoreButton);
+
+      await waitFor(() => {
+        expect(document.querySelector('movemodal-stub')).toBeInTheDocument();
+      });
+
+      const moveModalStub = document.querySelector('movemodal-stub');
+      moveModalStub.__vue__.$emit('target', 'new-parent-id');
+
+      await waitFor(() => {
+        expect(moveContentNodesSpy).toHaveBeenCalledWith(expect.objectContaining({
+          id__in: expect.any(Array),
+          parent: 'new-parent-id'
+        }));
+      });
+      moveContentNodesSpy.mockRestore();
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -235,35 +235,7 @@ describe('TrashModal', () => {
       expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
     });
 
-    it('clears selection when the move is completed', async () => {
-      jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
-      const { user } = await makeWrapper();
 
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[1]);
-      await user.click(checkboxes[2]);
-      expect(checkboxes[1]).toBeChecked();
-      await TrashModal.methods.moveNodes.call(
-        {
-          ...TrashModal.computed,
-          selected: ['test1', 'test2'],
-          moveContentNodes: TrashModal.methods.moveContentNodes,
-          reset: TrashModal.methods.reset,
-          loadNodes: jest.fn(),
-          toggleSelectAll: val => {
-            checkboxes[1].checked = val;
-            checkboxes[2].checked = val;
-          },
-          $refs: { moveModal: { moveComplete: jest.fn() } },
-        },
-        'target-id',
-      );
-
-      await waitFor(() => {
-        expect(checkboxes[1]).not.toBeChecked();
-        expect(checkboxes[2]).not.toBeChecked();
-      });
-    });
   });
 
   describe('selection count', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -17,8 +17,7 @@ const testChildren = [
   { id: 'test2', title: 'Item', kind: 'audio', modified: new Date(2020, 2, 1) },
   { id: 'test3', title: 'Topic', kind: 'topic', modified: new Date(2020, 1, 1) },
 ];
-
-async function makeWrapper(items = testChildren, isLoading = false, stubOverrides = {}) {
+async function makeWrapper(items = testChildren, isLoading = false) {
   const loadContentNodesSpy = jest.spyOn(TrashModal.methods, 'loadContentNodes').mockResolvedValue({});
   jest.spyOn(TrashModal.methods, 'loadAncestors').mockResolvedValue();
   jest.spyOn(TrashModal.methods, 'removeContentNodes').mockResolvedValue();
@@ -59,9 +58,20 @@ async function makeWrapper(items = testChildren, isLoading = false, stubOverride
         counts: () => ({ topicCount: 0, resourceCount: 0 }),
       },
       stubs: {
-        MoveModal: true,
         ResourceDrawer: true,
-        ...stubOverrides,
+        OfflineText: true,
+        MoveModal: {
+          template: `
+            <div>
+              <button data-test="move-target" @click="$emit('target', 'target-node-id'); $emit('input', false)">
+                Confirm move
+              </button>
+            </div>
+          `,
+          methods: {
+            moveComplete() {} 
+          }
+        },
         FullscreenModal: {
           template: `
             <div>
@@ -71,7 +81,6 @@ async function makeWrapper(items = testChildren, isLoading = false, stubOverride
             </div>
           `,
         },
-        OfflineText: true,
       },
     },
     localVue => {
@@ -248,47 +257,32 @@ describe('TrashModal', () => {
       await user.click(selectAll);
       await user.click(screen.getByTestId('restore'));
 
-      await waitFor(() => {
-        expect(document.querySelector('movemodal-stub')).toBeInTheDocument();
-      });
+      // Checks for the fake button from our clean MoveModal stub
+      expect(await screen.findByTestId('move-target')).toBeInTheDocument();
     });
 
     it('restoring items clears selection and closes the preview', async () => {
-    jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
-    const { user } = await makeWrapper(testChildren, false, {
-      MoveModal: {
-        methods: {
-          moveComplete() {},
-        },
-        template: `
-          <div>
-            <button
-              data-test="move-target"
-              @click="$emit('target', 'target-node-id'); $emit('input', false)"
-            >
-              Confirm move
-            </button>
-          </div>
-        `,
-      },
-    });
+      jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
+      const { user } = await makeWrapper(); // CLEAN: No stubOverrides needed!
 
-    await user.click(screen.getAllByTestId('item')[0]);
-    await waitFor(() => {
-      expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute('nodeid', testChildren[0].id);
-    });
-
-    await user.click(screen.getAllByRole('checkbox')[0]);
-    await user.click(screen.getByTestId('restore'));
-    await user.click(screen.getByTestId('move-target'));
-
-    await waitFor(() => {
-      screen.getAllByRole('checkbox').slice(1).forEach(cb => {
-        expect(cb).not.toBeChecked();
+      await user.click(screen.getAllByTestId('item')[0]);
+      await waitFor(() => {
+        expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute('nodeid', testChildren[0].id);
       });
-      expect(document.querySelector('resourcedrawer-stub')).not.toHaveAttribute('nodeid', testChildren[0].id);
+
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      await user.click(screen.getByTestId('restore'));
+      
+      // Click the fake move button
+      await user.click(screen.getByTestId('move-target'));
+
+      await waitFor(() => {
+        screen.getAllByRole('checkbox').slice(1).forEach(cb => {
+          expect(cb).not.toBeChecked();
+        });
+        expect(document.querySelector('resourcedrawer-stub')).not.toHaveAttribute('nodeid', testChildren[0].id);
+      });
     });
-  });
   });
 
   describe('selection count', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -114,8 +114,7 @@ describe('TrashModal', () => {
       expect(screen.getByTestId('delete')).toBeDisabled();
       expect(screen.getByTestId('restore')).toBeDisabled();
 
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[1]);
+      await user.click(screen.getAllByRole('checkbox')[1]);
 
       await waitFor(() => {
         expect(screen.getByTestId('delete')).toBeEnabled();
@@ -125,8 +124,7 @@ describe('TrashModal', () => {
 
     it('checking the select-all checkbox checks all items', async () => {
       const { user } = await makeWrapper();
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
 
       await waitFor(() => {
         screen
@@ -162,8 +160,7 @@ describe('TrashModal', () => {
 
     it('clicking Delete opens a confirmation dialog', async () => {
       const { user } = await makeWrapper();
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
       await user.click(screen.getByTestId('delete'));
 
       expect(await screen.findByText(/You cannot undo this action/i)).toBeInTheDocument();
@@ -171,8 +168,7 @@ describe('TrashModal', () => {
 
     it('clicking Cancel in the confirmation dialog closes it', async () => {
       const { user } = await makeWrapper();
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
       await user.click(screen.getByTestId('delete'));
       await screen.findByText(/You cannot undo this action/i);
 
@@ -190,8 +186,7 @@ describe('TrashModal', () => {
 
       const { user } = await makeWrapper();
 
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
       await user.click(screen.getByTestId('delete'));
       await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
 
@@ -205,8 +200,7 @@ describe('TrashModal', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch').mockImplementation(() => Promise.resolve());
 
       const { user, loadNodesSpy } = await makeWrapper();
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
       await user.click(screen.getByTestId('delete'));
       await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
 
@@ -227,8 +221,7 @@ describe('TrashModal', () => {
 
     it('clicking Restore opens the MoveModal', async () => {
       const { user } = await makeWrapper();
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
       await user.click(screen.getByTestId('restore'));
       expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
     });
@@ -240,8 +233,7 @@ describe('TrashModal', () => {
 
       expect(screen.queryByText(/items selected/i)).not.toBeInTheDocument();
 
-      const [selectAll] = screen.getAllByRole('checkbox');
-      await user.click(selectAll);
+      await user.click(screen.getByTestId('selectall'));
 
       expect(await screen.findByText(`${testChildren.length} items selected`)).toBeInTheDocument();
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -8,9 +8,7 @@ import TrashModal from '../TrashModal';
 
 const store = factory();
 
-const CHANNEL_ID = 'test-channel-id';
 const TRASH_ID = 'trash-root-id';
-const NODE_ID = 'tree-node-id';
 
 const testChildren = [
   { id: 'test1', title: 'Item', kind: 'video', modified: new Date(2020, 1, 20) },
@@ -46,7 +44,7 @@ async function makeWrapper(items = testChildren, isLoading = false) {
     ],
   });
 
-  router.replace({ name: RouteNames.TRASH, params: { nodeId: NODE_ID } }).catch(() => {});
+  router.replace({ name: RouteNames.TRASH, params: { nodeId: 'test' } }).catch(() => {});
 
   const routerPush = jest.spyOn(router, 'push').mockResolvedValue();
 
@@ -60,11 +58,11 @@ async function makeWrapper(items = testChildren, isLoading = false) {
         OfflineText: true,
       },
       computed: {
-        currentChannel: () => ({ id: CHANNEL_ID }),
+        currentChannel: () => ({ id: 'test-channel-id' }),
         trashId: () => TRASH_ID,
         items: () => items,
         offline: () => false,
-        backLink: () => ({ name: RouteNames.TREE_VIEW, params: { nodeId: NODE_ID } }),
+        backLink: () => ({ name: RouteNames.TREE_VIEW, params: { nodeId: 'test' } }),
         getSelectedTopicAndResourceCountText: () => ids => `${ids.length} items selected`,
         counts: () => ({ topicCount: 0, resourceCount: 0 }),
       },

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -17,8 +17,11 @@ const testChildren = [
   { id: 'test2', title: 'Item', kind: 'audio', modified: new Date(2020, 2, 1) },
   { id: 'test3', title: 'Topic', kind: 'topic', modified: new Date(2020, 1, 1) },
 ];
+
 async function makeWrapper(items = testChildren, isLoading = false) {
-  const loadContentNodesSpy = jest.spyOn(TrashModal.methods, 'loadContentNodes').mockResolvedValue({});
+  const loadContentNodesSpy = jest
+    .spyOn(TrashModal.methods, 'loadContentNodes')
+    .mockResolvedValue({});
   jest.spyOn(TrashModal.methods, 'loadAncestors').mockResolvedValue();
   jest.spyOn(TrashModal.methods, 'removeContentNodes').mockResolvedValue();
   const loadNodesSpy = jest.spyOn(TrashModal.methods, 'loadNodes');
@@ -35,7 +38,11 @@ async function makeWrapper(items = testChildren, isLoading = false) {
   const router = new VueRouter({
     routes: [
       { name: RouteNames.TRASH, path: '/:nodeId/trash', component: TrashModal },
-      { name: RouteNames.TREE_VIEW, path: '/:nodeId/:detailNodeId?', component: { template: '<div>Tree</div>' } },
+      {
+        name: RouteNames.TREE_VIEW,
+        path: '/:nodeId/:detailNodeId?',
+        component: { template: '<div>Tree</div>' },
+      },
     ],
   });
 
@@ -48,6 +55,10 @@ async function makeWrapper(items = testChildren, isLoading = false) {
     {
       store,
       router,
+      stubs: {
+        ResourceDrawer: true,
+        OfflineText: true,
+      },
       computed: {
         currentChannel: () => ({ id: CHANNEL_ID }),
         trashId: () => TRASH_ID,
@@ -56,31 +67,6 @@ async function makeWrapper(items = testChildren, isLoading = false) {
         backLink: () => ({ name: RouteNames.TREE_VIEW, params: { nodeId: NODE_ID } }),
         getSelectedTopicAndResourceCountText: () => ids => `${ids.length} items selected`,
         counts: () => ({ topicCount: 0, resourceCount: 0 }),
-      },
-      stubs: {
-        ResourceDrawer: true,
-        OfflineText: true,
-        MoveModal: {
-          template: `
-            <div>
-              <button data-test="move-target" @click="$emit('target', 'target-node-id'); $emit('input', false)">
-                Confirm move
-              </button>
-            </div>
-          `,
-          methods: {
-            moveComplete() {} 
-          }
-        },
-        FullscreenModal: {
-          template: `
-            <div>
-              <button data-test="close" @click="$emit('input', false)">Close</button>
-              <slot></slot>
-              <slot name="bottom"></slot>
-            </div>
-          `,
-        },
       },
     },
     localVue => {
@@ -123,21 +109,7 @@ describe('TrashModal', () => {
     });
   });
 
-  describe('on topic tree selection', () => {
-    it('clicking an item opens the resource drawer for that item', async () => {
-      const { user } = await makeWrapper();
-
-      expect(document.querySelector('resourcedrawer-stub')).not.toHaveAttribute('nodeid', testChildren[0].id);
-
-      await user.click(screen.getAllByTestId('item')[0]);
-
-      await waitFor(() => {
-        const drawer = document.querySelector('resourcedrawer-stub');
-        expect(drawer).toBeInTheDocument();
-        expect(drawer).toHaveAttribute('nodeid', testChildren[0].id);
-      });
-    });
-
+  describe('on item selection', () => {
     it('checking an item enables the Delete and Restore buttons', async () => {
       const { user } = await makeWrapper();
 
@@ -159,9 +131,12 @@ describe('TrashModal', () => {
       await user.click(selectAll);
 
       await waitFor(() => {
-        screen.getAllByRole('checkbox').slice(1).forEach(cb => {
-          expect(cb).toBeChecked();
-        });
+        screen
+          .getAllByRole('checkbox')
+          .slice(1)
+          .forEach(cb => {
+            expect(cb).toBeChecked();
+          });
       });
     });
   });
@@ -170,7 +145,8 @@ describe('TrashModal', () => {
     it('clicking the close button navigates back to the tree view', async () => {
       const { routerPush, user } = await makeWrapper();
 
-      await user.click(screen.getByTestId('close'));
+      const closeButton = await screen.findByTestId('close');
+      await user.click(closeButton);
 
       await waitFor(() => {
         expect(routerPush).toHaveBeenCalledWith(
@@ -256,31 +232,36 @@ describe('TrashModal', () => {
       const [selectAll] = screen.getAllByRole('checkbox');
       await user.click(selectAll);
       await user.click(screen.getByTestId('restore'));
-
-      // Checks for the fake button from our clean MoveModal stub
-      expect(await screen.findByTestId('move-target')).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
     });
 
-    it('restoring items clears selection and closes the preview', async () => {
+    it('clears selection when the move is completed', async () => {
       jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
-      const { user } = await makeWrapper(); // CLEAN: No stubOverrides needed!
+      const { user } = await makeWrapper();
 
-      await user.click(screen.getAllByTestId('item')[0]);
+      const checkboxes = screen.getAllByRole('checkbox');
+      await user.click(checkboxes[1]);
+      await user.click(checkboxes[2]);
+      expect(checkboxes[1]).toBeChecked();
+      await TrashModal.methods.moveNodes.call(
+        {
+          ...TrashModal.computed,
+          selected: ['test1', 'test2'],
+          moveContentNodes: TrashModal.methods.moveContentNodes,
+          reset: TrashModal.methods.reset,
+          loadNodes: jest.fn(),
+          toggleSelectAll: val => {
+            checkboxes[1].checked = val;
+            checkboxes[2].checked = val;
+          },
+          $refs: { moveModal: { moveComplete: jest.fn() } },
+        },
+        'target-id',
+      );
+
       await waitFor(() => {
-        expect(document.querySelector('resourcedrawer-stub')).toHaveAttribute('nodeid', testChildren[0].id);
-      });
-
-      await user.click(screen.getAllByRole('checkbox')[0]);
-      await user.click(screen.getByTestId('restore'));
-      
-      // Click the fake move button
-      await user.click(screen.getByTestId('move-target'));
-
-      await waitFor(() => {
-        screen.getAllByRole('checkbox').slice(1).forEach(cb => {
-          expect(cb).not.toBeChecked();
-        });
-        expect(document.querySelector('resourcedrawer-stub')).not.toHaveAttribute('nodeid', testChildren[0].id);
+        expect(checkboxes[1]).not.toBeChecked();
+        expect(checkboxes[2]).not.toBeChecked();
       });
     });
   });
@@ -294,9 +275,7 @@ describe('TrashModal', () => {
       const [selectAll] = screen.getAllByRole('checkbox');
       await user.click(selectAll);
 
-      expect(
-        await screen.findByText(`${testChildren.length} items selected`),
-      ).toBeInTheDocument();
+      expect(await screen.findByText(`${testChildren.length} items selected`)).toBeInTheDocument();
     });
   });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -259,6 +259,10 @@ describe('TrashModal', () => {
 
     it('successful restore clears selection and previewNodeId, and reloads nodes', async () => {
       jest.spyOn(TrashModal.methods, 'moveContentNodes').mockResolvedValue();
+      jest.spyOn(MoveModal.methods, 'moveComplete').mockImplementation(function () {
+        this.dialog = false;
+        this.moveNodesInProgress = false;
+      });
 
       const { user, loadNodesSpy } = await makeWrapper();
 

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -113,20 +113,20 @@ describe('TrashModal', () => {
     it('checking an item enables the Delete and Restore buttons', async () => {
       const { user } = await makeWrapper();
 
-      expect(screen.getByTestId('delete')).toBeDisabled();
-      expect(screen.getByTestId('restore')).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Restore/i })).toBeDisabled();
 
       await user.click(within(screen.getAllByTestId('checkbox')[0]).getByRole('checkbox'));
 
       await waitFor(() => {
-        expect(screen.getByTestId('delete')).toBeEnabled();
-        expect(screen.getByTestId('restore')).toBeEnabled();
+        expect(screen.getByRole('button', { name: /Delete/i })).toBeEnabled();
+        expect(screen.getByRole('button', { name: /Restore/i })).toBeEnabled();
       });
     });
 
     it('checking the select-all checkbox checks all items', async () => {
       const { user } = await makeWrapper();
-      await user.click(screen.getByTestId('selectall'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
 
       await waitFor(() => {
         screen.getAllByTestId('checkbox').forEach(container => {
@@ -168,21 +168,21 @@ describe('TrashModal', () => {
   describe('on delete', () => {
     it('Delete button is disabled when no items are selected', async () => {
       await makeWrapper();
-      expect(screen.getByTestId('delete')).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
     });
 
     it('clicking Delete opens a confirmation dialog', async () => {
       const { user } = await makeWrapper();
-      await user.click(screen.getByTestId('selectall'));
-      await user.click(screen.getByTestId('delete'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
+      await user.click(screen.getByRole('button', { name: /Delete/i }));
 
       expect(await screen.findByText(/You cannot undo this action/i)).toBeInTheDocument();
     });
 
     it('clicking Cancel in the confirmation dialog closes it', async () => {
       const { user } = await makeWrapper();
-      await user.click(screen.getByTestId('selectall'));
-      await user.click(screen.getByTestId('delete'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
+      await user.click(screen.getByRole('button', { name: /Delete/i }));
       await screen.findByText(/You cannot undo this action/i);
 
       await user.click(screen.getByRole('button', { name: /Cancel/i }));
@@ -199,8 +199,8 @@ describe('TrashModal', () => {
 
       const { user } = await makeWrapper();
 
-      await user.click(screen.getByTestId('selectall'));
-      await user.click(screen.getByTestId('delete'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
+      await user.click(screen.getByRole('button', { name: /Delete/i }));
       await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
 
       await waitFor(() => {
@@ -214,8 +214,8 @@ describe('TrashModal', () => {
       const { user, loadNodesSpy, store } = await makeWrapper();
       const dispatchSpy = jest.spyOn(store, 'dispatch').mockImplementation(() => Promise.resolve());
 
-      await user.click(screen.getByTestId('selectall'));
-      await user.click(screen.getByTestId('delete'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
+      await user.click(screen.getByRole('button', { name: /Delete/i }));
       await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
 
       await waitFor(() => {
@@ -230,13 +230,13 @@ describe('TrashModal', () => {
   describe('on restore', () => {
     it('Restore button is disabled when no items are selected', async () => {
       await makeWrapper();
-      expect(screen.getByTestId('restore')).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Restore/i })).toBeDisabled();
     });
 
     it('clicking Restore opens the MoveModal', async () => {
       const { user } = await makeWrapper();
-      await user.click(screen.getByTestId('selectall'));
-      await user.click(screen.getByTestId('restore'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
+      await user.click(screen.getByRole('button', { name: /Restore/i }));
       expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
     });
 
@@ -245,12 +245,12 @@ describe('TrashModal', () => {
 
       const { user, loadNodesSpy } = await makeWrapper();
 
-      await user.click(screen.getByTestId('selectall'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
 
       const itemLinks = screen.getAllByTestId('item');
       await user.click(itemLinks[0]);
 
-      await user.click(screen.getByTestId('restore'));
+      await user.click(screen.getByRole('button', { name: /Restore/i }));
 
       await user.click(await screen.findByRole('button', { name: /Move here/i }));
 
@@ -273,7 +273,7 @@ describe('TrashModal', () => {
 
       expect(screen.queryByText(/items selected/i)).not.toBeInTheDocument();
 
-      await user.click(screen.getByTestId('selectall'));
+      await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
 
       expect(await screen.findByText(`${testChildren.length} items selected`)).toBeInTheDocument();
     });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/trash/__tests__/trashModal.spec.js
@@ -5,6 +5,15 @@ import VueRouter from 'vue-router';
 import { factory } from '../../../store';
 import { RouteNames } from '../../../constants';
 import TrashModal from '../TrashModal';
+import MoveModal from '../../../components/move/MoveModal';
+import NodePanel from '../../NodePanel';
+import { createTranslator } from 'shared/i18n';
+
+const tr = createTranslator('TrashModal', TrashModal.$trs);
+const moveTr = createTranslator('MoveModal', MoveModal.$trs);
+const nodePanelTr = createTranslator('NodePanel', NodePanel.$trs);
+
+configure({ testIdAttribute: 'data-test' });
 
 const TRASH_ID = 'trash-root-id';
 
@@ -21,6 +30,9 @@ async function makeWrapper(items = testChildren, { isLoading = false, hasMore = 
     .spyOn(TrashModal.methods, 'loadContentNodes')
     .mockResolvedValue({});
   jest.spyOn(TrashModal.methods, 'loadAncestors').mockResolvedValue();
+  // removeContentNodes is called inside loadNodes() before loadChildren — mock it
+  // to prevent real store calls. loadNodes itself runs the real implementation so
+  // the loading state and `more` data are exercised through mocked loadChildren.
   jest.spyOn(TrashModal.methods, 'removeContentNodes').mockResolvedValue();
   // loadNodes is not mocked intentionally: we let the real implementation run so that
   // the loading state and `more` data are exercised through the mocked loadChildren below.
@@ -85,9 +97,6 @@ async function makeWrapper(items = testChildren, { isLoading = false, hasMore = 
 }
 
 describe('TrashModal', () => {
-  beforeAll(() => configure({ testIdAttribute: 'data-test' }));
-  afterAll(() => configure({ testIdAttribute: 'data-testid' }));
-
   beforeEach(() => {
     jest.restoreAllMocks();
   });
@@ -100,12 +109,12 @@ describe('TrashModal', () => {
 
     it('shows empty text when trash has no items', async () => {
       await makeWrapper([]);
-      expect(screen.getByTestId('empty')).toBeInTheDocument();
+      expect(screen.getByText(tr.$tr('trashEmptyText'))).toBeInTheDocument();
     });
 
     it('shows the item list when trash has items', async () => {
       await makeWrapper();
-      expect(screen.getByTestId('list')).toBeInTheDocument();
+      expect(screen.getAllByTestId('item')).toHaveLength(testChildren.length);
     });
   });
 
@@ -113,14 +122,14 @@ describe('TrashModal', () => {
     it('checking an item enables the Delete and Restore buttons', async () => {
       const { user } = await makeWrapper();
 
-      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
-      expect(screen.getByRole('button', { name: /Restore/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: tr.$tr('deleteButton') })).toBeDisabled();
+      expect(screen.getByRole('button', { name: tr.$tr('restoreButton') })).toBeDisabled();
 
       await user.click(within(screen.getAllByTestId('checkbox')[0]).getByRole('checkbox'));
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Delete/i })).toBeEnabled();
-        expect(screen.getByRole('button', { name: /Restore/i })).toBeEnabled();
+        expect(screen.getByRole('button', { name: tr.$tr('deleteButton') })).toBeEnabled();
+        expect(screen.getByRole('button', { name: tr.$tr('restoreButton') })).toBeEnabled();
       });
     });
 
@@ -168,27 +177,29 @@ describe('TrashModal', () => {
   describe('on delete', () => {
     it('Delete button is disabled when no items are selected', async () => {
       await makeWrapper();
-      expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: tr.$tr('deleteButton') })).toBeDisabled();
     });
 
     it('clicking Delete opens a confirmation dialog', async () => {
       const { user } = await makeWrapper();
       await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
-      await user.click(screen.getByRole('button', { name: /Delete/i }));
+      await user.click(screen.getByRole('button', { name: tr.$tr('deleteButton') }));
 
-      expect(await screen.findByText(/You cannot undo this action/i)).toBeInTheDocument();
+      expect(await screen.findByText(tr.$tr('deleteConfirmationText'))).toBeInTheDocument();
     });
 
     it('clicking Cancel in the confirmation dialog closes it', async () => {
       const { user } = await makeWrapper();
       await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
-      await user.click(screen.getByRole('button', { name: /Delete/i }));
-      await screen.findByText(/You cannot undo this action/i);
+      await user.click(screen.getByRole('button', { name: tr.$tr('deleteButton') }));
+      await screen.findByText(tr.$tr('deleteConfirmationText'));
 
-      await user.click(screen.getByRole('button', { name: /Cancel/i }));
+      await user.click(
+        screen.getByRole('button', { name: tr.$tr('deleteConfirmationCancelButton') }),
+      );
 
       await waitFor(() => {
-        expect(screen.queryByText(/You cannot undo this action/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(tr.$tr('deleteConfirmationText'))).not.toBeInTheDocument();
       });
     });
 
@@ -200,8 +211,10 @@ describe('TrashModal', () => {
       const { user } = await makeWrapper();
 
       await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
-      await user.click(screen.getByRole('button', { name: /Delete/i }));
-      await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
+      await user.click(screen.getByRole('button', { name: tr.$tr('deleteButton') }));
+      await user.click(
+        await screen.findByRole('button', { name: tr.$tr('deleteConfirmationDeleteButton') }),
+      );
 
       await waitFor(() => {
         expect(deleteContentNodes).toHaveBeenCalledWith(testChildren.map(c => c.id));
@@ -215,12 +228,14 @@ describe('TrashModal', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch').mockImplementation(() => Promise.resolve());
 
       await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
-      await user.click(screen.getByRole('button', { name: /Delete/i }));
-      await user.click(await screen.findByRole('button', { name: /Delete permanently/i }));
+      await user.click(screen.getByRole('button', { name: tr.$tr('deleteButton') }));
+      await user.click(
+        await screen.findByRole('button', { name: tr.$tr('deleteConfirmationDeleteButton') }),
+      );
 
       await waitFor(() => {
         expect(dispatchSpy).toHaveBeenCalledWith('showSnackbar', {
-          text: 'Permanently deleted',
+          text: tr.$tr('deleteSuccessMessage'),
         });
         expect(loadNodesSpy).toHaveBeenCalled();
       });
@@ -230,14 +245,16 @@ describe('TrashModal', () => {
   describe('on restore', () => {
     it('Restore button is disabled when no items are selected', async () => {
       await makeWrapper();
-      expect(screen.getByRole('button', { name: /Restore/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: tr.$tr('restoreButton') })).toBeDisabled();
     });
 
     it('clicking Restore opens the MoveModal', async () => {
       const { user } = await makeWrapper();
       await user.click(within(screen.getByTestId('selectall')).getByRole('checkbox'));
-      await user.click(screen.getByRole('button', { name: /Restore/i }));
-      expect(await screen.findByRole('button', { name: /Move here/i })).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: tr.$tr('restoreButton') }));
+      expect(
+        await screen.findByRole('button', { name: moveTr.$tr('moveHere') }),
+      ).toBeInTheDocument();
     });
 
     it('successful restore clears selection and previewNodeId, and reloads nodes', async () => {
@@ -250,9 +267,9 @@ describe('TrashModal', () => {
       const itemLinks = screen.getAllByTestId('item');
       await user.click(itemLinks[0]);
 
-      await user.click(screen.getByRole('button', { name: /Restore/i }));
+      await user.click(screen.getByRole('button', { name: tr.$tr('restoreButton') }));
 
-      await user.click(await screen.findByRole('button', { name: /Move here/i }));
+      await user.click(await screen.findByRole('button', { name: moveTr.$tr('moveHere') }));
 
       await waitFor(() => {
         expect(loadNodesSpy).toHaveBeenCalled();
@@ -282,12 +299,14 @@ describe('TrashModal', () => {
   describe('pagination', () => {
     it('shows a Show more button when there is more paginated content', async () => {
       await makeWrapper([testChildren[0]], { hasMore: true });
-      expect(await screen.findByRole('button', { name: /Show more/i })).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', { name: nodePanelTr.$tr('showMore') }),
+      ).toBeInTheDocument();
     });
 
     it('clicking Show more calls loadContentNodes with pagination params', async () => {
       const { user, loadContentNodesSpy } = await makeWrapper([testChildren[0]], { hasMore: true });
-      const showMoreBtn = await screen.findByRole('button', { name: /Show more/i });
+      const showMoreBtn = await screen.findByRole('button', { name: nodePanelTr.$tr('showMore') });
 
       await user.click(showMoreBtn);
 


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
Migrates trashModal.spec.js from @vue/test-utils to @testing-library/vue, as part of the broader effort to make Studio's frontend tests more user-centric and resilient to implementation changes.
Manual verification:
- Logged in as a@a.com, opened a published channel, removed resources, and verified the trash modal behavior .
- All the test cases passed.

[Screencast From 2026-04-07 16-36-39.webm](https://github.com/user-attachments/assets/95779652-c815-4cd1-82c5-e770a0fcefc1)

## References
Closes #5790 
See https://github.com/learningequality/studio/issues/5789

## Reviewer guidance
1)Only trashModal.spec.js was changed.
2) Reviewer need to check if all the needed testcases are present and testing-library is properly used.
<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Claude to help plan and implement the migration.I checked other Testing-library implementations and verified the tests written and updated wherever needed.I followed the guidance given in the issue description and its parent issue description.I again checked if all the test cases are passing properly.


