### PR TITLE
Update ESoCC strings after UX writing review

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/components/CommunityLibraryStatusButton.vue
+++ b/contentcuration/contentcuration/frontend/administration/components/CommunityLibraryStatusButton.vue
@@ -48,8 +48,8 @@
           icon: 'circleCheckmark',
         },
         [CommunityLibraryStatus.REJECTED]: {
-          text: 'Flagged',
-          tooltip: 'Review flagged submission',
+          text: 'Needs changes',
+          tooltip: 'Submission requires changes before approval',
           color: theme.red.v_100,
           darkColor: theme.red.v_200,
           labelColor: theme.red.v_600,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/PublishSidePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/PublishSidePanel.vue
@@ -16,10 +16,10 @@
           <component :is="showDraftMode ? 'KRadioButtonGroup' : 'div'">
             <KRadioButton
               v-if="showDraftMode"
-              :label="modeLive$()"
+              :label="publishChannelMode$()"
               :buttonValue="PublishModes.LIVE"
               :currentValue="mode"
-              :description="modeLiveDescription$()"
+              :description="publishChannelDescription$()"
               @input="mode = PublishModes.LIVE"
             />
 
@@ -53,7 +53,7 @@
                       showInvalidText
                       :label="versionDescriptionLabel$()"
                       :invalid="isVersionNotesBlurred && !isVersionNotesValid"
-                      :invalidText="versionNotesRequiredMessage$()"
+                      :invalidText="fieldRequired$()"
                       textArea
                       :maxlength="250"
                       :appearanceOverrides="{ maxWidth: 'none' }"
@@ -70,7 +70,7 @@
                       v-model="newChannelLanguage"
                       :label="languageLabel$()"
                       :invalid="isLanguageSelectBlurred && !isNewLanguageValid"
-                      :invalidText="languageRequiredMessage$()"
+                      :invalidText="fieldRequired$()"
                       :options="languageOptions"
                       @blur="isLanguageSelectBlurred = true"
                     />
@@ -112,15 +112,6 @@
                     >
                       {{ incompleteResourcesDescription1$() }}
                     </div>
-                    <div
-                      class="warning-description"
-                      :style="{
-                        color: $themePalette.grey.v_800,
-                        marginTop: '16px',
-                      }"
-                    >
-                      {{ incompleteResourcesDescription2$() }}
-                    </div>
                   </div>
                 </div>
               </div>
@@ -128,10 +119,10 @@
 
             <KRadioButton
               v-if="showDraftMode"
-              :label="modeDraft$()"
+              :label="publishDraftMode$()"
               :buttonValue="PublishModes.DRAFT"
               :currentValue="mode"
-              :description="modeDraftDescription$()"
+              :description="publishDraftDescription$()"
               @input="mode = PublishModes.DRAFT"
             />
           </component>
@@ -166,6 +157,7 @@
   import { Channel, CommunityLibrarySubmission } from 'shared/data/resources';
   import { forceServerSync } from 'shared/data/serverSync';
   import { communityChannelsStrings } from 'shared/strings/communityChannelsStrings';
+  import commonStrings from 'shared/translator';
   import { LanguagesList } from 'shared/leUtils/Languages';
   import logging from 'shared/logging';
   import { FeatureFlagKeys } from 'shared/constants';
@@ -205,22 +197,21 @@
         publishChannel$,
         publishAction$,
         saveDraft$,
-        modeLive$,
-        modeDraft$,
+        publishChannelMode$,
+        publishDraftMode$,
         versionNotesLabel$,
-        modeLiveDescription$,
-        modeDraftDescription$,
+        publishChannelDescription$,
+        publishDraftDescription$,
         publishingInfo$,
         versionDescriptionLabel$,
         incompleteResourcesWarning$,
         incompleteResourcesDescription1$,
-        incompleteResourcesDescription2$,
         cancelAction$,
         languageLabel$,
-        languageRequiredMessage$,
         draftBeingPublishedNotice$,
-        versionNotesRequiredMessage$,
       } = communityChannelsStrings;
+
+      const { fieldRequired$ } = commonStrings;
 
       const currentChannel = computed(() => store.getters['currentChannel/currentChannel']);
       const getContentNode = computed(() => store.getters['contentNode/getContentNode']);
@@ -416,21 +407,19 @@
         isVersionNotesValid,
         submitText,
 
-        modeLive$,
-        modeDraft$,
+        publishChannelMode$,
+        publishDraftMode$,
         publishChannel$,
         versionNotesLabel$,
-        modeLiveDescription$,
-        modeDraftDescription$,
+        publishChannelDescription$,
+        publishDraftDescription$,
         publishingInfo$,
         versionDescriptionLabel$,
         incompleteResourcesWarning$,
         incompleteResourcesDescription1$,
-        incompleteResourcesDescription2$,
         cancelAction$,
         languageLabel$,
-        languageRequiredMessage$,
-        versionNotesRequiredMessage$,
+        fieldRequired$,
 
         onClose,
         submit,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/SubmitToCommunityLibrarySidePanel/__tests__/SubmitToCommunityLibrarySidePanel.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/SubmitToCommunityLibrarySidePanel/__tests__/SubmitToCommunityLibrarySidePanel.spec.js
@@ -34,7 +34,6 @@ const {
   nonePrimaryInfo$,
   needsChangesPrimaryInfo$,
   approvedPrimaryInfo$,
-  submittedPrimaryInfo$,
   moreDetails$,
   countriesInfoText$,
 } = communityChannelsStrings;
@@ -225,7 +224,13 @@ describe('SubmitToCommunityLibrarySidePanel', () => {
 
       const infoSection = wrapper.find('.info-section');
       expect(infoSection.exists()).toBe(true);
-      expect(infoSection.text()).toContain(submittedPrimaryInfo$());
+      // PENDING status shows no primary info text — only the status chip
+      const infoText = wrapper.find('.info-text');
+      expect(infoText.text()).toBe('');
+      // Chip uses <script setup> with CSS v-bind (Vue 3 feature), so its text content is not
+      // available via VTU v1. Verify the chip is rendered with the correct status instead.
+      const statusChip = wrapper.findComponent(CommunityLibraryStatusChip);
+      expect(statusChip.exists()).toBe(true);
     });
   });
 

--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/SubmitToCommunityLibrarySidePanel/__tests__/SubmitToCommunityLibrarySidePanel.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/SubmitToCommunityLibrarySidePanel/__tests__/SubmitToCommunityLibrarySidePanel.spec.js
@@ -32,7 +32,7 @@ const store = factory();
 
 const {
   nonePrimaryInfo$,
-  flaggedPrimaryInfo$,
+  needsChangesPrimaryInfo$,
   approvedPrimaryInfo$,
   submittedPrimaryInfo$,
   moreDetails$,
@@ -201,7 +201,7 @@ describe('SubmitToCommunityLibrarySidePanel', () => {
 
       const infoSection = wrapper.find('.info-section');
       expect(infoSection.exists()).toBe(true);
-      expect(infoSection.text()).toContain(flaggedPrimaryInfo$());
+      expect(infoSection.text()).toContain(needsChangesPrimaryInfo$());
     });
 
     it('when the previous submission was approved', async () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/SubmitToCommunityLibrarySidePanel/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/SubmitToCommunityLibrarySidePanel/index.vue
@@ -231,7 +231,7 @@
               v-model="description"
               :disabled="!canBeEdited"
               :invalid="description.length < 1"
-              :invalidText="descriptionRequired$()"
+              :invalidText="fieldRequired$()"
               textArea
               :label="descriptionLabel$()"
               :maxlength="250"
@@ -296,6 +296,7 @@
   import { translateMetadataString } from 'shared/utils/metadataStringsTranslation';
   import countriesUtil from 'shared/utils/countries';
   import { communityChannelsStrings } from 'shared/strings/communityChannelsStrings';
+  import commonStrings from 'shared/translator';
   import { CommunityLibrarySubmission } from 'shared/data/resources';
 
   import SidePanelModal from 'shared/views/SidePanelModal';
@@ -333,7 +334,6 @@
         countryLabel$,
         countriesInfoText$,
         descriptionLabel$,
-        descriptionRequired$,
         notPublishedWarningTitle$,
         notPublishedWarningDescription$,
         publicWarningTitle$,
@@ -342,9 +342,8 @@
         alreadySubmittedWarningDescription$,
         submitButton$,
         cancelAction$,
-        submittedPrimaryInfo$,
         approvedPrimaryInfo$,
-        flaggedPrimaryInfo$,
+        needsChangesPrimaryInfo$,
         nonePrimaryInfo$,
         channelVersion$,
         submittedSnackbar$,
@@ -366,6 +365,8 @@
         viewCriteriaAction$,
         hideCriteriaAction$,
       } = communityChannelsStrings;
+
+      const { fieldRequired$ } = commonStrings;
 
       const annotationColor = computed(() => tokensTheme.annotation);
       const infoTextColor = computed(() => paletteTheme.grey.v_700);
@@ -415,17 +416,13 @@
         if (!latestSubmissionIsFinished.value) return undefined;
 
         switch (latestSubmissionStatus.value) {
-          case CommunityLibraryStatus.PENDING:
-            return {
-              primaryText: submittedPrimaryInfo$(),
-            };
           case CommunityLibraryStatus.APPROVED:
             return {
               primaryText: approvedPrimaryInfo$(),
             };
           case CommunityLibraryStatus.REJECTED:
             return {
-              primaryText: flaggedPrimaryInfo$(),
+              primaryText: needsChangesPrimaryInfo$(),
             };
           case null:
             return {
@@ -647,7 +644,7 @@
         countryLabel$,
         countriesInfoText$,
         descriptionLabel$,
-        descriptionRequired$,
+        fieldRequired$,
         channelVersion$,
         notPublishedWarningTitle$,
         notPublishedWarningDescription$,

--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/__tests__/PublishSidePanel.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/__tests__/PublishSidePanel.spec.js
@@ -8,6 +8,7 @@ import PublishSidePanel from '../PublishSidePanel.vue';
 import { Channel, CommunityLibrarySubmission } from 'shared/data/resources';
 import { forceServerSync } from 'shared/data/serverSync';
 import { communityChannelsStrings } from 'shared/strings/communityChannelsStrings';
+import commonStrings from 'shared/translator';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -79,8 +80,10 @@ describe('PublishSidePanel', () => {
     renderComponent();
 
     // Headers and default texts
-    expect(screen.getByText(communityChannelsStrings.publishChannel$())).toBeVisible();
-    expect(screen.getByText(communityChannelsStrings.publishChannelMode$())).toBeVisible();
+    expect(
+      screen.getByRole('heading', { name: communityChannelsStrings.publishChannel$() }),
+    ).toBeVisible();
+    expect(screen.getAllByText(communityChannelsStrings.publishChannelMode$())[0]).toBeVisible();
 
     expect(
       screen.getByText(communityChannelsStrings.publishingInfo$({ version: 2 })),
@@ -89,8 +92,8 @@ describe('PublishSidePanel', () => {
     // Default button text
     expect(screen.getByText(communityChannelsStrings.publishAction$())).toBeVisible();
 
-    // Live mode selected by default
-    const liveRadio = screen.getByRole('radio', { name: /Live/ });
+    // Live mode selected by default (first radio in the group)
+    const [liveRadio] = screen.getAllByRole('radio');
     expect(liveRadio).toBeChecked();
   });
 
@@ -106,7 +109,7 @@ describe('PublishSidePanel', () => {
 
     // Touch field to trigger validation visible
     await fireEvent.blur(notesInput);
-    expect(screen.getByText('Version notes are required')).toBeVisible();
+    expect(screen.getByText(commonStrings.fieldRequired$())).toBeVisible();
 
     // Type notes
     await fireEvent.update(notesInput, 'My version notes');
@@ -114,7 +117,7 @@ describe('PublishSidePanel', () => {
 
     // Validation error should disappear
     await waitFor(() =>
-      expect(screen.queryByText('Version notes are required')).not.toBeInTheDocument(),
+      expect(screen.queryByText(commonStrings.fieldRequired$())).not.toBeInTheDocument(),
     );
     await waitFor(() => expect(publishBtn).toBeEnabled());
   });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/__tests__/PublishSidePanel.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/sidePanels/__tests__/PublishSidePanel.spec.js
@@ -80,7 +80,7 @@ describe('PublishSidePanel', () => {
 
     // Headers and default texts
     expect(screen.getByText(communityChannelsStrings.publishChannel$())).toBeVisible();
-    expect(screen.getByText(communityChannelsStrings.modeLive$())).toBeVisible();
+    expect(screen.getByText(communityChannelsStrings.publishChannelMode$())).toBeVisible();
 
     expect(
       screen.getByText(communityChannelsStrings.publishingInfo$({ version: 2 })),

--- a/contentcuration/contentcuration/frontend/shared/strings/communityChannelsStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/strings/communityChannelsStrings.js
@@ -18,29 +18,29 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     message: 'Save draft',
     context: 'The action button to save a channel as a draft',
   },
-  modeLive: {
-    message: 'Live',
+  publishChannelMode: {
+    message: 'Publish channel',
     context: 'Label to select live publishing mode',
   },
-  modeDraft: {
-    message: 'Draft (staging)',
+  publishDraftMode: {
+    message: 'Publish draft channel',
     context: 'Label to select draft publishing mode',
   },
   versionNotesLabel: {
-    message: "Describe what's new in this channel version",
+    message: "Describe what's included in this channel version",
     context: 'Label for the version notes text area',
   },
   versionDescriptionLabel: {
     message: 'Version description',
     context: 'Label for the version description text area',
   },
-  modeLiveDescription: {
-    message: 'This edition will be accessible in Kolibri through a channel token.',
+  publishChannelDescription: {
+    message: 'To see your channel in Kolibri, import using the channel token.',
     context: 'Description for the live publishing mode',
   },
-  modeDraftDescription: {
+  publishDraftDescription: {
     message:
-      'Your channel will be saved as a draft, allowing you to review or conduct quality checks without altering the published version on Kolibri public library.',
+      'Your channel will be saved as a draft, allowing you to review or conduct quality checks without altering the version Kolibri users can access. To see your channel in Kolibri, import using the draft channel token.',
     context: 'Description for the draft publishing mode',
   },
   publishingInfo: {
@@ -61,10 +61,6 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
       'Incomplete resources will not be published and made available for download in Kolibri.',
     context: 'Description for incomplete resources',
   },
-  incompleteResourcesDescription2: {
-    message: "Click 'Publish' to confirm that you would like to publish anyway.",
-    context: 'Confirmation message for publishing incomplete resources',
-  },
   cancelAction: {
     message: 'Cancel',
     context: 'The action button to cancel an ongoing operation',
@@ -72,14 +68,6 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   languageLabel: {
     message: 'Language',
     context: 'Label for the language selection dropdown',
-  },
-  versionNotesRequiredMessage: {
-    message: 'Version notes are required',
-    context: 'Error message when version notes are required but not provided',
-  },
-  languageRequiredMessage: {
-    message: 'Language is required',
-    context: 'Error message when language selection is required but not provided',
   },
   // Channel version history strings
   seeAllVersions: {
@@ -116,24 +104,25 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   pendingStatus: {
     message: 'Submitted',
-    context: 'Status indicating that an Community Library submission is pending',
+    context: 'Status indicating that a Community Library submission is pending',
   },
   supersededStatus: {
     message: 'Superseded',
     context:
-      'Status indicating that an Community Library submission is superseded by a newer submission',
+      'Status indicating that a Community Library submission is superseded by a newer submission',
   },
   approvedStatus: {
     message: 'Approved',
-    context: 'Status indicating that an Community Library submission is approved',
+    context: 'Status indicating that a Community Library submission is approved',
   },
   flaggedStatus: {
-    message: 'Flagged',
-    context: 'Status indicating that an Community Library submission is rejected',
+    message: 'Needs changes',
+    context: 'Status indicating that a Community Library submission is rejected',
   },
-  liveStatus: {
-    message: 'Live',
-    context: 'Status indicating that an Community Library submission is live',
+  availableStatus: {
+    message: 'Available in Community Library',
+    context:
+      'Status indicating that a Community Library submission is now available in the Community Library',
   },
   // Submit to Community Library panel strings
   submitToCommunityLibrary: {
@@ -147,7 +136,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   submittedPrimaryInfo: {
     message:
-      'A previous version is still pending review. Reviewers will see the latest submission first.',
+      'A previous version is still pending review. Reviewers will see the most recent submission by default.',
     context:
       'Information shown in the "Submit to Community Library" panel when a previous version is pending review',
   },
@@ -157,11 +146,11 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     context:
       'Information shown in the "Submit to Community Library" panel when a previous version is approved and live',
   },
-  flaggedPrimaryInfo: {
+  needsChangesPrimaryInfo: {
     message:
-      'A previous version was flagged for review. Ensure you have fixed all highlighted issues before submitting.',
+      'Your previously submitted version needs changes. Make sure you have addressed all feedback before resubmitting.',
     context:
-      'Information shown in the "Submit to Community Library" panel when a previous version was flagged',
+      'Information shown in the "Submit to Community Library" panel when a previous version was not approved by an admin and requires changes.',
   },
   nonePrimaryInfo: {
     message:
@@ -175,7 +164,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
       'Button in the "Submit to Community Library" panel to show more details about the Community Library',
   },
   lessDetailsButton: {
-    message: 'Less details',
+    message: 'Hide details',
     context:
       'Button in the "Submit to Community Library" panel to hide details about the Community Library',
   },
@@ -217,7 +206,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   alreadySubmittedWarningDescription: {
     message:
-      'Please wait for review or make changes and publish a new version before submitting again.',
+      'Please wait for the channel to be reviewed. You will see a notification in your Studio account after the review is complete.',
     context:
       'Description of warning shown in the "Submit to Community Library" panel when the current version is already submitted',
   },
@@ -225,11 +214,6 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     message: "Describe what's included in this submission",
     context:
       'Label for the submission description field in the "Submit to Community Library" panel',
-  },
-  descriptionRequired: {
-    message: 'Description is required',
-    context:
-      'Error message shown in the "Submit to Community Library" panel when description is required but empty',
   },
   submitButton: {
     message: 'Submit for review',
@@ -270,12 +254,12 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     context: 'Label for the notes the editor can add to their submission to the Community Library',
   },
   feedbackNotesLabel: {
-    message: 'Feedback notes',
+    message: 'Notes from the reviewer',
     context:
       'Label for the feedback notes that reviewers can add to a submission in the Community Library ',
   },
   internalNotesLabel: {
-    message: 'Internal notes',
+    message: 'Admin notes (internal use only)',
     context:
       'Label for the notes that admins can add to a submission in the Community Library for themselves',
   },
@@ -352,7 +336,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   resubmitModalBodySecond: {
     message:
-      'Would you like to resubmit this version with your changes for community library review?',
+      'Would you like to resubmit this version with your changes for Community Library review?',
     context:
       'Second sentence of the body text of the modal shown after publishing a channel that already has Community Library submissions',
   },
@@ -365,7 +349,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     context: 'Action in the resubmit modal to dismiss the modal',
   },
   licenseCheckPassed: {
-    message: 'License check passed',
+    message: 'License check passed.',
     context: 'Title shown when license audit passes (no invalid licenses found)',
   },
   allLicensesCompatible: {
@@ -373,11 +357,11 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     context: 'Message shown after listing compatible licenses when license check passes',
   },
   incompatibleLicensesDetected: {
-    message: 'Incompatible licenses detected',
+    message: 'Incompatible licenses detected.',
     context: 'Title shown when invalid licenses are detected in the channel',
   },
   channelCannotBeDistributed: {
-    message: 'this channel cannot be distributed via Kolibri.',
+    message: 'This channel cannot be distributed via Kolibri.',
     context: 'Message explaining that channels with incompatible licenses cannot be distributed',
   },
   fixLicensingBeforeSubmission: {
@@ -386,7 +370,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   incompatibleLicensesDescription: {
     message:
-      '"{licenseNames}" - this channel cannot be distributed via Kolibri. Please fix licensing before submitting a new version.',
+      '"{licenseNames}" - this channel cannot be distributed via Kolibri.  If you cannot change the license, remove all resources with "{licenseNames}"  before submitting again.',
     context:
       'Description shown when incompatible licenses are detected, includes the license names and explanation',
   },
@@ -476,7 +460,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
       'Notification message shown to the user when their submission to the Community Library is successful',
   },
   flaggedNotification: {
-    message: '{author} ({userType}) flagged {channelVersion}',
+    message: 'Changes required for {channelVersion}',
     context: 'Notification message shown when a user flags a channel version for review',
   },
   submissionNotification: {
@@ -520,8 +504,8 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     message: 'Channel version token',
     context: 'Label for the channel version token included in submission details page',
   },
-  liveVersionLabel: {
-    message: 'Live version:',
+  publishedVersionLabel: {
+    message: 'Published version:',
     context: 'Label indicating the live version of a channel',
   },
   activityHistoryLabel: {
@@ -575,7 +559,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   channelTokenDescription: {
     message:
-      'To preview your draft channel right away, simply copy the unique draft channel token. This is the sole method to access the channel.',
+      'You can use this token to import and preview the draft channel in Kolibri. Please note that the token for the final published channel will be different.',
     context: 'Description for the channel token field in the draft preview instructions modal',
   },
   getDraftTokenAction: {

--- a/contentcuration/contentcuration/frontend/shared/strings/communityChannelsStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/strings/communityChannelsStrings.js
@@ -40,7 +40,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   publishDraftDescription: {
     message:
-      'Your channel will be saved as a draft, allowing you to review or conduct quality checks without altering the version Kolibri users can access. To see your channel in Kolibri, import using the draft channel token.',
+      'Your channel will be saved as a draft, allowing you to review and do quality checks on the draft, without altering the current version available for Kolibri users. To see this draft channel in Kolibri, import using the draft channel token.',
     context: 'Description for the draft publishing mode',
   },
   publishingInfo: {
@@ -148,7 +148,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
   },
   needsChangesPrimaryInfo: {
     message:
-      'Your previously submitted version needs changes. Make sure you have addressed all feedback before resubmitting.',
+      'Your previously submitted version needs changes. Make sure you have addressed all comments before resubmitting.',
     context:
       'Information shown in the "Submit to Community Library" panel when a previous version was not approved by an admin and requires changes.',
   },
@@ -284,7 +284,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     context: 'Label for the channel information checklist item in the channel fit checklist',
   },
   channelFitChecklistIntro: {
-    message: 'Is your channel a good fit?',
+    message: 'Criteria for submitting to the Community Library',
     context:
       'Introductory text before a checklist of criteria for submitting a channel to the Community Library',
   },
@@ -563,7 +563,7 @@ export const communityChannelsStrings = createTranslator('CommunityChannelsStrin
     context: 'Description for the channel token field in the draft preview instructions modal',
   },
   getDraftTokenAction: {
-    message: 'Get draft token',
+    message: 'Copy token for draft channel',
     context:
       'Button text for the action to retrieve the draft token in the draft preview instructions modal',
   },

--- a/contentcuration/contentcuration/frontend/shared/views/communityLibrary/CommunityLibraryStatusChip.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/communityLibrary/CommunityLibraryStatusChip.vue
@@ -37,7 +37,7 @@
 
   const theme = themePalette();
 
-  const { pendingStatus$, supersededStatus$, approvedStatus$, flaggedStatus$, liveStatus$ } =
+  const { pendingStatus$, supersededStatus$, approvedStatus$, flaggedStatus$, availableStatus$ } =
     communityChannelsStrings;
 
   const configChoices = {
@@ -63,7 +63,7 @@
       icon: 'circleCheckmark',
     },
     [CommunityLibraryStatus.LIVE]: {
-      text: liveStatus$(),
+      text: availableStatus$(),
       backgroundColor: theme.green.v_100,
       labelColor: theme.green.v_600,
       borderColor: theme.green.v_400,

--- a/contentcuration/contentcuration/frontend/shared/views/communityLibrary/SubmissionDetailsModal/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/communityLibrary/SubmissionDetailsModal/index.vue
@@ -59,7 +59,7 @@
             v-if="liveSubmission && submission.id !== liveSubmission.id"
             class="live-version"
           >
-            <span>{{ liveVersionLabel$() }}</span>
+            <span>{{ publishedVersionLabel$() }}</span>
             <KButton
               appearance="basic-link"
               :text="
@@ -285,7 +285,7 @@
     communityLibrarySubmissionLabel$,
     channelVersion$,
     channelVersionTokenLabel$,
-    liveVersionLabel$,
+    publishedVersionLabel$,
     reviewAction$,
   } = communityChannelsStrings;
 


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

…

## References
<!--
 * references to related issues and PRs
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
