### PR TITLE
Fix Administration  bug  when deleted users are still listed in the users table.

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/composables/useTable.js
+++ b/contentcuration/contentcuration/frontend/administration/composables/useTable.js
@@ -115,5 +115,6 @@ export function useTable({ fetchFunc, filterFetchQueryParams }) {
   return {
     pagination,
     loading,
+    loadItems,
   };
 }

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserItem.vue
@@ -113,6 +113,7 @@
       <UserActionsDropdown
         :userId="userId"
         flat
+        @deleted="$emit('deleted')"
       />
     </td>
   </tr>

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -123,6 +123,7 @@
         <UserItem
           v-model="selected"
           :userId="item"
+          @deleted="loadItems"
         />
       </template>
     </VDataTable>
@@ -246,7 +247,7 @@
         return store.dispatch('userAdmin/loadUsers', fetchParams);
       }
 
-      const { pagination, loading } = useTable({
+      const { pagination, loading, loadItems } = useTable({
         fetchFunc: fetchParams => loadUsers(fetchParams),
         filterFetchQueryParams,
       });
@@ -261,6 +262,7 @@
         clearSearch,
         pagination,
         loading,
+        loadItems,
         filterFetchQueryParams,
       };
     },

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -431,7 +431,7 @@ class AdminUserViewSet(
         "edit_count",
         "view_count",
     )
-    queryset = User.objects.all()
+    queryset = User.objects.filter(deleted=False)
 
     def annotate_queryset(self, queryset):
         edit_channel_query = (


### PR DESCRIPTION


## Summary
This PR  fixes a bug when a user is deleted, the table row disappears, but if I refresh the page, it appears again, and the user is listed as inactive
closes  #5705
### Before 
https://private-user-images.githubusercontent.com/79847249/550514727-6afe28e7-6e4c-43f7-954f-213aceae0a41.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzYzNTc1MzAsIm5iZiI6MTc3NjM1NzIzMCwicGF0aCI6Ii83OTg0NzI0OS81NTA1MTQ3MjctNmFmZTI4ZTctNmU0Yy00M2Y3LTk1NGYtMjEzYWNlYWUwYTQxLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA0MTYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNDE2VDE2MzM1MFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWJkM2E4ZDRkYTBkMGM0ODU1MTVlZWU0YWVmOGU3NTZiMWQ5YjY3OTY2ZTdmNzRmZDFhMzA0MWRkZTNiZTU4YzYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT12aWRlbyUyRm1wNCJ9.CPodhvtLGICjFDTw3ERLz5cp15vMC-qe-EXJHDj1GOY

### After



https://github.com/user-attachments/assets/524e8e9b-1d5a-4d95-b383-5f4aa1a2d6d0




## References
 #5705
## Reviewer guidance

- Sign in to Studio with an Admin user
- Go to Administration > Users and delete a user
- Observe that after reloading the page the user is still listed in the table


## AI usage
N/a