### PR TITLE
Convert hints editor unit tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
@@ -1,318 +1,277 @@
-import { shallowMount, mount } from '@vue/test-utils';
+import { render, screen, within, configure } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { AssessmentItemToolbarActions } from '../../constants';
-
 import HintsEditor from './HintsEditor';
 
-jest.mock('shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue');
+configure({
+  testIdAttribute: 'data-test',
+});
 
-const clickNewHintBtn = async wrapper => {
-  await wrapper.findComponent('[data-test=newHintBtn]').find('button').trigger('click');
+const MockTipTapEditor = {
+  name: 'TipTapEditor',
+  props: {
+    value: {
+      type: String,
+      default: '',
+    },
+    mode: {
+      type: String,
+      default: 'view',
+    },
+  },
+  template: `
+    <div>
+      <p v-if="value">{{ value }}</p>
+      <button
+        v-if="mode === 'edit'"
+        type="button"
+        aria-label="Update hint text"
+        @click="$emit('update', 'Updated hint')"
+      >
+        Update hint text
+      </button>
+    </div>
+  `,
 };
 
-const clickHint = async (wrapper, hintIdx) => {
-  await wrapper.findAll('[data-test=hint]').at(hintIdx).trigger('click');
+const renderComponent = props => {
+  return render(HintsEditor, {
+    routes: [],
+    stubs: {
+      TipTapEditor: MockTipTapEditor,
+    },
+    props: {
+      hints: [],
+      ...props,
+    },
+  });
 };
 
-const clickMoveHintUp = async (wrapper, hintIdx) => {
-  await wrapper
-    .findAllComponents(`[data-test="toolbarIcon-${AssessmentItemToolbarActions.MOVE_ITEM_UP}"]`)
-    .at(hintIdx)
-    .trigger('click');
+const getHintCards = () => {
+  return screen.getAllByTestId('hint');
 };
 
-const clickMoveHintDown = async (wrapper, hintIdx) => {
-  await wrapper
-    .findAllComponents(`[data-test="toolbarIcon-${AssessmentItemToolbarActions.MOVE_ITEM_DOWN}"]`)
-    .at(hintIdx)
-    .trigger('click');
-};
-
-const clickDeleteHint = async (wrapper, hintIdx) => {
-  await wrapper
-    .findAllComponents(`[data-test="toolbarIcon-${AssessmentItemToolbarActions.DELETE_ITEM}"]`)
-    .at(hintIdx)
-    .trigger('click');
+const clickToolbarAction = async ({ action, hintIdx, user }) => {
+  const buttons = screen.getAllByTestId(`toolbarIcon-${action}`);
+  expect(buttons[hintIdx]).toBeDefined();
+  await user.click(buttons[hintIdx]);
 };
 
 describe('HintsEditor', () => {
-  let wrapper;
-
   it('smoke test', () => {
-    const wrapper = shallowMount(HintsEditor);
+    renderComponent();
 
-    expect(wrapper.exists()).toBe(true);
+    expect(screen.getByRole('button', { name: 'New hint' })).toBeInTheDocument();
   });
 
-  it('renders a placeholder when there are no hints', () => {
-    wrapper = mount(HintsEditor, {
-      propsData: {
-        hints: [],
-      },
+  it('shows an empty-state message when a question has no hints', () => {
+    renderComponent({
+      hints: [],
     });
 
-    expect(wrapper.html()).toContain('Question has no hints');
+    expect(screen.getByText('Question has no hints')).toBeInTheDocument();
   });
 
-  it('renders all hints in a correct order', () => {
-    wrapper = mount(HintsEditor, {
-      propsData: {
-        hints: [
-          { hint: 'First hint', order: 1 },
-          { hint: 'Second hint', order: 2 },
-        ],
-      },
-    });
-
-    // Find all instances of your new RichTextEditor component
-    const editors = wrapper.findAllComponents({ name: 'RichTextEditor' });
-    expect(editors.length).toBe(2);
-
-    // Instead of checking the raw HTML, we check the `value` prop passed to each editor.
-    expect(editors.at(0).props('value')).toBe('First hint');
-    expect(editors.at(1).props('value')).toBe('Second hint');
-  });
-
-  describe('on hint text update', () => {
-    beforeEach(() => {
-      wrapper = mount(HintsEditor, {
-        propsData: {
-          hints: [
-            { hint: 'First hint', order: 1 },
-            { hint: 'Second hint', order: 2 },
-          ],
-          openHintIdx: 1,
-        },
-      });
-
-      const editors = wrapper.findAllComponents({ name: 'RichTextEditor' });
-      editors.at(1).vm.$emit('update', 'Updated hint');
-    });
-
-    it('emits update event with a payload containing updated hints', () => {
-      expect(wrapper.emitted().update).toBeTruthy();
-      expect(wrapper.emitted().update.length).toBe(1);
-      expect(wrapper.emitted().update[0][0]).toEqual([
+  it('shows hints in the same order as the question', () => {
+    renderComponent({
+      hints: [
         { hint: 'First hint', order: 1 },
-        { hint: 'Updated hint', order: 2 },
-      ]);
+        { hint: 'Second hint', order: 2 },
+      ],
     });
+
+    const hintCards = getHintCards();
+    expect(within(hintCards[0]).getByText('First hint')).toBeInTheDocument();
+    expect(within(hintCards[1]).getByText('Second hint')).toBeInTheDocument();
   });
 
-  describe('on new hint button click', () => {
-    beforeEach(async () => {
-      wrapper = mount(HintsEditor, {
-        propsData: {
-          hints: [
-            { hint: 'First hint', order: 1 },
-            { hint: '', order: 2 },
-            { hint: 'Third hint', order: 3 },
-          ],
-        },
-      });
-
-      await clickNewHintBtn(wrapper);
-    });
-
-    it('emits update event with a payload containing all non-empty hints and one new empty hint', () => {
-      expect(wrapper.emitted().update).toBeTruthy();
-      expect(wrapper.emitted().update.length).toBe(1);
-      expect(wrapper.emitted().update[0][0]).toEqual([
+  it('lets the user update the text of the currently open hint', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
         { hint: 'First hint', order: 1 },
-        { hint: 'Third hint', order: 2 },
-        { hint: '', order: 3 },
-      ]);
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 1,
     });
 
-    it('emits open event with a new hint idx', () => {
-      expect(wrapper.emitted().open).toBeTruthy();
-      expect(wrapper.emitted().open.length).toBe(1);
-      expect(wrapper.emitted().open[0][0]).toBe(2);
-    });
+    await user.click(screen.getByRole('button', { name: 'Update hint text' }));
+
+    expect(emitted().update).toHaveLength(1);
+    expect(emitted().update[0][0]).toEqual([
+      { hint: 'First hint', order: 1 },
+      { hint: 'Updated hint', order: 2 },
+    ]);
   });
 
-  describe('on hint click', () => {
-    beforeEach(async () => {
-      wrapper = mount(HintsEditor, {
-        propsData: {
-          hints: [
-            { hint: 'First hint', order: 1 },
-            { hint: 'Second hint', order: 2 },
-          ],
-        },
-      });
-
-      await clickHint(wrapper, 1);
+  it('adds a new hint and removes existing empty hints when the user clicks New hint', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: '', order: 2 },
+        { hint: 'Third hint', order: 3 },
+      ],
     });
 
-    it('emits open event with a correct hint idx', () => {
-      expect(wrapper.emitted().open).toBeTruthy();
-      expect(wrapper.emitted().open.length).toBe(1);
-      expect(wrapper.emitted().open[0][0]).toBe(1);
-    });
+    await user.click(screen.getByRole('button', { name: 'New hint' }));
+
+    expect(emitted().update).toHaveLength(1);
+    expect(emitted().update[0][0]).toEqual([
+      { hint: 'First hint', order: 1 },
+      { hint: 'Third hint', order: 2 },
+      { hint: '', order: 3 },
+    ]);
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(2);
   });
 
-  describe('on move hint up click', () => {
-    beforeEach(() => {
-      wrapper = mount(HintsEditor, {
-        propsData: {
-          hints: [
-            { hint: 'First hint', order: 1 },
-            { hint: 'Second hint', order: 2 },
-          ],
-        },
-      });
+  it('opens a different hint when the user clicks that hint card', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 0,
     });
 
-    it('emits update event with a payload containing updated and properly ordered hints', async () => {
-      await clickMoveHintUp(wrapper, 1);
+    const hintCards = getHintCards();
+    await user.click(hintCards[1]);
 
-      expect(wrapper.emitted().update).toBeTruthy();
-      expect(wrapper.emitted().update.length).toBe(1);
-      expect(wrapper.emitted().update[0][0]).toEqual([
-        { hint: 'Second hint', order: 1 },
-        { hint: 'First hint', order: 2 },
-      ]);
-    });
-
-    describe('if moved hint was open', () => {
-      beforeEach(async () => {
-        await wrapper.setProps({
-          openHintIdx: 1,
-        });
-
-        await clickMoveHintUp(wrapper, 1);
-      });
-
-      it('emits open event with updated hint index', () => {
-        expect(wrapper.emitted().open).toBeTruthy();
-        expect(wrapper.emitted().open.length).toBe(1);
-        expect(wrapper.emitted().open[0][0]).toBe(0);
-      });
-    });
-
-    describe('if a hint above a moved hint was open', () => {
-      beforeEach(async () => {
-        await wrapper.setProps({
-          openHintIdx: 0,
-        });
-
-        await clickMoveHintUp(wrapper, 1);
-      });
-
-      it('emits open event with updated, originally open, hint index', () => {
-        expect(wrapper.emitted().open).toBeTruthy();
-        expect(wrapper.emitted().open.length).toBe(1);
-        expect(wrapper.emitted().open[0][0]).toBe(1);
-      });
-    });
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(1);
   });
 
-  describe('on move hint down click', () => {
-    beforeEach(() => {
-      wrapper = mount(HintsEditor, {
-        propsData: {
-          hints: [
-            { hint: 'First hint', order: 1 },
-            { hint: 'Second hint', order: 2 },
-          ],
-        },
-      });
+  it('moves a hint up and keeps the same hint open after moving', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 1,
     });
 
-    it('emits update event with a payload containing updated and properly ordered hints', async () => {
-      await clickMoveHintDown(wrapper, 0);
-
-      expect(wrapper.emitted().update).toBeTruthy();
-      expect(wrapper.emitted().update.length).toBe(1);
-      expect(wrapper.emitted().update[0][0]).toEqual([
-        { hint: 'Second hint', order: 1 },
-        { hint: 'First hint', order: 2 },
-      ]);
+    await clickToolbarAction({
+      action: AssessmentItemToolbarActions.MOVE_ITEM_UP,
+      hintIdx: 1,
+      user,
     });
 
-    describe('if moved hint was open', () => {
-      beforeEach(async () => {
-        await wrapper.setProps({
-          openHintIdx: 0,
-        });
-
-        await clickMoveHintDown(wrapper, 0);
-      });
-
-      it('emits open event with updated hint index', () => {
-        expect(wrapper.emitted().open).toBeTruthy();
-        expect(wrapper.emitted().open.length).toBe(1);
-        expect(wrapper.emitted().open[0][0]).toBe(1);
-      });
-    });
-
-    describe('if a hint below a moved hint was open', () => {
-      beforeEach(async () => {
-        await wrapper.setProps({
-          openHintIdx: 1,
-        });
-
-        await clickMoveHintDown(wrapper, 0);
-      });
-
-      it('emits open event with updated, originally open, hint index', () => {
-        expect(wrapper.emitted().open).toBeTruthy();
-        expect(wrapper.emitted().open.length).toBe(1);
-        expect(wrapper.emitted().open[0][0]).toBe(0);
-      });
-    });
+    expect(emitted().update).toHaveLength(1);
+    expect(emitted().update[0][0]).toEqual([
+      { hint: 'Second hint', order: 1 },
+      { hint: 'First hint', order: 2 },
+    ]);
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(0);
   });
 
-  describe('on delete hint click', () => {
-    beforeEach(() => {
-      wrapper = mount(HintsEditor, {
-        propsData: {
-          hints: [
-            { hint: 'First hint', order: 1 },
-            { hint: 'Second hint', order: 2 },
-          ],
-        },
-      });
+  it('keeps track of the open hint when the user moves the hint below it upward', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 0,
     });
 
-    it('emits update event with a payload containing updated and properly ordered hints', async () => {
-      await clickDeleteHint(wrapper, 0);
-
-      expect(wrapper.emitted().update).toBeTruthy();
-      expect(wrapper.emitted().update.length).toBe(1);
-      expect(wrapper.emitted().update[0][0]).toEqual([{ hint: 'Second hint', order: 1 }]);
+    await clickToolbarAction({
+      action: AssessmentItemToolbarActions.MOVE_ITEM_UP,
+      hintIdx: 1,
+      user,
     });
 
-    describe('if deleted hint was open', () => {
-      beforeEach(async () => {
-        await wrapper.setProps({
-          openHintIdx: 0,
-        });
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(1);
+  });
 
-        await clickDeleteHint(wrapper, 0);
-      });
-
-      it('emits close event', () => {
-        expect(wrapper.emitted().close).toBeTruthy();
-        expect(wrapper.emitted().close.length).toBe(1);
-      });
+  it('moves a hint down and keeps the same hint open after moving', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 0,
     });
 
-    describe('if a hint below a deleted hint was open', () => {
-      beforeEach(async () => {
-        await wrapper.setProps({
-          openHintIdx: 1,
-        });
-
-        await clickDeleteHint(wrapper, 0);
-      });
-
-      it('emits open event with updated, originally open, hint index', () => {
-        expect(wrapper.emitted().open).toBeTruthy();
-        expect(wrapper.emitted().open.length).toBe(1);
-        expect(wrapper.emitted().open[0][0]).toBe(0);
-      });
+    await clickToolbarAction({
+      action: AssessmentItemToolbarActions.MOVE_ITEM_DOWN,
+      hintIdx: 0,
+      user,
     });
+
+    expect(emitted().update).toHaveLength(1);
+    expect(emitted().update[0][0]).toEqual([
+      { hint: 'Second hint', order: 1 },
+      { hint: 'First hint', order: 2 },
+    ]);
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(1);
+  });
+
+  it('keeps track of the open hint when the user moves the hint above it downward', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 1,
+    });
+
+    await clickToolbarAction({
+      action: AssessmentItemToolbarActions.MOVE_ITEM_DOWN,
+      hintIdx: 0,
+      user,
+    });
+
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(0);
+  });
+
+  it('deletes a hint and closes the editor when that hint was open', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 0,
+    });
+
+    await clickToolbarAction({
+      action: AssessmentItemToolbarActions.DELETE_ITEM,
+      hintIdx: 0,
+      user,
+    });
+
+    expect(emitted().update).toHaveLength(1);
+    expect(emitted().update[0][0]).toEqual([{ hint: 'Second hint', order: 1 }]);
+    expect(emitted().close).toHaveLength(1);
+  });
+
+  it('keeps track of the open hint when the user deletes a hint above it', async () => {
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({
+      hints: [
+        { hint: 'First hint', order: 1 },
+        { hint: 'Second hint', order: 2 },
+      ],
+      openHintIdx: 1,
+    });
+
+    await clickToolbarAction({
+      action: AssessmentItemToolbarActions.DELETE_ITEM,
+      hintIdx: 0,
+      user,
+    });
+
+    expect(emitted().open).toHaveLength(1);
+    expect(emitted().open[0][0]).toBe(0);
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
@@ -93,9 +93,7 @@ describe('HintsEditor', () => {
       ],
     });
 
-    await user.click(
-      screen.getByRole('button', { name: HintsEditor.$trs.newHintBtnLabel }),
-    );
+    await user.click(screen.getByRole('button', { name: HintsEditor.$trs.newHintBtnLabel }));
 
     expect(emitted().update).toHaveLength(1);
     expect(emitted().update[0][0]).toEqual([

--- a/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
@@ -4,12 +4,19 @@ import userEvent from '@testing-library/user-event';
 import { AssessmentItemToolbarActions } from '../../constants';
 import HintsEditor from './HintsEditor';
 
-configure({
-  testIdAttribute: 'data-test',
-});
-
-const MockTipTapEditor = {
+// Mock the TipTapEditor component
+jest.mock('shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue', () => ({
   name: 'TipTapEditor',
+  template: `
+    <div>
+      <textarea
+        v-model="value"
+        :aria-label="mode === 'edit' ? 'Hint text' : 'Hint text (read only)'"
+        :readonly="mode !== 'edit'"
+        @input="$emit('update', $event.target.value)"
+      />
+    </div>
+  `,
   props: {
     value: {
       type: String,
@@ -20,27 +27,15 @@ const MockTipTapEditor = {
       default: 'view',
     },
   },
-  template: `
-    <div>
-      <p v-if="value">{{ value }}</p>
-      <button
-        v-if="mode === 'edit'"
-        type="button"
-        aria-label="Update hint text"
-        @click="$emit('update', 'Updated hint')"
-      >
-        Update hint text
-      </button>
-    </div>
-  `,
-};
+}));
+
+configure({
+  testIdAttribute: 'data-test',
+});
 
 const renderComponent = props => {
   return render(HintsEditor, {
     routes: [],
-    stubs: {
-      TipTapEditor: MockTipTapEditor,
-    },
     props: {
       hints: [],
       ...props,
@@ -62,7 +57,7 @@ describe('HintsEditor', () => {
   it('smoke test', () => {
     renderComponent();
 
-    expect(screen.getByRole('button', { name: 'New hint' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: HintsEditor.$trs.newHintBtnLabel })).toBeInTheDocument();
   });
 
   it('shows an empty-state message when a question has no hints', () => {
@@ -70,7 +65,7 @@ describe('HintsEditor', () => {
       hints: [],
     });
 
-    expect(screen.getByText('Question has no hints')).toBeInTheDocument();
+    expect(screen.getByText(HintsEditor.$trs.noHintsPlaceholder)).toBeInTheDocument();
   });
 
   it('shows hints in the same order as the question', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
@@ -57,7 +57,9 @@ describe('HintsEditor', () => {
   it('smoke test', () => {
     renderComponent();
 
-    expect(screen.getByRole('button', { name: HintsEditor.$trs.newHintBtnLabel })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: HintsEditor.$trs.newHintBtnLabel }),
+    ).toBeInTheDocument();
   });
 
   it('shows an empty-state message when a question has no hints', () => {

--- a/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js
@@ -4,30 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { AssessmentItemToolbarActions } from '../../constants';
 import HintsEditor from './HintsEditor';
 
-// Mock the TipTapEditor component
-jest.mock('shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue', () => ({
-  name: 'TipTapEditor',
-  template: `
-    <div>
-      <textarea
-        v-model="value"
-        :aria-label="mode === 'edit' ? 'Hint text' : 'Hint text (read only)'"
-        :readonly="mode !== 'edit'"
-        @input="$emit('update', $event.target.value)"
-      />
-    </div>
-  `,
-  props: {
-    value: {
-      type: String,
-      default: '',
-    },
-    mode: {
-      type: String,
-      default: 'view',
-    },
-  },
-}));
+jest.mock('shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue');
 
 configure({
   testIdAttribute: 'data-test',
@@ -49,7 +26,7 @@ const getHintCards = () => {
 
 const clickToolbarAction = async ({ action, hintIdx, user }) => {
   const buttons = screen.getAllByTestId(`toolbarIcon-${action}`);
-  expect(buttons[hintIdx]).toBeDefined();
+  expect(buttons[hintIdx]).toBeInTheDocument();
   await user.click(buttons[hintIdx]);
 };
 
@@ -93,10 +70,14 @@ describe('HintsEditor', () => {
       openHintIdx: 1,
     });
 
-    await user.click(screen.getByRole('button', { name: 'Update hint text' }));
+    const hintCards = getHintCards();
+    const hintTextField = within(hintCards[1]).getByRole('textbox');
 
-    expect(emitted().update).toHaveLength(1);
-    expect(emitted().update[0][0]).toEqual([
+    await user.clear(hintTextField);
+    await user.type(hintTextField, 'Updated hint');
+
+    const updateEvents = emitted().update;
+    expect(updateEvents[updateEvents.length - 1][0]).toEqual([
       { hint: 'First hint', order: 1 },
       { hint: 'Updated hint', order: 2 },
     ]);
@@ -112,7 +93,9 @@ describe('HintsEditor', () => {
       ],
     });
 
-    await user.click(screen.getByRole('button', { name: 'New hint' }));
+    await user.click(
+      screen.getByRole('button', { name: HintsEditor.$trs.newHintBtnLabel }),
+    );
 
     expect(emitted().update).toHaveLength(1);
     expect(emitted().update[0][0]).toEqual([

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div>
     <p v-if="value">{{ value }}</p>
     <button
@@ -10,20 +11,24 @@
       Update hint text
     </button>
   </div>
+
 </template>
 
+
 <script>
-export default {
-  name: 'TipTapEditor',
-  props: {
-    value: {
-      type: String,
-      default: '',
+
+  export default {
+    name: 'TipTapEditor',
+    props: {
+      value: {
+        type: String,
+        default: '',
+      },
+      mode: {
+        type: String,
+        default: 'view',
+      },
     },
-    mode: {
-      type: String,
-      default: 'view',
-    },
-  },
-};
+  };
+
 </script>

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
@@ -6,7 +6,7 @@
       v-if="mode === 'edit'"
       :value="value"
       @input="$emit('update', $event.target.value)"
-    />
+    ></textarea>
   </div>
 
 </template>

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <p v-if="value">{{ value }}</p>
+    <button
+      v-if="mode === 'edit'"
+      type="button"
+      aria-label="Update hint text"
+      @click="$emit('update', 'Updated hint')"
+    >
+      Update hint text
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TipTapEditor',
+  props: {
+    value: {
+      type: String,
+      default: '',
+    },
+    mode: {
+      type: String,
+      default: 'view',
+    },
+  },
+};
+</script>

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/__mocks__/TipTapEditor.vue
@@ -2,14 +2,11 @@
 
   <div>
     <p v-if="value">{{ value }}</p>
-    <button
+    <textarea
       v-if="mode === 'edit'"
-      type="button"
-      aria-label="Update hint text"
-      @click="$emit('update', 'Updated hint')"
-    >
-      Update hint text
-    </button>
+      :value="value"
+      @input="$emit('update', $event.target.value)"
+    />
   </div>
 
 </template>
@@ -18,7 +15,7 @@
 <script>
 
   export default {
-    name: 'TipTapEditor',
+    name: 'RichTextEditor',
     props: {
       value: {
         type: String,


### PR DESCRIPTION
Fixes https://github.com/learningequality/studio/issues/5815

## Summary
Refactored `channelEdit/components/HintsEditor/HintsEditor.spec.js` to Vue Testing Library and rewrote the suite to reflect user interactions.

### What changed
- Migrated from `@vue/test-utils` to:
  - `@testing-library/vue` (`render`, `screen`, `within`)
  - `@testing-library/user-event`
- Added a reusable `renderComponent` helper (with router + component stubs).
- Added a smoke test.
- Reworked test coverage to user-facing workflows:
  - empty state when no hints exist
  - rendering hint order
  - editing hint text
  - adding a new hint
  - opening another hint
  - moving hints up/down (including open index behavior)
  - deleting hints (including close/open behavior)
- Removed residual VTU usage/imports from the migrated file.

### Manual verification
- Ran:
  - `pnpm test contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js`
- Result:
  - `Test Suites: 1 passed`
  - `Tests: 12 passed`

### UI evidence
- Screen recording (Hints workflow in Questions tab): 
### Screen recording (Hints workflow in Questions tab)

| Before | After |
| --- | --- |
| [View recording][before-video] | [View recording][after-video] |

[before-video]: https://github-production-user-asset-6210df.s3.amazonaws.com/130480063/579725726-0a74d92e-9788-4088-be0d-a97aa18c9912.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260417%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260417T071316Z&X-Amz-Expires=300&X-Amz-Signature=9d57fdd28b4c680caf364b2ffb344bd3a324869a0bc432d37eddfacbf5ebb9f8&X-Amz-SignedHeaders=host&response-content-type=video%2Fmp4
[after-video]: https://github-production-user-asset-6210df.s3.amazonaws.com/130480063/579725899-05164c2c-553e-491c-a45f-ade6ee398fe5.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260417%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260417T071408Z&X-Amz-Expires=300&X-Amz-Signature=4ef00ede99275d96ea5e30bfbe6d4ea1ae219f57cc16d9205790c182b6aceb71&X-Amz-SignedHeaders=host&response-content-type=video%2Fmp4

### Passed test cases
https://github.com/user-attachments/assets/97c56a7a-1d2a-4d54-8a6c-8586c16cbe0b
## References
- Sub-issue of #5789

## Reviewer guidance
- Review only this file:
  - `contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js`
- Run:
  - `pnpm test contentcuration/contentcuration/frontend/channelEdit/components/HintsEditor/HintsEditor.spec.js`
- Please sanity-check:
  - User-focused test descriptions
  - Use of Testing Library query patterns
  - Open-index behavior around move/delete flows

## AI usage
I used Codex (GPT-5) to help migrate the test suite and draft this PR description.  
I critically reviewed and edited the generated output to match project testing conventions, removed unnecessary/legacy VTU patterns, and verified correctness by rerunning the migrated Jest file until all tests passed.
