### PR TITLE
Robust solution for filtering unpublishable changes on frontend

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/serverSync.spec.js
@@ -1,9 +1,9 @@
 import { queueChange, debouncedSyncChanges } from '../serverSync';
 import { CreatedChange } from '../changes';
 import db from '../db';
-import { Session, Task } from 'shared/data/resources';
+import { Channel, Session, Task } from 'shared/data/resources';
 import client from 'shared/client';
-import { CHANGES_TABLE, CURRENT_USER, TABLE_NAMES } from 'shared/data/constants';
+import { CHANGE_TYPES, CHANGES_TABLE, CURRENT_USER, TABLE_NAMES } from 'shared/data/constants';
 import { mockChannelScope, resetMockChannelScope } from 'shared/utils/testing';
 
 async function makeChange(key, server_rev) {
@@ -224,5 +224,38 @@ describe('ServerSync tests', () => {
       const dbTask = await Task.get(task.task_id);
       expect(dbTask.status).toEqual(task.status);
     }
+  });
+
+  it('should not set unpublished_changes when response contains only unpublishable changes', async () => {
+    const channelId = 'test-channel-unpublishable';
+    await Channel.table.put({ id: channelId });
+
+    client.post.mockResolvedValue({
+      data: {
+        disallowed: [],
+        allowed: [],
+        returned: [],
+        errors: [],
+        successes: [
+          {
+            channel_id: channelId,
+            server_rev: 100,
+            created_by_id: 'some-user-id',
+            type: CHANGE_TYPES.UPDATED,
+            unpublishable: true,
+          },
+        ],
+        maxRevs: [],
+        tasks: [],
+      },
+    });
+
+    await debouncedSyncChanges();
+
+    const channel = await Channel.table.get(channelId);
+    expect(channel.unpublished_changes).not.toBe(true);
+
+    // Manual clean up
+    await Channel.table.delete(channelId);
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/data/serverSync.js
+++ b/contentcuration/contentcuration/frontend/shared/data/serverSync.js
@@ -175,7 +175,12 @@ function handleMaxRevs(response, userId) {
     maxRevs[`${MAX_REV_KEY}.${channelId}`] = channelChanges[0].server_rev;
     const lastChannelEditIndex = findLastIndex(
       channelChanges,
-      c => !c.errors && !c.user_id && c.created_by_id && c.type !== CHANGE_TYPES.PUBLISHED,
+      c =>
+        !c.errors &&
+        !c.user_id &&
+        c.created_by_id &&
+        c.type !== CHANGE_TYPES.PUBLISHED &&
+        !c.unpublishable,
     );
     const lastPublishIndex = findLastIndex(
       channelChanges,

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -3817,6 +3817,7 @@ class Change(models.Model):
                 "channel_id": get_attribute(change, ["channel_id"]),
                 "user_id": get_attribute(change, ["user_id"]),
                 "created_by_id": get_attribute(change, ["created_by_id"]),
+                "unpublishable": get_attribute(change, ["unpublishable"]),
             }
         )
         return datum

--- a/contentcuration/contentcuration/tests/viewsets/test_community_library_submission.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_community_library_submission.py
@@ -720,12 +720,12 @@ class AdminViewSetTestCase(StudioAPITestCase):
         self.assertEqual(resolved_submission.resolved_by, self.admin_user)
         self.assertEqual(resolved_submission.date_updated, self.resolved_time)
 
-        self.assertTrue(
-            Change.objects.filter(
-                channel=self.submission.channel,
-                change_type=ADDED_TO_COMMUNITY_LIBRARY,
-            ).exists()
+        change = Change.objects.get(
+            channel=self.submission.channel,
+            change_type=ADDED_TO_COMMUNITY_LIBRARY,
         )
+        self.assertEqual(change.created_by_id, self.admin_user.id)
+        self.assertTrue(change.unpublishable)
         apply_task_mock.fetch_or_enqueue.assert_called_once_with(
             self.admin_user,
             channel_id=self.submission.channel.id,

--- a/contentcuration/contentcuration/viewsets/community_library_submission.py
+++ b/contentcuration/contentcuration/viewsets/community_library_submission.py
@@ -320,6 +320,7 @@ class AdminCommunityLibrarySubmissionViewSet(
                 categories=submission.categories,
                 country_codes=country_codes,
             ),
+            created_by_id=submission.resolved_by_id,
             # This change is not publishable and should not trigger publish-related logic
             unpublishable=True,
         )

--- a/contentcuration/contentcuration/viewsets/sync/endpoint.py
+++ b/contentcuration/contentcuration/viewsets/sync/endpoint.py
@@ -155,6 +155,7 @@ class SyncView(APIView):
                 "table",
                 "change_type",
                 "kwargs",
+                "unpublishable",
             )
             .order_by("server_rev")[:CHANGE_RETURN_LIMIT]
         )


### PR DESCRIPTION
## Summary

In https://github.com/learningequality/studio/pull/5825, I noticed that `unpublishable` changes were still changing the `unpublished_changes` condition on the frontend because we weren't returning this from the backend, and less so acknowledging it on the frontend. I just followed the tendency to just remove the `created_by_id` attribute from the change, just to not mess with the sync endpoint.

However, didn't notice that in the add_to_community_library flow, we use [get_edit_queryset](https://github.com/AlexVelezLl/studio/blob/105dbe27980f85f1b4e47bb4ea5c625f81be94a4/contentcuration/contentcuration/viewsets/channel.py#L832) to filter the channel, so we needed the `created_by_id`. This PR returns the `unpublishable` field to the frontend, and filters changes to compute the `unpublished_changes` field.

### Verification steps
* I have gone through the whole flow of approving a Community Library Submission, and seeing the channel live on the Community Library.
* No unwanted enabled publish button after that.
* Verified that other publishable sync changes from other browsers keep working correctly and setting the `unpublished_changes` field properly.

## References
Fixes https://github.com/learningequality/studio/issues/5843.

## Reviewer guidance

* Create a community library submission.
* Approve it.
* Check that the channel is live on the community library page.
