### PR TITLE
Remove expires header from GCS response

### DIFF
--- a/docker/nginx/includes/content/_cache.conf
+++ b/docker/nginx/includes/content/_cache.conf
@@ -1,8 +1,9 @@
 # location {} settings for /content caching
 # used by files in this directory, via `include` directive
 
-# ignore cache-control from upstream so this value is authoritative
+# ignore 'expires' and 'cache-control' headers from upstream so this value is authoritative
 proxy_hide_header Cache-Control;
+proxy_hide_header Expires;
 
 # content is md5-addressed, so cache aggressively for successful responses
 add_header Cache-Control "public, max-age=31536000, immutable, no-transform";


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Removes `Expires` headers from upstream GCS response, in parity with removal of `Cache-control`.

## References
<!--
 * references to related issues and PRs
-->
Followup to: https://github.com/learningequality/studio/pull/5829

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I walked through it with Gemini on whether this made sense and whether any other headers should be removed.