### PR TITLE
Revert "Temporarily hide draft button."

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.spec.js
@@ -20,6 +20,7 @@ const GETTERS = {
   global: {
     isCompactViewMode: jest.fn(),
     appendChannelName: () => () => jest.fn(),
+    hasFeatureEnabled: () => () => false,
   },
   currentChannel: {
     rootId: () => ROOT_ID,

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreePage/index.vue
@@ -227,7 +227,7 @@
             </VBtn>
 
             <VBtn
-              v-if="false"
+              v-if="showDraftMode"
               color="primary"
               data-test="display-publish-draft-dialog-btn"
               @click="displayPublishDraftDialog = true"
@@ -365,6 +365,7 @@
   import MainNavigationDrawer from 'shared/views/MainNavigationDrawer';
   import OfflineText from 'shared/views/OfflineText';
   import { Channel } from 'shared/data/resources';
+  import { FeatureFlagKeys } from 'shared/constants';
 
   export default {
     name: 'StagingTreePage',
@@ -409,7 +410,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isCompactViewMode']),
+      ...mapGetters(['isCompactViewMode', 'hasFeatureEnabled']),
       ...mapGetters('currentChannel', [
         'currentChannel',
         'rootId',
@@ -491,6 +492,9 @@
       },
       fileSizeDiff() {
         return this.fileSizeStaged - this.fileSizeLive;
+      },
+      showDraftMode() {
+        return this.hasFeatureEnabled(FeatureFlagKeys.draft_channels);
       },
     },
     watch: {
@@ -648,7 +652,6 @@
         this.isPublishingDraft = true;
 
         this.publishStagingChannel()
-          .then(publishDraftchange => Channel.waitForPublishingDraft(publishDraftchange))
           .then(() => {
             this.isPublishingDraft = false;
             this.showSnackbar({


### PR DESCRIPTION
## Summary
This reverts commit 95648062e57526dc6c9f9974533aa0fd7d4a7de3.
Reverts the PR that temporarily hid the "Publish draft" button on staging channels
Adds toggle by feature flag instead
Removes call to deleted function that had been absorbed into the draft publish function that was already being called.

## References
Reverts #5652

## Reviewer guidance
Did I delete `v-if="false"` correctly?

## AI usage
None - crafted with my own two hands!