### PR TITLE
Fix lookup not finding draft tokens

### DIFF
--- a/contentcuration/kolibri_public/views_v1.py
+++ b/contentcuration/kolibri_public/views_v1.py
@@ -108,7 +108,6 @@ def _get_channel_list_v1(params, identifier=None):
             ).filter(
                 secret_token__token=identifier,
                 channel__deleted=False,
-                channel__main_tree__published=True,
             )
             if channel_version.exists():
                 # return early as we won't need to apply the other filters for channel version tokens


### PR DESCRIPTION
## Summary

While testing http://github.com/learningequality/studio/pull/5856 I published a draft version of a ricecooker channel that hadn't been published yet, and the lookup endpoint was returning 404 for its token. This was because we were only looking at channel versions whose main channel tree was published, but this doesn't apply to draft versions prior to the `v1` version of the channel.

## Reviewer guidance
* Publish a draft version before publishing the first live version of a channel.
* Verify that the lookup endpoint returns the draft version using the draft token.