### PR TITLE
Exclude po and json files from end-of-file-fixer hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         exclude: '^.+?\.ttf$'
       - id: debug-statements
       - id: end-of-file-fixer
-        exclude: '^.+?\.json.+?\.yml$'
+        exclude: '^.+?(\.json|\.po)$'
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.2
     hooks:


### PR DESCRIPTION
## Summary
* Brings the pre-commit exclude for end-of-file-fixer in line with Kolibri to avoid issues with autoformatting of downloaded i18n files.

## Reviewer guidance
Linting should pass (it runs for yml files).

## AI usage
None.