### PR TITLE
Ignore topics since they will not be present in the CSV for Khan channels

### DIFF
--- a/contentcuration/contentcuration/management/commands/fix_missing_import_sources.py
+++ b/contentcuration/contentcuration/management/commands/fix_missing_import_sources.py
@@ -14,6 +14,7 @@ from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models.expressions import F
 from django_cte import With
+from le_utils.constants import content_kinds
 
 from contentcuration.models import Channel
 from contentcuration.models import ContentNode
@@ -215,6 +216,7 @@ class Command(BaseCommand):
                 public_channel_name=public_cte.col.name,
                 public_channel_deleted=public_cte.col.deleted,
             )
+            .exclude(kind=content_kinds.TOPIC)
             .filter(
                 Q(public_channel_deleted=True)
                 | ~Exists(

--- a/contentcuration/contentcuration/tests/management/commands/test_fix_missing_import_sources.py
+++ b/contentcuration/contentcuration/tests/management/commands/test_fix_missing_import_sources.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.core.management import call_command
+from le_utils.constants import content_kinds
 
 from contentcuration.management.commands.fix_missing_import_sources import (
     LicensingFixesLookup,
@@ -116,6 +117,31 @@ class CommandTestCase(StudioTestCase):
         self.assertEqual(self.copied_node.license_id, original_license_id)
         self.assertEqual(self.copied_node.license_description, "Nothing")
         self.assertEqual(self.copied_node.copyright_holder, "Nothing")
+
+    def test_handle__skips_topic_nodes_with_missing_source(self):
+        self.original_node.delete()
+        self.copied_node.refresh_from_db()
+        self.copied_node.kind_id = content_kinds.TOPIC
+        self.copied_node.license = None
+        self.copied_node.license_description = ""
+        self.copied_node.copyright_holder = ""
+        self.copied_node.save()
+
+        with patch(
+            "contentcuration.management.commands.fix_missing_import_sources.LicensingFixesLookup"
+        ) as lookup_cls:
+            lookup = lookup_cls.return_value
+            lookup.get_info.return_value = (5, "", "Khan Academy")
+
+            call_command("fix_missing_import_sources")
+
+        lookup.get_info.assert_not_called()
+
+        self.copied_node.refresh_from_db()
+        self.assertIsNone(self.copied_node.license_id)
+        self.assertEqual(self.copied_node.kind_id, content_kinds.TOPIC)
+        self.assertEqual(self.copied_node.license_description, "")
+        self.assertEqual(self.copied_node.copyright_holder, "")
 
 
 class LicensingFixesLookupTestCase(StudioTestCase):


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
Observed during testing:
```
Failed to find licensing info for channel: c1f2b7e6ac9f56a2bb44fa7a48b66dce
```

I know from the previous export, there were many topics/folders copied to channels, but for the purposes of the current command, those do not need to be altered and can be skipped.

## References
<!--
 * references to related issues and PRs
-->
followup to https://github.com/learningequality/studio/pull/5760


<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Had the AI write the test and verified afterwards