### PR TITLE
Fix disk space popup in admin users table

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserStorage.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserStorage.vue
@@ -23,23 +23,17 @@
           :rules="spaceRules"
         />
       </VFlex>
-      <DropdownWrapper
-        component="VFlex"
-        style="max-width: 75px"
-      >
-        <template #default="{ attach, menuProps }">
-          <VSelect
-            v-model="unit"
-            :items="unitOptions"
-            :attach="attach"
-            :menuProps="menuProps"
-            box
-            single-line
-            required
-            :rules="unitRules"
-          />
-        </template>
-      </DropdownWrapper>
+      <VFlex style="min-width: 75px; max-width: 112px">
+        <VSelect
+          v-model="unit"
+          :items="unitOptions"
+          :menu-props="{ offsetY: true }"
+          box
+          single-line
+          required
+          :rules="unitRules"
+        />
+      </VFlex>
     </VLayout>
     <KButtonGroup>
       <KButton
@@ -66,7 +60,6 @@
   import { mapActions } from 'vuex';
   import findLastKey from 'lodash/findLastKey';
   import { ONE_B, ONE_KB, ONE_MB, ONE_GB, ONE_TB } from 'shared/constants';
-  import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
   const units = {
     ONE_B,
@@ -78,7 +71,6 @@
 
   export default {
     name: 'UserStorage',
-    components: { DropdownWrapper },
     props: {
       value: {
         type: Number,


### PR DESCRIPTION
## Summary

Updated the `UserStorage` unit selector popup, removing `DropdownWrapper` inside the user table storage popover, while preserving the vertical dropdown positioning with `menu-props="{ offsetY: true }"`

Manual verification:

1. Opened the user storage edit popover from the Users table.
2. Confirmed the unit dropdown is readable and the options are visible without the previous clipped/transparent scrolling behavior.
3. Confirmed the storage form still saves valid changes and validates invalid input.
4. Checked the same UserStorage form in the user details modal to confirm the wider selector still fits correctly.

Before:

https://github.com/user-attachments/assets/16efc9e4-8300-413b-8cea-7d046271d33f


After:


https://github.com/user-attachments/assets/cb834c1f-e7d2-4528-861e-002632681b16



## References
Fixes #5706 

## Reviewer guidance
Test the disk space editor in both places where `UserStorage` is used:
- Users table: click the edit icon in the Disk space column, open the unit dropdown, and verify the options render cleanly over the table.
- User details modal: open a user profile, use the Disk space form, and verify the layout still looks correct.

The main area to check is dropdown rendering inside the table popover, since that was the broken layout.

## AI usage
I used Codex to evaluate the dropdown behavior, reviewed the suggested approach, removed unnecessary shared-component changes, and manually verified the UI behavior.