### PR TITLE
fix(texteditor): align markdown output with Perseus grammar

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -386,7 +386,9 @@
       // Categories that can overflow (in order of overflow priority)
       const OVERFLOW_CATEGORIES = [
         'insert',
-        'script',
+        // Perseus flavoured markdown does not support super and sub script,
+        // so we disable this for now until we stop using markdown as the primary target
+        // 'script',
         'lists',
         'clearFormat',
         'align',

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/utils/markdown.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/utils/markdown.js
@@ -39,6 +39,11 @@ export const paramsToImageMd = ({ src, alt, width, height, permanentSrc, textAli
   return `![${alt || ''}](${IMAGE_PLACEHOLDER}/${fileName}${alignSuffix})`;
 };
 
+// --- Underline Translation ---
+// Perseus simple-markdown treats __text__ as <u>; marked treats it as <strong>.
+// Rewrite before marked runs so the round-trip preserves underline.
+export const UNDERLINE_REGEX = /__([\s\S]+?)__(?!_)/g;
+
 // --- Math/Formula Translation ---
 export const MATH_REGEX = /\$\$([^$]+)\$\$/g;
 
@@ -150,6 +155,8 @@ export function preprocessMarkdown(markdown) {
     if (!params) return match;
     return `<span data-latex="${params.latex}"></span>`;
   });
+
+  processedMarkdown = processedMarkdown.replace(UNDERLINE_REGEX, '<u>$1</u>');
 
   return marked(processedMarkdown);
 }

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/utils/markdownSerializer.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/utils/markdownSerializer.js
@@ -24,7 +24,7 @@ export const createCustomMarkdownSerializer = editor => {
             trimmedText = `*${trimmedText}*`;
             break;
           case 'underline':
-            trimmedText = `<u>${trimmedText}</u>`;
+            trimmedText = `__${trimmedText}__`;
             break;
           case 'strike':
             trimmedText = `~~${trimmedText}~~`;

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/markdown.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/markdown.spec.js
@@ -70,7 +70,28 @@ describe('preprocessMarkdown', () => {
     });
   });
 
-  // 4: Standard Markdown Passthrough
+  // 4: Perseus Underline Handling
+  // Perseus's simple-markdown treats __text__ as <u>, but `marked` (CommonMark)
+  // treats it as <strong>. We must rewrite __text__ -> <u>text</u> before marked
+  // sees it, so the round-trip preserves underline instead of turning it into bold.
+  describe('Perseus Underline Handling', () => {
+    it('should rewrite __text__ to <u>text</u> before passing to marked', () => {
+      preprocessMarkdown('This is __underlined__ text.');
+      expect(marked).toHaveBeenCalledWith('This is <u>underlined</u> text.');
+    });
+
+    it('should rewrite multiple __ runs on the same line independently', () => {
+      preprocessMarkdown('__one__ and __two__');
+      expect(marked).toHaveBeenCalledWith('<u>one</u> and <u>two</u>');
+    });
+
+    it('should rewrite __ spanning multiple words', () => {
+      preprocessMarkdown('__multi word underline__');
+      expect(marked).toHaveBeenCalledWith('<u>multi word underline</u>');
+    });
+  });
+
+  // 5: Standard Markdown Passthrough
   describe('Standard Markdown Passthrough', () => {
     it('should pass non-custom syntax through to the marked library', () => {
       const standardMd = 'Here is **bold** and a [link](url).';

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/markdownSerializer.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/markdownSerializer.spec.js
@@ -209,7 +209,7 @@ describe('createCustomMarkdownSerializer', () => {
       expect(getMarkdown()).toBe('*' + '**bold and italic**' + '*');
     });
 
-    it('should serialize an underlined node with a <u> tag', () => {
+    it('should serialize an underlined node with __ delimiters (Perseus syntax)', () => {
       const docContent = [
         {
           type: 'paragraph',
@@ -224,7 +224,7 @@ describe('createCustomMarkdownSerializer', () => {
       ];
       const mockEditor = createMockEditor(docContent);
       const getMarkdown = createCustomMarkdownSerializer(mockEditor);
-      expect(getMarkdown()).toBe('<u>underlined</u>');
+      expect(getMarkdown()).toBe('__underlined__');
     });
 
     it('should serialize a link node correctly', () => {


### PR DESCRIPTION
## Summary

- **Underline**: serialise as `__text__`; preprocessor rewrites it back to `<u>` before `marked` runs so it isn't re-parsed as `<strong>` - was previously being encoded as <u> because of commonmark usage.
- **Super/subscript**: toolbar buttons hidden — Perseus has no `<sup>`/`<sub>` rule, needs a different approach later.

| Screenshot |
|---|
| ![Editor with hidden script buttons and underlined "rainbow"](https://i.imgur.com/CF5Qw5n.png) |

## References

Closes #5887

## Reviewer guidance

**Test:**
1. Create an exercise with an underlined word, save and publish, verify it renders underlined in Kolibri (the original bug).
2. Reopen the saved question — underline should round-trip as underline, not bold.
3. Confirm super/subscript buttons no longer appear in the toolbar.

## AI usage

Used Claude Code (Opus 4.7) to implement the markdown fix via TDD: failing tests first for both the serializer and preprocessor, then minimal changes. I reviewed each step and supplied the Perseus grammar reference. The `EditorToolbar.vue` commit was hand-written.