### PR TITLE
Since pre-post-test creation and editing is not implemented in studio…

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/MasteryCriteriaGoal.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/CompletionOptions/MasteryCriteriaGoal.vue
@@ -36,7 +36,10 @@
     translateValidator,
     getInvalidText,
   } from 'shared/utils/validation';
-  import MasteryModels, { MasteryModelsList } from 'shared/leUtils/MasteryModels';
+  import MasteryModels, {
+    MasteryModelsList,
+    MasteryModelsNames,
+  } from 'shared/leUtils/MasteryModels';
   import { constantsTranslationMixin } from 'shared/mixins';
   import DropdownWrapper from 'shared/views/form/DropdownWrapper';
 
@@ -84,10 +87,13 @@
         },
       },
       masteryCriteria() {
-        return MasteryModelsList.map(model => ({
-          text: this.translateConstant(model),
-          value: model,
-        }));
+        // temporarily exclude pre/post test until the creation/editing UI is done
+        return MasteryModelsList.filter(model => model !== MasteryModelsNames.PRE_POST_TEST).map(
+          model => ({
+            text: this.translateConstant(model),
+            value: model,
+          }),
+        );
       },
       masteryRules() {
         return this.required ? getMasteryModelValidators().map(translateValidator) : [];

--- a/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/__tests__/masteryCriteriaGoal.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/contentNodeFields/__tests__/masteryCriteriaGoal.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import MasteryCriteriaGoal from '../CompletionOptions/MasteryCriteriaGoal';
 import TestForm from 'shared/views/__tests__/TestForm';
 import { constantStrings } from 'shared/mixins';
-import MasteryModels from 'shared/leUtils/MasteryModels';
+import MasteryModels, { MasteryModelsNames } from 'shared/leUtils/MasteryModels';
 
 describe('MasteryCriteriaGoal', () => {});
 async function makeWrapper(propsData = {}) {
@@ -28,9 +28,15 @@ describe('masteryCriteriaGoal', () => {
 
   describe('on load', () => {
     MasteryModels.forEach(model => {
-      it(`${model} mastery option should be an option to select`, () => {
-        expect(wrapper.findComponent('.v-list').text()).toContain(constantStrings.$tr(model));
-      });
+      if (model === MasteryModelsNames.PRE_POST_TEST) {
+        it(`${model} mastery option should not be an option to select (not yet implemented)`, () => {
+          expect(wrapper.findComponent('.v-list').text()).not.toContain(constantStrings.$tr(model));
+        });
+      } else {
+        it(`${model} mastery option should be an option to select`, () => {
+          expect(wrapper.findComponent('.v-list').text()).toContain(constantStrings.$tr(model));
+        });
+      }
     });
     it('should render according to masteryModel prop', async () => {
       for (const model of MasteryModels) {


### PR DESCRIPTION
## Summary

Hides the pre-post test completion goal option from the edit modal since editing/creating in studio is not yet implemented

## References

Fixes #5883 



## Reviewer guidance
Confirm no longer an option in the dropdown, and that this is a reasonable way of filtering out. 

Before: 
<img width="1704" height="1060" alt="image" src="https://github.com/user-attachments/assets/8786e636-6adc-4410-9423-484f7ff0987f" />

After:
<img width="1072" height="726" alt="Screenshot 2026-05-11 at 6 50 26 PM" src="https://github.com/user-attachments/assets/5b9691a6-d403-451c-ba61-d7c0afa0e835" />


## AI usage
Claude and I raced since it was a simple fix, and yet claude fixed it before I even found the right component to edit :) I reviewed and added the comment