### PR TITLE
Update editor toolbar and mobile toolbar to remove unsupported buttons

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -391,7 +391,9 @@
         // 'script',
         'lists',
         'clearFormat',
-        'align',
+        // Perseus flavoured markdown does not support alignment,
+        // so we disable this for now until we stop using markdown as the primary target
+        // 'align',
         'clipboard',
         'textFormat',
       ];

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/MobileFormattingBar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/MobileFormattingBar.vue
@@ -81,13 +81,17 @@
         :is-active="action.isActive"
         @click="action.handler"
       />
+      <!-- Perseus flavoured markdown does not support alignment,
+        so we disable this for now until we stop using markdown as the primary target
       <ToolbarDivider />
       <ToolbarButton
         :title="alignAction.title"
         :icon="alignAction.icon"
         :is-active="alignAction.isActive"
         @click="alignAction.handler"
-      />
+      /> -->
+      <!-- Perseus flavoured markdown does not support super and sub script,
+        so we disable this for now until we stop using markdown as the primary target
       <ToolbarDivider />
       <ToolbarButton
         v-for="action in scriptActions"
@@ -96,7 +100,7 @@
         :icon="action.icon"
         :is-active="action.isActive"
         @click="action.handler"
-      />
+      /> -->
       <ToolbarDivider />
       <ToolbarButton
         v-for="tool in insertTools"
@@ -138,8 +142,7 @@
         textFormattingToolbar$,
       } = getTipTapEditorStrings();
 
-      const { textActions, listActions, scriptActions, insertTools, alignAction } =
-        useToolbarActions(emit);
+      const { textActions, listActions, insertTools } = useToolbarActions(emit);
 
       const { canIncreaseFormat, canDecreaseFormat, increaseFormat, decreaseFormat } =
         useFormatControls();
@@ -206,9 +209,7 @@
         keyboardOffset,
         textActions,
         listActions,
-        scriptActions,
         insertTools,
-        alignAction,
         toggleToolbar,
         canIncreaseFormat,
         canDecreaseFormat,


### PR DESCRIPTION
## Summary

- Removes the text alignment button temporarily, as it is not supported with perseum markdown
- also removes the sub/superscript on mobile as it was still appearing

## References
Fixes https://github.com/learningequality/studio/issues/5894


Mobile after:
<img width="525" height="699" alt="Screenshot 2026-05-12 at 1 46 30 PM" src="https://github.com/user-attachments/assets/db01c175-ea17-41a0-97e8-1eb0c677a111" />



## Reviewer guidance
Confirm text alignment and super/subscript are both hidden on mobile and desktop screen displays

## AI usage
Claude helped me find where the mobile button management was 😂 