### PR TITLE
Stop exposing exception details in HTTP responses

### DIFF
--- a/contentcuration/contentcuration/views/subscription.py
+++ b/contentcuration/contentcuration/views/subscription.py
@@ -79,9 +79,9 @@ class CreateCheckoutSessionView(APIView):
 
             return Response({"checkout_url": session.url})
 
-        except stripe.error.StripeError as e:
-            logger.error(f"Stripe error creating checkout session: {e}")
-            return Response({"error": str(e)}, status=400)
+        except stripe.error.StripeError:
+            logger.exception("Stripe error creating checkout session")
+            return Response({"error": "Unable to create checkout session"}, status=400)
 
 
 class CreatePortalSessionView(APIView):
@@ -105,9 +105,9 @@ class CreatePortalSessionView(APIView):
             )
             return Response({"portal_url": session.url})
 
-        except stripe.error.StripeError as e:
-            logger.error(f"Stripe error creating portal session: {e}")
-            return Response({"error": str(e)}, status=400)
+        except stripe.error.StripeError:
+            logger.exception("Stripe error creating portal session")
+            return Response({"error": "Unable to create portal session"}, status=400)
 
 
 class SubscriptionStatusView(APIView):

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -468,8 +468,9 @@ class ChannelViewSet(ValuesViewset):
         try:
             self.perform_create(serializer)
 
-        except IntegrityError as e:
-            return Response({"error": str(e)}, status=409)
+        except IntegrityError:
+            logging.exception("Integrity error creating channel")
+            return Response({"error": "Channel could not be created"}, status=409)
         instance = serializer.instance
         Change.create_change(
             generate_create_event(


### PR DESCRIPTION
## Summary

Replaces `str(exception)` in HTTP error responses with generic messages and switches the corresponding `logger.error` calls to `logger.exception` so the traceback is still captured by Sentry. Addresses three CodeQL "Information exposure through an exception" findings flagged on PR #5902:

- `views/subscription.py:84` (Stripe checkout session)
- `views/subscription.py:110` (Stripe customer portal session)
- `viewsets/channel.py:472` (channel `IntegrityError` on create)

## References

- PR #5902 — the release PR where CodeQL surfaced these alerts

## Reviewer guidance

- Frontend (`useSubscription.js`) only checks `error` truthiness, so the generic responses don't change user-facing UX.

## AI usage

Used Claude Code to identify the three CodeQL findings, apply the fixes, and verify the frontend doesn't depend on the exception text in the response body.