### PR TITLE
update how linebreaks are saved so they render properly in perseus

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/utils/markdownSerializer.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/utils/markdownSerializer.js
@@ -57,14 +57,25 @@ export const createCustomMarkdownSerializer = editor => {
       switch (node.type.name) {
         case 'doc': {
           const parts = [];
-          // Process all children
           if (node.content && node.content.size > 0) {
             for (let i = 0; i < node.content.size; i++) {
               const child = node.content.content[i];
-              if (child) parts.push(serializeNode(child, null, depth));
+              if (child)
+                parts.push({ type: child.type?.name, md: serializeNode(child, null, depth) });
             }
           }
-          return parts.join('\n\n');
+          // Use a hard break (  \n) between consecutive plain paragraphs so Perseus
+          // renders them as <br> (inline-safe). All other block transitions keep \n\n
+          // so marked still parses lists, headings, etc. correctly.
+          return parts
+            .map((part, idx) => {
+              if (idx === 0) return part.md;
+              const prev = parts[idx - 1];
+              const separator =
+                prev.type === 'paragraph' && part.type === 'paragraph' ? '  \n' : '\n\n';
+              return separator + part.md;
+            })
+            .join('');
         }
 
         case 'paragraph': {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/markdownSerializer.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/markdownSerializer.spec.js
@@ -177,14 +177,32 @@ describe('createCustomMarkdownSerializer', () => {
       expect(getMarkdown()).toBe('- Item 1\n  - Nested 1.1\n- Item 2');
     });
 
-    it('should place two newlines between block elements', () => {
+    it('should use a hard break between consecutive paragraphs so Perseus renders them as <br>', () => {
       const docContent = [
         { type: 'paragraph', content: [{ type: 'text', text: 'First paragraph.' }] },
         { type: 'paragraph', content: [{ type: 'text', text: 'Second paragraph.' }] },
       ];
       const mockEditor = createMockEditor(docContent);
       const getMarkdown = createCustomMarkdownSerializer(mockEditor);
-      expect(getMarkdown()).toBe('First paragraph.\n\nSecond paragraph.');
+      expect(getMarkdown()).toBe('First paragraph.  \nSecond paragraph.');
+    });
+
+    it('should use two newlines between a paragraph and a non-paragraph block', () => {
+      const docContent = [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Intro.' }] },
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item A' }] }],
+            },
+          ],
+        },
+      ];
+      const mockEditor = createMockEditor(docContent);
+      const getMarkdown = createCustomMarkdownSerializer(mockEditor);
+      expect(getMarkdown()).toBe('Intro.\n\n- Item A');
     });
   });
 
@@ -405,7 +423,7 @@ describe('createCustomMarkdownSerializer', () => {
     const mockEditor = createMockEditor(docContent);
     const getMarkdown = createCustomMarkdownSerializer(mockEditor);
     expect(getMarkdown()).toBe(
-      '<p style="text-align: center">Centered</p>\n\nNormal\n\n<p style="text-align: right">Right</p>',
+      '<p style="text-align: center">Centered</p>  \nNormal  \n<p style="text-align: right">Right</p>',
     );
   });
 


### PR DESCRIPTION
## Summary
Addresses the second part of: https://github.com/learningequality/studio/issues/5894

(This was not a regression, thus we will put in our first patch release)


## References
Fixes https://github.com/learningequality/studio/issues/5894 

<img width="1121" height="768" alt="Screenshot 2026-05-13 at 11 22 37 AM" src="https://github.com/user-attachments/assets/5ef1f558-f824-43d0-96ac-ca2d12ce9752" />


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Confirm line breaks save and display properly on Studio -- in initial create and on save/edit
2. export to kolibri 
3. confirm line breaks appear properly in ANSWER rendering

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage

I used claude to both identify the cause of the issue and implement the solution here