### PR TITLE
Removes double scrollbar in Settings > Storage

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/StudioPage.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/StudioPage.vue
@@ -58,12 +58,12 @@
 
   .studio-page-outer {
     width: 100%;
-    margin-bottom: 16px;
     overflow-y: auto;
   }
 
   .studio-page-inner {
     width: 100%;
+    padding-bottom: 16px;
   }
 
 </style>


### PR DESCRIPTION
## Summary

`StudioPage` sets `height: calc(100vh - marginTop)` on its outer element to create a fixed-height scrollable content area. However, the outer element also had `margin-bottom: 16px` in CSS, making the total rendered document height `100vh + 16px`. That extra 16px caused the browser to show a page-level scrollbar alongside StudioPage's own `overflow-y: auto` inner scroll — producing the double scrollbar seen in the issue.

**Fix:** move `margin-bottom: 16px` from `.studio-page-outer` to `padding-bottom: 16px` on `.studio-page-inner`. The spacing is preserved (appears at the bottom of scrollable content), but it now lives inside the scroll container so document height stays at exactly `100vh`.

Before (from issue — double scrollbar visible on the right):

<img width="1776" height="1164" alt="Image" src="https://github.com/user-attachments/assets/6384666f-5ac1-4a6b-9ea3-f22030996cc9" />

After: single scrollbar inside the content area only.

https://github.com/user-attachments/assets/a013d4d4-359c-44ab-ac9d-2c07408d304e

## References

Fixes #5864

## Reviewer guidance

- Verify at Settings > Storage: only one scrollbar should appear on the right side of the content area.
- Also spot-check Settings > Account and Settings > About Studio — all three tabs use the same `StudioPage` wrapper.
- `StudioImmersiveModal` also uses `StudioPage` (with `marginTop=0`) — open any channel editor modal and confirm scrolling still works correctly there.

## AI usage

I used Claude Code to diagnose the root cause (identifying that `margin-bottom` on the fixed-height outer element was the 16px overflow causing the page-level scroll) and to implement the one-line fix. I reviewed the change and verified it preserves the visual spacing while eliminating the extra document height.