### PR TITLE
Close RTE dropdowns on mousedown instead of click

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/EditorToolbar.vue
@@ -535,7 +535,7 @@
           window.addEventListener('resize', handleWindowResize, { passive: true });
         }
 
-        document.addEventListener('click', handleClickOutside, { passive: true });
+        document.addEventListener('mousedown', handleClickOutside, { passive: true });
       });
 
       onUnmounted(() => {
@@ -544,7 +544,7 @@
         } else {
           window.removeEventListener('resize', handleWindowResize);
         }
-        document.removeEventListener('click', handleClickOutside);
+        document.removeEventListener('mousedown', handleClickOutside);
       });
 
       return {

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/FormatDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/FormatDropdown.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div
+    ref="containerRef"
     class="dropdown-container"
     @keydown="handleContainerKeydown"
   >
@@ -65,6 +66,7 @@
         showHeadersDropdown: isOpen,
         toggleHeadersDropdown: toggleDropdown,
         selectFormat,
+        containerRef,
       } = useDropdowns();
 
       const { handleFormatChange } = useToolbarActions();
@@ -193,6 +195,7 @@
         handleContainerKeydown,
         textFormatOptions$,
         formatOptions$,
+        containerRef,
       };
     },
   });

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/PasteDropdown.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/components/toolbar/PasteDropdown.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div
+    ref="containerRef"
     class="dropdown-container paste-button-container"
     @keydown="handleContainerKeydown"
   >
@@ -78,6 +79,7 @@
         pasteOptions,
         showPasteDropdown: isOpen,
         togglePasteDropdown: toggleDropdown,
+        containerRef,
       } = useDropdowns();
 
       const { handlePaste } = useToolbarActions();
@@ -214,6 +216,7 @@
         paste$,
         pasteOptions$,
         pasteOptionsMenu$,
+        containerRef,
       };
     },
   });

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useDropdowns.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useDropdowns.js
@@ -79,6 +79,8 @@ export function useDropdowns() {
 
   const containerRef = ref(null);
 
+  // Each instance checks only its own container so
+  // clicking one dropdown's trigger closes the other.
   const handleClickOutside = event => {
     if (!containerRef.value || containerRef.value.contains(event.target)) {
       return;

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useDropdowns.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useDropdowns.js
@@ -93,7 +93,7 @@ export function useDropdowns() {
   };
 
   onMounted(() => {
-    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
     // Setup editor listener when component mounts
     setupEditorListener();
     // Initial format detection
@@ -101,7 +101,7 @@ export function useDropdowns() {
   });
 
   onUnmounted(() => {
-    document.removeEventListener('click', handleClickOutside);
+    document.removeEventListener('mousedown', handleClickOutside);
     if (offTransaction) offTransaction();
   });
 

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useDropdowns.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/composables/useDropdowns.js
@@ -77,19 +77,13 @@ export function useDropdowns() {
     selectedFormat.value = format.label;
   };
 
+  const containerRef = ref(null);
+
   const handleClickOutside = event => {
-    const dropdownContainers = document.querySelectorAll('.dropdown-container');
-    let isOutside = true;
-
-    dropdownContainers.forEach(container => {
-      if (container.contains(event.target)) {
-        isOutside = false;
-      }
-    });
-
-    if (isOutside) {
-      closeAllDropdowns();
+    if (!containerRef.value || containerRef.value.contains(event.target)) {
+      return;
     }
+    closeAllDropdowns();
   };
 
   onMounted(() => {
@@ -149,5 +143,6 @@ export function useDropdowns() {
     togglePasteDropdown,
     selectFormat,
     updateSelectedFormat,
+    containerRef,
   };
 }


### PR DESCRIPTION
## Summary

- RTE dropdown menus (font, paste, "More" overflow) now close when clicking anywhere outside them — including in the editor content area, on toolbar buttons, or outside the editor entirely

**Root cause:** Two separate `preventDefault()` calls suppress the `click` event inside the editor, per the [HTML spec](https://www.w3.org/TR/uievents/#event-type-click):
1. `ToolbarButton.vue` uses `@mousedown.prevent` on every toolbar button — this prevents `click` from firing after any toolbar button press
2. ProseMirror calls `preventDefault()` on `mouseup` when repositioning the cursor — this prevents `click` from firing when clicking into the editor content area

**How it works:** Switched the document-level `handleClickOutside` listener from `'click'` to `'mousedown'` in `useDropdowns.js` (font & paste dropdowns) and `EditorToolbar.vue` (More overflow dropdown). The `mousedown` event always propagates to the document regardless of any `preventDefault()` calls, making dropdown closing reliable for all interactions.

https://github.com/user-attachments/assets/f2567be7-6bdf-489f-a91c-e81358e6184f

## References

Fixes #5886

## Reviewer guidance

- Open an exercise and click into an answer RTE
- Open the format dropdown (heading selector) — click anywhere outside it (editor text area, Bold/Italic buttons, padding, outside editor) — dropdown should close immediately
- Same for the paste dropdown and the "More" overflow dropdown (narrow the window to trigger it)
- Verify clicking *inside* an open dropdown does not close it
- Verify Bold, Italic, and other toolbar buttons still apply formatting normally

## AI usage

Implemented with Claude Code. I reviewed the generated diff and confirmed the root cause analysis (ProseMirror `mouseup` preventDefault + ToolbarButton `@mousedown.prevent` both suppressing `click` events).