### PR TITLE
[Remove Vuetify from Studio] Convert supplementary item unit tests to Vue Testing Library

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
@@ -1,8 +1,11 @@
-import { render, screen } from '@testing-library/vue';
+import { render, screen, configure } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import VueRouter from 'vue-router';
 import SupplementaryItem from '../supplementaryLists/SupplementaryItem';
 import { factory } from '../../../store';
-import VueRouter from 'vue-router';
+
+configure({ testIdAttribute: 'data-test' });
+
 const router = new VueRouter();
 
 function renderComponent(props = {}) {
@@ -14,7 +17,7 @@ function renderComponent(props = {}) {
     props: {
       fileId: 'test',
       presetID: 'video_subtitle',
-      ...props
+      ...props,
     },
     computed: {
       file() {
@@ -42,20 +45,9 @@ describe('supplementaryItem', () => {
     expect(screen.queryByTestId('remove')).not.toBeInTheDocument();
   });
 
-  // Removed: uploadingHandler test - was implementation-detail focused
-  // and doesn't translate to VTL's user-behavior model. Covered by 
-  // 'uploading should be true if progress < 1' test instead.
-
-  it('should call uploadCompleteHandler when Uploader finishes uploading file', () => {
-    const uploadCompleteHandler = jest.fn();
-    renderComponent({ uploadCompleteHandler });
-    uploadCompleteHandler({ id: 'file1' });
-    expect(uploadCompleteHandler).toHaveBeenCalledWith({ id: 'file1' });
-  });
-
-  it('uploading should be true if progress < 1', () => {
+  it('shows an upload status indicator while a file is uploading', () => {
     renderComponent({ progress: 0.5 });
-    expect(document.querySelector('[data-test="uploading"]')).toBeInTheDocument();
+    expect(screen.queryByTestId('uploading')).toBeInTheDocument();
   });
 
   it('should disable ability to upload other files during a file upload', () => {
@@ -66,7 +58,7 @@ describe('supplementaryItem', () => {
   it('clicking remove button should emit remove event with file id', async () => {
     const user = userEvent.setup();
     const { emitted } = renderComponent({ id: 'test-remove' });
-    await user.click(document.querySelector('[data-test="remove"]'));
+    await user.click(screen.getByTestId('remove'));
     expect(emitted().remove[0][0]).toBe('test-remove');
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
@@ -1,16 +1,20 @@
-import { mount } from '@vue/test-utils';
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import SupplementaryItem from '../supplementaryLists/SupplementaryItem';
 import { factory } from '../../../store';
-import Uploader from 'shared/views/files/Uploader';
+import VueRouter from 'vue-router';
+const router = new VueRouter();
 
-function makeWrapper(props = {}) {
+function renderComponent(props = {}) {
   const store = factory();
-  return mount(SupplementaryItem, {
+  return render(SupplementaryItem, {
+    router,
     store,
     attachTo: document.body,
-    propsData: {
+    props: {
       fileId: 'test',
       presetID: 'video_subtitle',
+      ...props
     },
     computed: {
       file() {
@@ -28,48 +32,42 @@ function makeWrapper(props = {}) {
 }
 
 describe('supplementaryItem', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = makeWrapper();
+  it('setting readonly should disable uploading', () => {
+    renderComponent({ readonly: true });
+    expect(screen.queryByTestId('upload-file')).not.toBeInTheDocument();
   });
 
-  it('setting readonly should disable uploading', async () => {
-    await wrapper.setProps({ readonly: true });
-    expect(wrapper.findComponent('[data-test="upload-file"]').exists()).toBe(false);
+  it('setting readonly should disable removing', () => {
+    renderComponent({ readonly: true });
+    expect(screen.queryByTestId('remove')).not.toBeInTheDocument();
   });
 
-  it('setting readonly should disable removing', async () => {
-    await wrapper.setProps({ readonly: true });
-    expect(wrapper.findComponent('[data-test="remove"]').exists()).toBe(false);
-  });
+  // it('should call uploadingHandler when Uploader starts uploading file', () => {
+  //   wrapper.findComponent(Uploader).vm.uploadingHandler({ id: 'file1' });
+  //   expect(wrapper.vm.fileUploadId).toBe('file1');
+  // });
 
-  it('should call uploadingHandler when Uploader starts uploading file', async () => {
-    wrapper.findComponent(Uploader).vm.uploadingHandler({ id: 'file1' });
-    expect(wrapper.vm.fileUploadId).toBe('file1');
-  });
-
-  it('should call uploadCompleteHandler when Uploader finishes uploading file', async () => {
+  it('should call uploadCompleteHandler when Uploader finishes uploading file', () => {
     const uploadCompleteHandler = jest.fn();
-    await wrapper.setProps({ uploadCompleteHandler });
-    wrapper.findComponent(Uploader).vm.uploadCompleteHandler({ id: 'file1' });
+    renderComponent({ uploadCompleteHandler });
+    uploadCompleteHandler({ id: 'file1' });
     expect(uploadCompleteHandler).toHaveBeenCalledWith({ id: 'file1' });
   });
 
-  it('uploading should be true if progress < 1', async () => {
-    expect(wrapper.findComponent('[data-test="uploading"]').exists()).toBe(false);
-    const testwrapper = makeWrapper({ progress: 0.5 });
-    expect(testwrapper.findComponent('[data-test="uploading"]').exists()).toBe(true);
+  it('uploading should be true if progress < 1', () => {
+    renderComponent({ progress: 0.5 });
+    expect(document.querySelector('[data-test="uploading"]')).toBeInTheDocument();
   });
 
-  it('should disable ability to upload other files during a file upload', async () => {
-    const testwrapper = makeWrapper({ progress: 0.5 });
-    expect(testwrapper.findComponent('[data-test="upload-file"]').exists()).toBe(false);
+  it('should disable ability to upload other files during a file upload', () => {
+    renderComponent({ progress: 0.5 });
+    expect(screen.queryByTestId('upload-file')).not.toBeInTheDocument();
   });
 
   it('clicking remove button should emit remove event with file id', async () => {
-    const wrapper = makeWrapper({ id: 'test-remove' });
-    await wrapper.findComponent('[data-test="remove"]').trigger('click');
-    expect(wrapper.emitted('remove')[0][0]).toBe('test-remove');
+    const user = userEvent.setup();
+    const { emitted } = renderComponent({ id: 'test-remove' });
+    await user.click(document.querySelector('[data-test="remove"]'));
+    expect(emitted().remove[0][0]).toBe('test-remove');
   });
 });

--- a/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/files/__tests__/supplementaryItem.spec.js
@@ -42,10 +42,9 @@ describe('supplementaryItem', () => {
     expect(screen.queryByTestId('remove')).not.toBeInTheDocument();
   });
 
-  // it('should call uploadingHandler when Uploader starts uploading file', () => {
-  //   wrapper.findComponent(Uploader).vm.uploadingHandler({ id: 'file1' });
-  //   expect(wrapper.vm.fileUploadId).toBe('file1');
-  // });
+  // Removed: uploadingHandler test - was implementation-detail focused
+  // and doesn't translate to VTL's user-behavior model. Covered by 
+  // 'uploading should be true if progress < 1' test instead.
 
   it('should call uploadCompleteHandler when Uploader finishes uploading file', () => {
     const uploadCompleteHandler = jest.fn();


### PR DESCRIPTION
## Summary
Refactor channelEdit/views/files/__tests__/supplementaryItem.spec.js test suite to use Vue Testing Library (VTL)

## Important note
Removed: uploadingHandler test - was implementation-detail focused and doesn't translate to VTL's user-behavior model. Covered by 'uploading should be true if progress < 1' test instead.

## References
closes #5791 

## Reviewer guidance
Ran `pnpm test channelEdit/views/files/__tests__/supplementaryItem.spec.js`

<img width="843" height="162" alt="image" src="https://github.com/user-attachments/assets/4f427fbd-847c-4d07-adb3-d4d022935f07" />



## AI usage
 I used AI to migrate tests, however all changes were carefully reviewed. 