### PR TITLE
Bump pnpm/action-setup to v6.0.8 to fix Node version CI failure

### DIFF
--- a/.github/workflows/deploytest.yml
+++ b/.github/workflows/deploytest.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -63,7 +63,7 @@ jobs:
         # Use uv to install dependencies directly from requirements files
         uv pip sync requirements.txt
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/frontendtest.yml
+++ b/.github/workflows/frontendtest.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/i18n-download.yml
+++ b/.github/workflows/i18n-download.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv pip sync requirements.txt
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v6.0.3
+        uses: pnpm/action-setup@v6.0.8
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv pip sync requirements.txt
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v6.0.3
+        uses: pnpm/action-setup@v6.0.8
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: '3.10'
         ignore-nothing-to-cache: 'true'
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
## Summary

CI was failing because `pnpm/action-setup@v6.0.3` ignores the pinned pnpm version and installs pnpm 11, which needs Node ≥22.13 and breaks on our Node 20 runners ([#225](https://github.com/pnpm/action-setup/issues/225), [#227](https://github.com/pnpm/action-setup/issues/227)). v6.0.8 has the upstream fix, restoring pnpm 10.33.0.

## References

- pnpm/action-setup [#225](https://github.com/pnpm/action-setup/issues/225), [#227](https://github.com/pnpm/action-setup/issues/227) — upstream regression this bump resolves

## Reviewer guidance

Confirm CI is green here — the "Use pnpm" step should install pnpm 10.33.0 (not 11), and no job should warn `requires at least Node.js v22.13`. The upstream issues are still open, so if any job still pulls pnpm 11, the fallback is pinning to `v5`.

## AI usage

Used Claude Code to diagnose the CI failures — tracing them to the `pnpm/action-setup` v6 regression by reading the action source and the upstream issue tracker — and to apply the version bump. Confirmed v6.0.8 contains the upstream fix before selecting it.