### PR TITLE
ci: bump pnpm/action-setup to v6.0.8 (hotfixes backport)

### DIFF
--- a/.github/workflows/deploytest.yml
+++ b/.github/workflows/deploytest.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -59,7 +59,7 @@ jobs:
         # Use uv to install dependencies directly from requirements files
         uv pip sync requirements.txt
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/frontendtest.yml
+++ b/.github/workflows/frontendtest.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/i18n-download.yml
+++ b/.github/workflows/i18n-download.yml
@@ -22,7 +22,7 @@ jobs:
         run: uv pip sync requirements.txt
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v6.0.3
+        uses: pnpm/action-setup@v6.0.8
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/i18n-upload.yml
+++ b/.github/workflows/i18n-upload.yml
@@ -22,7 +22,7 @@ jobs:
         run: uv pip sync requirements.txt
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v6.0.3
+        uses: pnpm/action-setup@v6.0.8
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: '3.10'
         ignore-nothing-to-cache: 'true'
     - name: Use pnpm
-      uses: pnpm/action-setup@v6.0.3
+      uses: pnpm/action-setup@v6.0.8
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
Backport of #5939 to `hotfixes`.

`pnpm/action-setup@v6.0.3` has a regression ([pnpm/action-setup#225](https://github.com/pnpm/action-setup/issues/225)) that ignores the pinned pnpm version and installs pnpm 11, which requires Node.js ≥22.13 and fails on our Node 20 runners. v6.0.8 restores correct handling of the `packageManager`-pinned version (10.33.0).

This is causing CI failures on PRs targeting `hotfixes` (e.g. #5926).