### PR TITLE
refactor(TipTapEditor): emit markdown on blur and cache last emitted value

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue
@@ -197,7 +197,10 @@
         return editor.value.storage.markdown.getMarkdown();
       };
 
-      let isUpdatingFromOutside = false; // A flag to prevent infinite update loops
+      // Cache of the latest markdown value emitted by this component. Used to
+      // detect when an incoming prop.value is just our own emitted value echoed
+      // back, so we can skip unnecessary re-rendering of the editor content.
+      let lastEmittedMarkdown = null;
 
       watch(
         () => props.mode,
@@ -217,6 +220,13 @@
       watch(
         () => props.value,
         newValue => {
+          // If the incoming value matches what we last emitted, the editor
+          // already reflects this content, so skip re-rendering to avoid
+          // unnecessary work and resetting the editor state.
+          if (newValue === lastEmittedMarkdown) {
+            return;
+          }
+
           const processedContent = preprocessMarkdown(newValue);
 
           if (!editor.value) {
@@ -228,36 +238,31 @@
 
           const editorContent = getMarkdownContent();
           if (editorContent !== newValue) {
-            isUpdatingFromOutside = true;
             editor.value.commands.setContent(processedContent, false);
-            nextTick(() => {
-              isUpdatingFromOutside = false;
-            });
           }
         },
         { immediate: true },
       );
 
-      // sync changes from the editor to the parent component
-      watch(
-        () => editor.value?.state,
-        () => {
-          if (
-            !editor.value ||
-            !isReady.value ||
-            isUpdatingFromOutside ||
-            !editor.value.storage?.markdown
-          ) {
-            return;
-          }
+      // sync changes from the editor to the parent component, only on blur
+      const emitMarkdownUpdate = () => {
+        if (!editor.value || !isReady.value || !editor.value.storage?.markdown) {
+          return;
+        }
 
-          const markdown = getMarkdownContent();
-          if (markdown !== props.value) {
-            emit('update', markdown);
-          }
-        },
-        { deep: true },
-      );
+        const markdown = getMarkdownContent();
+        if (markdown !== props.value) {
+          lastEmittedMarkdown = markdown;
+          emit('update', markdown);
+        }
+      };
+
+      // Emit the markdown update only when the editor loses focus (blur).
+      watch(isFocused, (focused, wasFocused) => {
+        if (wasFocused && !focused) {
+          emitMarkdownUpdate();
+        }
+      });
 
       const handleContainerKeydown = event => {
         if (event.key === 'Enter') {


### PR DESCRIPTION
## Summary

Changes how the `TipTapEditor` component syncs content with its parent:

- **Emit on blur only.** Previously the editor emitted an `update` on *every* editor state change via a deep watcher on `editor.state`, causing frequent markdown re-serialization. The update is now emitted only when the editor loses focus (blur).
- **Cache the last emitted markdown.** The latest emitted value is stored. When `prop.value` changes, it is compared against the cache so a value the parent simply echoes back is ignored — skipping unnecessary re-rendering / `setContent` of the editor content.
- **Removed `isUpdatingFromOutside`.** That flag existed only to break the feedback loop created by the deep state watcher (parent update → `setContent` → state change → emit → back to parent). With emits now driven by blur (which `setContent(..., false)` never triggers), the loop can't occur, so the flag is dead code. Echo protection is instead handled from the other direction by the new cache.

## Behavior change

Programmatic content changes (image/link/math insertions, toolbar formatting) no longer emit live — the parent now receives the updated markdown only once the editor blurs. This is intentional per the requested behavior.

## Test plan

- [ ] Type in the editor, blur it, confirm parent receives a single `update` with the correct markdown
- [ ] Confirm no `update` is emitted while actively editing (before blur)
- [ ] Change `value` from the parent and confirm the editor re-renders
- [ ] Echo the emitted value back as `value` and confirm the editor does **not** needlessly re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)