### PR TITLE
feat: Initial  Scaffold for  QTI editor components and add a development page

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -18,7 +18,6 @@ export const RouteNames = {
   TRASH: 'TRASH',
   ADD_PREVIOUS_STEPS: 'ADD_PREVIOUS_STEPS',
   ADD_NEXT_STEPS: 'ADD_NEXT_STEPS',
-  QTI_DEMO: 'QTI_DEMO',
 };
 
 export const viewModes = {

--- a/contentcuration/contentcuration/frontend/channelEdit/constants.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/constants.js
@@ -18,6 +18,7 @@ export const RouteNames = {
   TRASH: 'TRASH',
   ADD_PREVIOUS_STEPS: 'ADD_PREVIOUS_STEPS',
   ADD_NEXT_STEPS: 'ADD_NEXT_STEPS',
+  QTI_DEMO: 'QTI_DEMO',
 };
 
 export const viewModes = {

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/QTIDemoPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/QTIDemoPage.vue
@@ -1,0 +1,72 @@
+<template>
+
+  <div>
+    <div style="padding: 16px 24px 0">
+      <div
+        style="
+  padding: 16px;
+  color: #2196f3;
+  background-color: transparent;
+  border: 1px solid #2196f3;
+  border-radius: 4px;
+        "
+      >
+        <strong>QTI Editor — Dev Demo</strong>
+        &nbsp;Hardcoded items. Changes are local only and not persisted.
+      </div>
+    </div>
+
+    <QTIEditor
+      :assessments="assessments"
+      @update="onUpdate"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, defineComponent } from 'vue';
+  import QTIEditor from 'shared/views/QTIEditor/index';
+  import { QtiInteraction } from 'shared/views/QTIEditor/constants';
+
+  /**
+   * Hardcoded items covering three interaction types so the closed-card
+   * type label can be visually verified.
+   */
+  const INITIAL_ASSESSMENTS = [
+    {
+      id: 'demo-item-1',
+      type: QtiInteraction.CHOICE,
+      title: 'Which planet is closest to the Sun?',
+    },
+    {
+      id: 'demo-item-2',
+      type: QtiInteraction.EXTENDED_TEXT,
+      title: 'Describe the water cycle in your own words.',
+    },
+    {
+      id: 'demo-item-3',
+      type: QtiInteraction.ORDER,
+      title: 'Arrange these events in chronological order.',
+    },
+  ];
+
+  export default defineComponent({
+    name: 'QTIDemoPage',
+
+    components: { QTIEditor },
+
+    setup() {
+      const assessments = ref(INITIAL_ASSESSMENTS);
+
+      function onUpdate(newList) {
+        assessments.value = newList;
+      }
+
+      return { assessments, onUpdate };
+    },
+  });
+
+</script>

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -246,7 +246,7 @@ const router = new VueRouter({
       },
     },
     {
-      name: RouteNames.QTI_DEMO,
+      name: 'QTI_DEMO',
       path: '/qti-demo',
       component: QTIDemoPage,
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/router.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/router.js
@@ -9,6 +9,7 @@ import TrashModal from './views/trash/TrashModal';
 import SearchOrBrowseWindow from './views/ImportFromChannels/SearchOrBrowseWindow';
 import ReviewSelectionsPage from './views/ImportFromChannels/ReviewSelectionsPage';
 import EditModal from './components/edit/EditModal';
+import QTIDemoPage from './pages/QTIDemoPage';
 import ChannelDetailsModal from 'shared/views/channel/ChannelDetailsModal';
 import ChannelModal from 'shared/views/channel/ChannelModal';
 import { RouteNames as ChannelRouteNames } from 'frontend/channelList/constants';
@@ -243,6 +244,11 @@ const router = new VueRouter({
             });
           });
       },
+    },
+    {
+      name: RouteNames.QTI_DEMO,
+      path: '/qti-demo',
+      component: QTIDemoPage,
     },
     {
       name: RouteNames.TREE_VIEW,

--- a/contentcuration/contentcuration/frontend/shared/strings/commonStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/strings/commonStrings.js
@@ -42,4 +42,8 @@ export const commonStrings = createTranslator('CommonStrings', {
     message: 'Copy channel token',
     context: 'A label for an action that copies the channel token to the clipboard',
   },
+  optionsLabel: {
+    message: 'Options',
+    context: 'Tooltip for the generic options menu icon',
+  },
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/CollapsibleToolbar/__tests__/CollapsibleToolbar.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/CollapsibleToolbar/__tests__/CollapsibleToolbar.spec.js
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import VueRouter from 'vue-router';
+import CollapsibleToolbar from '../index.vue';
+import { commonStrings } from 'shared/strings/commonStrings';
+
+const { optionsLabel$ } = commonStrings;
+
+const makeAction = (overrides = {}) => ({
+  id: 'action-1',
+  icon: 'edit',
+  label: 'Edit',
+  handler: jest.fn(),
+  collapsed: false,
+  disabled: false,
+  ...overrides,
+});
+
+const renderComponent = (actions = [], optionsLabel = null) => {
+  return render(CollapsibleToolbar, {
+    props: { actions, optionsLabel },
+    routes: new VueRouter(),
+  });
+};
+
+describe('CollapsibleToolbar', () => {
+  describe('visible icon actions', () => {
+    test('renders icon buttons for non-collapsed actions with icons', () => {
+      const actions = [
+        makeAction({ id: 'a1', label: 'Edit', icon: 'edit', collapsed: false }),
+        makeAction({ id: 'a2', label: 'Move up', icon: 'chevronUp', collapsed: false }),
+      ];
+      renderComponent(actions);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Move up' })).toBeInTheDocument();
+    });
+
+    test('does not render an icon button for collapsed actions', () => {
+      const actions = [
+        makeAction({ id: 'a1', label: 'Edit', icon: 'edit', collapsed: false }),
+        makeAction({ id: 'a2', label: 'Delete', icon: 'delete', collapsed: true }),
+      ];
+      renderComponent(actions);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+      // 'Delete' only appears inside the dropdown, not as a standalone icon button
+      expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    });
+
+    test('calls the action handler when an icon button is clicked', async () => {
+      const user = userEvent.setup();
+      const handler = jest.fn();
+      const actions = [
+        makeAction({ id: 'a1', label: 'Edit', icon: 'edit', collapsed: false, handler }),
+      ];
+      renderComponent(actions);
+      await user.click(screen.getByRole('button', { name: 'Edit' }));
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('collapsed dropdown menu', () => {
+    test('does not render the options button when there are no collapsed actions', () => {
+      const actions = [makeAction({ id: 'a1', icon: 'edit', collapsed: false })];
+      renderComponent(actions);
+      expect(screen.queryByRole('button', { name: optionsLabel$() })).not.toBeInTheDocument();
+    });
+
+    test('renders the options button when there are collapsed actions', () => {
+      const actions = [
+        makeAction({ id: 'a1', icon: 'edit', collapsed: false }),
+        makeAction({ id: 'a2', icon: null, label: 'Delete', collapsed: true, handler: jest.fn() }),
+      ];
+      renderComponent(actions);
+      expect(screen.getByRole('button', { name: optionsLabel$() })).toBeInTheDocument();
+    });
+
+    test('renders the options button when an action has no icon (forces it to menu)', () => {
+      const actions = [makeAction({ id: 'a1', icon: null, label: 'Delete', collapsed: false })];
+      renderComponent(actions);
+      expect(screen.getByRole('button', { name: optionsLabel$() })).toBeInTheDocument();
+    });
+
+    test('uses the provided optionsLabel prop for the menu button', () => {
+      const actions = [makeAction({ id: 'a1', icon: null, label: 'Delete', collapsed: true })];
+      renderComponent(actions, 'Custom options label');
+      expect(screen.getByRole('button', { name: 'Custom options label' })).toBeInTheDocument();
+    });
+  });
+
+  describe('disabled state', () => {
+    test('renders the icon button as disabled when action.disabled is true', () => {
+      const actions = [
+        makeAction({ id: 'a1', label: 'Edit', icon: 'edit', collapsed: false, disabled: true }),
+      ];
+      renderComponent(actions);
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/CollapsibleToolbar/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/CollapsibleToolbar/index.vue
@@ -18,8 +18,8 @@
       v-if="collapsedMenuActions.length > 0"
       icon="optionsVertical"
       :color="$themePalette.grey.v_800"
-      :tooltip="optionsLabel"
-      :ariaLabel="optionsLabel"
+      :tooltip="optionsLabel || optionsLabel$()"
+      :ariaLabel="optionsLabel || optionsLabel$()"
     >
       <template #menu>
         <KDropdownMenu
@@ -35,12 +35,14 @@
 
 <script>
 
-  import { computed, defineComponent } from 'vue';
+  import { computed } from 'vue';
+  import { commonStrings } from 'shared/strings/commonStrings';
 
-  export default defineComponent({
+  export default {
     name: 'CollapsibleToolbar',
 
     setup(props) {
+      const { optionsLabel$ } = commonStrings;
       /** Actions with an icon that are not explicitly collapsed */
       const visibleIconActions = computed(() => {
         return props.actions.filter(a => !a.collapsed && Boolean(a.icon));
@@ -71,6 +73,7 @@
         collapsedMenuActions,
         dropdownOptions,
         handleSelect,
+        optionsLabel$,
       };
     },
 
@@ -101,10 +104,10 @@
       /** Tooltip text for the generic options menu icon */
       optionsLabel: {
         type: String,
-        default: 'Options',
+        default: null,
       },
     },
-  });
+  };
 
 </script>
 

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/CollapsibleToolbar/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/CollapsibleToolbar/index.vue
@@ -1,0 +1,127 @@
+<template>
+
+  <div class="collapsible-toolbar">
+    <div class="icon-actions-wrapper">
+      <KIconButton
+        v-for="action in visibleIconActions"
+        :key="action.id"
+        :icon="action.icon"
+        :tooltip="action.label"
+        :ariaLabel="action.label"
+        :disabled="action.disabled"
+        :color="action.disabled ? $themeTokens.textDisabled : $themePalette.grey.v_800"
+        @click="action.handler"
+      />
+    </div>
+
+    <KIconButton
+      v-if="collapsedMenuActions.length > 0"
+      icon="optionsVertical"
+      :color="$themePalette.grey.v_800"
+      :tooltip="optionsLabel"
+      :ariaLabel="optionsLabel"
+    >
+      <template #menu>
+        <KDropdownMenu
+          :options="dropdownOptions"
+          @select="handleSelect"
+        />
+      </template>
+    </KIconButton>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed, defineComponent } from 'vue';
+
+  export default defineComponent({
+    name: 'CollapsibleToolbar',
+
+    setup(props) {
+      /** Actions with an icon that are not explicitly collapsed */
+      const visibleIconActions = computed(() => {
+        return props.actions.filter(a => !a.collapsed && Boolean(a.icon));
+      });
+
+      /** Actions without an icon MUST go to the menu, along with explicitly collapsed ones */
+      const collapsedMenuActions = computed(() => {
+        return props.actions.filter(a => a.collapsed || !a.icon);
+      });
+
+      const dropdownOptions = computed(() => {
+        return collapsedMenuActions.value.map(action => ({
+          label: action.label,
+          value: action.id,
+          disabled: action.disabled,
+        }));
+      });
+
+      function handleSelect(option) {
+        const action = collapsedMenuActions.value.find(a => a.id === option.value);
+        if (action && action.handler) {
+          action.handler();
+        }
+      }
+
+      return {
+        visibleIconActions,
+        collapsedMenuActions,
+        dropdownOptions,
+        handleSelect,
+      };
+    },
+
+    props: {
+      /**
+       * Array of actions:
+       * {
+       *   id: string,
+       *   icon: string | null,
+       *   label: string,
+       *   handler: Function,
+       *   collapsed?: boolean,
+       *   disabled?: boolean
+       * }
+       */
+      actions: {
+        type: Array,
+        required: true,
+        validator(actions) {
+          return actions.every(
+            a =>
+              typeof a.id === 'string' &&
+              typeof a.label === 'string' &&
+              typeof a.handler === 'function',
+          );
+        },
+      },
+      /** Tooltip text for the generic options menu icon */
+      optionsLabel: {
+        type: String,
+        default: 'Options',
+      },
+    },
+  });
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .collapsible-toolbar {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  .icon-actions-wrapper {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import QTIItemEditor from '../index.vue';
+import { qtiEditorStrings } from '../../../qtiEditorStrings';
+import { QtiInteraction } from '../../../constants';
+
+const { closeBtnLabel$, questionContentPlaceholder$ } = qtiEditorStrings;
+
+const defaultProps = {
+  item: {
+    id: 'test-item-id',
+    type: QtiInteraction.CHOICE,
+    title: 'Test Choice Interaction',
+  },
+  index: 0,
+  total: 5,
+  mode: 'view',
+  displayAnswersPreview: false,
+};
+
+const renderComponent = (props = {}, slots = {}) => {
+  return render(QTIItemEditor, {
+    props: { ...defaultProps, ...props },
+    slots,
+    routes: new VueRouter(),
+  });
+};
+
+describe('QTIItemEditor', () => {
+  describe('view mode', () => {
+    test('does not show the card body', () => {
+      renderComponent({ mode: 'view' });
+      expect(screen.queryByText(questionContentPlaceholder$())).not.toBeInTheDocument();
+    });
+
+    test('does not show the close button', () => {
+      renderComponent({ mode: 'view' });
+      expect(screen.queryByRole('button', { name: closeBtnLabel$() })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('edit mode', () => {
+    test('shows the card body', () => {
+      renderComponent({ mode: 'edit' });
+      expect(screen.getByText(questionContentPlaceholder$())).toBeInTheDocument();
+    });
+
+    test('shows the close button', () => {
+      renderComponent({ mode: 'edit' });
+      expect(screen.getByRole('button', { name: closeBtnLabel$() })).toBeInTheDocument();
+    });
+
+    test('emits a close event when the close button is clicked', async () => {
+      const { emitted } = renderComponent({ mode: 'edit' });
+      await fireEvent.click(screen.getByRole('button', { name: closeBtnLabel$() }));
+      expect(emitted().close).toHaveLength(1);
+    });
+  });
+
+  describe('displayAnswersPreview', () => {
+    test('shows the card body in view mode when displayAnswersPreview is true', () => {
+      renderComponent({ mode: 'view', displayAnswersPreview: true });
+      expect(screen.getByText(questionContentPlaceholder$())).toBeInTheDocument();
+    });
+
+    test('does not show the close button even when displayAnswersPreview is true', () => {
+      renderComponent({ mode: 'view', displayAnswersPreview: true });
+      expect(screen.queryByRole('button', { name: closeBtnLabel$() })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('toolbarActions slot', () => {
+    test('renders content injected into the toolbarActions slot', () => {
+      renderComponent({}, { toolbarActions: '<button>Edit</button>' });
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
@@ -4,7 +4,6 @@
     noPadding
     :topMargin="0"
     class="item question-card"
-    data-test="item"
   >
     <div
       class="question-card-header"
@@ -32,7 +31,7 @@
       class="question-card-body"
     >
       <p :style="{ color: $themePalette.grey.v_500, margin: 0, fontStyle: 'italic' }">
-        {{ questionContentPlaceholder }}
+        {{ questionContentPlaceholder$() }}
       </p>
     </div>
 
@@ -41,9 +40,8 @@
       class="question-card-footer"
     >
       <KButton
-        :text="closeBtnLabel"
+        :text="closeBtnLabel$()"
         class="close-item-btn"
-        data-test="closeBtn"
         @click="$emit('close')"
       />
     </div>
@@ -54,7 +52,7 @@
 
 <script>
 
-  import { computed, defineComponent } from 'vue';
+  import { computed } from 'vue';
   import { qtiEditorStrings } from '../../qtiEditorStrings';
   import { QtiInteraction } from '../../constants';
 
@@ -67,7 +65,7 @@
     [QtiInteraction.EXTENDED_TEXT]: 'interactionTypeExtendedText',
   };
 
-  export default defineComponent({
+  export default {
     name: 'QTIItemEditor',
 
     setup(props) {
@@ -81,7 +79,7 @@
 
       const questionNumberLabel = computed(() =>
         questionNumberLabel$({
-          number: props.index,
+          number: props.index + 1,
           total: props.total,
         }),
       );
@@ -90,20 +88,17 @@
         const typeKey = INTERACTION_TYPE_STRING_KEY[props.item.type];
         const typeLabel = typeKey ? qtiEditorStrings[`${typeKey}$`]() : interactionTypeUnknown$();
         return questionNumberAndTypeLabel$({
-          number: props.index,
+          number: props.index + 1,
           total: props.total,
           type: typeLabel,
         });
       });
 
-      const closeBtnLabel = closeBtnLabel$();
-      const questionContentPlaceholder = questionContentPlaceholder$();
-
       return {
         questionNumberLabel,
         questionNumberAndTypeLabel,
-        closeBtnLabel,
-        questionContentPlaceholder,
+        closeBtnLabel$,
+        questionContentPlaceholder$,
       };
     },
 
@@ -113,7 +108,7 @@
         type: Object,
         required: true,
       },
-      /** 1-based position in the list */
+      /** 0-based position in the list */
       index: {
         type: Number,
         required: true,
@@ -135,8 +130,9 @@
         default: false,
       },
     },
+
     emits: ['close'],
-  });
+  };
 
 </script>
 

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
@@ -4,19 +4,17 @@
     noPadding
     :topMargin="0"
     class="item question-card"
-    :class="{ closed: !isOpen }"
     data-test="item"
-    @click.native="onCardClick"
   >
     <div
       class="question-card-header"
-      :style="{ borderBottom: isOpen ? `1px solid ${$themePalette.grey.v_200}` : 'none' }"
+      :style="{ borderBottom: mode === 'edit' ? `1px solid ${$themeTokens.fineLine}` : 'none' }"
     >
       <h3
         class="question-card-title"
         :style="{ color: $themePalette.grey.v_800 }"
       >
-        <template v-if="isOpen">
+        <template v-if="mode === 'edit'">
           {{ questionNumberLabel }}
         </template>
         <template v-else>
@@ -25,24 +23,12 @@
       </h3>
 
       <div class="question-card-actions toolbar">
-        <AssessmentItemToolbar
-          :iconActionsConfig="iconActionsConfig"
-          :menuActionsConfig="menuActionsConfig"
-          :displayMenu="true"
-          :canMoveUp="canMoveUp"
-          :canMoveDown="canMoveDown"
-          :canEdit="!isOpen"
-          :collapse="windowIsSmall"
-          :itemLabel="toolbarItemLabel"
-          analyticsLabel="QTI Question"
-          data-test="toolbar"
-          @click="action => $emit('action', action)"
-        />
+        <slot name="toolbarActions"></slot>
       </div>
     </div>
 
     <div
-      v-if="isOpen || displayAnswersPreview"
+      v-if="mode === 'edit' || displayAnswersPreview"
       class="question-card-body"
     >
       <p :style="{ color: $themePalette.grey.v_500, margin: 0, fontStyle: 'italic' }">
@@ -51,7 +37,7 @@
     </div>
 
     <div
-      v-if="isOpen"
+      v-if="mode === 'edit'"
       class="question-card-footer"
     >
       <KButton
@@ -69,11 +55,8 @@
 <script>
 
   import { computed, defineComponent } from 'vue';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import { useQTIStr } from '../../qtiEditorStrings';
+  import { qtiEditorStrings } from '../../qtiEditorStrings';
   import { QtiInteraction } from '../../constants';
-  import AssessmentItemToolbar from 'frontend/channelEdit/components/AssessmentItemToolbar';
-  import { AssessmentItemToolbarActions } from 'frontend/channelEdit/constants';
 
   // QTI XML element name → i18n string key, used to build closed-card labels.
   const INTERACTION_TYPE_STRING_KEY = {
@@ -87,13 +70,17 @@
   export default defineComponent({
     name: 'QTIItemEditor',
 
-    components: { AssessmentItemToolbar },
-
-    setup(props, { emit }) {
-      const { windowIsSmall } = useKResponsiveWindow();
+    setup(props) {
+      const {
+        questionNumberLabel$,
+        questionNumberAndTypeLabel$,
+        closeBtnLabel$,
+        questionContentPlaceholder$,
+        interactionTypeUnknown$,
+      } = qtiEditorStrings;
 
       const questionNumberLabel = computed(() =>
-        useQTIStr('questionNumberLabel', {
+        questionNumberLabel$({
           number: props.index,
           total: props.total,
         }),
@@ -101,53 +88,22 @@
 
       const questionNumberAndTypeLabel = computed(() => {
         const typeKey = INTERACTION_TYPE_STRING_KEY[props.item.type];
-        const typeLabel = typeKey ? useQTIStr(typeKey) : useQTIStr('interactionTypeUnknown');
-        return useQTIStr('questionNumberAndTypeLabel', {
+        const typeLabel = typeKey ? qtiEditorStrings[`${typeKey}$`]() : interactionTypeUnknown$();
+        return questionNumberAndTypeLabel$({
           number: props.index,
           total: props.total,
           type: typeLabel,
         });
       });
-      const toolbarItemLabel = useQTIStr('toolbarItemLabel');
-      const closeBtnLabel = useQTIStr('closeBtnLabel');
-      const questionContentPlaceholder = useQTIStr('questionContentPlaceholder');
 
-      const canMoveUp = computed(() => props.index > 1);
-      const canMoveDown = computed(() => props.index < props.total);
-
-      const iconActionsConfig = [
-        [AssessmentItemToolbarActions.MOVE_ITEM_UP, { collapse: true }],
-        [AssessmentItemToolbarActions.MOVE_ITEM_DOWN, { collapse: true }],
-      ];
-      const menuActionsConfig = [
-        AssessmentItemToolbarActions.ADD_ITEM_ABOVE,
-        AssessmentItemToolbarActions.ADD_ITEM_BELOW,
-        AssessmentItemToolbarActions.DELETE_ITEM,
-      ];
-
-      function onCardClick(event) {
-        if (props.isOpen) return;
-        if (
-          event.target.closest('.toolbar') !== null ||
-          event.target.closest('.close-item-btn') !== null
-        ) {
-          return;
-        }
-        emit('open');
-      }
+      const closeBtnLabel = closeBtnLabel$();
+      const questionContentPlaceholder = questionContentPlaceholder$();
 
       return {
-        windowIsSmall,
         questionNumberLabel,
         questionNumberAndTypeLabel,
-        toolbarItemLabel,
         closeBtnLabel,
         questionContentPlaceholder,
-        canMoveUp,
-        canMoveDown,
-        iconActionsConfig,
-        menuActionsConfig,
-        onCardClick,
       };
     },
 
@@ -167,10 +123,11 @@
         type: Number,
         required: true,
       },
-      /** Whether this card is currently expanded */
-      isOpen: {
-        type: Boolean,
-        default: false,
+      /** Whether this card is currently in view or edit mode */
+      mode: {
+        type: String,
+        default: 'view',
+        validator: val => ['view', 'edit'].includes(val),
       },
       /** Whether to show answers previews for closed items */
       displayAnswersPreview: {
@@ -178,6 +135,7 @@
         default: false,
       },
     },
+    emits: ['close'],
   });
 
 </script>
@@ -188,14 +146,7 @@
   .question-card {
     --question-card-horizontal-padding: 20px;
 
-    position: relative;
-    min-height: 75px;
     padding: 0;
-    margin-bottom: 16px;
-
-    &.closed {
-      cursor: pointer;
-    }
   }
 
   .question-card-header {

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
@@ -1,0 +1,231 @@
+<template>
+
+  <KPageContainer
+    noPadding
+    :topMargin="0"
+    class="item question-card"
+    :class="{ closed: !isOpen }"
+    data-test="item"
+    @click.native="onCardClick"
+  >
+    <div
+      class="question-card-header"
+      :style="{ borderBottom: isOpen ? `1px solid ${$themePalette.grey.v_200}` : 'none' }"
+    >
+      <h3
+        class="question-card-title"
+        :style="{ color: $themePalette.grey.v_800 }"
+      >
+        <template v-if="isOpen">
+          {{ questionNumberLabel }}
+        </template>
+        <template v-else>
+          {{ questionNumberAndTypeLabel }}
+        </template>
+      </h3>
+
+      <div class="question-card-actions toolbar">
+        <AssessmentItemToolbar
+          :iconActionsConfig="iconActionsConfig"
+          :menuActionsConfig="menuActionsConfig"
+          :displayMenu="true"
+          :canMoveUp="canMoveUp"
+          :canMoveDown="canMoveDown"
+          :canEdit="!isOpen"
+          :collapse="windowIsSmall"
+          :itemLabel="toolbarItemLabel"
+          analyticsLabel="QTI Question"
+          data-test="toolbar"
+          @click="action => $emit('action', action)"
+        />
+      </div>
+    </div>
+
+    <div
+      v-if="isOpen || displayAnswersPreview"
+      class="question-card-body"
+    >
+      <p :style="{ color: $themePalette.grey.v_500, margin: 0, fontStyle: 'italic' }">
+        {{ questionContentPlaceholder }}
+      </p>
+    </div>
+
+    <div
+      v-if="isOpen"
+      class="question-card-footer"
+    >
+      <KButton
+        :text="closeBtnLabel"
+        class="close-item-btn"
+        data-test="closeBtn"
+        @click="$emit('close')"
+      />
+    </div>
+  </KPageContainer>
+
+</template>
+
+
+<script>
+
+  import { computed, defineComponent } from 'vue';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import { useQTIStr } from '../../qtiEditorStrings';
+  import { QtiInteraction } from '../../constants';
+  import AssessmentItemToolbar from 'frontend/channelEdit/components/AssessmentItemToolbar';
+  import { AssessmentItemToolbarActions } from 'frontend/channelEdit/constants';
+
+  // QTI XML element name → i18n string key, used to build closed-card labels.
+  const INTERACTION_TYPE_STRING_KEY = {
+    [QtiInteraction.CHOICE]: 'interactionTypeChoice',
+    [QtiInteraction.ORDER]: 'interactionTypeOrder',
+    [QtiInteraction.MATCH]: 'interactionTypeMatch',
+    [QtiInteraction.TEXT_ENTRY]: 'interactionTypeTextEntry',
+    [QtiInteraction.EXTENDED_TEXT]: 'interactionTypeExtendedText',
+  };
+
+  export default defineComponent({
+    name: 'QTIItemEditor',
+
+    components: { AssessmentItemToolbar },
+
+    setup(props, { emit }) {
+      const { windowIsSmall } = useKResponsiveWindow();
+
+      const questionNumberLabel = computed(() =>
+        useQTIStr('questionNumberLabel', {
+          number: props.index,
+          total: props.total,
+        }),
+      );
+
+      const questionNumberAndTypeLabel = computed(() => {
+        const typeKey = INTERACTION_TYPE_STRING_KEY[props.item.type];
+        const typeLabel = typeKey ? useQTIStr(typeKey) : useQTIStr('interactionTypeUnknown');
+        return useQTIStr('questionNumberAndTypeLabel', {
+          number: props.index,
+          total: props.total,
+          type: typeLabel,
+        });
+      });
+      const toolbarItemLabel = useQTIStr('toolbarItemLabel');
+      const closeBtnLabel = useQTIStr('closeBtnLabel');
+      const questionContentPlaceholder = useQTIStr('questionContentPlaceholder');
+
+      const canMoveUp = computed(() => props.index > 1);
+      const canMoveDown = computed(() => props.index < props.total);
+
+      const iconActionsConfig = [
+        [AssessmentItemToolbarActions.MOVE_ITEM_UP, { collapse: true }],
+        [AssessmentItemToolbarActions.MOVE_ITEM_DOWN, { collapse: true }],
+      ];
+      const menuActionsConfig = [
+        AssessmentItemToolbarActions.ADD_ITEM_ABOVE,
+        AssessmentItemToolbarActions.ADD_ITEM_BELOW,
+        AssessmentItemToolbarActions.DELETE_ITEM,
+      ];
+
+      function onCardClick(event) {
+        if (props.isOpen) return;
+        if (
+          event.target.closest('.toolbar') !== null ||
+          event.target.closest('.close-item-btn') !== null
+        ) {
+          return;
+        }
+        emit('open');
+      }
+
+      return {
+        windowIsSmall,
+        questionNumberLabel,
+        questionNumberAndTypeLabel,
+        toolbarItemLabel,
+        closeBtnLabel,
+        questionContentPlaceholder,
+        canMoveUp,
+        canMoveDown,
+        iconActionsConfig,
+        menuActionsConfig,
+        onCardClick,
+      };
+    },
+
+    props: {
+      /** Assessment item: { id, type (QtiInteraction value), title } */
+      item: {
+        type: Object,
+        required: true,
+      },
+      /** 1-based position in the list */
+      index: {
+        type: Number,
+        required: true,
+      },
+      /** Total items in the list */
+      total: {
+        type: Number,
+        required: true,
+      },
+      /** Whether this card is currently expanded */
+      isOpen: {
+        type: Boolean,
+        default: false,
+      },
+      /** Whether to show answers previews for closed items */
+      displayAnswersPreview: {
+        type: Boolean,
+        default: false,
+      },
+    },
+  });
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .question-card {
+    --question-card-horizontal-padding: 20px;
+
+    position: relative;
+    min-height: 75px;
+    padding: 0;
+    margin-bottom: 16px;
+
+    &.closed {
+      cursor: pointer;
+    }
+  }
+
+  .question-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px var(--question-card-horizontal-padding);
+  }
+
+  .question-card-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .question-card-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .question-card-body {
+    min-width: 0;
+    padding: 10px var(--question-card-horizontal-padding);
+  }
+
+  .question-card-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 var(--question-card-horizontal-padding) 20px;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
@@ -1,0 +1,28 @@
+export const Cardinality = Object.freeze({
+  SINGLE: 'single',
+  MULTIPLE: 'multiple',
+  ORDERED: 'ordered',
+  RECORD: 'record',
+});
+
+export const BaseType = Object.freeze({
+  IDENTIFIER: 'identifier',
+  BOOLEAN: 'boolean',
+  INTEGER: 'integer',
+  FLOAT: 'float',
+  STRING: 'string',
+  POINT: 'point',
+  PAIR: 'pair',
+  DIRECTED_PAIR: 'directedPair',
+  DURATION: 'duration',
+  FILE: 'file',
+  URI: 'uri',
+});
+
+export const QtiInteraction = Object.freeze({
+  CHOICE: 'choiceInteraction',
+  ORDER: 'orderInteraction',
+  MATCH: 'matchInteraction',
+  TEXT_ENTRY: 'textEntryInteraction',
+  EXTENDED_TEXT: 'extendedTextInteraction',
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
@@ -10,49 +10,44 @@
         <div class="show-answers-inner">
           <Checkbox
             v-model="displayAnswersPreview"
-            :label="showAnswersLabel"
+            :label="showAnswers$()"
             class="ma-0"
-            data-test="showAnswersCheckbox"
+            data-testid="showAnswersCheckbox"
             style="font-size: 16px"
           />
         </div>
       </KPageContainer>
 
-      <transition-group
-        name="list-complete"
-        tag="div"
-        class="question-list"
-      >
+      <div class="question-list">
         <QTIItemEditor
           v-for="(item, idx) in items"
           :key="item.id"
           :item="item"
-          :index="idx + 1"
+          :index="idx"
           :total="items.length"
           :mode="activeId === item.id ? 'edit' : 'view'"
           :displayAnswersPreview="displayAnswersPreview"
-          data-test="item"
+          data-testid="item"
           @close="closeItem"
         >
           <template #toolbarActions>
             <CollapsibleToolbar
               :actions="getToolbarActions(item, idx)"
-              :optionsLabel="optionsLabel"
-              data-test="toolbar"
+              data-testid="toolbar"
             />
           </template>
         </QTIItemEditor>
-      </transition-group>
+      </div>
     </template>
 
     <div v-else>
-      {{ noQuestionsPlaceholder }}
+      {{ noQuestionsPlaceholder$() }}
     </div>
 
     <KButton
-      :text="newQuestionBtnLabel"
+      :text="newQuestionBtnLabel$()"
       style="margin-top: 16px; margin-left: 0"
-      data-test="newQuestionBtn"
+      data-testid="newQuestionBtn"
       @click="addItem()"
     />
   </div>
@@ -62,26 +57,26 @@
 
 <script>
 
-  import { ref, computed, defineComponent } from 'vue';
-  import { v4 as uuidv4 } from 'uuid';
+  import { ref, computed } from 'vue';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { qtiEditorStrings } from './qtiEditorStrings';
   import { QtiInteraction } from './constants';
   import QTIItemEditor from './components/QTIItemEditor/index';
   import CollapsibleToolbar from './components/CollapsibleToolbar/index.vue';
   import useQTIEditorActions from './useQTIEditorActions';
+  import { uuid4 } from 'shared/data/resources';
   import Checkbox from 'shared/views/form/Checkbox';
 
   /** Creates a blank item with a stable UUID and the default interaction type. */
   function createBlankItem() {
     return {
-      id: uuidv4(),
+      id: uuid4(),
       type: QtiInteraction.CHOICE,
       title: '',
     };
   }
 
-  export default defineComponent({
+  export default {
     name: 'QTIEditor',
 
     components: { QTIItemEditor, CollapsibleToolbar, Checkbox },
@@ -156,13 +151,9 @@
         deleteItem,
       });
 
-      const { noQuestionsPlaceholder$, newQuestionBtnLabel$, showAnswers$, options$ } =
-        qtiEditorStrings;
+      const { noQuestionsPlaceholder$, newQuestionBtnLabel$, showAnswers$ } = qtiEditorStrings;
 
       return {
-        noQuestionsPlaceholder: noQuestionsPlaceholder$(),
-        newQuestionBtnLabel: newQuestionBtnLabel$(),
-        showAnswersLabel: showAnswers$(),
         containerStyle,
         items,
         activeId,
@@ -170,7 +161,9 @@
         closeItem,
         addItem,
         getToolbarActions,
-        optionsLabel: options$(),
+        noQuestionsPlaceholder$,
+        newQuestionBtnLabel$,
+        showAnswers$,
       };
     },
 
@@ -191,7 +184,7 @@
     },
 
     emits: ['update'],
-  });
+  };
 
 </script>
 
@@ -206,22 +199,6 @@
     display: flex;
     align-items: center;
     padding: 12px;
-  }
-
-  /* Transition Group Animations */
-  .list-complete-enter-active,
-  .list-complete-leave-active {
-    transition: all 0.3s ease;
-  }
-
-  .list-complete-enter,
-  .list-complete-leave-to {
-    opacity: 0;
-    transform: translateY(16px);
-  }
-
-  .list-complete-move {
-    transition: transform 0.3s ease;
   }
 
   .question-list {

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div :style="[containerStyle, { padding: '16px' }]">
+  <div :style="containerStyle">
     <template v-if="items && items.length">
       <KPageContainer
         class="show-answers-container"
@@ -21,6 +21,7 @@
       <transition-group
         name="list-complete"
         tag="div"
+        class="question-list"
       >
         <QTIItemEditor
           v-for="(item, idx) in items"
@@ -28,13 +29,19 @@
           :item="item"
           :index="idx + 1"
           :total="items.length"
-          :isOpen="activeId === item.id"
+          :mode="activeId === item.id ? 'edit' : 'view'"
           :displayAnswersPreview="displayAnswersPreview"
           data-test="item"
-          @open="openItem(item.id)"
           @close="closeItem"
-          @action="onItemAction($event, item, idx)"
-        />
+        >
+          <template #toolbarActions>
+            <CollapsibleToolbar
+              :actions="getToolbarActions(item, idx)"
+              :optionsLabel="optionsLabel"
+              data-test="toolbar"
+            />
+          </template>
+        </QTIItemEditor>
       </transition-group>
     </template>
 
@@ -58,11 +65,12 @@
   import { ref, computed, defineComponent } from 'vue';
   import { v4 as uuidv4 } from 'uuid';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
-  import { useQTIStr } from './qtiEditorStrings';
+  import { qtiEditorStrings } from './qtiEditorStrings';
   import { QtiInteraction } from './constants';
   import QTIItemEditor from './components/QTIItemEditor/index';
+  import CollapsibleToolbar from './components/CollapsibleToolbar/index.vue';
+  import useQTIEditorActions from './useQTIEditorActions';
   import Checkbox from 'shared/views/form/Checkbox';
-  import { AssessmentItemToolbarActions } from 'frontend/channelEdit/constants';
 
   /** Creates a blank item with a stable UUID and the default interaction type. */
   function createBlankItem() {
@@ -76,14 +84,16 @@
   export default defineComponent({
     name: 'QTIEditor',
 
-    components: { QTIItemEditor, Checkbox },
+    components: { QTIItemEditor, CollapsibleToolbar, Checkbox },
 
     setup(props, { emit }) {
       const { windowIsSmall } = useKResponsiveWindow();
 
-      const containerStyle = computed(() =>
-        windowIsSmall.value ? {} : { maxWidth: '85%', margin: '0 auto' },
-      );
+      const containerStyle = computed(() => ({
+        maxWidth: '1200px',
+        margin: '0 auto',
+        padding: windowIsSmall.value ? '16px' : '32px',
+      }));
 
       const items = computed(() => props.assessments);
 
@@ -98,8 +108,6 @@
         activeId.value = null;
       }
 
-      const cloneList = () => [...props.assessments];
-
       /**
        * Add a blank item.
        * @param {Object} [opts]
@@ -107,73 +115,62 @@
        */
       function addItem({ atIndex } = {}) {
         const newItem = createBlankItem();
-        const list = cloneList();
+        const list = [...props.assessments];
         const pos = atIndex !== undefined ? atIndex : list.length;
         list.splice(pos, 0, newItem);
         emit('update', list);
-        // Open the newly created card on the next tick
-        setTimeout(() => {
-          activeId.value = newItem.id;
-        }, 0);
+        // open the newly created card
+        activeId.value = newItem.id;
       }
 
       function deleteItem(item) {
         if (activeId.value === item.id) closeItem();
         emit(
           'update',
-          cloneList().filter(i => i.id !== item.id),
+          props.assessments.filter(i => i.id !== item.id),
         );
       }
 
       function moveItemUp(idx) {
         if (idx === 0) return;
-        const list = cloneList();
+        const list = [...props.assessments];
         [list[idx - 1], list[idx]] = [list[idx], list[idx - 1]];
         emit('update', list);
       }
 
       function moveItemDown(idx) {
         if (idx === props.assessments.length - 1) return;
-        const list = cloneList();
+        const list = [...props.assessments];
         [list[idx], list[idx + 1]] = [list[idx + 1], list[idx]];
         emit('update', list);
       }
 
-      function onItemAction(action, item, idx) {
-        switch (action) {
-          case AssessmentItemToolbarActions.EDIT_ITEM:
-            openItem(item.id);
-            break;
-          case AssessmentItemToolbarActions.DELETE_ITEM:
-            deleteItem(item);
-            break;
-          case AssessmentItemToolbarActions.ADD_ITEM_ABOVE:
-            addItem({ atIndex: idx });
-            break;
-          case AssessmentItemToolbarActions.ADD_ITEM_BELOW:
-            addItem({ atIndex: idx + 1 });
-            break;
-          case AssessmentItemToolbarActions.MOVE_ITEM_UP:
-            moveItemUp(idx);
-            break;
-          case AssessmentItemToolbarActions.MOVE_ITEM_DOWN:
-            moveItemDown(idx);
-            break;
-        }
-      }
+      const { getToolbarActions } = useQTIEditorActions({
+        items,
+        activeId,
+        windowIsSmall,
+        openItem,
+        moveItemUp,
+        moveItemDown,
+        addItem,
+        deleteItem,
+      });
+
+      const { noQuestionsPlaceholder$, newQuestionBtnLabel$, showAnswers$, options$ } =
+        qtiEditorStrings;
 
       return {
-        noQuestionsPlaceholder: useQTIStr('noQuestionsPlaceholder'),
-        newQuestionBtnLabel: useQTIStr('newQuestionBtnLabel'),
-        showAnswersLabel: useQTIStr('showAnswers'),
+        noQuestionsPlaceholder: noQuestionsPlaceholder$(),
+        newQuestionBtnLabel: newQuestionBtnLabel$(),
+        showAnswersLabel: showAnswers$(),
         containerStyle,
         items,
         activeId,
         displayAnswersPreview,
-        openItem,
         closeItem,
         addItem,
-        onItemAction,
+        getToolbarActions,
+        optionsLabel: options$(),
       };
     },
 
@@ -209,6 +206,28 @@
     display: flex;
     align-items: center;
     padding: 12px;
+  }
+
+  /* Transition Group Animations */
+  .list-complete-enter-active,
+  .list-complete-leave-active {
+    transition: all 0.3s ease;
+  }
+
+  .list-complete-enter,
+  .list-complete-leave-to {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  .list-complete-move {
+    transition: transform 0.3s ease;
+  }
+
+  .question-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
@@ -1,0 +1,214 @@
+<template>
+
+  <div :style="[containerStyle, { padding: '16px' }]">
+    <template v-if="items && items.length">
+      <KPageContainer
+        class="show-answers-container"
+        :topMargin="0"
+        noPadding
+      >
+        <div class="show-answers-inner">
+          <Checkbox
+            v-model="displayAnswersPreview"
+            :label="showAnswersLabel"
+            class="ma-0"
+            data-test="showAnswersCheckbox"
+            style="font-size: 16px"
+          />
+        </div>
+      </KPageContainer>
+
+      <transition-group
+        name="list-complete"
+        tag="div"
+      >
+        <QTIItemEditor
+          v-for="(item, idx) in items"
+          :key="item.id"
+          :item="item"
+          :index="idx + 1"
+          :total="items.length"
+          :isOpen="activeId === item.id"
+          :displayAnswersPreview="displayAnswersPreview"
+          data-test="item"
+          @open="openItem(item.id)"
+          @close="closeItem"
+          @action="onItemAction($event, item, idx)"
+        />
+      </transition-group>
+    </template>
+
+    <div v-else>
+      {{ noQuestionsPlaceholder }}
+    </div>
+
+    <KButton
+      :text="newQuestionBtnLabel"
+      style="margin-top: 16px; margin-left: 0"
+      data-test="newQuestionBtn"
+      @click="addItem()"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, computed, defineComponent } from 'vue';
+  import { v4 as uuidv4 } from 'uuid';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
+  import { useQTIStr } from './qtiEditorStrings';
+  import { QtiInteraction } from './constants';
+  import QTIItemEditor from './components/QTIItemEditor/index';
+  import Checkbox from 'shared/views/form/Checkbox';
+  import { AssessmentItemToolbarActions } from 'frontend/channelEdit/constants';
+
+  /** Creates a blank item with a stable UUID and the default interaction type. */
+  function createBlankItem() {
+    return {
+      id: uuidv4(),
+      type: QtiInteraction.CHOICE,
+      title: '',
+    };
+  }
+
+  export default defineComponent({
+    name: 'QTIEditor',
+
+    components: { QTIItemEditor, Checkbox },
+
+    setup(props, { emit }) {
+      const { windowIsSmall } = useKResponsiveWindow();
+
+      const containerStyle = computed(() =>
+        windowIsSmall.value ? {} : { maxWidth: '85%', margin: '0 auto' },
+      );
+
+      const items = computed(() => props.assessments);
+
+      const activeId = ref(null);
+      const displayAnswersPreview = ref(false);
+
+      function openItem(id) {
+        activeId.value = id;
+      }
+
+      function closeItem() {
+        activeId.value = null;
+      }
+
+      const cloneList = () => [...props.assessments];
+
+      /**
+       * Add a blank item.
+       * @param {Object} [opts]
+       * @param {number} [opts.atIndex] splice position; defaults to end of list
+       */
+      function addItem({ atIndex } = {}) {
+        const newItem = createBlankItem();
+        const list = cloneList();
+        const pos = atIndex !== undefined ? atIndex : list.length;
+        list.splice(pos, 0, newItem);
+        emit('update', list);
+        // Open the newly created card on the next tick
+        setTimeout(() => {
+          activeId.value = newItem.id;
+        }, 0);
+      }
+
+      function deleteItem(item) {
+        if (activeId.value === item.id) closeItem();
+        emit(
+          'update',
+          cloneList().filter(i => i.id !== item.id),
+        );
+      }
+
+      function moveItemUp(idx) {
+        if (idx === 0) return;
+        const list = cloneList();
+        [list[idx - 1], list[idx]] = [list[idx], list[idx - 1]];
+        emit('update', list);
+      }
+
+      function moveItemDown(idx) {
+        if (idx === props.assessments.length - 1) return;
+        const list = cloneList();
+        [list[idx], list[idx + 1]] = [list[idx + 1], list[idx]];
+        emit('update', list);
+      }
+
+      function onItemAction(action, item, idx) {
+        switch (action) {
+          case AssessmentItemToolbarActions.EDIT_ITEM:
+            openItem(item.id);
+            break;
+          case AssessmentItemToolbarActions.DELETE_ITEM:
+            deleteItem(item);
+            break;
+          case AssessmentItemToolbarActions.ADD_ITEM_ABOVE:
+            addItem({ atIndex: idx });
+            break;
+          case AssessmentItemToolbarActions.ADD_ITEM_BELOW:
+            addItem({ atIndex: idx + 1 });
+            break;
+          case AssessmentItemToolbarActions.MOVE_ITEM_UP:
+            moveItemUp(idx);
+            break;
+          case AssessmentItemToolbarActions.MOVE_ITEM_DOWN:
+            moveItemDown(idx);
+            break;
+        }
+      }
+
+      return {
+        noQuestionsPlaceholder: useQTIStr('noQuestionsPlaceholder'),
+        newQuestionBtnLabel: useQTIStr('newQuestionBtnLabel'),
+        showAnswersLabel: useQTIStr('showAnswers'),
+        containerStyle,
+        items,
+        activeId,
+        displayAnswersPreview,
+        openItem,
+        closeItem,
+        addItem,
+        onItemAction,
+      };
+    },
+
+    props: {
+      /**
+       * Ordered list of assessment items. Each item must have:
+       *   id    {String}  — stable unique identifier (UUID)
+       *   type  {String}  — a QtiInteraction value
+       *   title {String}  — optional display title
+       *
+       * Array index is the display order.
+       * This component never mutates the prop — it emits `update` with the new list.
+       */
+      assessments: {
+        type: Array,
+        default: () => [],
+      },
+    },
+
+    emits: ['update'],
+  });
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .show-answers-container {
+    margin-bottom: 16px;
+  }
+
+  .show-answers-inner {
+    display: flex;
+    align-items: center;
+    padding: 12px;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
@@ -8,7 +8,7 @@
         noPadding
       >
         <div class="show-answers-inner">
-          <Checkbox
+          <KCheckbox
             v-model="displayAnswersPreview"
             :label="showAnswers$()"
             class="ma-0"
@@ -57,6 +57,7 @@
 
 <script>
 
+  import { v4 as uuidv4 } from 'uuid';
   import { ref, computed } from 'vue';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { qtiEditorStrings } from './qtiEditorStrings';
@@ -64,8 +65,11 @@
   import QTIItemEditor from './components/QTIItemEditor/index';
   import CollapsibleToolbar from './components/CollapsibleToolbar/index.vue';
   import useQTIEditorActions from './useQTIEditorActions';
-  import { uuid4 } from 'shared/data/resources';
-  import Checkbox from 'shared/views/form/Checkbox';
+
+  // Custom uuid4 function to match our dashless uuids on the server side
+  function uuid4() {
+    return uuidv4().replace(/-/g, '');
+  }
 
   /** Creates a blank item with a stable UUID and the default interaction type. */
   function createBlankItem() {
@@ -79,7 +83,7 @@
   export default {
     name: 'QTIEditor',
 
-    components: { QTIItemEditor, CollapsibleToolbar, Checkbox },
+    components: { QTIItemEditor, CollapsibleToolbar },
 
     setup(props, { emit }) {
       const { windowIsSmall } = useKResponsiveWindow();

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
@@ -1,0 +1,68 @@
+import { createTranslator } from 'shared/i18n';
+
+const NAMESPACE = 'QTIEditorStrings';
+
+const MESSAGES = {
+  noQuestionsPlaceholder: {
+    message: 'No questions yet',
+    context: 'Shown when the question list is empty',
+  },
+  newQuestionBtnLabel: {
+    message: 'New question',
+    context: 'Button that adds a new question to the list',
+  },
+  questionNumberLabel: {
+    message: 'Question {number} of {total}',
+    context: 'Card header when card is open, e.g. "Question 2 of 5"',
+  },
+  questionNumberAndTypeLabel: {
+    message: 'Question {number} of {total} \u2014 {type}',
+    context: 'Card header when card is closed, e.g. "Question 1 of 3 \u2014 Choice"',
+  },
+  toolbarItemLabel: {
+    message: 'question',
+    context: 'Noun used by the toolbar for accessible action labels',
+  },
+  closeBtnLabel: {
+    message: 'Close',
+    context: 'Button that collapses the open question card',
+  },
+  questionContentPlaceholder: {
+    message: 'Question content editor coming soon',
+    context: 'Placeholder inside an open card until interaction editors are built',
+  },
+  showAnswers: {
+    message: 'Show answers',
+    context: 'Checkbox label to toggle displaying answers/previews',
+  },
+  interactionTypeChoice: {
+    message: 'Choice',
+    context: 'Display name for choiceInteraction',
+  },
+  interactionTypeOrder: {
+    message: 'Order',
+    context: 'Display name for orderInteraction',
+  },
+  interactionTypeMatch: {
+    message: 'Match',
+    context: 'Display name for matchInteraction',
+  },
+  interactionTypeTextEntry: {
+    message: 'Text entry',
+    context: 'Display name for textEntryInteraction',
+  },
+  interactionTypeExtendedText: {
+    message: 'Extended text',
+    context: 'Display name for extendedTextInteraction',
+  },
+  interactionTypeUnknown: {
+    message: 'Unknown type',
+    context: 'Fallback when an item has an unrecognised interaction type',
+  },
+};
+
+export const qtiEditorStrings = createTranslator(NAMESPACE, MESSAGES);
+
+export function useQTIStr(key, args) {
+  return qtiEditorStrings.$tr(key, args);
+}

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
@@ -77,8 +77,4 @@ export const qtiEditorStrings = createTranslator('QTIEditorStrings', {
     message: 'Add question below',
     context: 'Action to add a new question below the current one',
   },
-  options: {
-    message: 'Options',
-    context: 'Tooltip for the options menu icon',
-  },
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
@@ -1,8 +1,6 @@
 import { createTranslator } from 'shared/i18n';
 
-const NAMESPACE = 'QTIEditorStrings';
-
-const MESSAGES = {
+export const qtiEditorStrings = createTranslator('QTIEditorStrings', {
   noQuestionsPlaceholder: {
     message: 'No questions yet',
     context: 'Shown when the question list is empty',
@@ -18,10 +16,6 @@ const MESSAGES = {
   questionNumberAndTypeLabel: {
     message: 'Question {number} of {total} \u2014 {type}',
     context: 'Card header when card is closed, e.g. "Question 1 of 3 \u2014 Choice"',
-  },
-  toolbarItemLabel: {
-    message: 'question',
-    context: 'Noun used by the toolbar for accessible action labels',
   },
   closeBtnLabel: {
     message: 'Close',
@@ -59,10 +53,32 @@ const MESSAGES = {
     message: 'Unknown type',
     context: 'Fallback when an item has an unrecognised interaction type',
   },
-};
-
-export const qtiEditorStrings = createTranslator(NAMESPACE, MESSAGES);
-
-export function useQTIStr(key, args) {
-  return qtiEditorStrings.$tr(key, args);
-}
+  toolbarLabelEdit: {
+    message: 'Edit',
+    context: 'Action to edit the item',
+  },
+  toolbarLabelMoveUp: {
+    message: 'Move up',
+    context: 'Action to move the item up',
+  },
+  toolbarLabelMoveDown: {
+    message: 'Move down',
+    context: 'Action to move the item down',
+  },
+  toolbarLabelDelete: {
+    message: 'Delete',
+    context: 'Action to delete the item',
+  },
+  toolbarLabelAddAbove: {
+    message: 'Add question above',
+    context: 'Action to add a new question above the current one',
+  },
+  toolbarLabelAddBelow: {
+    message: 'Add question below',
+    context: 'Action to add a new question below the current one',
+  },
+  options: {
+    message: 'Options',
+    context: 'Tooltip for the options menu icon',
+  },
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/useQTIEditorActions.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/useQTIEditorActions.js
@@ -26,35 +26,32 @@ export default function useQTIEditorActions({
     const result = [];
     const isEditMode = activeId.value === item.id;
 
-    if (!isEditMode) {
-      result.push({
-        id: 'edit',
-        icon: 'edit',
-        label: toolbarLabelEdit$(),
-        handler: () => openItem(item.id),
-        collapsed: false,
-      });
-    }
+    result.push({
+      id: 'edit',
+      icon: 'edit',
+      label: toolbarLabelEdit$(),
+      handler: () => openItem(item.id),
+      collapsed: false,
+      disabled: isEditMode,
+    });
 
-    if (idx > 0) {
-      result.push({
-        id: 'move-up',
-        icon: 'chevronUp',
-        label: toolbarLabelMoveUp$(),
-        handler: () => moveItemUp(idx),
-        collapsed: windowIsSmall.value,
-      });
-    }
+    result.push({
+      id: 'move-up',
+      icon: 'chevronUp',
+      label: toolbarLabelMoveUp$(),
+      handler: () => moveItemUp(idx),
+      collapsed: windowIsSmall.value,
+      disabled: idx === 0,
+    });
 
-    if (idx < items.value.length - 1) {
-      result.push({
-        id: 'move-down',
-        icon: 'chevronDown',
-        label: toolbarLabelMoveDown$(),
-        handler: () => moveItemDown(idx),
-        collapsed: windowIsSmall.value,
-      });
-    }
+    result.push({
+      id: 'move-down',
+      icon: 'chevronDown',
+      label: toolbarLabelMoveDown$(),
+      handler: () => moveItemDown(idx),
+      collapsed: windowIsSmall.value,
+      disabled: idx === items.value.length - 1,
+    });
 
     result.push(
       {

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/useQTIEditorActions.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/useQTIEditorActions.js
@@ -1,0 +1,87 @@
+import { qtiEditorStrings } from './qtiEditorStrings';
+
+/**
+ * Generates the toolbar actions array for a specific QTI item in the list.
+ */
+export default function useQTIEditorActions({
+  items,
+  activeId,
+  windowIsSmall,
+  openItem,
+  moveItemUp,
+  moveItemDown,
+  addItem,
+  deleteItem,
+}) {
+  const {
+    toolbarLabelEdit$,
+    toolbarLabelMoveUp$,
+    toolbarLabelMoveDown$,
+    toolbarLabelAddAbove$,
+    toolbarLabelAddBelow$,
+    toolbarLabelDelete$,
+  } = qtiEditorStrings;
+
+  function getToolbarActions(item, idx) {
+    const result = [];
+    const isEditMode = activeId.value === item.id;
+
+    if (!isEditMode) {
+      result.push({
+        id: 'edit',
+        icon: 'edit',
+        label: toolbarLabelEdit$(),
+        handler: () => openItem(item.id),
+        collapsed: false,
+      });
+    }
+
+    if (idx > 0) {
+      result.push({
+        id: 'move-up',
+        icon: 'chevronUp',
+        label: toolbarLabelMoveUp$(),
+        handler: () => moveItemUp(idx),
+        collapsed: windowIsSmall.value,
+      });
+    }
+
+    if (idx < items.value.length - 1) {
+      result.push({
+        id: 'move-down',
+        icon: 'chevronDown',
+        label: toolbarLabelMoveDown$(),
+        handler: () => moveItemDown(idx),
+        collapsed: windowIsSmall.value,
+      });
+    }
+
+    result.push(
+      {
+        id: 'add-above',
+        icon: null,
+        label: toolbarLabelAddAbove$(),
+        handler: () => addItem({ atIndex: idx }),
+        collapsed: true,
+      },
+      {
+        id: 'add-below',
+        icon: null,
+        label: toolbarLabelAddBelow$(),
+        handler: () => addItem({ atIndex: idx + 1 }),
+        collapsed: true,
+      },
+      {
+        id: 'delete',
+        icon: 'close',
+        label: toolbarLabelDelete$(),
+        handler: () => deleteItem(item),
+        collapsed: true,
+      },
+    );
+
+    return result;
+  }
+
+  return { getToolbarActions };
+}


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR This PR introduces the initial frontend scaffolding for a brand-new QTI 3.0 authoring editor.
affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

This PR introduces the initial frontend scaffolding for a brand-new QTI 3.0 authoring editor.

<img width="1920" height="924" alt="image" src="https://github.com/user-attachments/assets/8979801a-5e4f-464f-a9b7-a0be26b178f2" />


## References
<!--
 * references to related issues and PRs
-->

Closes #5961 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to any channel in the Studio channel editor.
2. Replace the end of the URL with `/#/qti-demo`.
3. You will see the new standalone QTIEditor loaded with three hardcoded questions.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage

Used Antigravity for final review and nitpicks.