### PR TITLE
Validation against invalid UUID for remove-self endpoint

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_user.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_user.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from contentcuration.models import Change
 from contentcuration.tests import testdata
 from contentcuration.tests.base import StudioAPITestCase
+from contentcuration.tests.helpers import reverse_with_query
 from contentcuration.tests.viewsets.base import generate_create_event
 from contentcuration.tests.viewsets.base import generate_delete_event
 from contentcuration.tests.viewsets.base import SyncTestMixin
@@ -366,6 +367,28 @@ class ChannelUserCRUDTestCase(StudioAPITestCase):
         )
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(response.json(), [])
+
+    def test_remove_self_with_invalid_channel_id_returns_bad_request(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            reverse_with_query(
+                "channeluser-remove-self",
+                kwargs={"pk": self.user.id},
+                query={"channel_id": "not-a-valid-uuid"},
+            )
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_remove_self_with_missing_channel_returns_not_found(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            reverse_with_query(
+                "channeluser-remove-self",
+                kwargs={"pk": self.user.id},
+                query={"channel_id": "00000000-0000-0000-0000-000000000000"},
+            )
+        )
+        self.assertEqual(response.status_code, 404, response.content)
 
 
 class MarkReadNotificationsTimestampTestCase(StudioAPITestCase):

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import uuid
 from datetime import date
 from functools import reduce
 
@@ -51,7 +52,7 @@ from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import VIEWER_M2M
-import uuid
+
 
 logger = logging.getLogger(__name__)
 
@@ -342,7 +343,7 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
         if not channel_id:
             return HttpResponseBadRequest("Channel ID is required.")
         try:
-            uuid.UUID(channel_id)
+            channel_id = uuid.UUID(channel_id).hex
         except ValueError:
             return HttpResponseBadRequest("Invalid channel ID")
 
@@ -350,8 +351,6 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
             channel = Channel.objects.get(id=channel_id)
         except Channel.DoesNotExist:
             return HttpResponseNotFound("Channel not found {}".format(channel_id))
-        except ValueError:
-            return HttpResponseBadRequest("Invalid channel ID: {}".format(channel_id))
 
         if request.user != user and not request.user.can_edit(channel_id):
             return HttpResponseForbidden(

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -346,6 +346,8 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
             channel = Channel.objects.get(id=channel_id)
         except Channel.DoesNotExist:
             return HttpResponseNotFound("Channel not found {}".format(channel_id))
+        except ValueError:
+            return HttpResponseBadRequest("Invalid channel ID: {}".format(channel_id))
 
         if request.user != user and not request.user.can_edit(channel_id):
             return HttpResponseForbidden(

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -51,7 +51,7 @@ from contentcuration.viewsets.sync.constants import CREATED
 from contentcuration.viewsets.sync.constants import DELETED
 from contentcuration.viewsets.sync.constants import EDITOR_M2M
 from contentcuration.viewsets.sync.constants import VIEWER_M2M
-
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -341,6 +341,10 @@ class ChannelUserViewSet(ReadOnlyValuesViewset):
 
         if not channel_id:
             return HttpResponseBadRequest("Channel ID is required.")
+        try:
+            uuid.UUID(channel_id)
+        except ValueError:
+            return HttpResponseBadRequest("Invalid channel ID")
 
         try:
             channel = Channel.objects.get(id=channel_id)


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

This PR fixes an unhandled exception in `ChannelUserViewSet.remove_self` where malformed `channel_id` values could trigger a 500 error. It adds proper validation handling to return a 400 Bad Request instead.

The change is localized to `contentcuration/contentcuration/viewsets/user.py`, aligning error handling with existing patterns in the codebase.


## References
<!--
 * references to related issues and PRs
-->
Original: https://github.com/learningequality/studio/pull/5776
closes #5779 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Sending a request with a malformed `channel_id` (e.g., `not-a-valid-uuid`) now returns a **400 Bad Request** instead of a 500 error. Valid but non existent UUIDs correctly return **404 Not Found**, while valid existing IDs continue to work as expected.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
> AI was used only to help improve the phrasing of this pull request description.
>
> The issue identification, debugging, and implementation were done manually after reviewing the code and reproducing the behavior locally. The fix was verified to ensure correct handling of malformed, non-existent, and valid UUID inputs.

In followup, AI was used to address remaining review feedback.