### PR TITLE
Optimize query for user CSV export

### DIFF
--- a/contentcuration/contentcuration/tests/test_user.py
+++ b/contentcuration/contentcuration/tests/test_user.py
@@ -16,7 +16,9 @@ from .base import BaseAPITestCase
 from .base import StudioTestCase
 from .testdata import fileobj_video
 from contentcuration.models import DEFAULT_CONTENT_DEFAULTS
+from contentcuration.models import File
 from contentcuration.models import Invitation
+from contentcuration.models import Language
 from contentcuration.models import User
 from contentcuration.models import UserSubscription
 from contentcuration.tests import testdata
@@ -162,6 +164,59 @@ class UserAccountTestCase(BaseAPITestCase):
                         self.assertIn(videos[index - 1].original_filename, row)
                         self.assertIn(_format_size(videos[index - 1].file_size), row)
             self.assertEqual(index, len(videos))
+
+    def test_user_csv_export_reports_channel_and_content_metadata(self):
+        language = Language.objects.create(lang_code="fr", readable_name="French")
+        file_record = File.objects.filter(
+            contentnode__tree_id=self.channel.main_tree.tree_id
+        ).first()
+        file_record.uploaded_by = self.user
+        file_record.original_filename = "sample-video.mp4"
+        file_record.language = None
+        file_record.save()
+
+        contentnode = file_record.contentnode
+        contentnode.title = "CSV Content Title"
+        contentnode.description = "CSV Description"
+        contentnode.author = "CSV Author"
+        contentnode.language = language
+        contentnode.license_description = "CSV License Description"
+        contentnode.copyright_holder = "CSV Copyright Holder"
+        contentnode.save()
+
+        with tempfile.NamedTemporaryFile(suffix=".csv") as tempf:
+            write_user_csv(self.user, path=tempf.name)
+
+            with io.open(tempf.name, "r", encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file, delimiter=","))
+
+        self.assertTrue(rows)
+        row = rows[0]
+        self.assertEqual(row["Channel"], self.channel.name)
+        self.assertEqual(row["Title"], "CSV Content Title")
+        self.assertEqual(row["Filename"], "sample-video.mp4")
+        self.assertEqual(row["Description"], "CSV Description")
+        self.assertEqual(row["Author"], "CSV Author")
+        self.assertEqual(row["Language"], "French")
+        self.assertEqual(row["License Description"], "CSV License Description")
+        self.assertEqual(row["Copyright Holder"], "CSV Copyright Holder")
+
+    def test_user_csv_export_reports_staged_files(self):
+        self.user.staged_files.create(checksum="stagedchecksum", file_size=2048)
+
+        with tempfile.NamedTemporaryFile(suffix=".csv") as tempf:
+            write_user_csv(self.user, path=tempf.name)
+
+            with io.open(tempf.name, "r", encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file, delimiter=","))
+
+        staged_rows = [row for row in rows if row["Filename"] == "Staged File"]
+        self.assertEqual(len(staged_rows), 1)
+        staged_row = staged_rows[0]
+        self.assertEqual(staged_row["Channel"], "No Channel")
+        self.assertEqual(staged_row["Title"], "No Resource")
+        self.assertEqual(staged_row["File Size"], _format_size(2048))
+        self.assertEqual(staged_row["URL"], "")
 
 
 class UserEffectiveDiskSpaceTest(StudioTestCase):

--- a/contentcuration/contentcuration/tests/test_user.py
+++ b/contentcuration/contentcuration/tests/test_user.py
@@ -218,6 +218,27 @@ class UserAccountTestCase(BaseAPITestCase):
         self.assertEqual(staged_row["File Size"], _format_size(2048))
         self.assertEqual(staged_row["URL"], "")
 
+    def test_user_csv_export_includes_files_without_contentnode(self):
+        file_without_contentnode = fileobj_video()
+        self.assertIsNone(file_without_contentnode.contentnode_id)
+        file_without_contentnode.uploaded_by = self.user
+        file_without_contentnode.original_filename = "no-contentnode.mp4"
+        file_without_contentnode.save()
+
+        with tempfile.NamedTemporaryFile(suffix=".csv") as tempf:
+            write_user_csv(self.user, path=tempf.name)
+
+            with io.open(tempf.name, "r", encoding="utf-8") as csv_file:
+                rows = list(csv.DictReader(csv_file, delimiter=","))
+
+        row = next(
+            row
+            for row in rows
+            if row["Filename"] == file_without_contentnode.original_filename
+        )
+        self.assertEqual(row["Title"], "No resource")
+        self.assertEqual(row["Channel"], "No Channel")
+
 
 class UserEffectiveDiskSpaceTest(StudioTestCase):
     def setUp(self):

--- a/contentcuration/contentcuration/utils/csv_writer.py
+++ b/contentcuration/contentcuration/utils/csv_writer.py
@@ -6,13 +6,17 @@ import sys
 
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.db.models import Exists
+from django.db.models import F
 from django.db.models import OuterRef
-from django.db.models import Q
 from django.db.models import Subquery
+from django.db.models.sql.constants import LOUTER
 from django.utils.translation import gettext as _
 from le_utils.constants import content_kinds
 
+from contentcuration.db.models.query import With
 from contentcuration.models import Channel
+from contentcuration.models import ContentNode
 from contentcuration.models import generate_storage_url
 
 if not os.path.exists(settings.CSV_ROOT):
@@ -43,29 +47,24 @@ def generate_user_csv_filename(user):
 
 
 def _write_user_row(file, writer, domain):
-    filename = "{}.{}".format(file["checksum"], file["file_format__extension"])
+    filename = "{}.{}".format(file["checksum"], file["file_extension"])
     writer.writerow(
         [
             file["channel_name"] or _("No Channel"),
-            file["contentnode__title"] or _("No resource"),
+            file["node_title"] or _("No resource"),
             next(
-                (
-                    k[1]
-                    for k in content_kinds.choices
-                    if k[0] == file["contentnode__kind_id"]
-                ),
+                (k[1] for k in content_kinds.choices if k[0] == file["node_kind_id"]),
                 "",
             ),
             file["original_filename"],
             _format_size(file["file_size"] or 0),
             generate_storage_url(filename),
-            file["contentnode__description"],
-            file["contentnode__author"],
-            file["language__readable_name"]
-            or file["contentnode__language__readable_name"],
-            file["contentnode__license__license_name"],
-            file["contentnode__license_description"],
-            file["contentnode__copyright_holder"],
+            file["node_description"],
+            file["node_author"],
+            file["file_language"] or file["node_language"],
+            file["node_license_name"],
+            file["node_license_description"],
+            file["node_copyright_holder"],
         ]
     )
 
@@ -100,34 +99,105 @@ def write_user_csv(user, path=None):
 
         domain = Site.objects.get(pk=1).domain
 
-        # Get all user files
-        channel_query = Channel.objects.filter(
-            Q(main_tree__tree_id=OuterRef("contentnode__tree_id"))
-            | Q(trash_tree__tree_id=OuterRef("contentnode__tree_id"))
+        # Build CTEs so we first reduce to this user's files, then resolve only
+        # needed content node and channel fields.
+        user_files_cte = With(
+            user.files.values(
+                "id",
+                "contentnode_id",
+                "original_filename",
+                "file_size",
+                "checksum",
+                file_extension=F("file_format__extension"),
+                file_language=F("language__readable_name"),
+            ),
+            name="user_files",
+        )
+
+        content_nodes_cte = With(
+            user_files_cte.join(
+                ContentNode.objects.all(),
+                id=user_files_cte.col.contentnode_id,
+            )
+            .values(
+                "id",
+                "tree_id",
+                node_title=F("title"),
+                node_kind_id=F("kind_id"),
+                node_description=F("description"),
+                node_author=F("author"),
+                node_language=F("language__readable_name"),
+                node_license_name=F("license__license_name"),
+                node_license_description=F("license_description"),
+                node_copyright_holder=F("copyright_holder"),
+            )
+            .distinct(),
+            name="content_nodes",
+        )
+
+        main_channel_names = Channel.objects.filter(
+            Exists(
+                content_nodes_cte.queryset().filter(
+                    tree_id=OuterRef("main_tree__tree_id")
+                )
+            )
+        ).values(
+            tree_id=F("main_tree__tree_id"),
+            channel_name=F("name"),
+        )
+        trash_channel_names = Channel.objects.filter(
+            Exists(
+                content_nodes_cte.queryset().filter(
+                    tree_id=OuterRef("trash_tree__tree_id")
+                )
+            )
+        ).values(
+            tree_id=F("trash_tree__tree_id"),
+            channel_name=F("name"),
+        )
+        channel_names_cte = With(
+            main_channel_names.union(trash_channel_names), name="channel_names"
         )
 
         user_files = (
-            user.files.select_related("language", "contentnode", "file_format")
+            content_nodes_cte.join(
+                user_files_cte.queryset(),
+                contentnode_id=content_nodes_cte.col.id,
+                _join_type=LOUTER,
+            )
+            .with_cte(user_files_cte)
+            .with_cte(content_nodes_cte)
+            .with_cte(channel_names_cte)
             .annotate(
-                channel_name=Subquery(channel_query.values_list("name", flat=True)[:1])
+                channel_name=Subquery(
+                    channel_names_cte.queryset()
+                    .filter(tree_id=content_nodes_cte.col.tree_id)
+                    .values("channel_name")[:1]
+                ),
+                node_title=content_nodes_cte.col.node_title,
+                node_kind_id=content_nodes_cte.col.node_kind_id,
+                node_description=content_nodes_cte.col.node_description,
+                node_author=content_nodes_cte.col.node_author,
+                node_language=content_nodes_cte.col.node_language,
+                node_license_name=content_nodes_cte.col.node_license_name,
+                node_license_description=content_nodes_cte.col.node_license_description,
+                node_copyright_holder=content_nodes_cte.col.node_copyright_holder,
             )
             .values(
                 "channel_name",
                 "original_filename",
                 "file_size",
                 "checksum",
-                "file_format__extension",
-                "language__readable_name",
-                "contentnode__title",
-                "contentnode__language__readable_name",
-                "contentnode__license__license_name",
-                "contentnode__kind_id",
-                "contentnode__description",
-                "contentnode__author",
-                "contentnode__provider",
-                "contentnode__aggregator",
-                "contentnode__license_description",
-                "contentnode__copyright_holder",
+                "file_extension",
+                "file_language",
+                "node_title",
+                "node_kind_id",
+                "node_description",
+                "node_author",
+                "node_language",
+                "node_license_name",
+                "node_license_description",
+                "node_copyright_holder",
             )
         )
         for file in user_files:


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->
- Targeting `hotfixes` for early deployment with next patch
- Adds regression test to ensure functionality before and after changes
- Optimizes export queries by using CTEs, avoiding large joins on big tables, and aligning filtering with indices

### Before
```sql
SELECT "contentcuration_file"."original_filename",
       "contentcuration_file"."file_size",
       "contentcuration_file"."checksum",
       "contentcuration_file"."file_format_id",
       "contentcuration_language"."readable_name",
       "contentcuration_contentnode"."title",
       T6."readable_name",
       "contentcuration_license"."license_name",
       "contentcuration_contentnode"."kind_id",
       "contentcuration_contentnode"."description",
       "contentcuration_contentnode"."author",
       "contentcuration_contentnode"."provider",
       "contentcuration_contentnode"."aggregator",
       "contentcuration_contentnode"."license_description",
       "contentcuration_contentnode"."copyright_holder",
       (
         SELECT U0."name"
         FROM "contentcuration_channel" U0
         LEFT OUTER JOIN "contentcuration_contentnode" U1 ON (U0."main_tree_id" = U1."id")
         LEFT OUTER JOIN "contentcuration_contentnode" U2 ON (U0."trash_tree_id" = U2."id")
         WHERE (
           U1."tree_id" = "contentcuration_contentnode"."tree_id"
           OR U2."tree_id" = "contentcuration_contentnode"."tree_id"
         )
         LIMIT 1
       ) AS "channel_name"
FROM "contentcuration_file"
LEFT OUTER JOIN "contentcuration_contentnode"
  ON ("contentcuration_file"."contentnode_id" = "contentcuration_contentnode"."id")
LEFT OUTER JOIN "contentcuration_language"
  ON ("contentcuration_file"."language_id" = "contentcuration_language"."id")
LEFT OUTER JOIN "contentcuration_language" T6
  ON ("contentcuration_contentnode"."language_id" = T6."id")
LEFT OUTER JOIN "contentcuration_license"
  ON ("contentcuration_contentnode"."license_id" = "contentcuration_license"."id")
WHERE "contentcuration_file"."uploaded_by_id" = 2512
;
```

```
Nested Loop Left Join  (cost=1647.96..149498236.05 rows=6723 width=1240) (actual time=265.645..104656.723 rows=676 loops=1)
  ->  Gather  (cost=1647.67..52382.00 rows=6723 width=611) (actual time=1.663..3.158 rows=676 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Hash Left Join  (cost=647.67..50709.70 rows=2801 width=611) (actual time=0.756..3.910 rows=225 loops=3)
              Hash Cond: (contentcuration_contentnode.license_id = contentcuration_license.id)
              ->  Hash Left Join  (cost=634.74..50689.24 rows=2801 width=497) (actual time=0.689..3.789 rows=225 loops=3)
                    Hash Cond: ((contentcuration_contentnode.language_id)::text = (t6.id)::text)
                    ->  Nested Loop Left Join  (cost=169.23..50216.38 rows=2801 width=282) (actual time=0.190..3.236 rows=225 loops=3)
                          ->  Parallel Bitmap Heap Scan on contentcuration_file  (cost=168.67..26240.80 rows=2801 width=99) (actual time=0.164..0.312 rows=225 loops=3)
                                Recheck Cond: (uploaded_by_id = 2512)
                                Heap Blocks: exact=1
                                ->  Bitmap Index Scan on contentcuration_file_4095e96b  (cost=0.00..166.99 rows=6723 width=0) (actual time=0.384..0.385 rows=676 loops=1)
                                      Index Cond: (uploaded_by_id = 2512)
                          ->  Index Scan using contentcuration_contentnode_pkey on contentcuration_contentnode  (cost=0.56..8.56 rows=1 width=249) (actual time=0.012..0.012 rows=1 loops=676)
                                Index Cond: ((id)::text = (contentcuration_file.contentnode_id)::text)
                    ->  Hash  (cost=403.56..403.56 rows=4956 width=264) (actual time=0.414..0.414 rows=289 loops=3)
                          Buckets: 8192  Batches: 1  Memory Usage: 78kB
                          ->  Seq Scan on contentcuration_language t6  (cost=0.00..403.56 rows=4956 width=264) (actual time=0.012..0.359 rows=289 loops=3)
              ->  Hash  (cost=11.30..11.30 rows=130 width=122) (actual time=0.029..0.030 rows=9 loops=3)
                    Buckets: 1024  Batches: 1  Memory Usage: 9kB
                    ->  Seq Scan on contentcuration_license  (cost=0.00..11.30 rows=130 width=122) (actual time=0.015..0.027 rows=9 loops=3)
  ->  Memoize  (cost=0.29..7.32 rows=1 width=264) (actual time=0.002..0.002 rows=0 loops=676)
        Cache Key: contentcuration_file.language_id
        Cache Mode: logical
        Hits: 672  Misses: 4  Evictions: 0  Overflows: 0  Memory Usage: 1kB
        ->  Index Scan using contentcuration_language_pkey on contentcuration_language  (cost=0.28..7.31 rows=1 width=264) (actual time=0.010..0.010 rows=1 loops=4)
              Index Cond: ((id)::text = (contentcuration_file.language_id)::text)
  SubPlan 1
    ->  Limit  (cost=1001.12..22228.92 rows=1 width=20) (actual time=154.795..154.800 rows=1 loops=676)
          ->  Nested Loop Left Join  (cost=1001.12..276962.46 rows=13 width=20) (actual time=154.542..154.547 rows=1 loops=676)
                Filter: ((u1.tree_id = contentcuration_contentnode.tree_id) OR (u2.tree_id = contentcuration_contentnode.tree_id))
                Rows Removed by Filter: 14337
                ->  Gather  (cost=1000.56..86995.63 rows=22263 width=57) (actual time=2.569..7.361 rows=14338 loops=676)
                      Workers Planned: 2
                      Workers Launched: 2
                      ->  Nested Loop Left Join  (cost=0.56..83769.33 rows=9276 width=57) (actual time=0.044..53.143 rows=5096 loops=2028)
                            ->  Parallel Seq Scan on contentcuration_channel u0  (cost=0.00..4757.76 rows=9276 width=86) (actual time=0.009..2.214 rows=5096 loops=2028)
                            ->  Index Scan using contentcuration_contentnode_pkey on contentcuration_contentnode u1  (cost=0.56..8.52 rows=1 width=37) (actual time=0.010..0.010 rows=1 loops=10334261)
                                  Index Cond: ((id)::text = (u0.main_tree_id)::text)
                ->  Index Scan using contentcuration_contentnode_pkey on contentcuration_contentnode u2  (cost=0.56..8.52 rows=1 width=37) (actual time=0.010..0.010 rows=1 loops=9692472)
                      Index Cond: ((id)::text = (u0.trash_tree_id)::text)
Planning Time: 7.173 ms
Execution Time: 104658.708 ms
```

### After
```sql
WITH RECURSIVE "user_files" AS (
  SELECT
    "contentcuration_file"."id",
    "contentcuration_file"."contentnode_id",
    "contentcuration_file"."original_filename",
    "contentcuration_file"."file_size",
    "contentcuration_file"."checksum",
    "contentcuration_file"."file_format_id" AS "file_extension",
    "contentcuration_language"."readable_name" AS "file_language"
  FROM "contentcuration_file"
  LEFT OUTER JOIN "contentcuration_language"
    ON ("contentcuration_file"."language_id" = "contentcuration_language"."id")
  WHERE "contentcuration_file"."uploaded_by_id" = 2512
),
"content_nodes" AS (
  SELECT DISTINCT
    "contentcuration_contentnode"."id",
    "contentcuration_contentnode"."tree_id",
    "contentcuration_contentnode"."title" AS "node_title",
    "contentcuration_contentnode"."kind_id" AS "node_kind_id",
    "contentcuration_contentnode"."description" AS "node_description",
    "contentcuration_contentnode"."author" AS "node_author",
    "contentcuration_language"."readable_name" AS "node_language",
    "contentcuration_license"."license_name" AS "node_license_name",
    "contentcuration_contentnode"."license_description" AS "node_license_description",
    "contentcuration_contentnode"."copyright_holder" AS "node_copyright_holder",
    "contentcuration_contentnode"."lft"
  FROM "contentcuration_contentnode"
  INNER JOIN "user_files"
    ON "contentcuration_contentnode"."id" = "user_files"."contentnode_id"
  LEFT OUTER JOIN "contentcuration_language"
    ON ("contentcuration_contentnode"."language_id" = "contentcuration_language"."id")
  LEFT OUTER JOIN "contentcuration_license"
    ON ("contentcuration_contentnode"."license_id" = "contentcuration_license"."id")
  ORDER BY "contentcuration_contentnode"."tree_id" ASC, "contentcuration_contentnode"."lft" ASC
),
"channel_names" AS (
  (SELECT
     "contentcuration_contentnode"."tree_id" AS "tree_id",
     "contentcuration_channel"."name" AS "channel_name"
   FROM "contentcuration_channel"
   LEFT OUTER JOIN "contentcuration_contentnode"
     ON ("contentcuration_channel"."main_tree_id" = "contentcuration_contentnode"."id")
   WHERE EXISTS (
     SELECT (1) AS "a"
     FROM "content_nodes" U0
     WHERE U0."tree_id" = "contentcuration_contentnode"."tree_id"
     LIMIT 1
   ))
  UNION
  (SELECT
     "contentcuration_contentnode"."tree_id" AS "tree_id",
     "contentcuration_channel"."name" AS "channel_name"
   FROM "contentcuration_channel"
   LEFT OUTER JOIN "contentcuration_contentnode"
     ON ("contentcuration_channel"."trash_tree_id" = "contentcuration_contentnode"."id")
   WHERE EXISTS (
     SELECT (1) AS "a"
     FROM "content_nodes" U0
     WHERE U0."tree_id" = "contentcuration_contentnode"."tree_id"
     LIMIT 1
   ))
)
SELECT
  "user_files"."original_filename",
  "user_files"."file_size",
  "user_files"."checksum",
  "user_files"."file_extension" AS "file_extension",
  "user_files"."file_language" AS "file_language",
  (
    SELECT U0."channel_name" AS "channel_name"
    FROM "channel_names" U0
    WHERE U0."tree_id" = "content_nodes"."tree_id"
    LIMIT 1
  ) AS "channel_name",
  "content_nodes"."node_title" AS "node_title",
  "content_nodes"."node_kind_id" AS "node_kind_id",
  "content_nodes"."node_description" AS "node_description",
  "content_nodes"."node_author" AS "node_author",
  "content_nodes"."node_language" AS "node_language",
  "content_nodes"."node_license_name" AS "node_license_name",
  "content_nodes"."node_license_description" AS "node_license_description",
  "content_nodes"."node_copyright_holder" AS "node_copyright_holder"
FROM "user_files"
LEFT OUTER JOIN "content_nodes"
  ON "user_files"."contentnode_id" = "content_nodes"."id";
```

```
Merge Left Join  (cost=68848.98..11664991211.38 rows=225994 width=4326) (actual time=45.839..389.574 rows=676 loops=1)
  Merge Cond: ((user_files.contentnode_id)::text = (content_nodes.id)::text)
  CTE user_files
    ->  Nested Loop Left Join  (cost=0.86..8143.55 rows=6723 width=347) (actual time=0.046..0.700 rows=676 loops=1)
          ->  Index Scan using contentcuration_file_4095e96b on contentcuration_file  (cost=0.57..7634.81 rows=6723 width=132) (actual time=0.031..0.377 rows=676 loops=1)
                Index Cond: (uploaded_by_id = 2512)
          ->  Memoize  (cost=0.29..3.63 rows=1 width=264) (actual time=0.000..0.000 rows=0 loops=676)
                Cache Key: contentcuration_file.language_id
                Cache Mode: logical
                Hits: 672  Misses: 4  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                ->  Index Scan using contentcuration_language_pkey on contentcuration_language  (cost=0.28..3.62 rows=1 width=264) (actual time=0.008..0.008 rows=1 loops=4)
                      Index Cond: ((id)::text = (contentcuration_file.language_id)::text)
  CTE content_nodes
    ->  Unique  (cost=59380.00..59581.69 rows=6723 width=579) (actual time=9.071..9.319 rows=513 loops=1)
          ->  Sort  (cost=59380.00..59396.81 rows=6723 width=579) (actual time=9.070..9.104 rows=668 loops=1)
                Sort Key: contentcuration_contentnode.tree_id, contentcuration_contentnode.lft, contentcuration_contentnode.id, contentcuration_contentnode.title, contentcuration_contentnode.kind_id, contentcuration_contentnode.description, contentcuration_contentnode.author, contentcuration_language_1.readable_name, contentcuration_license.license_name, contentcuration_contentnode.license_description, contentcuration_contentnode.copyright_holder
                Sort Method: quicksort  Memory: 125kB
                ->  Nested Loop Left Join  (cost=1.13..58952.59 rows=6723 width=579) (actual time=0.065..8.233 rows=668 loops=1)
                      ->  Nested Loop Left Join  (cost=0.85..58718.56 rows=6723 width=465) (actual time=0.050..7.963 rows=668 loops=1)
                            ->  Nested Loop  (cost=0.56..57680.99 rows=6723 width=250) (actual time=0.036..7.680 rows=668 loops=1)
                                  ->  CTE Scan on user_files user_files_1  (cost=0.00..134.46 rows=6723 width=82) (actual time=0.001..0.108 rows=676 loops=1)
                                  ->  Index Scan using contentcuration_contentnode_pkey on contentcuration_contentnode  (cost=0.56..8.56 rows=1 width=250) (actual time=0.011..0.011 rows=1 loops=676)
                                        Index Cond: ((id)::text = (user_files_1.contentnode_id)::text)
                            ->  Memoize  (cost=0.29..7.08 rows=1 width=264) (actual time=0.000..0.000 rows=0 loops=668)
                                  Cache Key: contentcuration_contentnode.language_id
                                  Cache Mode: logical
                                  Hits: 661  Misses: 7  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                                  ->  Index Scan using contentcuration_language_pkey on contentcuration_language contentcuration_language_1  (cost=0.28..7.07 rows=1 width=264) (actual time=0.005..0.006 rows=1 loops=7)
                                        Index Cond: ((id)::text = (contentcuration_contentnode.language_id)::text)
                      ->  Memoize  (cost=0.28..6.70 rows=1 width=122) (actual time=0.000..0.000 rows=1 loops=668)
                            Cache Key: contentcuration_contentnode.license_id
                            Cache Mode: logical
                            Hits: 659  Misses: 9  Evictions: 0  Overflows: 0  Memory Usage: 2kB
                            ->  Index Scan using contentcuration_license_pkey on contentcuration_license  (cost=0.27..6.69 rows=1 width=122) (actual time=0.003..0.003 rows=1 loops=9)
                                  Index Cond: (id = contentcuration_contentnode.license_id)
  ->  Sort  (cost=561.87..578.68 rows=6723 width=1434) (actual time=1.937..2.175 rows=676 loops=1)
        Sort Key: user_files.contentnode_id
        Sort Method: quicksort  Memory: 106kB
        ->  CTE Scan on user_files  (cost=0.00..134.46 rows=6723 width=1434) (actual time=0.048..1.096 rows=676 loops=1)
  ->  Sort  (cost=561.87..578.68 rows=6723 width=2642) (actual time=10.121..10.337 rows=668 loops=1)
        Sort Key: content_nodes.id
        Sort Method: quicksort  Memory: 103kB
        ->  CTE Scan on content_nodes  (cost=0.00..134.46 rows=6723 width=2642) (actual time=9.075..9.477 rows=513 loops=1)
  SubPlan 3
    ->  Limit  (cost=51616.04..51616.06 rows=1 width=418) (actual time=0.556..0.556 rows=1 loops=676)
          ->  Subquery Scan on u0  (cost=51616.04..51616.32 rows=14 width=418) (actual time=0.555..0.555 rows=1 loops=676)
                ->  HashAggregate  (cost=51616.04..51616.18 rows=14 width=422) (actual time=0.555..0.555 rows=1 loops=676)
                      Group Key: contentcuration_contentnode_1.tree_id, contentcuration_channel.name
                      Batches: 1  Memory Usage: 24kB
                      ->  Append  (cost=5166.48..51615.97 rows=14 width=422) (actual time=0.240..0.554 rows=1 loops=676)
                            ->  Nested Loop Semi Join  (cost=5166.48..25807.95 rows=7 width=24) (actual time=0.187..0.308 rows=1 loops=676)
                                  ->  Hash Join  (cost=5166.48..25656.43 rows=7 width=24) (actual time=0.177..0.298 rows=1 loops=676)
                                        Hash Cond: ((contentcuration_contentnode_1.id)::text = (contentcuration_channel.main_tree_id)::text)
                                        ->  Index Scan using contentcuration_contentnode_656442a0 on contentcuration_contentnode contentcuration_contentnode_1  (cost=0.56..20472.98 rows=4655 width=37) (actual time=0.006..0.198 rows=395 loops=676)
                                              Index Cond: (tree_id = content_nodes.tree_id)
                                        ->  Hash  (cost=4887.63..4887.63 rows=22263 width=53) (actual time=15.487..15.488 rows=22269 loops=1)
                                              Buckets: 32768  Batches: 1  Memory Usage: 2111kB
                                              ->  Seq Scan on contentcuration_channel  (cost=0.00..4887.63 rows=22263 width=53) (actual time=0.013..10.393 rows=22269 loops=1)
                                  ->  CTE Scan on content_nodes u0_1  (cost=0.00..151.27 rows=34 width=4) (actual time=0.014..0.014 rows=1 loops=459)
                                        Filter: (tree_id = content_nodes.tree_id)
                                        Rows Removed by Filter: 182
                            ->  Nested Loop Semi Join  (cost=5166.48..25807.95 rows=7 width=24) (actual time=0.230..0.246 rows=0 loops=676)
                                  ->  Hash Join  (cost=5166.48..25656.43 rows=7 width=24) (actual time=0.225..0.241 rows=0 loops=676)
                                        Hash Cond: ((contentcuration_contentnode_2.id)::text = (contentcuration_channel_1.trash_tree_id)::text)
                                        ->  Index Scan using contentcuration_contentnode_656442a0 on contentcuration_contentnode contentcuration_contentnode_2  (cost=0.56..20472.98 rows=4655 width=37) (actual time=0.004..0.146 rows=395 loops=676)
                                              Index Cond: (tree_id = content_nodes.tree_id)
                                        ->  Hash  (cost=4887.63..4887.63 rows=22263 width=53) (actual time=14.815..14.816 rows=22269 loops=1)
                                              Buckets: 32768  Batches: 1  Memory Usage: 2111kB
                                              ->  Seq Scan on contentcuration_channel contentcuration_channel_1  (cost=0.00..4887.63 rows=22263 width=53) (actual time=0.013..10.075 rows=22269 loops=1)
                                  ->  CTE Scan on content_nodes u0_2  (cost=0.00..151.27 rows=34 width=4) (actual time=0.033..0.033 rows=1 loops=90)
                                        Filter: (tree_id = content_nodes.tree_id)
                                        Rows Removed by Filter: 342
Planning Time: 7.400 ms
Execution Time: 390.302 ms

```

## References
<!--
 * references to related issues and PRs
-->
closes https://github.com/learningequality/studio/issues/5954

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Directed AI to tackle this issue by first writing the regression tests and capturing the original raw SQL. Then allowed the AI to optimize it by instructing how to break the overall query down. Then humanly further optimized the CTE query after its completion. Ran the `EXPLAIN ANALYZE` on production.