### PR TITLE
feat: implement QTI interaction registry, descriptor validation, and XML parsing logic for the QTI Editor.

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/QTIDemoPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/QTIDemoPage.vue
@@ -30,7 +30,7 @@
   import { ref, defineComponent } from 'vue';
   import { CHOICE_ITEM_XML, MULTI_CHOICE_ITEM_XML } from './qtiDemoData';
   import QTIEditor from 'shared/views/QTIEditor/index';
-  import { QtiInteraction } from 'shared/views/QTIEditor/constants';
+  import { AssessmentItemTypes } from 'shared/views/QTIEditor/constants';
 
   /**
    * Hardcoded items covering different states:
@@ -40,26 +40,22 @@
    */
   const INITIAL_ASSESSMENTS = [
     {
-      id: 'demo-item-1',
-      type: QtiInteraction.CHOICE,
-      title: 'Which planet is closest to the Sun?',
+      assessment_id: 'demo-item-1',
+      type: AssessmentItemTypes.QTI,
       raw_data: CHOICE_ITEM_XML,
     },
     {
-      id: 'demo-item-2',
-      type: QtiInteraction.CHOICE,
-      title: 'Select all the prime numbers.',
+      assessment_id: 'demo-item-2',
+      type: AssessmentItemTypes.QTI,
       raw_data: MULTI_CHOICE_ITEM_XML,
     },
     {
-      id: 'demo-item-3',
-      type: QtiInteraction.EXTENDED_TEXT,
-      title: 'Describe the water cycle in your own words.',
+      assessment_id: 'demo-item-3',
+      type: AssessmentItemTypes.QTI,
     },
     {
-      id: 'demo-item-4',
-      type: QtiInteraction.ORDER,
-      title: 'Arrange these events in chronological order.',
+      assessment_id: 'demo-item-4',
+      type: AssessmentItemTypes.QTI,
     },
   ];
 

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/QTIDemoPage.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/QTIDemoPage.vue
@@ -3,13 +3,13 @@
   <div>
     <div style="padding: 16px 24px 0">
       <div
-        style="
-  padding: 16px;
-  color: #2196f3;
-  background-color: transparent;
-  border: 1px solid #2196f3;
-  border-radius: 4px;
-        "
+        :style="{
+          padding: '16px',
+          color: $themePalette.blue.v_600,
+          backgroundColor: 'transparent',
+          border: `1px solid ${$themePalette.blue.v_600}`,
+          borderRadius: '4px',
+        }"
       >
         <strong>QTI Editor — Dev Demo</strong>
         &nbsp;Hardcoded items. Changes are local only and not persisted.
@@ -28,26 +28,36 @@
 <script>
 
   import { ref, defineComponent } from 'vue';
+  import { CHOICE_ITEM_XML, MULTI_CHOICE_ITEM_XML } from './qtiDemoData';
   import QTIEditor from 'shared/views/QTIEditor/index';
   import { QtiInteraction } from 'shared/views/QTIEditor/constants';
 
   /**
-   * Hardcoded items covering three interaction types so the closed-card
-   * type label can be visually verified.
+   * Hardcoded items covering different states:
+   *  - item-1: has raw_data (real QTI XML) → exercises the full load path
+   *  - item-2: no raw_data → shows placeholder (blank new item state)
+   *  - item-3: no raw_data → shows placeholder
    */
   const INITIAL_ASSESSMENTS = [
     {
       id: 'demo-item-1',
       type: QtiInteraction.CHOICE,
       title: 'Which planet is closest to the Sun?',
+      raw_data: CHOICE_ITEM_XML,
     },
     {
       id: 'demo-item-2',
+      type: QtiInteraction.CHOICE,
+      title: 'Select all the prime numbers.',
+      raw_data: MULTI_CHOICE_ITEM_XML,
+    },
+    {
+      id: 'demo-item-3',
       type: QtiInteraction.EXTENDED_TEXT,
       title: 'Describe the water cycle in your own words.',
     },
     {
-      id: 'demo-item-3',
+      id: 'demo-item-4',
       type: QtiInteraction.ORDER,
       title: 'Arrange these events in chronological order.',
     },

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/qtiDemoData.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/qtiDemoData.js
@@ -1,0 +1,76 @@
+/**
+ * Demo item 1: a real choice interaction XML so the full load path can
+ * be verified end-to-end (parseItem → useQtiItem → InteractionSection →
+ * ChoiceInteractionEditor).
+ */
+export const CHOICE_ITEM_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item
+  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+  identifier="item-1"
+  title="Which planet is closest to the Sun?"
+  adaptive="false"
+  time-dependent="false"
+  xml:lang="en"
+>
+  <qti-response-declaration
+    identifier="RESPONSE"
+    cardinality="single"
+    base-type="identifier"
+  >
+    <qti-correct-response>
+      <qti-value>mercury</qti-value>
+    </qti-correct-response>
+  </qti-response-declaration>
+
+  <qti-item-body>
+    <qti-choice-interaction
+      response-identifier="RESPONSE"
+      max-choices="1"
+    >
+      <qti-prompt>Which planet is closest to the Sun?</qti-prompt>
+      <qti-simple-choice identifier="mercury">Mercury</qti-simple-choice>
+      <qti-simple-choice identifier="venus">Venus</qti-simple-choice>
+      <qti-simple-choice identifier="earth">Earth</qti-simple-choice>
+      <qti-simple-choice identifier="mars">Mars</qti-simple-choice>
+    </qti-choice-interaction>
+  </qti-item-body>
+</qti-assessment-item>`;
+
+/**
+ * Demo item 2: a multi-select choice interaction XML (max-choices > 1).
+ */
+export const MULTI_CHOICE_ITEM_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item
+  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+  identifier="item-2"
+  title="Select all the prime numbers."
+  adaptive="false"
+  time-dependent="false"
+  xml:lang="en"
+>
+  <qti-response-declaration
+    identifier="RESPONSE"
+    cardinality="multiple"
+    base-type="identifier"
+  >
+    <qti-correct-response>
+      <qti-value>two</qti-value>
+      <qti-value>three</qti-value>
+      <qti-value>five</qti-value>
+    </qti-correct-response>
+  </qti-response-declaration>
+
+  <qti-item-body>
+    <qti-choice-interaction
+      response-identifier="RESPONSE"
+      max-choices="4"
+    >
+      <qti-prompt>Select all the prime numbers.</qti-prompt>
+      <qti-simple-choice identifier="one">1</qti-simple-choice>
+      <qti-simple-choice identifier="two">2</qti-simple-choice>
+      <qti-simple-choice identifier="three">3</qti-simple-choice>
+      <qti-simple-choice identifier="four">4</qti-simple-choice>
+      <qti-simple-choice identifier="five">5</qti-simple-choice>
+    </qti-choice-interaction>
+  </qti-item-body>
+</qti-assessment-item>`;

--- a/contentcuration/contentcuration/frontend/channelEdit/pages/qtiDemoData.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/qtiDemoData.js
@@ -1,3 +1,5 @@
+import { AssessmentItemTypes } from 'shared/views/QTIEditor/constants';
+
 /**
  * Demo item 1: a real choice interaction XML so the full load path can
  * be verified end-to-end (parseItem → useQtiItem → InteractionSection →
@@ -74,3 +76,26 @@ export const MULTI_CHOICE_ITEM_XML = `<?xml version="1.0" encoding="UTF-8"?>
     </qti-choice-interaction>
   </qti-item-body>
 </qti-assessment-item>`;
+
+/**
+ * Hardcoded items covering different states:
+ *  - item-1: has raw_data (real QTI XML) → exercises the full load path
+ *  - item-2: no raw_data → shows placeholder (blank new item state)
+ *  - item-3: no raw_data → shows placeholder
+ */
+export const INITIAL_ASSESSMENTS = [
+  {
+    assessment_id: 'demo-item-1',
+    type: AssessmentItemTypes.QTI,
+    raw_data: CHOICE_ITEM_XML,
+  },
+  {
+    assessment_id: 'demo-item-2',
+    type: AssessmentItemTypes.QTI,
+    raw_data: MULTI_CHOICE_ITEM_XML,
+  },
+  {
+    assessment_id: 'demo-item-3',
+    type: AssessmentItemTypes.QTI,
+  },
+];

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/__tests__/InteractionSection.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/__tests__/InteractionSection.spec.js
@@ -5,7 +5,7 @@ import InteractionSection from '../index.vue';
 import {
   CHOICE_SINGLE_SELECT_XML,
   UNKNOWN_INTERACTION_XML,
-  mockInteractionBlock as block,
+  mockInteractionBlock as interactionBlock,
 } from '../../../utils/testingFixtures';
 
 const renderSection = (props = {}) =>
@@ -21,18 +21,18 @@ const renderSection = (props = {}) =>
 describe('InteractionSection', () => {
   describe('choice interaction', () => {
     it('renders the prompt from the XML via ChoiceInteractionEditor', () => {
-      renderSection({ block: block(CHOICE_SINGLE_SELECT_XML) });
+      renderSection({ interaction: interactionBlock(CHOICE_SINGLE_SELECT_XML) });
       expect(screen.getByText('Which planet is closest to the Sun?')).toBeInTheDocument();
     });
 
     it('renders radio buttons for a single-select choice interaction', () => {
-      renderSection({ block: block(CHOICE_SINGLE_SELECT_XML) });
+      renderSection({ interaction: interactionBlock(CHOICE_SINGLE_SELECT_XML) });
       const radios = screen.getAllByRole('radio');
       expect(radios).toHaveLength(3);
     });
 
     it('renders the choice labels', () => {
-      renderSection({ block: block(CHOICE_SINGLE_SELECT_XML) });
+      renderSection({ interaction: interactionBlock(CHOICE_SINGLE_SELECT_XML) });
       expect(screen.getByText('Mercury')).toBeInTheDocument();
       expect(screen.getByText('Venus')).toBeInTheDocument();
     });
@@ -40,7 +40,7 @@ describe('InteractionSection', () => {
 
   describe('parse error handling', () => {
     it('shows a parse error message and no interaction when XML is malformed', () => {
-      renderSection({ block: block('not-xml<{{') });
+      renderSection({ interaction: interactionBlock('not-xml<{{') });
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
       // At minimum no interactive elements render
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
@@ -51,7 +51,9 @@ describe('InteractionSection', () => {
   describe('unknown interaction type', () => {
     it('falls back silently when the interaction tag is unrecognized', () => {
       // Should not throw — just renders the fallback component
-      expect(() => renderSection({ block: block(UNKNOWN_INTERACTION_XML) })).not.toThrow();
+      expect(() =>
+        renderSection({ interaction: interactionBlock(UNKNOWN_INTERACTION_XML) }),
+      ).not.toThrow();
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/__tests__/InteractionSection.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/__tests__/InteractionSection.spec.js
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import InteractionSection from '../index.vue';
+
+import {
+  CHOICE_SINGLE_SELECT_XML,
+  UNKNOWN_INTERACTION_XML,
+  mockInteractionBlock as block,
+} from '../../../utils/testingFixtures';
+
+const renderSection = (props = {}) =>
+  render(InteractionSection, {
+    props: { mode: 'edit', ...props },
+    routes: new VueRouter(),
+  });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('InteractionSection', () => {
+  describe('choice interaction', () => {
+    it('renders the prompt from the XML via ChoiceInteractionEditor', () => {
+      renderSection({ block: block(CHOICE_SINGLE_SELECT_XML) });
+      expect(screen.getByText('Which planet is closest to the Sun?')).toBeInTheDocument();
+    });
+
+    it('renders radio buttons for a single-select choice interaction', () => {
+      renderSection({ block: block(CHOICE_SINGLE_SELECT_XML) });
+      const radios = screen.getAllByRole('radio');
+      expect(radios).toHaveLength(3);
+    });
+
+    it('renders the choice labels', () => {
+      renderSection({ block: block(CHOICE_SINGLE_SELECT_XML) });
+      expect(screen.getByText('Mercury')).toBeInTheDocument();
+      expect(screen.getByText('Venus')).toBeInTheDocument();
+    });
+  });
+
+  describe('parse error handling', () => {
+    it('shows a parse error message and no interaction when XML is malformed', () => {
+      renderSection({ block: block('not-xml<{{') });
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+      // At minimum no interactive elements render
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('unknown interaction type', () => {
+    it('falls back silently when the interaction tag is unrecognized', () => {
+      // Should not throw — just renders the fallback component
+      expect(() => renderSection({ block: block(UNKNOWN_INTERACTION_XML) })).not.toThrow();
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/__tests__/InteractionSection.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/__tests__/InteractionSection.spec.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/vue';
+import { nextTick } from 'vue';
 import VueRouter from 'vue-router';
 import InteractionSection from '../index.vue';
 
@@ -25,8 +26,9 @@ describe('InteractionSection', () => {
       expect(screen.getByText('Which planet is closest to the Sun?')).toBeInTheDocument();
     });
 
-    it('renders radio buttons for a single-select choice interaction', () => {
+    it('renders radio buttons for a single-select choice interaction', async () => {
       renderSection({ interaction: interactionBlock(CHOICE_SINGLE_SELECT_XML) });
+      await nextTick();
       const radios = screen.getAllByRole('radio');
       expect(radios).toHaveLength(3);
     });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/index.vue
@@ -12,8 +12,9 @@
       v-else
       :key="descriptor.type"
       :questionType="questionType"
-      :block="block"
+      :interaction="interaction"
       :mode="mode"
+      :showAnswers="showAnswers"
     />
   </div>
 
@@ -22,22 +23,30 @@
 
 <script>
 
-  import { computed } from 'vue';
+  import { computed, watch } from 'vue';
   import useInteractionDescriptor from '../../composables/useInteractionDescriptor';
 
   export default {
     name: 'InteractionSection',
 
-    setup(props) {
-      const bodyXmlRef = computed(() => props.block.bodyXml);
+    setup(props, { emit }) {
+      const bodyXmlRef = computed(() => props.interaction?.bodyXml);
       const { descriptor, questionType, parseError } = useInteractionDescriptor(bodyXmlRef);
+
+      watch(
+        questionType,
+        newType => {
+          if (newType) emit('update:questionType', newType);
+        },
+        { immediate: true },
+      );
 
       return { descriptor, questionType, parseError };
     },
 
     props: {
       /** The raw XML block representing an interaction and its response declarations */
-      block: {
+      interaction: {
         type: Object,
         required: true,
       },
@@ -46,7 +55,14 @@
         type: String,
         default: 'view',
       },
+      /** Whether to display correct answers (used in view mode previews) */
+      showAnswers: {
+        type: Boolean,
+        default: false,
+      },
     },
+
+    emits: ['update:questionType'],
   };
 
 </script>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/index.vue
@@ -1,0 +1,52 @@
+<template>
+
+  <div>
+    <p
+      v-if="parseError"
+      :style="{ color: $themePalette.red.v_700, margin: 0 }"
+    >
+      {{ parseError }}
+    </p>
+    <component
+      :is="descriptor.editorComponent"
+      v-else
+      :key="descriptor.type"
+      :questionType="questionType"
+      :block="block"
+      :mode="mode"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed } from 'vue';
+  import useInteractionDescriptor from '../../composables/useInteractionDescriptor';
+
+  export default {
+    name: 'InteractionSection',
+
+    setup(props) {
+      const bodyXmlRef = computed(() => props.block.bodyXml);
+      const { descriptor, questionType, parseError } = useInteractionDescriptor(bodyXmlRef);
+
+      return { descriptor, questionType, parseError };
+    },
+
+    props: {
+      /** The raw XML block representing an interaction and its response declarations */
+      block: {
+        type: Object,
+        required: true,
+      },
+      /** View or edit mode */
+      mode: {
+        type: String,
+        default: 'view',
+      },
+    },
+  };
+
+</script>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/InteractionSection/index.vue
@@ -45,15 +45,20 @@
     },
 
     props: {
-      /** The raw XML block representing an interaction and its response declarations */
+      /**
+       * The raw interaction block.
+       * Expected shape: { bodyXml: string, responseDeclarations: string[] }
+       */
       interaction: {
         type: Object,
         required: true,
+        validator: val => typeof val.bodyXml === 'string',
       },
       /** View or edit mode */
       mode: {
         type: String,
         default: 'view',
+        validator: val => ['view', 'edit'].includes(val),
       },
       /** Whether to display correct answers (used in view mode previews) */
       showAnswers: {

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
@@ -28,9 +28,9 @@ const renderComponent = (props = {}, slots = {}) => {
 
 describe('QTIItemEditor', () => {
   describe('view mode', () => {
-    test('does not show the card body', () => {
+    test('shows the card body (placeholder) even in view mode', () => {
       renderComponent({ mode: 'view' });
-      expect(screen.queryByText(questionContentPlaceholder$())).not.toBeInTheDocument();
+      expect(screen.getByText(questionContentPlaceholder$())).toBeInTheDocument();
     });
 
     test('does not show the close button', () => {

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
@@ -15,7 +15,7 @@ const defaultProps = {
   index: 0,
   total: 5,
   mode: 'view',
-  displayAnswersPreview: false,
+  showAnswers: false,
 };
 
 const renderComponent = (props = {}, slots = {}) => {
@@ -57,14 +57,14 @@ describe('QTIItemEditor', () => {
     });
   });
 
-  describe('displayAnswersPreview', () => {
-    test('shows the card body in view mode when displayAnswersPreview is true', () => {
-      renderComponent({ mode: 'view', displayAnswersPreview: true });
+  describe('showAnswers', () => {
+    test('shows the card body in view mode when showAnswers is true', () => {
+      renderComponent({ mode: 'view', showAnswers: true });
       expect(screen.getByText(questionContentPlaceholder$())).toBeInTheDocument();
     });
 
-    test('does not show the close button even when displayAnswersPreview is true', () => {
-      renderComponent({ mode: 'view', displayAnswersPreview: true });
+    test('does not show the close button even when showAnswers is true', () => {
+      renderComponent({ mode: 'view', showAnswers: true });
       expect(screen.queryByRole('button', { name: closeBtnLabel$() })).not.toBeInTheDocument();
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/__tests__/QTIItemEditor.spec.js
@@ -2,15 +2,14 @@ import { render, screen, fireEvent } from '@testing-library/vue';
 import VueRouter from 'vue-router';
 import QTIItemEditor from '../index.vue';
 import { qtiEditorStrings } from '../../../qtiEditorStrings';
-import { QtiInteraction } from '../../../constants';
+import { AssessmentItemTypes } from '../../../constants';
 
 const { closeBtnLabel$, questionContentPlaceholder$ } = qtiEditorStrings;
 
 const defaultProps = {
   item: {
-    id: 'test-item-id',
-    type: QtiInteraction.CHOICE,
-    title: 'Test Choice Interaction',
+    assessment_id: 'test-item-id',
+    type: AssessmentItemTypes.QTI,
   },
   index: 0,
   total: 5,

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
@@ -61,7 +61,7 @@
 
   import { computed, ref } from 'vue';
   import { qtiEditorStrings } from '../../qtiEditorStrings';
-  import { AssessmentItemTypes, QuestionType } from '../../constants';
+  import { QuestionType } from '../../constants';
   import useQtiItem from '../../composables/useQtiItem';
   import InteractionSection from '../InteractionSection/index.vue';
 
@@ -76,7 +76,7 @@
         questionNumberAndTypeLabel$,
         closeBtnLabel$,
         questionContentPlaceholder$,
-        interactionTypeUnknown$,
+        unknownTypeLabel$,
       } = qtiEditorStrings;
 
       const { interactions } = useQtiItem(props.item.raw_data);
@@ -88,17 +88,25 @@
         }),
       );
 
-      const currentQuestionType = ref(props.item.type || AssessmentItemTypes.QTI);
+      /**
+       * Tracks the current question type (a QuestionType value).
+       * Initialized to null — populated via the update:questionType event
+       * emitted by InteractionSection once the XML is parsed on mount.
+       */
+      const currentQuestionType = ref(null);
 
-      const interactionTypeLabel = computed(() => {
-        if (currentQuestionType.value === QuestionType.SINGLE_SELECT) {
-          return qtiEditorStrings.interactionTypeSingleChoice$();
-        }
-        if (currentQuestionType.value === QuestionType.MULTI_SELECT) {
-          return qtiEditorStrings.interactionTypeMultipleChoice$();
-        }
-        return interactionTypeUnknown$();
-      });
+      /**
+       * Maps each QuestionType to its localized display label.
+       * Add new entries here as more question types are introduced.
+       */
+      const QUESTION_TYPE_LABELS = {
+        [QuestionType.SINGLE_SELECT]: () => qtiEditorStrings.singleChoiceLabel$(),
+        [QuestionType.MULTI_SELECT]: () => qtiEditorStrings.multipleChoiceLabel$(),
+      };
+
+      const interactionTypeLabel = computed(
+        () => QUESTION_TYPE_LABELS[currentQuestionType.value]?.() ?? unknownTypeLabel$(),
+      );
 
       const questionNumberAndTypeLabel = computed(() =>
         questionNumberAndTypeLabel$({

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
@@ -29,9 +29,10 @@
     <div class="question-card-body">
       <InteractionSection
         v-if="interactions.length > 0"
-        :block="interactions[0]"
+        :interaction="interactions[0]"
         :mode="mode"
-        :displayAnswersPreview="displayAnswersPreview"
+        :showAnswers="showAnswers"
+        @update:questionType="type => (currentQuestionType = type)"
       />
       <p
         v-else
@@ -58,22 +59,11 @@
 
 <script>
 
-  import { computed } from 'vue';
+  import { computed, ref } from 'vue';
   import { qtiEditorStrings } from '../../qtiEditorStrings';
-  import { QtiInteraction } from '../../constants';
-  import useInteractionDescriptor from '../../composables/useInteractionDescriptor';
+  import { AssessmentItemTypes, QuestionType } from '../../constants';
   import useQtiItem from '../../composables/useQtiItem';
   import InteractionSection from '../InteractionSection/index.vue';
-
-  // QTI interaction tag name → i18n string key, used for closed-card labels
-  // on items that have no raw_data yet (blank new items).
-  const INTERACTION_TYPE_STRING_KEY = {
-    [QtiInteraction.CHOICE]: 'interactionTypeSingleChoice', // defaults to single choice if no XML yet
-    [QtiInteraction.ORDER]: 'interactionTypeOrder',
-    [QtiInteraction.MATCH]: 'interactionTypeMatch',
-    [QtiInteraction.TEXT_ENTRY]: 'interactionTypeTextEntry',
-    [QtiInteraction.EXTENDED_TEXT]: 'interactionTypeExtendedText',
-  };
 
   export default {
     name: 'QTIItemEditor',
@@ -98,28 +88,16 @@
         }),
       );
 
-      const firstBlockXml = computed(() =>
-        interactions.value.length > 0 ? interactions.value[0].bodyXml : null,
-      );
-      const { descriptor, questionType } = useInteractionDescriptor(firstBlockXml);
+      const currentQuestionType = ref(props.item.type || AssessmentItemTypes.QTI);
 
-      /**
-       * Derives the type label for the closed-card header.
-       * When raw_data is present: parses the first interaction's bodyXml and uses
-       * the matching descriptor's label — this is the source of truth from the XML.
-       * When raw_data is absent (blank new items): falls back to item.type enum lookup.
-       */
       const interactionTypeLabel = computed(() => {
-        if (firstBlockXml.value) {
-          if (descriptor.value?.type === QtiInteraction.CHOICE) {
-            return questionType.value === 'singleSelect'
-              ? qtiEditorStrings.interactionTypeSingleChoice$()
-              : qtiEditorStrings.interactionTypeMultipleChoice$();
-          }
-          return descriptor.value ? descriptor.value.label : interactionTypeUnknown$();
+        if (currentQuestionType.value === QuestionType.SINGLE_SELECT) {
+          return qtiEditorStrings.interactionTypeSingleChoice$();
         }
-        const typeKey = INTERACTION_TYPE_STRING_KEY[props.item.type];
-        return typeKey ? qtiEditorStrings[`${typeKey}$`]() : interactionTypeUnknown$();
+        if (currentQuestionType.value === QuestionType.MULTI_SELECT) {
+          return qtiEditorStrings.interactionTypeMultipleChoice$();
+        }
+        return interactionTypeUnknown$();
       });
 
       const questionNumberAndTypeLabel = computed(() =>
@@ -131,6 +109,7 @@
       );
 
       return {
+        currentQuestionType,
         interactions,
         questionNumberLabel,
         questionNumberAndTypeLabel,
@@ -141,7 +120,7 @@
 
     props: {
       /**
-       * Assessment item: { id, type (QtiInteraction value), title, raw_data? }
+       * Assessment item: { assessment_id, type, raw_data? }
        * raw_data is the full QTI XML string; absent on blank newly-created items.
        */
       item: {
@@ -165,7 +144,7 @@
         validator: val => ['view', 'edit'].includes(val),
       },
       /** Whether to show answer previews for closed items */
-      displayAnswersPreview: {
+      showAnswers: {
         type: Boolean,
         default: false,
       },

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/components/QTIItemEditor/index.vue
@@ -26,11 +26,17 @@
       </div>
     </div>
 
-    <div
-      v-if="mode === 'edit' || displayAnswersPreview"
-      class="question-card-body"
-    >
-      <p :style="{ color: $themePalette.grey.v_500, margin: 0, fontStyle: 'italic' }">
+    <div class="question-card-body">
+      <InteractionSection
+        v-if="interactions.length > 0"
+        :block="interactions[0]"
+        :mode="mode"
+        :displayAnswersPreview="displayAnswersPreview"
+      />
+      <p
+        v-else
+        :style="{ color: $themePalette.grey.v_500, margin: 0, fontStyle: 'italic' }"
+      >
         {{ questionContentPlaceholder$() }}
       </p>
     </div>
@@ -55,10 +61,14 @@
   import { computed } from 'vue';
   import { qtiEditorStrings } from '../../qtiEditorStrings';
   import { QtiInteraction } from '../../constants';
+  import useInteractionDescriptor from '../../composables/useInteractionDescriptor';
+  import useQtiItem from '../../composables/useQtiItem';
+  import InteractionSection from '../InteractionSection/index.vue';
 
-  // QTI XML element name → i18n string key, used to build closed-card labels.
+  // QTI interaction tag name → i18n string key, used for closed-card labels
+  // on items that have no raw_data yet (blank new items).
   const INTERACTION_TYPE_STRING_KEY = {
-    [QtiInteraction.CHOICE]: 'interactionTypeChoice',
+    [QtiInteraction.CHOICE]: 'interactionTypeSingleChoice', // defaults to single choice if no XML yet
     [QtiInteraction.ORDER]: 'interactionTypeOrder',
     [QtiInteraction.MATCH]: 'interactionTypeMatch',
     [QtiInteraction.TEXT_ENTRY]: 'interactionTypeTextEntry',
@@ -67,6 +77,8 @@
 
   export default {
     name: 'QTIItemEditor',
+
+    components: { InteractionSection },
 
     setup(props) {
       const {
@@ -77,6 +89,8 @@
         interactionTypeUnknown$,
       } = qtiEditorStrings;
 
+      const { interactions } = useQtiItem(props.item.raw_data);
+
       const questionNumberLabel = computed(() =>
         questionNumberLabel$({
           number: props.index + 1,
@@ -84,17 +98,40 @@
         }),
       );
 
-      const questionNumberAndTypeLabel = computed(() => {
+      const firstBlockXml = computed(() =>
+        interactions.value.length > 0 ? interactions.value[0].bodyXml : null,
+      );
+      const { descriptor, questionType } = useInteractionDescriptor(firstBlockXml);
+
+      /**
+       * Derives the type label for the closed-card header.
+       * When raw_data is present: parses the first interaction's bodyXml and uses
+       * the matching descriptor's label — this is the source of truth from the XML.
+       * When raw_data is absent (blank new items): falls back to item.type enum lookup.
+       */
+      const interactionTypeLabel = computed(() => {
+        if (firstBlockXml.value) {
+          if (descriptor.value?.type === QtiInteraction.CHOICE) {
+            return questionType.value === 'singleSelect'
+              ? qtiEditorStrings.interactionTypeSingleChoice$()
+              : qtiEditorStrings.interactionTypeMultipleChoice$();
+          }
+          return descriptor.value ? descriptor.value.label : interactionTypeUnknown$();
+        }
         const typeKey = INTERACTION_TYPE_STRING_KEY[props.item.type];
-        const typeLabel = typeKey ? qtiEditorStrings[`${typeKey}$`]() : interactionTypeUnknown$();
-        return questionNumberAndTypeLabel$({
-          number: props.index + 1,
-          total: props.total,
-          type: typeLabel,
-        });
+        return typeKey ? qtiEditorStrings[`${typeKey}$`]() : interactionTypeUnknown$();
       });
 
+      const questionNumberAndTypeLabel = computed(() =>
+        questionNumberAndTypeLabel$({
+          number: props.index + 1,
+          total: props.total,
+          type: interactionTypeLabel.value,
+        }),
+      );
+
       return {
+        interactions,
         questionNumberLabel,
         questionNumberAndTypeLabel,
         closeBtnLabel$,
@@ -103,7 +140,10 @@
     },
 
     props: {
-      /** Assessment item: { id, type (QtiInteraction value), title } */
+      /**
+       * Assessment item: { id, type (QtiInteraction value), title, raw_data? }
+       * raw_data is the full QTI XML string; absent on blank newly-created items.
+       */
       item: {
         type: Object,
         required: true,
@@ -124,7 +164,7 @@
         default: 'view',
         validator: val => ['view', 'edit'].includes(val),
       },
-      /** Whether to show answers previews for closed items */
+      /** Whether to show answer previews for closed items */
       displayAnswersPreview: {
         type: Boolean,
         default: false,

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/__tests__/useInteractionDescriptor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/__tests__/useInteractionDescriptor.spec.js
@@ -11,9 +11,9 @@ import {
 } from '../../utils/testingFixtures';
 
 // ---------------------------------------------------------------------------
-// Helper: renders a wrapper component that runs the composable inside setup()
-// Returns { result, bodyXmlRef } — result holds the reactive return value,
-// bodyXmlRef can be mutated to test reactivity.
+// Helper: renders a wrapper component that runs the composable inside setup().
+// Because questionType is now set on mount (not as a computed), we must wait
+// for the component to mount before checking reactive values.
 // ---------------------------------------------------------------------------
 
 function renderDescriptor(initialXml = null) {
@@ -38,94 +38,97 @@ function renderDescriptor(initialXml = null) {
 
 describe('useInteractionDescriptor', () => {
   describe('with a valid choice interaction', () => {
-    it('resolves the Choice descriptor by its type', () => {
+    it('resolves the Choice descriptor by its type', async () => {
       const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      await nextTick();
       expect(result.descriptor.value.type).toBe(QtiInteraction.CHOICE);
     });
 
-    it('resolves questionType as singleSelect when max-choices is 1', () => {
+    it('resolves questionType as singleSelect when max-choices is 1', async () => {
       const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      await nextTick();
       expect(result.questionType.value).toBe(QuestionType.SINGLE_SELECT);
     });
 
-    it('resolves questionType as multiSelect when max-choices > 1', () => {
+    it('resolves questionType as multiSelect when max-choices > 1', async () => {
       const { result } = renderDescriptor(CHOICE_MULTI_SELECT_XML);
+      await nextTick();
       expect(result.questionType.value).toBe(QuestionType.MULTI_SELECT);
     });
 
-    it('returns null parseError for valid XML', () => {
+    it('returns null parseError for valid XML', async () => {
       const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      await nextTick();
       expect(result.parseError.value).toBeNull();
     });
   });
 
   describe('with an unrecognized interaction type', () => {
-    it('falls back to the default descriptor without a parse error', () => {
+    it('falls back to the default descriptor without a parse error', async () => {
       const { result } = renderDescriptor(UNKNOWN_INTERACTION_XML);
+      await nextTick();
       expect(result.parseError.value).toBeNull();
     });
 
-    it('still returns a defined fallback descriptor', () => {
+    it('still returns a defined fallback descriptor', async () => {
       const { result } = renderDescriptor(UNKNOWN_INTERACTION_XML);
+      await nextTick();
       expect(result.descriptor.value).toBeDefined();
       expect(typeof result.descriptor.value.matches).toBe('function');
     });
   });
 
   describe('with a null or empty bodyXmlRef', () => {
-    it('returns a defined descriptor when bodyXmlRef is null', () => {
+    it('returns the default descriptor when bodyXmlRef is null', async () => {
       const { result } = renderDescriptor(null);
+      await nextTick();
       expect(result.descriptor.value).toBeDefined();
       expect(result.parseError.value).toBeNull();
     });
 
-    it('returns null questionType when bodyXmlRef is null', () => {
+    it('returns null questionType when bodyXmlRef is null', async () => {
       const { result } = renderDescriptor(null);
+      await nextTick();
       expect(result.questionType.value).toBeNull();
     });
 
-    it('returns a defined descriptor when bodyXmlRef is an empty string', () => {
+    it('returns the default descriptor when bodyXmlRef is an empty string', async () => {
       const { result } = renderDescriptor('');
+      await nextTick();
       expect(result.descriptor.value).toBeDefined();
       expect(result.parseError.value).toBeNull();
     });
   });
 
   describe('with malformed XML', () => {
-    it('returns a non-null parseError', () => {
+    it('returns a non-null parseError', async () => {
       const { result } = renderDescriptor('<unclosed');
+      await nextTick();
       expect(result.parseError.value).not.toBeNull();
       expect(typeof result.parseError.value).toBe('string');
     });
 
-    it('still returns a defined fallback descriptor on parse error', () => {
+    it('still returns a defined fallback descriptor on parse error', async () => {
       const { result } = renderDescriptor('<bad xml!!{');
+      await nextTick();
       expect(result.descriptor.value).toBeDefined();
     });
   });
 
-  describe('reactivity', () => {
-    it('recomputes questionType when bodyXmlRef changes from null to single-select', async () => {
-      const { result, bodyXmlRef } = renderDescriptor(null);
-      await nextTick();
-
-      expect(result.questionType.value).toBeNull();
-
-      bodyXmlRef.value = CHOICE_SINGLE_SELECT_XML;
+  describe('questionType as a writable ref', () => {
+    it('descriptor recomputes when questionType is changed directly', async () => {
+      const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
       await nextTick();
 
       expect(result.questionType.value).toBe(QuestionType.SINGLE_SELECT);
-    });
+      expect(result.descriptor.value.type).toBe(QtiInteraction.CHOICE);
 
-    it('recomputes questionType when switching from single-select to multi-select', async () => {
-      const { result, bodyXmlRef } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      // Simulate user switching question type via the selector
+      result.questionType.value = QuestionType.MULTI_SELECT;
       await nextTick();
 
-      expect(result.questionType.value).toBe(QuestionType.SINGLE_SELECT);
-
-      bodyXmlRef.value = CHOICE_MULTI_SELECT_XML;
-      await nextTick();
-
+      // Still the same descriptor (choice handles both), but questionType changed
+      expect(result.descriptor.value.type).toBe(QtiInteraction.CHOICE);
       expect(result.questionType.value).toBe(QuestionType.MULTI_SELECT);
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/__tests__/useInteractionDescriptor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/__tests__/useInteractionDescriptor.spec.js
@@ -1,0 +1,132 @@
+import { render } from '@testing-library/vue';
+import { defineComponent, ref, nextTick } from 'vue';
+import VueRouter from 'vue-router';
+import useInteractionDescriptor from '../useInteractionDescriptor';
+import { QtiInteraction } from '../../constants';
+
+import {
+  CHOICE_SINGLE_SELECT_XML,
+  CHOICE_MULTI_SELECT_XML,
+  UNKNOWN_INTERACTION_XML,
+} from '../../utils/testingFixtures';
+
+// ---------------------------------------------------------------------------
+// Helper: renders a wrapper component that runs the composable inside setup()
+// Returns { result, bodyXmlRef } — result holds the reactive return value,
+// bodyXmlRef can be mutated to test reactivity.
+// ---------------------------------------------------------------------------
+
+function renderDescriptor(initialXml = null) {
+  const bodyXmlRef = ref(initialXml);
+  let result;
+
+  const TestWrapper = defineComponent({
+    setup() {
+      result = useInteractionDescriptor(bodyXmlRef);
+      return {};
+    },
+    template: '<div></div>',
+  });
+
+  render(TestWrapper, { routes: new VueRouter() });
+  return { result, bodyXmlRef };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useInteractionDescriptor', () => {
+  describe('with a valid choice interaction', () => {
+    it('resolves the Choice descriptor by its type', () => {
+      const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      expect(result.descriptor.value.type).toBe(QtiInteraction.CHOICE);
+    });
+
+    it('resolves questionType as singleSelect when max-choices is 1', () => {
+      const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      expect(result.questionType.value).toBe('singleSelect');
+    });
+
+    it('resolves questionType as multiSelect when max-choices > 1', () => {
+      const { result } = renderDescriptor(CHOICE_MULTI_SELECT_XML);
+      expect(result.questionType.value).toBe('multiSelect');
+    });
+
+    it('returns null parseError for valid XML', () => {
+      const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      expect(result.parseError.value).toBeNull();
+    });
+  });
+
+  describe('with an unrecognized interaction type', () => {
+    it('falls back to the default descriptor without a parse error', () => {
+      const { result } = renderDescriptor(UNKNOWN_INTERACTION_XML);
+      expect(result.parseError.value).toBeNull();
+    });
+
+    it('still returns a defined fallback descriptor', () => {
+      const { result } = renderDescriptor(UNKNOWN_INTERACTION_XML);
+      expect(result.descriptor.value).toBeDefined();
+      expect(typeof result.descriptor.value.matches).toBe('function');
+    });
+  });
+
+  describe('with a null or empty bodyXmlRef', () => {
+    it('returns a defined descriptor when bodyXmlRef is null', () => {
+      const { result } = renderDescriptor(null);
+      expect(result.descriptor.value).toBeDefined();
+      expect(result.parseError.value).toBeNull();
+    });
+
+    it('returns null questionType when bodyXmlRef is null', () => {
+      const { result } = renderDescriptor(null);
+      expect(result.questionType.value).toBeNull();
+    });
+
+    it('returns a defined descriptor when bodyXmlRef is an empty string', () => {
+      const { result } = renderDescriptor('');
+      expect(result.descriptor.value).toBeDefined();
+      expect(result.parseError.value).toBeNull();
+    });
+  });
+
+  describe('with malformed XML', () => {
+    it('returns a non-null parseError', () => {
+      const { result } = renderDescriptor('<unclosed');
+      expect(result.parseError.value).not.toBeNull();
+      expect(typeof result.parseError.value).toBe('string');
+    });
+
+    it('still returns a defined fallback descriptor on parse error', () => {
+      const { result } = renderDescriptor('<bad xml!!{');
+      expect(result.descriptor.value).toBeDefined();
+    });
+  });
+
+  describe('reactivity', () => {
+    it('recomputes questionType when bodyXmlRef changes from null to single-select', async () => {
+      const { result, bodyXmlRef } = renderDescriptor(null);
+      await nextTick();
+
+      expect(result.questionType.value).toBeNull();
+
+      bodyXmlRef.value = CHOICE_SINGLE_SELECT_XML;
+      await nextTick();
+
+      expect(result.questionType.value).toBe('singleSelect');
+    });
+
+    it('recomputes questionType when switching from single-select to multi-select', async () => {
+      const { result, bodyXmlRef } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
+      await nextTick();
+
+      expect(result.questionType.value).toBe('singleSelect');
+
+      bodyXmlRef.value = CHOICE_MULTI_SELECT_XML;
+      await nextTick();
+
+      expect(result.questionType.value).toBe('multiSelect');
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/__tests__/useInteractionDescriptor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/__tests__/useInteractionDescriptor.spec.js
@@ -2,7 +2,7 @@ import { render } from '@testing-library/vue';
 import { defineComponent, ref, nextTick } from 'vue';
 import VueRouter from 'vue-router';
 import useInteractionDescriptor from '../useInteractionDescriptor';
-import { QtiInteraction } from '../../constants';
+import { QtiInteraction, QuestionType } from '../../constants';
 
 import {
   CHOICE_SINGLE_SELECT_XML,
@@ -45,12 +45,12 @@ describe('useInteractionDescriptor', () => {
 
     it('resolves questionType as singleSelect when max-choices is 1', () => {
       const { result } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
-      expect(result.questionType.value).toBe('singleSelect');
+      expect(result.questionType.value).toBe(QuestionType.SINGLE_SELECT);
     });
 
     it('resolves questionType as multiSelect when max-choices > 1', () => {
       const { result } = renderDescriptor(CHOICE_MULTI_SELECT_XML);
-      expect(result.questionType.value).toBe('multiSelect');
+      expect(result.questionType.value).toBe(QuestionType.MULTI_SELECT);
     });
 
     it('returns null parseError for valid XML', () => {
@@ -114,19 +114,19 @@ describe('useInteractionDescriptor', () => {
       bodyXmlRef.value = CHOICE_SINGLE_SELECT_XML;
       await nextTick();
 
-      expect(result.questionType.value).toBe('singleSelect');
+      expect(result.questionType.value).toBe(QuestionType.SINGLE_SELECT);
     });
 
     it('recomputes questionType when switching from single-select to multi-select', async () => {
       const { result, bodyXmlRef } = renderDescriptor(CHOICE_SINGLE_SELECT_XML);
       await nextTick();
 
-      expect(result.questionType.value).toBe('singleSelect');
+      expect(result.questionType.value).toBe(QuestionType.SINGLE_SELECT);
 
       bodyXmlRef.value = CHOICE_MULTI_SELECT_XML;
       await nextTick();
 
-      expect(result.questionType.value).toBe('multiSelect');
+      expect(result.questionType.value).toBe(QuestionType.MULTI_SELECT);
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/useInteractionDescriptor.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/useInteractionDescriptor.js
@@ -1,49 +1,71 @@
-import { computed } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { parseXML } from '../serialization/parseItem';
 import { descriptors, registry, DEFAULT_INTERACTION } from '../interactions/index';
 
 /**
- * Composable that analyzes a QTI interaction block's XML and resolves the
- * appropriate plugin descriptor and sub-question type.
+ * Composable that manages the question type and descriptor for a single
+ * interaction block.
  *
- * @param {import('vue').Ref<string>} bodyXmlRef Ref to interaction's bodyXml string
+ * Design rationale (three separate type concepts):
+ *  - The XML is parsed **once on mount** to infer the initial questionType.
+ *  - `questionType` is a writable `ref` so the type-selector UI can change it
+ *    without triggering a re-parse of the XML.
+ *  - `descriptor` is a `computed` derived from `questionType`, using each
+ *    descriptor's `questionTypes` array for the lookup.  This means the
+ *    rendered editor component reacts to user selections, not to XML changes.
+ *
+ * @param {import('vue').Ref<string|null>} bodyXmlRef  Ref to interaction bodyXml string.
  */
 export default function useInteractionDescriptor(bodyXmlRef) {
-  const parsed = computed(() => {
-    if (!bodyXmlRef.value) {
-      return {
-        error: null,
-        descriptor: registry[DEFAULT_INTERACTION],
-        questionType: null,
-      };
+  /** Writable question type — set from XML on mount, then driven by UI selections. */
+  const questionType = ref(null);
+  /** Any parse error message from the initial XML parse; null when clean. */
+  const parseError = ref(null);
+
+  /**
+   * Parses bodyXml and returns { descriptor, questionType } without touching
+   * any reactive state — pure helper used only on mount.
+   */
+  function inferFromXml(xml) {
+    if (!xml) {
+      return { descriptor: registry[DEFAULT_INTERACTION], questionType: null, error: null };
     }
-
     try {
-      // bodyXml is the full <qti-*-interaction> element — its root IS the interaction.
-      const doc = parseXML(bodyXmlRef.value);
+      const doc = parseXML(xml);
       const interactionEl = doc.documentElement;
-
-      const descriptor =
-        descriptors.find(d => d.matches(interactionEl)) ?? registry[DEFAULT_INTERACTION];
-      const questionType = descriptor.getQuestionType(interactionEl) ?? null;
-
+      const desc = descriptors.find(d => d.matches(interactionEl)) ?? registry[DEFAULT_INTERACTION];
       return {
+        descriptor: desc,
+        questionType: desc.getQuestionType(interactionEl) ?? null,
         error: null,
-        descriptor,
-        questionType,
       };
     } catch (e) {
       return {
-        error: e.message,
         descriptor: registry[DEFAULT_INTERACTION],
         questionType: null,
+        error: e.message,
       };
     }
+  }
+
+  /** Parse XML once when the host component mounts to set the initial state. */
+  onMounted(() => {
+    const inferred = inferFromXml(bodyXmlRef.value);
+    questionType.value = inferred.questionType;
+    parseError.value = inferred.error;
   });
 
-  return {
-    descriptor: computed(() => parsed.value.descriptor),
-    questionType: computed(() => parsed.value.questionType),
-    parseError: computed(() => parsed.value.error),
-  };
+  /**
+   * Descriptor is derived from the current questionType ref.
+   * Uses each descriptor's `questionTypes` array so the lookup stays accurate
+   * when the user changes the question type via the selector.
+   * Falls back to the default descriptor when no match is found.
+   */
+  const descriptor = computed(
+    () =>
+      descriptors.find(d => d.questionTypes.includes(questionType.value)) ??
+      registry[DEFAULT_INTERACTION],
+  );
+
+  return { descriptor, questionType, parseError };
 }

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/useInteractionDescriptor.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/useInteractionDescriptor.js
@@ -1,0 +1,49 @@
+import { computed } from 'vue';
+import { parseXML } from '../serialization/parseItem';
+import { descriptors, registry, DEFAULT_INTERACTION } from '../interactions/index';
+
+/**
+ * Composable that analyzes a QTI interaction block's XML and resolves the
+ * appropriate plugin descriptor and sub-question type.
+ *
+ * @param {import('vue').Ref<string>} bodyXmlRef Ref to interaction's bodyXml string
+ */
+export default function useInteractionDescriptor(bodyXmlRef) {
+  const parsed = computed(() => {
+    if (!bodyXmlRef.value) {
+      return {
+        error: null,
+        descriptor: registry[DEFAULT_INTERACTION],
+        questionType: null,
+      };
+    }
+
+    try {
+      // bodyXml is the full <qti-*-interaction> element — its root IS the interaction.
+      const doc = parseXML(bodyXmlRef.value);
+      const interactionEl = doc.documentElement;
+
+      const descriptor =
+        descriptors.find(d => d.matches(interactionEl)) ?? registry[DEFAULT_INTERACTION];
+      const questionType = descriptor.getQuestionType(interactionEl) ?? null;
+
+      return {
+        error: null,
+        descriptor,
+        questionType,
+      };
+    } catch (e) {
+      return {
+        error: e.message,
+        descriptor: registry[DEFAULT_INTERACTION],
+        questionType: null,
+      };
+    }
+  });
+
+  return {
+    descriptor: computed(() => parsed.value.descriptor),
+    questionType: computed(() => parsed.value.questionType),
+    parseError: computed(() => parsed.value.error),
+  };
+}

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/useQtiItem.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/composables/useQtiItem.js
@@ -1,0 +1,39 @@
+import { ref } from 'vue';
+import { parseItem } from '../serialization/parseItem';
+
+/**
+ * Composable that parses a raw QTI XML string once and exposes the
+ * structured item model as reactive refs.
+ *
+ * Scope: read / parse only. No dirty tracking, no XML assembly, no emit-up.
+ *
+ * @param {string | null | undefined} rawData - Raw QTI XML string from item.raw_data
+ * @returns {{
+ *   identifier: import('vue').Ref<string>,
+ *   title: import('vue').Ref<string>,
+ *   language: import('vue').Ref<string>,
+ *   interactions: import('vue').Ref<Array<{ bodyXml: string, responseDeclarations: string[] }>>,
+ *   parseError: import('vue').Ref<string | null>,
+ * }}
+ */
+export default function useQtiItem(rawData) {
+  const identifier = ref('');
+  const title = ref('');
+  const language = ref('');
+  const interactions = ref([]);
+  const parseError = ref(null);
+
+  if (rawData) {
+    try {
+      const model = parseItem(rawData);
+      identifier.value = model.identifier;
+      title.value = model.title;
+      language.value = model.language;
+      interactions.value = model.interactions;
+    } catch (e) {
+      parseError.value = e.message;
+    }
+  }
+
+  return { identifier, title, language, interactions, parseError };
+}

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
@@ -19,10 +19,21 @@ export const BaseType = Object.freeze({
   URI: 'uri',
 });
 
+/**
+ * QTI 3.0 interaction type identifiers.
+ * Values are the actual XML element tag names used in QTI 3.0 documents,
+ * so they serve as both type keys and CSS selectors for querySelectorAll.
+ */
 export const QtiInteraction = Object.freeze({
-  CHOICE: 'choiceInteraction',
-  ORDER: 'orderInteraction',
-  MATCH: 'matchInteraction',
-  TEXT_ENTRY: 'textEntryInteraction',
-  EXTENDED_TEXT: 'extendedTextInteraction',
+  CHOICE: 'qti-choice-interaction',
+  ORDER: 'qti-order-interaction',
+  MATCH: 'qti-match-interaction',
+  TEXT_ENTRY: 'qti-text-entry-interaction',
+  EXTENDED_TEXT: 'qti-extended-text-interaction',
 });
+
+/**
+ * Selector-ready list of all known QTI interaction element tag names.
+ * Derived directly from QtiInteraction so there is a single source of truth.
+ */
+export const QTI_INTERACTION_TAGS = Object.freeze(Object.values(QtiInteraction));

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
@@ -20,6 +20,26 @@ export const BaseType = Object.freeze({
 });
 
 /**
+ * There are three distinct type concepts used within the QTI architecture:
+ *
+ * 1. AssessmentItemType (AssessmentItemTypes) -> The type stored in the database.
+ *    Values representing how the backend and legacy code interpret items. For
+ *    all QTI 3.0 items, this will be AssessmentItemTypes.QTI.
+ *
+ * 2. QuestionType -> The type editors will select per assessment item.
+ *    It's different from AssessmentItemType because we will extend this for all
+ *    new question types without confusing it with values stored in the database
+ *    (all of these will be assessment item type: "qti"). Value is related to how
+ *    Studio presents different question options to users in the UI.
+ *
+ * 3. InteractionType (QtiInteraction) -> The actual interactions defined by QTI,
+ *    and the ones that dictate how to parse and what descriptor we will use.
+ *    Each QTI interaction can have multiple related question types (e.g., choice
+ *    can be singleSelect or multiSelect), but all of them will have assessment
+ *    item type "qti".
+ */
+
+/**
  * QTI 3.0 interaction type identifiers.
  * Values are the actual XML element tag names used in QTI 3.0 documents,
  * so they serve as both type keys and CSS selectors for querySelectorAll.
@@ -32,8 +52,19 @@ export const QtiInteraction = Object.freeze({
   EXTENDED_TEXT: 'qti-extended-text-interaction',
 });
 
-/**
- * Selector-ready list of all known QTI interaction element tag names.
- * Derived directly from QtiInteraction so there is a single source of truth.
- */
 export const QTI_INTERACTION_TAGS = Object.freeze(Object.values(QtiInteraction));
+
+export const AssessmentItemTypes = Object.freeze({
+  SINGLE_SELECTION: 'single_selection',
+  MULTIPLE_SELECTION: 'multiple_selection',
+  TRUE_FALSE: 'true_false',
+  INPUT_QUESTION: 'input_question',
+  PERSEUS_QUESTION: 'perseus_question',
+  FREE_RESPONSE: 'free_response',
+  QTI: 'qti',
+});
+
+export const QuestionType = Object.freeze({
+  SINGLE_SELECT: 'single_selection',
+  MULTI_SELECT: 'multiple_selection',
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/constants.js
@@ -54,17 +54,22 @@ export const QtiInteraction = Object.freeze({
 
 export const QTI_INTERACTION_TAGS = Object.freeze(Object.values(QtiInteraction));
 
+/**
+ * Assessment item types as stored in the database.
+ * Within the QTI Editor, all authored items will have type QTI.
+ * The other legacy values are kept here for reference but are handled
+ * by the broader Studio assessment system, not by this editor.
+ */
 export const AssessmentItemTypes = Object.freeze({
-  SINGLE_SELECTION: 'single_selection',
-  MULTIPLE_SELECTION: 'multiple_selection',
-  TRUE_FALSE: 'true_false',
-  INPUT_QUESTION: 'input_question',
-  PERSEUS_QUESTION: 'perseus_question',
-  FREE_RESPONSE: 'free_response',
   QTI: 'qti',
 });
 
+/**
+ * UI-facing question type values — what the type selector shows to authors.
+ * These are distinct from AssessmentItemTypes (database) and QtiInteraction (XML tags).
+ * One QtiInteraction can map to multiple QuestionTypes (e.g. choice → singleSelect | multiSelect).
+ */
 export const QuestionType = Object.freeze({
-  SINGLE_SELECT: 'single_selection',
-  MULTI_SELECT: 'multiple_selection',
+  SINGLE_SELECT: 'singleSelect',
+  MULTI_SELECT: 'multiSelect',
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/index.vue
@@ -9,7 +9,7 @@
       >
         <div class="show-answers-inner">
           <KCheckbox
-            v-model="displayAnswersPreview"
+            v-model="showAnswers"
             :label="showAnswers$()"
             class="ma-0"
             data-testid="showAnswersCheckbox"
@@ -21,12 +21,12 @@
       <div class="question-list">
         <QTIItemEditor
           v-for="(item, idx) in items"
-          :key="item.id"
+          :key="item.assessment_id"
           :item="item"
           :index="idx"
           :total="items.length"
-          :mode="activeId === item.id ? 'edit' : 'view'"
-          :displayAnswersPreview="displayAnswersPreview"
+          :mode="activeId === item.assessment_id ? 'edit' : 'view'"
+          :showAnswers="showAnswers"
           data-testid="item"
           @close="closeItem"
         >
@@ -61,7 +61,7 @@
   import { ref, computed } from 'vue';
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { qtiEditorStrings } from './qtiEditorStrings';
-  import { QtiInteraction } from './constants';
+  import { AssessmentItemTypes } from './constants';
   import QTIItemEditor from './components/QTIItemEditor/index';
   import CollapsibleToolbar from './components/CollapsibleToolbar/index.vue';
   import useQTIEditorActions from './useQTIEditorActions';
@@ -74,9 +74,8 @@
   /** Creates a blank item with a stable UUID and the default interaction type. */
   function createBlankItem() {
     return {
-      id: uuid4(),
-      type: QtiInteraction.CHOICE,
-      title: '',
+      assessment_id: uuid4(),
+      type: AssessmentItemTypes.QTI,
     };
   }
 
@@ -97,7 +96,7 @@
       const items = computed(() => props.assessments);
 
       const activeId = ref(null);
-      const displayAnswersPreview = ref(false);
+      const showAnswers = ref(false);
 
       function openItem(id) {
         activeId.value = id;
@@ -118,15 +117,14 @@
         const pos = atIndex !== undefined ? atIndex : list.length;
         list.splice(pos, 0, newItem);
         emit('update', list);
-        // open the newly created card
-        activeId.value = newItem.id;
+        activeId.value = newItem.assessment_id;
       }
 
       function deleteItem(item) {
-        if (activeId.value === item.id) closeItem();
+        if (activeId.value === item.assessment_id) closeItem();
         emit(
           'update',
-          props.assessments.filter(i => i.id !== item.id),
+          props.assessments.filter(i => i.assessment_id !== item.assessment_id),
         );
       }
 
@@ -161,7 +159,7 @@
         containerStyle,
         items,
         activeId,
-        displayAnswersPreview,
+        showAnswers,
         closeItem,
         addItem,
         getToolbarActions,
@@ -174,9 +172,9 @@
     props: {
       /**
        * Ordered list of assessment items. Each item must have:
-       *   id    {String}  — stable unique identifier (UUID)
-       *   type  {String}  — a QtiInteraction value
-       *   title {String}  — optional display title
+       *   assessment_id {String}  — stable unique identifier (UUID)
+       *   type          {String}  — e.g., AssessmentItemTypes.QTI
+       *   raw_data      {String}  — optional, full QTI XML string
        *
        * Array index is the display order.
        * This component never mutates the prop — it emits `update` with the new list.

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/__tests__/defineInteraction.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/__tests__/defineInteraction.spec.js
@@ -4,7 +4,6 @@ import defineInteraction from '../defineInteraction';
 const makeValidDescriptor = (overrides = {}) => ({
   type: 'test',
   placement: 'block',
-  label: 'Test',
   editorComponent: {},
   convertsFrom: [],
   matches: () => false,
@@ -23,7 +22,6 @@ describe('defineInteraction', () => {
   const REQUIRED_KEYS = [
     'type',
     'placement',
-    'label',
     'editorComponent',
     'convertsFrom',
     'matches',

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/__tests__/defineInteraction.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/__tests__/defineInteraction.spec.js
@@ -1,0 +1,55 @@
+import defineInteraction from '../defineInteraction';
+
+// A minimal valid descriptor with all required keys present.
+const makeValidDescriptor = (overrides = {}) => ({
+  type: 'test',
+  placement: 'block',
+  label: 'Test',
+  editorComponent: {},
+  convertsFrom: [],
+  matches: () => false,
+  getQuestionType: () => null,
+  parse: () => ({}),
+  validate: () => [],
+  ...overrides,
+});
+
+describe('defineInteraction', () => {
+  it('returns the descriptor unchanged when all required keys are present', () => {
+    const descriptor = makeValidDescriptor();
+    expect(defineInteraction(descriptor)).toBe(descriptor);
+  });
+
+  const REQUIRED_KEYS = [
+    'type',
+    'placement',
+    'label',
+    'editorComponent',
+    'convertsFrom',
+    'matches',
+    'getQuestionType',
+    'parse',
+    'validate',
+  ];
+
+  it.each(REQUIRED_KEYS)('throws when the required key "%s" is missing', key => {
+    const descriptor = makeValidDescriptor();
+    delete descriptor[key];
+    expect(() => defineInteraction(descriptor)).toThrow(
+      new RegExp(`missing required key "${key}"`, 'i'),
+    );
+  });
+
+  it('includes the descriptor type in the error message when type is present', () => {
+    const descriptor = makeValidDescriptor({ type: 'myPlugin' });
+    delete descriptor.editorComponent;
+    expect(() => defineInteraction(descriptor)).toThrow(/myPlugin/);
+  });
+
+  it('uses "(unknown)" in the error message when type is also missing', () => {
+    const descriptor = makeValidDescriptor();
+    delete descriptor.type;
+    delete descriptor.editorComponent;
+    expect(() => defineInteraction(descriptor)).toThrow(/\(unknown\)/);
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/__tests__/defineInteraction.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/__tests__/defineInteraction.spec.js
@@ -4,6 +4,7 @@ import defineInteraction from '../defineInteraction';
 const makeValidDescriptor = (overrides = {}) => ({
   type: 'test',
   placement: 'block',
+  questionTypes: [],
   editorComponent: {},
   convertsFrom: [],
   matches: () => false,
@@ -22,6 +23,7 @@ describe('defineInteraction', () => {
   const REQUIRED_KEYS = [
     'type',
     'placement',
+    'questionTypes',
     'editorComponent',
     'convertsFrom',
     'matches',

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/ChoiceInteractionEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/ChoiceInteractionEditor.vue
@@ -10,10 +10,10 @@
       {{ prompt }}
     </p>
 
-    <!-- Choices (hidden in view mode) -->
-    <template v-if="mode === 'edit'">
+    <!-- Choices (shown in edit mode, or when showAnswers is true in view mode) -->
+    <template v-if="mode === 'edit' || showAnswers">
       <!-- Single-select choices — KRadioButton -->
-      <template v-if="questionType === 'singleSelect'">
+      <template v-if="questionType === QuestionType.SINGLE_SELECT">
         <KRadioButton
           v-for="choice in choices"
           :key="choice.identifier"
@@ -42,6 +42,7 @@
 <script>
 
   import { computed, ref } from 'vue';
+  import { QuestionType } from '../../constants';
   import { parseXML } from '../../serialization/parseItem';
 
   export default {
@@ -62,11 +63,11 @@
       }
 
       const parsed = computed(() => {
-        if (!props.block || !props.block.bodyXml) {
+        if (!props.interaction || !props.interaction.bodyXml) {
           return { prompt: '', choices: [] };
         }
         try {
-          const doc = parseXML(props.block.bodyXml);
+          const doc = parseXML(props.interaction.bodyXml);
           const root = doc.documentElement;
 
           const promptEl = root.querySelector('qti-prompt');
@@ -87,7 +88,7 @@
       const prompt = computed(() => parsed.value.prompt);
       const choices = computed(() => parsed.value.choices);
 
-      return { prompt, choices, selectedValue, selectedValues, toggleValue };
+      return { prompt, choices, selectedValue, selectedValues, toggleValue, QuestionType };
     },
 
     props: {
@@ -95,11 +96,11 @@
        * The raw interaction block — shape: { bodyXml: string, responseDeclarations: string[] }.
        * Parsed here to extract the prompt and simple-choice elements.
        */
-      block: {
+      interaction: {
         type: Object,
         default: null,
       },
-      /** 'singleSelect' | 'multiSelect' — derived from max-choices by the registry. */
+      /** One of QuestionType derived from max-choices by the registry. */
       questionType: {
         type: String,
         default: null,
@@ -108,6 +109,11 @@
       mode: {
         type: String,
         default: 'view',
+      },
+      /** Whether to display correct answers (used in view mode previews) */
+      showAnswers: {
+        type: Boolean,
+        default: false,
       },
     },
   };

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/ChoiceInteractionEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/ChoiceInteractionEditor.vue
@@ -1,0 +1,134 @@
+<template>
+
+  <div class="choice-interaction-editor">
+    <!-- Prompt -->
+    <p
+      v-if="prompt"
+      class="choice-prompt"
+      :style="{ color: $themePalette.grey.v_900 }"
+    >
+      {{ prompt }}
+    </p>
+
+    <!-- Choices (hidden in view mode) -->
+    <template v-if="mode === 'edit'">
+      <!-- Single-select choices — KRadioButton -->
+      <template v-if="questionType === 'singleSelect'">
+        <KRadioButton
+          v-for="choice in choices"
+          :key="choice.identifier"
+          v-model="selectedValue"
+          :buttonValue="choice.identifier"
+          :label="choice.text"
+        />
+      </template>
+
+      <!-- Multi-select choices — KCheckbox -->
+      <template v-else>
+        <KCheckbox
+          v-for="choice in choices"
+          :key="choice.identifier"
+          :checked="selectedValues.includes(choice.identifier)"
+          :label="choice.text"
+          @change="checked => toggleValue(choice.identifier, checked)"
+        />
+      </template>
+    </template>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { computed, ref } from 'vue';
+  import { parseXML } from '../../serialization/parseItem';
+
+  export default {
+    name: 'ChoiceInteractionEditor',
+
+    setup(props) {
+      /** Dummy model value so KRadioButton renders without warnings. */
+      const selectedValue = ref(null);
+      /** Tracked identifiers for multi-select mode. */
+      const selectedValues = ref([]);
+
+      function toggleValue(identifier, checked) {
+        if (checked) {
+          selectedValues.value = [...selectedValues.value, identifier];
+        } else {
+          selectedValues.value = selectedValues.value.filter(v => v !== identifier);
+        }
+      }
+
+      const parsed = computed(() => {
+        if (!props.block || !props.block.bodyXml) {
+          return { prompt: '', choices: [] };
+        }
+        try {
+          const doc = parseXML(props.block.bodyXml);
+          const root = doc.documentElement;
+
+          const promptEl = root.querySelector('qti-prompt');
+          const prompt = promptEl ? promptEl.textContent.trim() : '';
+
+          const choiceEls = [...root.querySelectorAll('qti-simple-choice')];
+          const choices = choiceEls.map(el => ({
+            identifier: el.getAttribute('identifier') ?? el.textContent.trim(),
+            text: el.textContent.trim(),
+          }));
+
+          return { prompt, choices };
+        } catch {
+          return { prompt: '', choices: [] };
+        }
+      });
+
+      const prompt = computed(() => parsed.value.prompt);
+      const choices = computed(() => parsed.value.choices);
+
+      return { prompt, choices, selectedValue, selectedValues, toggleValue };
+    },
+
+    props: {
+      /**
+       * The raw interaction block — shape: { bodyXml: string, responseDeclarations: string[] }.
+       * Parsed here to extract the prompt and simple-choice elements.
+       */
+      block: {
+        type: Object,
+        default: null,
+      },
+      /** 'singleSelect' | 'multiSelect' — derived from max-choices by the registry. */
+      questionType: {
+        type: String,
+        default: null,
+      },
+      /** View or edit mode */
+      mode: {
+        type: String,
+        default: 'view',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .choice-interaction-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 0 8px;
+  }
+
+  .choice-prompt {
+    margin: 0 0 12px;
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/__tests__/ChoiceInteractionEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/__tests__/ChoiceInteractionEditor.spec.js
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import ChoiceInteractionEditor from '../ChoiceInteractionEditor.vue';
+
+import {
+  CHOICE_SINGLE_SELECT_XML,
+  CHOICE_MULTI_SELECT_XML,
+  CHOICE_NO_PROMPT_XML,
+  mockInteractionBlock as block,
+} from '../../../utils/testingFixtures';
+
+const renderEditor = (props = {}) =>
+  render(ChoiceInteractionEditor, {
+    props: { mode: 'edit', ...props },
+    routes: new VueRouter(),
+  });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChoiceInteractionEditor', () => {
+  describe('prompt rendering', () => {
+    it('renders the prompt text from the XML', () => {
+      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      expect(screen.getByText('Which planet is closest to the Sun?')).toBeInTheDocument();
+    });
+
+    it('renders no prompt element when the XML has no <qti-prompt>', () => {
+      renderEditor({ block: block(CHOICE_NO_PROMPT_XML), questionType: 'singleSelect' });
+      expect(screen.queryByText('Which planet is closest to the Sun?')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('singleSelect (KRadioButton)', () => {
+    it('renders a radio button for each choice', () => {
+      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      const radios = screen.getAllByRole('radio');
+      expect(radios).toHaveLength(3);
+    });
+
+    it('renders the correct choice labels', () => {
+      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      expect(screen.getByText('Mercury')).toBeInTheDocument();
+      expect(screen.getByText('Venus')).toBeInTheDocument();
+      expect(screen.getByText('Earth')).toBeInTheDocument();
+    });
+
+    it('allows selecting a radio button', async () => {
+      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      const mercury = screen.getByRole('radio', { name: 'Mercury' });
+      expect(mercury).not.toBeChecked();
+      await fireEvent.click(mercury);
+      expect(mercury).toBeChecked();
+    });
+  });
+
+  describe('multiSelect (KCheckbox)', () => {
+    it('renders a checkbox for each choice', () => {
+      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(3);
+    });
+
+    it('renders the correct choice labels', () => {
+      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      expect(screen.getByText('Option A')).toBeInTheDocument();
+      expect(screen.getByText('Option B')).toBeInTheDocument();
+      expect(screen.getByText('Option C')).toBeInTheDocument();
+    });
+
+    it('allows checking multiple checkboxes independently', async () => {
+      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      const [checkA, checkB] = screen.getAllByRole('checkbox');
+      await fireEvent.click(checkA);
+      await fireEvent.click(checkB);
+      expect(checkA).toBeChecked();
+      expect(checkB).toBeChecked();
+    });
+
+    it('allows unchecking a checked checkbox', async () => {
+      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      const [checkA] = screen.getAllByRole('checkbox');
+      await fireEvent.click(checkA);
+      expect(checkA).toBeChecked();
+      await fireEvent.click(checkA);
+      expect(checkA).not.toBeChecked();
+    });
+  });
+
+  describe('graceful fallback', () => {
+    it('renders nothing interactive when block is null', () => {
+      renderEditor({ block: null, questionType: 'singleSelect' });
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing interactive when block.bodyXml is an empty string', () => {
+      renderEditor({ block: block(''), questionType: 'singleSelect' });
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing interactive when XML is malformed', () => {
+      renderEditor({ block: block('<unclosed'), questionType: 'singleSelect' });
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/__tests__/ChoiceInteractionEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/__tests__/ChoiceInteractionEditor.spec.js
@@ -8,6 +8,7 @@ import {
   CHOICE_NO_PROMPT_XML,
   mockInteractionBlock as block,
 } from '../../../utils/testingFixtures';
+import { QuestionType } from '../../../constants';
 
 const renderEditor = (props = {}) =>
   render(ChoiceInteractionEditor, {
@@ -22,32 +23,47 @@ const renderEditor = (props = {}) =>
 describe('ChoiceInteractionEditor', () => {
   describe('prompt rendering', () => {
     it('renders the prompt text from the XML', () => {
-      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      renderEditor({
+        interaction: block(CHOICE_SINGLE_SELECT_XML),
+        questionType: QuestionType.SINGLE_SELECT,
+      });
       expect(screen.getByText('Which planet is closest to the Sun?')).toBeInTheDocument();
     });
 
     it('renders no prompt element when the XML has no <qti-prompt>', () => {
-      renderEditor({ block: block(CHOICE_NO_PROMPT_XML), questionType: 'singleSelect' });
+      renderEditor({
+        interaction: block(CHOICE_NO_PROMPT_XML),
+        questionType: QuestionType.SINGLE_SELECT,
+      });
       expect(screen.queryByText('Which planet is closest to the Sun?')).not.toBeInTheDocument();
     });
   });
 
   describe('singleSelect (KRadioButton)', () => {
     it('renders a radio button for each choice', () => {
-      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      renderEditor({
+        interaction: block(CHOICE_SINGLE_SELECT_XML),
+        questionType: QuestionType.SINGLE_SELECT,
+      });
       const radios = screen.getAllByRole('radio');
       expect(radios).toHaveLength(3);
     });
 
     it('renders the correct choice labels', () => {
-      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      renderEditor({
+        interaction: block(CHOICE_SINGLE_SELECT_XML),
+        questionType: QuestionType.SINGLE_SELECT,
+      });
       expect(screen.getByText('Mercury')).toBeInTheDocument();
       expect(screen.getByText('Venus')).toBeInTheDocument();
       expect(screen.getByText('Earth')).toBeInTheDocument();
     });
 
     it('allows selecting a radio button', async () => {
-      renderEditor({ block: block(CHOICE_SINGLE_SELECT_XML), questionType: 'singleSelect' });
+      renderEditor({
+        interaction: block(CHOICE_SINGLE_SELECT_XML),
+        questionType: QuestionType.SINGLE_SELECT,
+      });
       const mercury = screen.getByRole('radio', { name: 'Mercury' });
       expect(mercury).not.toBeChecked();
       await fireEvent.click(mercury);
@@ -57,20 +73,29 @@ describe('ChoiceInteractionEditor', () => {
 
   describe('multiSelect (KCheckbox)', () => {
     it('renders a checkbox for each choice', () => {
-      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      renderEditor({
+        interaction: block(CHOICE_MULTI_SELECT_XML),
+        questionType: QuestionType.MULTI_SELECT,
+      });
       const checkboxes = screen.getAllByRole('checkbox');
       expect(checkboxes).toHaveLength(3);
     });
 
     it('renders the correct choice labels', () => {
-      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      renderEditor({
+        interaction: block(CHOICE_MULTI_SELECT_XML),
+        questionType: QuestionType.MULTI_SELECT,
+      });
       expect(screen.getByText('Option A')).toBeInTheDocument();
       expect(screen.getByText('Option B')).toBeInTheDocument();
       expect(screen.getByText('Option C')).toBeInTheDocument();
     });
 
     it('allows checking multiple checkboxes independently', async () => {
-      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      renderEditor({
+        interaction: block(CHOICE_MULTI_SELECT_XML),
+        questionType: QuestionType.MULTI_SELECT,
+      });
       const [checkA, checkB] = screen.getAllByRole('checkbox');
       await fireEvent.click(checkA);
       await fireEvent.click(checkB);
@@ -79,7 +104,7 @@ describe('ChoiceInteractionEditor', () => {
     });
 
     it('allows unchecking a checked checkbox', async () => {
-      renderEditor({ block: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
+      renderEditor({ interaction: block(CHOICE_MULTI_SELECT_XML), questionType: 'multiSelect' });
       const [checkA] = screen.getAllByRole('checkbox');
       await fireEvent.click(checkA);
       expect(checkA).toBeChecked();
@@ -96,12 +121,12 @@ describe('ChoiceInteractionEditor', () => {
     });
 
     it('renders nothing interactive when block.bodyXml is an empty string', () => {
-      renderEditor({ block: block(''), questionType: 'singleSelect' });
+      renderEditor({ interaction: block(''), questionType: 'singleSelect' });
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
     });
 
     it('renders nothing interactive when XML is malformed', () => {
-      renderEditor({ block: block('<unclosed'), questionType: 'singleSelect' });
+      renderEditor({ interaction: block('<unclosed'), questionType: 'singleSelect' });
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
     });
   });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/index.js
@@ -1,0 +1,66 @@
+import defineInteraction from '../defineInteraction';
+import { QtiInteraction } from '../../constants';
+import { qtiEditorStrings } from '../../qtiEditorStrings';
+import ChoiceInteractionEditor from './ChoiceInteractionEditor.vue';
+
+/**
+ * Choice interaction plugin — handles both single-select (max-choices="1")
+ * and multi-select (max-choices > 1) via the same <qti-choice-interaction> element.
+ */
+export default defineInteraction({
+  /** Registry key — matches the QTI 3.0 interaction element tag name. */
+  type: QtiInteraction.CHOICE,
+
+  /** Block-level interaction: occupies its own paragraph in the item body. */
+  placement: 'block',
+
+  /** Display label used by the (future) type selector UI. */
+  get label() {
+    return qtiEditorStrings.choiceInteractionLabel$();
+  },
+
+  /** Vue component rendered inside InteractionSection when this descriptor owns the block. */
+  editorComponent: ChoiceInteractionEditor,
+
+  /**
+   * Types this plugin can absorb when the author switches interaction type.
+   * Populated in a future task — empty for now.
+   */
+  convertsFrom: [],
+
+  /**
+   * Returns true when this descriptor owns the given interaction element.
+   * @param {Element} el
+   */
+  matches(el) {
+    return el.tagName.toLowerCase() === QtiInteraction.CHOICE;
+  },
+
+  /**
+   * Derives the UI-facing question type from the interaction element.
+   * Reads max-choices: '1' → 'singleSelect', anything else → 'multiSelect'.
+   * @param {Element} el
+   * @returns {'singleSelect' | 'multiSelect'}
+   */
+  getQuestionType(el) {
+    return el.getAttribute('max-choices') === '1' ? 'singleSelect' : 'multiSelect';
+  },
+
+  /**
+   * Extracts a structured state object from the interaction element.
+   * Stub — full parsing is a future task.
+   * @returns {object}
+   */
+  parse() {
+    return {};
+  },
+
+  /**
+   * Validates the interaction state and returns an array of error strings.
+   * Stub — full validation is a future task.
+   * @returns {string[]}
+   */
+  validate() {
+    return [];
+  },
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/index.js
@@ -13,12 +13,18 @@ export default defineInteraction({
   /** Block-level interaction: occupies its own paragraph in the item body. */
   placement: 'block',
 
+  /**
+   * All QuestionType values this descriptor can render.
+   * Allows the registry to resolve a descriptor from a selected question type
+   * without re-parsing XML.
+   */
+  questionTypes: [QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT],
+
   /** Vue component rendered inside InteractionSection when this descriptor owns the block. */
   editorComponent: ChoiceInteractionEditor,
 
   /**
    * Types this plugin can absorb when the author switches interaction type.
-   * Populated in a future task — empty for now.
    */
   convertsFrom: [],
 

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/choice/index.js
@@ -1,6 +1,5 @@
 import defineInteraction from '../defineInteraction';
-import { QtiInteraction } from '../../constants';
-import { qtiEditorStrings } from '../../qtiEditorStrings';
+import { QtiInteraction, QuestionType } from '../../constants';
 import ChoiceInteractionEditor from './ChoiceInteractionEditor.vue';
 
 /**
@@ -13,11 +12,6 @@ export default defineInteraction({
 
   /** Block-level interaction: occupies its own paragraph in the item body. */
   placement: 'block',
-
-  /** Display label used by the (future) type selector UI. */
-  get label() {
-    return qtiEditorStrings.choiceInteractionLabel$();
-  },
 
   /** Vue component rendered inside InteractionSection when this descriptor owns the block. */
   editorComponent: ChoiceInteractionEditor,
@@ -38,12 +32,14 @@ export default defineInteraction({
 
   /**
    * Derives the UI-facing question type from the interaction element.
-   * Reads max-choices: '1' → 'singleSelect', anything else → 'multiSelect'.
+   * Reads max-choices: '1' → singleSelect, anything else → multiSelect.
    * @param {Element} el
-   * @returns {'singleSelect' | 'multiSelect'}
+   * @returns {string} One of QuestionType
    */
   getQuestionType(el) {
-    return el.getAttribute('max-choices') === '1' ? 'singleSelect' : 'multiSelect';
+    return el.getAttribute('max-choices') === '1'
+      ? QuestionType.SINGLE_SELECT
+      : QuestionType.MULTI_SELECT;
   },
 
   /**

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/defineInteraction.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/defineInteraction.js
@@ -1,0 +1,34 @@
+/**
+ * Required keys every interaction descriptor must provide.
+ * Validated at import time so missing fields surface immediately during development.
+ */
+const REQUIRED_KEYS = [
+  'type',
+  'placement',
+  'label',
+  'editorComponent',
+  'convertsFrom',
+  'matches',
+  'getQuestionType',
+  'parse',
+  'validate',
+];
+
+/**
+ * Validates that a descriptor has every required key and returns it unchanged.
+ * Throws at call-time (i.e. module import time) if any key is absent.
+ *
+ * @template {object} T
+ * @param {T} descriptor - The interaction descriptor to validate
+ * @returns {T} The same descriptor, unmodified
+ * @throws {Error} If any required key is missing from the descriptor
+ */
+export default function defineInteraction(descriptor) {
+  for (const key of REQUIRED_KEYS) {
+    if (!(key in descriptor)) {
+      const name = descriptor.type ?? '(unknown)';
+      throw new Error(`defineInteraction: missing required key "${key}" on descriptor "${name}"`);
+    }
+  }
+  return descriptor;
+}

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/defineInteraction.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/defineInteraction.js
@@ -5,7 +5,6 @@
 const REQUIRED_KEYS = [
   'type',
   'placement',
-  'label',
   'editorComponent',
   'convertsFrom',
   'matches',

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/defineInteraction.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/defineInteraction.js
@@ -5,6 +5,7 @@
 const REQUIRED_KEYS = [
   'type',
   'placement',
+  'questionTypes',
   'editorComponent',
   'convertsFrom',
   'matches',

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/index.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/interactions/index.js
@@ -1,0 +1,23 @@
+import { QtiInteraction } from '../constants';
+import choiceDescriptor from './choice/index';
+
+/**
+ * The default interaction type used as fallback when no descriptor matches
+ * the interaction element found in the XML body.
+ */
+export const DEFAULT_INTERACTION = QtiInteraction.CHOICE;
+
+/**
+ * Ordered array of all registered interaction descriptors.
+ * InteractionSection iterates this to find the first descriptor whose
+ * matches(el) returns true.
+ */
+export const descriptors = [choiceDescriptor];
+
+/**
+ * Registry map keyed by descriptor.type for O(1) direct lookup.
+ * Built from the descriptors array — do not populate manually.
+ *
+ * @type {Object.<string, import('./defineInteraction').InteractionDescriptor>}
+ */
+export const registry = Object.fromEntries(descriptors.map(d => [d.type, d]));

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
@@ -81,13 +81,4 @@ export const qtiEditorStrings = createTranslator('QTIEditorStrings', {
     message: 'Add question below',
     context: 'Action to add a new question below the current one',
   },
-  choiceInteractionLabel: {
-    message: 'Choice',
-    context: 'Label for the choice interaction plugin, shown in the type selector',
-  },
-  choiceEditorPlaceholder: {
-    message: 'Choice interaction editor — {questionType} (coming soon)',
-    context:
-      'Placeholder inside the choice interaction editor card while the real editor is being built',
-  },
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
@@ -29,33 +29,33 @@ export const qtiEditorStrings = createTranslator('QTIEditorStrings', {
     message: 'Show answers',
     context: 'Checkbox label to toggle displaying answers/previews',
   },
-  interactionTypeSingleChoice: {
+  singleChoiceLabel: {
     message: 'Single Choice',
-    context: 'Display name for single-select choice interaction',
+    context: 'Display name for a single-select question type',
   },
-  interactionTypeMultipleChoice: {
+  multipleChoiceLabel: {
     message: 'Multiple Choice',
-    context: 'Display name for multi-select choice interaction',
+    context: 'Display name for a multiple-select question type',
   },
-  interactionTypeOrder: {
+  orderLabel: {
     message: 'Order',
-    context: 'Display name for orderInteraction',
+    context: 'Display name for an order question type',
   },
-  interactionTypeMatch: {
+  matchLabel: {
     message: 'Match',
-    context: 'Display name for matchInteraction',
+    context: 'Display name for a match question type',
   },
-  interactionTypeTextEntry: {
+  textEntryLabel: {
     message: 'Text entry',
-    context: 'Display name for textEntryInteraction',
+    context: 'Display name for a text entry question type',
   },
-  interactionTypeExtendedText: {
+  extendedTextLabel: {
     message: 'Extended text',
-    context: 'Display name for extendedTextInteraction',
+    context: 'Display name for an extended text question type',
   },
-  interactionTypeUnknown: {
+  unknownTypeLabel: {
     message: 'Unknown type',
-    context: 'Fallback when an item has an unrecognised interaction type',
+    context: 'Fallback when an item has an unrecognised question type',
   },
   toolbarLabelEdit: {
     message: 'Edit',

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/qtiEditorStrings.js
@@ -29,9 +29,13 @@ export const qtiEditorStrings = createTranslator('QTIEditorStrings', {
     message: 'Show answers',
     context: 'Checkbox label to toggle displaying answers/previews',
   },
-  interactionTypeChoice: {
-    message: 'Choice',
-    context: 'Display name for choiceInteraction',
+  interactionTypeSingleChoice: {
+    message: 'Single Choice',
+    context: 'Display name for single-select choice interaction',
+  },
+  interactionTypeMultipleChoice: {
+    message: 'Multiple Choice',
+    context: 'Display name for multi-select choice interaction',
   },
   interactionTypeOrder: {
     message: 'Order',
@@ -76,5 +80,14 @@ export const qtiEditorStrings = createTranslator('QTIEditorStrings', {
   toolbarLabelAddBelow: {
     message: 'Add question below',
     context: 'Action to add a new question below the current one',
+  },
+  choiceInteractionLabel: {
+    message: 'Choice',
+    context: 'Label for the choice interaction plugin, shown in the type selector',
+  },
+  choiceEditorPlaceholder: {
+    message: 'Choice interaction editor — {questionType} (coming soon)',
+    context:
+      'Placeholder inside the choice interaction editor card while the real editor is being built',
   },
 });

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/serialization/__tests__/parseItem.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/serialization/__tests__/parseItem.spec.js
@@ -1,0 +1,112 @@
+import { parseXML, parseItem } from '../parseItem';
+import { VALID_CHOICE_ITEM_DOCUMENT, TWO_INTERACTIONS_DOCUMENT } from '../../utils/testingFixtures';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ITEM_NO_INTERACTIONS = `<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item
+  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+  identifier="item-empty"
+  title="Empty"
+  adaptive="false"
+  time-dependent="false"
+  xml:lang="en"
+>
+  <qti-item-body></qti-item-body>
+</qti-assessment-item>`;
+
+// ---------------------------------------------------------------------------
+// parseXML
+// ---------------------------------------------------------------------------
+
+describe('parseXML', () => {
+  it('parses valid XML into a Document', () => {
+    const doc = parseXML(VALID_CHOICE_ITEM_DOCUMENT);
+    expect(doc).toBeInstanceOf(Document);
+    expect(doc.querySelector('qti-assessment-item')).not.toBeNull();
+  });
+
+  it('throws for malformed XML', () => {
+    expect(() => parseXML('<unclosed')).toThrow(/QTI XML parse error/i);
+  });
+
+  it('throws for XML with a parsererror node', () => {
+    // An extra closing tag causes a parsererror in jsdom
+    expect(() => parseXML('<root></root></extra>')).toThrow(/QTI XML parse error/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseItem — meta extraction
+// ---------------------------------------------------------------------------
+
+describe('parseItem — meta', () => {
+  it('returns an object with the top-level item attributes', () => {
+    const model = parseItem(VALID_CHOICE_ITEM_DOCUMENT);
+    expect(model.identifier).toBe('item-test-1');
+    expect(model.title).toBe('Test Question');
+    expect(model.language).toBe('en');
+  });
+
+  it('returns empty strings for missing meta attributes', () => {
+    const xml =
+      '<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"><qti-item-body /></qti-assessment-item>';
+    const model = parseItem(xml);
+    expect(model.identifier).toBe('');
+    expect(model.title).toBe('');
+    expect(model.language).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseItem — interaction blocks
+// ---------------------------------------------------------------------------
+
+describe('parseItem — interaction blocks', () => {
+  it('extracts interactions and their corresponding response declarations', () => {
+    const model = parseItem(VALID_CHOICE_ITEM_DOCUMENT);
+    expect(model.interactions).toHaveLength(1);
+
+    const block = model.interactions[0];
+    expect(block.bodyXml).toContain('<qti-choice-interaction');
+    expect(block.responseDeclarations).toHaveLength(1);
+    expect(block.responseDeclarations[0]).toContain('identifier="RESPONSE"');
+  });
+
+  it('returns two blocks for an item with two interactions', () => {
+    const model = parseItem(TWO_INTERACTIONS_DOCUMENT);
+    expect(model.interactions).toHaveLength(2);
+  });
+
+  it('returns empty interactions array for an item with no interactions', () => {
+    const model = parseItem(ITEM_NO_INTERACTIONS);
+    expect(model.interactions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseItem — response declaration matching
+// ---------------------------------------------------------------------------
+
+describe('parseItem — response declaration matching', () => {
+  it('matches each interaction to its own response declaration', () => {
+    const model = parseItem(TWO_INTERACTIONS_DOCUMENT);
+    expect(model.interactions[0].responseDeclarations[0]).toContain('identifier="RESP1"');
+    expect(model.interactions[1].responseDeclarations[0]).toContain('identifier="RESP2"');
+  });
+
+  it('returns empty responseDeclarations when no declaration matches', () => {
+    // interaction references RESP-MISSING which has no declaration
+    const xml = `<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" identifier="x" title="" adaptive="false" time-dependent="false" xml:lang="en">
+      <qti-item-body>
+        <qti-choice-interaction response-identifier="RESP-MISSING" max-choices="1">
+          <qti-simple-choice identifier="a">A</qti-simple-choice>
+        </qti-choice-interaction>
+      </qti-item-body>
+    </qti-assessment-item>`;
+    const model = parseItem(xml);
+    expect(model.interactions[0].responseDeclarations).toHaveLength(0);
+  });
+});

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/serialization/parseItem.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/serialization/parseItem.js
@@ -1,6 +1,7 @@
 import { QTI_INTERACTION_TAGS } from '../constants';
 
 const serializer = new XMLSerializer();
+const parser = new DOMParser();
 
 /**
  * Parses a QTI XML string into a validated XML Document.
@@ -10,7 +11,7 @@ const serializer = new XMLSerializer();
  * @throws {Error} If the XML is malformed or contains a parsererror
  */
 export function parseXML(xmlString) {
-  const doc = new DOMParser().parseFromString(xmlString, 'text/xml');
+  const doc = parser.parseFromString(xmlString, 'text/xml');
 
   // DOMParser never throws — it signals failure via a <parsererror> node.
   const error = doc.querySelector('parsererror');
@@ -40,9 +41,9 @@ export function parseItem(rawData) {
   const doc = parseXML(rawData);
 
   const root = doc.querySelector('qti-assessment-item');
-  const identifier = root ? (root.getAttribute('identifier') ?? '') : '';
-  const title = root ? (root.getAttribute('title') ?? '') : '';
-  const language = root ? (root.getAttribute('xml:lang') ?? '') : '';
+  const identifier = root?.getAttribute('identifier') ?? '';
+  const title = root?.getAttribute('title') ?? '';
+  const language = root?.getAttribute('xml:lang') ?? '';
 
   const body = doc.querySelector('qti-item-body');
 

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/serialization/parseItem.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/serialization/parseItem.js
@@ -1,0 +1,73 @@
+import { QTI_INTERACTION_TAGS } from '../constants';
+
+const serializer = new XMLSerializer();
+
+/**
+ * Parses a QTI XML string into a validated XML Document.
+ *
+ * @param {string} xmlString - Raw QTI XML string
+ * @returns {Document} Parsed XML Document
+ * @throws {Error} If the XML is malformed or contains a parsererror
+ */
+export function parseXML(xmlString) {
+  const doc = new DOMParser().parseFromString(xmlString, 'text/xml');
+
+  // DOMParser never throws — it signals failure via a <parsererror> node.
+  const error = doc.querySelector('parsererror');
+  if (error) {
+    throw new Error(`QTI XML parse error: ${error.textContent.trim()}`);
+  }
+
+  return doc;
+}
+
+/**
+ * Parses a raw QTI XML string into the structured ItemModel.
+ *
+ * Each interaction block in the item body becomes one entry in `interactions`.
+ * A response declaration belongs to an interaction when the declaration's
+ * `identifier` matches the interaction's `response-identifier` attribute.
+ *
+ * @param {string} rawData - Raw QTI XML string (the full assessment item XML)
+ * @returns {{
+ *   identifier: string,
+ *   title: string,
+ *   language: string,
+ *   interactions: Array<{ bodyXml: string, responseDeclarations: string[] }>
+ * }}
+ */
+export function parseItem(rawData) {
+  const doc = parseXML(rawData);
+
+  const root = doc.querySelector('qti-assessment-item');
+  const identifier = root ? (root.getAttribute('identifier') ?? '') : '';
+  const title = root ? (root.getAttribute('title') ?? '') : '';
+  const language = root ? (root.getAttribute('xml:lang') ?? '') : '';
+
+  const body = doc.querySelector('qti-item-body');
+
+  // Collect all response declarations from the document.
+  const allDeclarations = [...doc.querySelectorAll('qti-response-declaration')];
+
+  const interactions = [];
+
+  if (body) {
+    const selector = QTI_INTERACTION_TAGS.join(', ');
+    const interactionEls = [...body.querySelectorAll(selector)];
+
+    for (const el of interactionEls) {
+      const responseId = el.getAttribute('response-identifier');
+
+      const responseDeclarations = allDeclarations
+        .filter(d => d.getAttribute('identifier') === responseId)
+        .map(d => serializer.serializeToString(d));
+
+      interactions.push({
+        bodyXml: serializer.serializeToString(el),
+        responseDeclarations,
+      });
+    }
+  }
+
+  return { identifier, title, language, interactions };
+}

--- a/contentcuration/contentcuration/frontend/shared/views/QTIEditor/utils/testingFixtures.js
+++ b/contentcuration/contentcuration/frontend/shared/views/QTIEditor/utils/testingFixtures.js
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------
+// Centralized QTI Mock XML Fixtures for Unit Tests
+// ---------------------------------------------------------------------------
+
+export const CHOICE_SINGLE_SELECT_XML = `<qti-choice-interaction response-identifier="RESPONSE" max-choices="1">
+  <qti-prompt>Which planet is closest to the Sun?</qti-prompt>
+  <qti-simple-choice identifier="mercury">Mercury</qti-simple-choice>
+  <qti-simple-choice identifier="venus">Venus</qti-simple-choice>
+  <qti-simple-choice identifier="earth">Earth</qti-simple-choice>
+</qti-choice-interaction>`;
+
+export const CHOICE_MULTI_SELECT_XML = `<qti-choice-interaction response-identifier="RESPONSE" max-choices="2">
+  <qti-prompt>Select all that apply.</qti-prompt>
+  <qti-simple-choice identifier="a">Option A</qti-simple-choice>
+  <qti-simple-choice identifier="b">Option B</qti-simple-choice>
+  <qti-simple-choice identifier="c">Option C</qti-simple-choice>
+</qti-choice-interaction>`;
+
+export const CHOICE_NO_PROMPT_XML = `<qti-choice-interaction response-identifier="RESPONSE" max-choices="1">
+  <qti-simple-choice identifier="a">A</qti-simple-choice>
+</qti-choice-interaction>`;
+
+export const UNKNOWN_INTERACTION_XML = `<qti-unknown-interaction response-identifier="RESPONSE">
+  <qti-prompt>Unknown.</qti-prompt>
+</qti-unknown-interaction>`;
+
+// ---------------------------------------------------------------------------
+// Full QTI Assessment Item XML Documents
+// ---------------------------------------------------------------------------
+
+export const VALID_CHOICE_ITEM_DOCUMENT = `<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item
+  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+  identifier="item-test-1"
+  title="Test Question"
+  adaptive="false"
+  time-dependent="false"
+  xml:lang="en"
+>
+  <qti-response-declaration
+    identifier="RESPONSE"
+    cardinality="single"
+    base-type="identifier"
+  >
+    <qti-correct-response>
+      <qti-value>choice-a</qti-value>
+    </qti-correct-response>
+  </qti-response-declaration>
+
+  <qti-item-body>
+    <qti-choice-interaction response-identifier="RESPONSE" max-choices="1">
+      <qti-prompt>Pick one.</qti-prompt>
+      <qti-simple-choice identifier="choice-a">A</qti-simple-choice>
+      <qti-simple-choice identifier="choice-b">B</qti-simple-choice>
+    </qti-choice-interaction>
+  </qti-item-body>
+</qti-assessment-item>`;
+
+export const TWO_INTERACTIONS_DOCUMENT = `<?xml version="1.0" encoding="UTF-8"?>
+<qti-assessment-item
+  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+  identifier="item-multi"
+  title="Multi Interaction"
+  adaptive="false"
+  time-dependent="false"
+  xml:lang="fr"
+>
+  <qti-response-declaration identifier="RESP1" cardinality="single" base-type="identifier" />
+  <qti-response-declaration identifier="RESP2" cardinality="single" base-type="string" />
+
+  <qti-item-body>
+    <p>Intro text</p>
+    <qti-choice-interaction response-identifier="RESP1" max-choices="1">
+      <qti-prompt>Question 1</qti-prompt>
+    </qti-choice-interaction>
+    <p>Middle text</p>
+    <qti-text-entry-interaction response-identifier="RESP2" />
+  </qti-item-body>
+</qti-assessment-item>`;
+
+/**
+ * Wraps a snippet of interaction XML into a mock 'block' object
+ * simulating the output of useQtiItem()
+ * @param {string} bodyXml
+ * @returns {object}
+ */
+export const mockInteractionBlock = bodyXml => ({
+  bodyXml,
+  responseDeclarations: [],
+});


### PR DESCRIPTION

<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

This PR:
- Adds `serialization/parseItem.js` with `parseXML` (string → validated XML Document) and `parseItem` (splits a QTI item into interaction blocks and metadata).
- Introduces the `interactions/` plugin folder: a `defineInteraction` contract helper that validates descriptor shape, an aggregator `index.js` that builds the registry, and a `choice` plugin that handles both single- and multi-select interactions.
- Adds `composables/useQtiItem.js` — a read-only composable that parses an item's `raw_data` XML and exposes a reactive model (`identifier`, `title`, `language`, `interactions`).
- Adds `composables/useInteractionDescriptor.js` — resolves the correct plugin descriptor and derives `questionType` (`singleSelect` / `multiSelect`) by parsing the interaction's `bodyXml`.
- Adds `components/InteractionSection/index.vue` — detects the interaction type via the registry's `matches()`, mounts the descriptor's `editorComponent`, and passes `questionType` as a prop.
- Adds `interactions/choice/ChoiceInteractionEditor.vue` — renders `KRadioButton` for single-select and `KCheckbox` for multi-select; hides choices in view mode so only the prompt text is shown.
- Updates `QTIItemEditor/index.vue` to use `useQtiItem`, render the first interaction via `InteractionSection`, and display an explicit "Single Choice" or "Multiple Choice" label in the closed-card header.
- Extends `constants.js` with `QTI_INTERACTION_TAGS` and `qtiEditorStrings.js` with explicit single/multi-choice labels.
- Updates the QTI Demo Page with a second (multi-choice) hardcoded item so the demo exercises both interaction types end-to-end.
- Ships unit tests for all new modules using Vue Testing Library (68 tests, all passing).
****
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/c5774eb4-1dca-45aa-b092-f156f31b45fd" />

## References
<!--
 * references to related issues and PRs
-->

Closes #5964 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Open a channel in the Studio channel editor and append `/#/qti-demo` to the URL.
- You will see two hardcoded questions — one single-choice and one multi-choice.
- Expand/collapse cards to verify prompt text is shown when collapsed and choices appear only when expanded.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Used Antigravity for final review and nitpicks.