### PR TITLE
feat: add format prop to TipTapEditor to support HTML content alongside markdown and include unit tests

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/TipTapEditor/TipTapEditor.vue
@@ -190,10 +190,10 @@
         document.removeEventListener('click', handleClickOutside);
       });
 
-      const getMarkdownContent = () => {
-        if (!editor.value || !isReady.value || !editor.value.storage?.markdown) {
-          return '';
-        }
+      const getContent = () => {
+        if (!editor.value || !isReady.value) return '';
+        if (props.format === 'html') return editor.value.getHTML();
+        if (!editor.value.storage?.markdown) return '';
         return editor.value.storage.markdown.getMarkdown();
       };
 
@@ -217,7 +217,8 @@
       watch(
         () => props.value,
         newValue => {
-          const processedContent = preprocessMarkdown(newValue);
+          const processedContent =
+            props.format === 'html' ? newValue : preprocessMarkdown(newValue);
 
           if (!editor.value) {
             initializeEditor(processedContent, props.mode, {
@@ -226,8 +227,7 @@
             return;
           }
 
-          const editorContent = getMarkdownContent();
-          if (editorContent !== newValue) {
+          if (getContent() !== newValue) {
             isUpdatingFromOutside = true;
             editor.value.commands.setContent(processedContent, false);
             nextTick(() => {
@@ -242,18 +242,11 @@
       watch(
         () => editor.value?.state,
         () => {
-          if (
-            !editor.value ||
-            !isReady.value ||
-            isUpdatingFromOutside ||
-            !editor.value.storage?.markdown
-          ) {
-            return;
-          }
+          if (!editor.value || !isReady.value || isUpdatingFromOutside) return;
 
-          const markdown = getMarkdownContent();
-          if (markdown !== props.value) {
-            emit('update', markdown);
+          const content = getContent();
+          if (content !== props.value) {
+            emit('update', content);
           }
         },
         { deep: true },
@@ -311,6 +304,11 @@
       minHeight: {
         type: String,
         default: null,
+      },
+      format: {
+        type: String,
+        default: 'markdown',
+        validator: v => ['markdown', 'html'].includes(v),
       },
     },
     emits: ['update', 'minimize', 'open-editor'],

--- a/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/TipTapEditor.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/views/TipTapEditor/__tests__/TipTapEditor.spec.js
@@ -1,0 +1,89 @@
+import TipTapEditor from '../TipTapEditor/TipTapEditor.vue';
+
+function makeEditorStub({ markdownOut, htmlOut }) {
+  return {
+    storage: {
+      markdown: { getMarkdown: () => markdownOut },
+    },
+    getHTML: () => htmlOut,
+  };
+}
+
+function getContent(editor, isReady, format) {
+  if (!editor || !isReady) return '';
+  if (format === 'html') return editor.getHTML();
+  if (!editor.storage?.markdown) return '';
+  return editor.storage.markdown.getMarkdown();
+}
+describe('TipTapEditor — format prop declaration', () => {
+  const { format: formatProp } = TipTapEditor.props;
+
+  it('exists on the component', () => {
+    expect(formatProp).toBeDefined();
+  });
+
+  it('defaults to markdown', () => {
+    expect(formatProp.default).toBe('markdown');
+  });
+
+  it('validator accepts markdown', () => {
+    expect(formatProp.validator('markdown')).toBe(true);
+  });
+
+  it('validator accepts html', () => {
+    expect(formatProp.validator('html')).toBe(true);
+  });
+
+  it('validator rejects anything else', () => {
+    expect(formatProp.validator('xml')).toBe(false);
+    expect(formatProp.validator('')).toBe(false);
+    expect(formatProp.validator('JSON')).toBe(false);
+  });
+});
+
+describe('TipTapEditor — getContent() logic', () => {
+  const MARKDOWN = '**bold**';
+  const HTML = '<p><strong>bold</strong></p>';
+
+  describe('when editor is not ready', () => {
+    it('returns empty string when editor is null', () => {
+      expect(getContent(null, true, 'markdown')).toBe('');
+    });
+
+    it('returns empty string when isReady is false', () => {
+      const editor = makeEditorStub({ markdownOut: MARKDOWN, htmlOut: HTML });
+      expect(getContent(editor, false, 'markdown')).toBe('');
+    });
+  });
+
+  describe('format="markdown" (default)', () => {
+    it('returns markdown from storage', () => {
+      const editor = makeEditorStub({ markdownOut: MARKDOWN, htmlOut: HTML });
+      expect(getContent(editor, true, 'markdown')).toBe(MARKDOWN);
+    });
+
+    it('returns empty string when markdown storage is absent', () => {
+      const editor = { storage: {}, getHTML: () => HTML };
+      expect(getContent(editor, true, 'markdown')).toBe('');
+    });
+  });
+
+  describe('format="html"', () => {
+    it('returns HTML from editor.getHTML()', () => {
+      const editor = makeEditorStub({ markdownOut: MARKDOWN, htmlOut: HTML });
+      expect(getContent(editor, true, 'html')).toBe(HTML);
+    });
+
+    it('does not call getMarkdown() in html mode', () => {
+      const getMarkdown = jest.fn(() => MARKDOWN);
+      const editor = { storage: { markdown: { getMarkdown } }, getHTML: () => HTML };
+      getContent(editor, true, 'html');
+      expect(getMarkdown).not.toHaveBeenCalled();
+    });
+
+    it('works even when markdown storage is absent', () => {
+      const editor = { storage: {}, getHTML: () => HTML };
+      expect(getContent(editor, true, 'html')).toBe(HTML);
+    });
+  });
+});


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
-->

Added format prop to TipTapEditor to support HTML content alongside markdown and include unit tests

## References
<!--
 * references to related issues and PRs
-->

Fixes #5966 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
Used Antigravity for final review and nitpicks.