### PR TITLE
Pin redis client to RESP2 for compatibility with deployed Redis v4

### DIFF
--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -96,6 +96,16 @@ INSTALLED_APPS = (
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
+# redis-py 8 defaults to RESP3, whose HELLO handshake the pinned Redis v4
+# server rejects. Force RESP2 globally rather than per connection: our paths
+# (cache, native RedisCache, kombu broker) set protocol differently and kombu
+# exposes no knob for it. Remove once the Redis server is upgraded.
+import redis.connection
+import redis.utils
+
+redis.connection.DEFAULT_RESP_VERSION = 2
+redis.utils.DEFAULT_RESP_VERSION = 2
+
 REDIS_URL = "redis://:{password}@{endpoint}/".format(
     password=os.getenv("CELERY_REDIS_PASSWORD") or "",
     endpoint=os.getenv("CELERY_BROKER_ENDPOINT") or "localhost:6379",


### PR DESCRIPTION
## Summary
Pin the redis protocol to RESP2 rather than the redis-py 8 default of RESP3, for backwards compatibility with the older deployed Redis server (v4). RESP3's `HELLO` handshake is rejected by Redis < 6, breaking every connection.

## References
- Redis client bumped to 8.0.1 in #6022

## Reviewer guidance
- `contentcuration/contentcuration/settings.py` overrides `DEFAULT_RESP_VERSION` globally — the one lever that reaches all three connection paths (django-redis cache, native `RedisCache`, kombu/Celery broker).
- Confirm none of those paths rely on RESP3-only behaviour.
- Revert once the deployed Redis server is upgraded to ≥ 6.

## AI usage
Used Claude Code to trace the breakage to redis-py 8 switching its default to RESP3 and to implement the global RESP2 override.