### PR TITLE
6009: add organizations to invitation querysets and sync

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1895,6 +1895,40 @@ class Organization(models.Model):
     def __str__(self):
         return self.name
 
+    @classmethod
+    def filter_edit_queryset(cls, queryset, user):
+        if user.is_anonymous:
+            return queryset.none()
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(
+            user_roles__user=user,
+            user_roles__role=ORGANIZATION_ADMIN,
+            user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            deleted=False,
+        ).distinct()
+
+    @classmethod
+    def filter_view_queryset(cls, queryset, user):
+        if user.is_anonymous:
+            return queryset.none()
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(
+            user_roles__user=user,
+            user_roles__role__in=[
+                ORGANIZATION_ADMIN,
+                ORGANIZATION_EDITOR,
+                ORGANIZATION_VIEWER,
+            ],
+            user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            deleted=False,
+        ).distinct()
+
 
 class OrganizationRole(models.Model):
     """
@@ -3807,7 +3841,14 @@ class Invitation(models.Model):
             return queryset
 
         return queryset.filter(
-            Q(email__iexact=user.email) | Q(sender=user) | Q(channel__editors=user)
+            Q(email__iexact=user.email)
+            | Q(sender=user)
+            | Q(channel__editors=user)
+            | Q(
+                organization__user_roles__user=user,
+                organization__user_roles__role=ORGANIZATION_ADMIN,
+                organization__user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
         ).distinct()
 
     @classmethod
@@ -3822,6 +3863,15 @@ class Invitation(models.Model):
             | Q(sender=user)
             | Q(channel__editors=user)
             | Q(channel__viewers=user)
+            | Q(
+                organization__user_roles__user=user,
+                organization__user_roles__role__in=[
+                    ORGANIZATION_ADMIN,
+                    ORGANIZATION_EDITOR,
+                    ORGANIZATION_VIEWER,
+                ],
+                organization__user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
         ).distinct()
 
 

--- a/contentcuration/contentcuration/tests/test_models.py
+++ b/contentcuration/contentcuration/tests/test_models.py
@@ -16,6 +16,15 @@ from le_utils.constants.labels import subjects
 from contentcuration.constants import channel_history
 from contentcuration.constants import community_library_submission
 from contentcuration.constants import user_history
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import ORGANIZATION_EDITOR
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
+)
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_PENDING,
+)
+from contentcuration.constants.organization_roles import ORGANIZATION_VIEWER
 from contentcuration.models import AssessmentItem
 from contentcuration.models import AuditedSpecialPermissionsLicense
 from contentcuration.models import Change
@@ -34,6 +43,8 @@ from contentcuration.models import Invitation
 from contentcuration.models import Language
 from contentcuration.models import License
 from contentcuration.models import object_storage_name
+from contentcuration.models import Organization
+from contentcuration.models import OrganizationRole
 from contentcuration.models import RecommendationsEvent
 from contentcuration.models import RecommendationsInteractionEvent
 from contentcuration.models import User
@@ -307,6 +318,165 @@ class ChannelTestCase(PermissionQuerysetTestCase):
         )
 
         self.assertEqual(channel.get_server_rev(), 2)
+
+
+class OrganizationTestCase(PermissionQuerysetTestCase):
+    @property
+    def base_queryset(self):
+        return Organization.objects.all()
+
+    def test_filter_edit_queryset__admin_role(self):
+        organization = testdata.organization()
+        user = testdata.user()
+
+        queryset = Organization.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=organization.id)
+
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        queryset = Organization.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetContains(queryset, pk=organization.id)
+
+    def test_filter_edit_queryset__editor_role_cannot_edit(self):
+        organization = testdata.organization()
+        user = testdata.user()
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_EDITOR,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+
+        queryset = Organization.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=organization.id)
+
+    def test_filter_edit_queryset__pending_admin_cannot_edit(self):
+        organization = testdata.organization()
+        user = testdata.user()
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_PENDING,
+        )
+
+        queryset = Organization.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=organization.id)
+
+    def test_filter_edit_queryset__anonymous(self):
+        organization = testdata.organization()
+
+        queryset = Organization.filter_edit_queryset(
+            self.base_queryset, user=self.anonymous_user
+        )
+        self.assertQuerysetDoesNotContain(queryset, pk=organization.id)
+
+    def test_filter_view_queryset__viewer_role(self):
+        organization = testdata.organization()
+        user = testdata.user()
+
+        queryset = Organization.filter_view_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=organization.id)
+
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        queryset = Organization.filter_view_queryset(self.base_queryset, user=user)
+        self.assertQuerysetContains(queryset, pk=organization.id)
+
+    def test_filter_view_queryset__anonymous(self):
+        organization = testdata.organization()
+
+        queryset = Organization.filter_view_queryset(
+            self.base_queryset, user=self.anonymous_user
+        )
+        self.assertQuerysetDoesNotContain(queryset, pk=organization.id)
+
+
+class InvitationOrganizationTestCase(PermissionQuerysetTestCase):
+    @property
+    def base_queryset(self):
+        return Invitation.objects.all()
+
+    def _make_org_invitation(self):
+        organization = testdata.organization()
+        invitee = testdata.user(email="org-invitee@le.com")
+        invitation = Invitation.objects.create(
+            email=invitee.email, organization=organization
+        )
+        return organization, invitation
+
+    def test_filter_edit_queryset__organization_admin(self):
+        organization, invitation = self._make_org_invitation()
+        user = testdata.user()
+
+        queryset = Invitation.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=invitation.id)
+
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        queryset = Invitation.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetContains(queryset, pk=invitation.id)
+
+    def test_filter_edit_queryset__organization_editor_cannot_edit(self):
+        organization, invitation = self._make_org_invitation()
+        user = testdata.user()
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_EDITOR,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+
+        queryset = Invitation.filter_edit_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=invitation.id)
+
+    def test_filter_view_queryset__organization_editor(self):
+        organization, invitation = self._make_org_invitation()
+        user = testdata.user()
+
+        queryset = Invitation.filter_view_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=invitation.id)
+
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_EDITOR,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        queryset = Invitation.filter_view_queryset(self.base_queryset, user=user)
+        self.assertQuerysetContains(queryset, pk=invitation.id)
+
+    def test_filter_view_queryset__organization_viewer(self):
+        organization, invitation = self._make_org_invitation()
+        user = testdata.user()
+        OrganizationRole.objects.create(
+            user=user,
+            organization=organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+
+        queryset = Invitation.filter_view_queryset(self.base_queryset, user=user)
+        self.assertQuerysetContains(queryset, pk=invitation.id)
+
+    def test_filter_view_queryset__unrelated_user(self):
+        organization, invitation = self._make_org_invitation()
+        user = testdata.user()
+
+        queryset = Invitation.filter_view_queryset(self.base_queryset, user=user)
+        self.assertQuerysetDoesNotContain(queryset, pk=invitation.id)
 
 
 class ContentNodeTestCase(PermissionQuerysetTestCase):

--- a/contentcuration/contentcuration/tests/testdata.py
+++ b/contentcuration/contentcuration/tests/testdata.py
@@ -19,6 +19,10 @@ from contentcuration import models as cc
 from contentcuration.constants import (
     community_library_submission as community_library_submission_constants,
 )
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
+)
 from contentcuration.tests.utils import mixer
 
 
@@ -251,6 +255,18 @@ def channel(name="testchannel"):
     channel.save()
 
     return channel
+
+
+def organization(name="Test Organization"):
+    return cc.Organization.objects.create(name=name)
+
+
+def organization_role(
+    user, organization, role=ORGANIZATION_ADMIN, status=ORGANIZATION_ROLE_STATUS_ACTIVE
+):
+    return cc.OrganizationRole.objects.create(
+        user=user, organization=organization, role=role, status=status
+    )
 
 
 def random_string(chars=10):

--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -3,6 +3,12 @@ import uuid
 from django.urls import reverse
 
 from contentcuration import models
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import ORGANIZATION_EDITOR
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
+)
+from contentcuration.models import ADMIN_ACCESS
 from contentcuration.tests import testdata
 from contentcuration.tests.base import StudioAPITestCase
 from contentcuration.tests.viewsets.base import generate_create_event
@@ -141,6 +147,27 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         )
         self.assertTrue(models.Change.objects.filter(channel=self.channel).exists())
 
+    def test_update_invitation_accept_admin_share_mode_grants_editor_access(self):
+        invitation = models.Invitation.objects.create(
+            share_mode=ADMIN_ACCESS, **self.invitation_db_metadata
+        )
+
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.accepted)
+        self.assertTrue(self.channel.editors.filter(pk=self.invited_user.id).exists())
+
     def test_update_invitation_revoke(self):
 
         invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
@@ -230,6 +257,27 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
         invitation = models.Invitation.objects.get(id=invitation.id)
         self.assertFalse(invitation.accepted)
         self.assertFalse(invitation.declined)
+
+    def test_update_invitation_cannot_add_organization(self):
+        invitation = models.Invitation.objects.create(**self.invitation_db_metadata)
+        organization = testdata.organization()
+        testdata.organization_role(self.user, organization)
+
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"organization": organization.id},
+                    channel_id=self.channel.id,
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(len(response.json()["errors"]), 1)
+        invitation.refresh_from_db()
+        self.assertIsNone(invitation.organization_id)
 
     def test_update_invitation_decline(self):
 
@@ -344,6 +392,222 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
             self.fail("Invitation 2 was not deleted")
         except models.Invitation.DoesNotExist:
             pass
+
+
+class OrganizationInvitationSyncTestCase(SyncTestMixin, StudioAPITestCase):
+    def setUp(self):
+        super(OrganizationInvitationSyncTestCase, self).setUp()
+        self.organization = testdata.organization()
+        self.org_admin = testdata.user("org-admin@inc.com")
+        testdata.organization_role(self.org_admin, self.organization)
+        self.invited_user = testdata.user("org-invitee@inc.com")
+        self.client.force_authenticate(user=self.org_admin)
+
+    def test_accept_organization_invitation_creates_role(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            invited=self.invited_user,
+            sender=self.org_admin,
+        )
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.accepted)
+        role = models.OrganizationRole.objects.get(
+            user=self.invited_user, organization=self.organization
+        )
+        self.assertEqual(role.role, ORGANIZATION_EDITOR)
+        self.assertEqual(role.status, ORGANIZATION_ROLE_STATUS_ACTIVE)
+
+    def test_revoke_organization_invitation_by_admin(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"revoked": True},
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.revoked)
+
+    def test_revoke_organization_invitation_by_non_admin_rejected(self):
+        editor = testdata.user("org-editor2@inc.com")
+        testdata.organization_role(editor, self.organization, role=ORGANIZATION_EDITOR)
+        self.client.force_authenticate(user=editor)
+
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"revoked": True},
+                    user_id=editor.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertFalse(invitation.revoked)
+
+    def test_revoke_organization_invitation_by_different_admin(self):
+        other_admin = testdata.user("org-admin-3@inc.com")
+        testdata.organization_role(other_admin, self.organization)
+
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        self.client.force_authenticate(user=other_admin)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"revoked": True},
+                    user_id=other_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.revoked)
+
+    def test_admin_cannot_force_accept_on_behalf_of_invitee(self):
+        # Org-admin edit rights must not let an admin trigger accept() on
+        # someone else's invitation - accepted stays read-only for them.
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertFalse(invitation.accepted)
+        self.assertFalse(
+            models.OrganizationRole.objects.filter(
+                user=self.invited_user, organization=self.organization
+            ).exists()
+        )
+
+    def test_invitee_cannot_raise_own_share_mode_before_accepting(self):
+        # share_mode must be read-only for the invitee, same as
+        # accepted/revoked - otherwise they could self-escalate to org
+        # admin (which itself grants edit rights over the org's invitations)
+        # by requesting "admin" access before accepting.
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"share_mode": ADMIN_ACCESS, "accepted": True},
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.accepted)
+        self.assertNotEqual(invitation.share_mode, ADMIN_ACCESS)
+        role = models.OrganizationRole.objects.get(
+            user=self.invited_user, organization=self.organization
+        )
+        self.assertNotEqual(role.role, ORGANIZATION_ADMIN)
+        self.assertEqual(role.role, ORGANIZATION_EDITOR)
+
+    def test_delete_organization_invitation(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_delete_event(
+                    invitation.id,
+                    INVITATION,
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Organization invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_list_invitations_filtered_by_organization(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        other_organization = testdata.organization()
+        other_invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=other_organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.client.get(
+            reverse("invitation-list"), {"organization": self.organization.id}
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        payload = response.json()
+        results = payload["results"] if isinstance(payload, dict) else payload
+        returned_ids = [item["id"] for item in results]
+        self.assertIn(invitation.id, returned_ids)
+        self.assertNotIn(other_invitation.id, returned_ids)
 
 
 class CRUDTestCase(StudioAPITestCase):

--- a/contentcuration/contentcuration/tests/viewsets/test_invitation.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_invitation.py
@@ -3,6 +3,11 @@ import uuid
 from django.urls import reverse
 
 from contentcuration import models
+from contentcuration.constants.organization_roles import ORGANIZATION_EDITOR
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
+)
+from contentcuration.models import ADMIN_ACCESS
 from contentcuration.tests import testdata
 from contentcuration.tests.base import StudioAPITestCase
 from contentcuration.tests.viewsets.base import generate_create_event
@@ -140,6 +145,29 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
             ).exists()
         )
         self.assertTrue(models.Change.objects.filter(channel=self.channel).exists())
+
+    def test_update_invitation_accept_admin_share_mode_grants_editor_access(self):
+        # _accept_channel_invitation only special-cases VIEW_ACCESS, so
+        # "admin" currently grants the same editor access as "edit".
+        invitation = models.Invitation.objects.create(
+            share_mode=ADMIN_ACCESS, **self.invitation_db_metadata
+        )
+
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.accepted)
+        self.assertTrue(self.channel.editors.filter(pk=self.invited_user.id).exists())
 
     def test_update_invitation_revoke(self):
 
@@ -346,6 +374,402 @@ class SyncTestCase(SyncTestMixin, StudioAPITestCase):
             pass
 
 
+class OrganizationInvitationSyncTestCase(SyncTestMixin, StudioAPITestCase):
+    @property
+    def invitation_metadata(self):
+        return {
+            "id": uuid.uuid4().hex,
+            "organization": self.organization.id,
+            "email": self.invited_user.email,
+        }
+
+    def setUp(self):
+        super(OrganizationInvitationSyncTestCase, self).setUp()
+        self.organization = testdata.organization()
+        self.org_admin = testdata.user("org-admin@inc.com")
+        testdata.organization_role(self.org_admin, self.organization)
+        self.invited_user = testdata.user("org-invitee@inc.com")
+        self.client.force_authenticate(user=self.org_admin)
+
+    def test_create_organization_invitation(self):
+        invitation = self.invitation_metadata
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+        except models.Invitation.DoesNotExist:
+            self.fail("Organization invitation was not created")
+
+    def test_create_organization_invitation_by_non_admin_rejected(self):
+        editor = testdata.user("org-editor@inc.com")
+        testdata.organization_role(editor, self.organization, role=ORGANIZATION_EDITOR)
+        self.client.force_authenticate(user=editor)
+
+        invitation = self.invitation_metadata
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    user_id=editor.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+            self.fail("Organization invitation was created by a non-admin")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_create_invitation_requires_channel_or_organization(self):
+        self.client.force_authenticate(user=self.invited_user)
+        invitation = {
+            "id": uuid.uuid4().hex,
+            "email": self.invited_user.email,
+        }
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+            self.fail("Invitation without channel or organization was created")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_accept_organization_invitation_creates_role(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            invited=self.invited_user,
+            sender=self.org_admin,
+        )
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.accepted)
+        role = models.OrganizationRole.objects.get(
+            user=self.invited_user, organization=self.organization
+        )
+        self.assertEqual(role.role, ORGANIZATION_EDITOR)
+        self.assertEqual(role.status, ORGANIZATION_ROLE_STATUS_ACTIVE)
+
+    def test_revoke_organization_invitation_by_admin(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"revoked": True},
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.revoked)
+
+    def test_revoke_organization_invitation_by_non_admin_rejected(self):
+        editor = testdata.user("org-editor2@inc.com")
+        testdata.organization_role(editor, self.organization, role=ORGANIZATION_EDITOR)
+        self.client.force_authenticate(user=editor)
+
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"revoked": True},
+                    user_id=editor.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertFalse(invitation.revoked)
+
+    def test_invitation_with_channel_and_organization_is_rejected(self):
+        channel = testdata.channel()
+        channel.editors.add(self.org_admin)
+        invitation = {
+            "id": uuid.uuid4().hex,
+            "channel": channel.id,
+            "organization": self.organization.id,
+            "email": self.invited_user.email,
+        }
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    channel_id=channel.id,
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+            self.fail("Invitation with both channel and organization was created")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_create_organization_invitation_without_user_id_is_rejected(self):
+        # No org-specific routing in handle_changes - a missing user_id is
+        # rejected like any other self-only change, with feedback returned.
+        invitation = self.invitation_metadata
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(len(response.data["disallowed"]), 1)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+            self.fail(
+                "Organization invitation without a client-supplied user_id "
+                "was created"
+            )
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_organization_invitation_change_with_mismatched_user_id_is_rejected(self):
+        # A user_id that doesn't match the actor is rejected, not routed
+        # elsewhere - it must not inject a change into another user's feed.
+        unrelated_user = testdata.user("unrelated-target@inc.com")
+        invitation = self.invitation_metadata
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    user_id=unrelated_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(len(response.data["disallowed"]), 1)
+        self.assertFalse(
+            models.Change.objects.filter(
+                table=INVITATION, kwargs__key=invitation["id"]
+            ).exists()
+        )
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+            self.fail("Invitation was created despite a mismatched user_id")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_create_organization_invitation_for_different_org_is_rejected(self):
+        other_organization = testdata.organization()
+        invitation = self.invitation_metadata
+        invitation["organization"] = other_organization.id
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation["id"])
+            self.fail(
+                "Invitation was created for an organization the admin doesn't manage"
+            )
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_revoke_organization_invitation_by_different_admin(self):
+        other_admin = testdata.user("org-admin-3@inc.com")
+        testdata.organization_role(other_admin, self.organization)
+
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        self.client.force_authenticate(user=other_admin)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"revoked": True},
+                    user_id=other_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertTrue(invitation.revoked)
+
+    def test_admin_cannot_force_accept_on_behalf_of_invitee(self):
+        # Org-admin edit rights must not let an admin trigger accept() on
+        # someone else's invitation - accepted stays read-only for them.
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation.id,
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        invitation.refresh_from_db()
+        self.assertFalse(invitation.accepted)
+        self.assertFalse(
+            models.OrganizationRole.objects.filter(
+                user=self.invited_user, organization=self.organization
+            ).exists()
+        )
+
+    def test_delete_organization_invitation(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.sync_changes(
+            [
+                generate_delete_event(
+                    invitation.id,
+                    INVITATION,
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        try:
+            models.Invitation.objects.get(id=invitation.id)
+            self.fail("Organization invitation was not deleted")
+        except models.Invitation.DoesNotExist:
+            pass
+
+    def test_accept_organization_invitation_created_via_sync(self):
+        # Unlike the fixtures above, an invitation created via sync never
+        # gets `invited` populated - the real invitee must still accept it.
+        invitation = self.invitation_metadata
+        response = self.sync_changes(
+            [
+                generate_create_event(
+                    invitation["id"],
+                    INVITATION,
+                    invitation,
+                    user_id=self.org_admin.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        created = models.Invitation.objects.get(id=invitation["id"])
+        self.assertIsNone(created.invited)
+
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.sync_changes(
+            [
+                generate_update_event(
+                    invitation["id"],
+                    INVITATION,
+                    {"accepted": True},
+                    user_id=self.invited_user.id,
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        created.refresh_from_db()
+        self.assertTrue(created.accepted)
+        self.assertTrue(
+            models.OrganizationRole.objects.filter(
+                user=self.invited_user, organization=self.organization
+            ).exists()
+        )
+
+    def test_list_invitations_filtered_by_organization(self):
+        invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=self.organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        other_organization = testdata.organization()
+        other_invitation = models.Invitation.objects.create(
+            id=uuid.uuid4().hex,
+            organization=other_organization,
+            email=self.invited_user.email,
+            sender=self.org_admin,
+        )
+        response = self.client.get(
+            reverse("invitation-list"), {"organization": self.organization.id}
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        payload = response.json()
+        results = payload["results"] if isinstance(payload, dict) else payload
+        returned_ids = [item["id"] for item in results]
+        self.assertIn(invitation.id, returned_ids)
+        self.assertNotIn(other_invitation.id, returned_ids)
+
+
 class CRUDTestCase(StudioAPITestCase):
     @property
     def invitation_metadata(self):
@@ -375,6 +799,23 @@ class CRUDTestCase(StudioAPITestCase):
     def test_create_invitation(self):
         self.client.force_authenticate(user=self.user)
         invitation = self.invitation_metadata
+        response = self.client.post(
+            reverse("invitation-list"),
+            invitation,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 405, response.content)
+
+    def test_create_organization_invitation(self):
+        organization = testdata.organization()
+        org_admin = testdata.user("crud-org-admin@inc.com")
+        testdata.organization_role(org_admin, organization)
+        self.client.force_authenticate(user=org_admin)
+        invitation = {
+            "id": uuid.uuid4().hex,
+            "organization": organization.id,
+            "email": self.invited_user.email,
+        }
         response = self.client.post(
             reverse("invitation-list"),
             invitation,

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from contentcuration.models import Change
 from contentcuration.models import Channel
 from contentcuration.models import Invitation
+from contentcuration.models import Organization
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
@@ -25,7 +26,12 @@ class InvitationSerializer(BulkModelSerializer):
     accepted = serializers.BooleanField(read_only=True)
     declined = serializers.BooleanField(read_only=True)
 
-    channel = UserFilteredPrimaryKeyRelatedField(queryset=Channel.objects.all())
+    channel = UserFilteredPrimaryKeyRelatedField(
+        queryset=Channel.objects.all(), required=False
+    )
+    organization = UserFilteredPrimaryKeyRelatedField(
+        queryset=Organization.objects.all(), required=False
+    )
 
     class Meta:
         model = Invitation
@@ -36,11 +42,27 @@ class InvitationSerializer(BulkModelSerializer):
             "revoked",
             "email",
             "channel",
+            "organization",
             "share_mode",
             "first_name",
             "last_name",
         )
         list_serializer_class = BulkListSerializer
+
+    def validate(self, data):
+        channel = data.get("channel", getattr(self.instance, "channel_id", None))
+        organization = data.get(
+            "organization", getattr(self.instance, "organization_id", None)
+        )
+        if not channel and not organization:
+            raise serializers.ValidationError(
+                "Invitation must specify either a channel or an organization."
+            )
+        if channel and organization:
+            raise serializers.ValidationError(
+                "Invitation cannot specify both a channel and an organization."
+            )
+        return data
 
     def create(self, validated_data):
         # Need to remove default values for these non-model fields here
@@ -52,8 +74,10 @@ class InvitationSerializer(BulkModelSerializer):
 
     def update(self, instance, validated_data):
         instance = super(InvitationSerializer, self).update(instance, validated_data)
-        accepted = self.initial_data.get("accepted") or instance.accepted
-        revoked = self.initial_data.get("revoked") or instance.revoked
+        # validated_data, not initial_data, respects get_fields' read-only
+        # flags; only trigger accept() on an actual incoming toggle.
+        accepted = validated_data.get("accepted")
+        revoked = validated_data.get("revoked") or instance.revoked
 
         if accepted and not revoked:
             instance.accept()
@@ -65,6 +89,7 @@ class InvitationSerializer(BulkModelSerializer):
                         "accepted": True,
                     },
                     channel_id=instance.channel_id,
+                    user_id=self.context["request"].user.id,
                 )
             )
 
@@ -76,11 +101,27 @@ class InvitationSerializer(BulkModelSerializer):
 
         # allow invitation state to be modified under the right conditions
         if request and request.user and self.instance:
-            if self.instance.invited == request.user:
+            # Match on email, not the `invited` FK - `invited` is only set by
+            # the channel email-invite flow, never for sync-created invitations.
+            if (request.user.email or "").lower() == (
+                self.instance.email or ""
+            ).lower():
                 fields["accepted"].read_only = self.instance.revoked
                 fields["declined"].read_only = False
-            if self.instance.sender == request.user:
+
+            is_org_admin = (
+                self.instance.organization_id
+                and Organization.filter_edit_queryset(
+                    Organization.objects.filter(id=self.instance.organization_id),
+                    request.user,
+                ).exists()
+            )
+            if self.instance.sender == request.user or is_org_admin:
                 fields["revoked"].read_only = False
+            else:
+                # Otherwise the invitee could raise their own access level
+                # (e.g. to org admin) via share_mode before accepting.
+                fields["share_mode"].read_only = True
 
         return fields
 
@@ -88,12 +129,14 @@ class InvitationSerializer(BulkModelSerializer):
 class InvitationFilter(FilterSet):
     invited = CharFilter(method="filter_invited")
     channel = CharFilter(method="filter_channel")
+    organization = CharFilter(method="filter_organization")
 
     class Meta:
         model = Invitation
         fields = (
             "invited",
             "channel",
+            "organization",
         )
 
     def filter_invited(self, queryset, name, value):
@@ -101,6 +144,9 @@ class InvitationFilter(FilterSet):
 
     def filter_channel(self, queryset, name, value):
         return queryset.filter(channel_id=value)
+
+    def filter_organization(self, queryset, name, value):
+        return queryset.filter(organization_id=value)
 
 
 def get_sender_name(item):
@@ -124,6 +170,7 @@ class InvitationViewSet(ValuesViewset):
         "sender__first_name",
         "sender__last_name",
         "channel_id",
+        "organization_id",
         "share_mode",
         "channel__name",
     )
@@ -133,6 +180,7 @@ class InvitationViewSet(ValuesViewset):
         "sender_name": get_sender_name,
         "channel_name": "channel__name",
         "channel": "channel_id",
+        "organization": "organization_id",
     }
 
     def perform_update(self, serializer):
@@ -163,6 +211,7 @@ class InvitationViewSet(ValuesViewset):
                 INVITATION,
                 {"accepted": True},
                 channel_id=invitation.channel_id,
+                user_id=request.user.id,
             ),
             applied=True,
             created_by_id=request.user.id,
@@ -181,6 +230,7 @@ class InvitationViewSet(ValuesViewset):
                 INVITATION,
                 {"declined": True},
                 channel_id=invitation.channel_id,
+                user_id=request.user.id,
             ),
             applied=True,
             created_by_id=request.user.id,

--- a/contentcuration/contentcuration/viewsets/invitation.py
+++ b/contentcuration/contentcuration/viewsets/invitation.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from contentcuration.models import Change
 from contentcuration.models import Channel
 from contentcuration.models import Invitation
+from contentcuration.models import Organization
 from contentcuration.viewsets.base import BulkListSerializer
 from contentcuration.viewsets.base import BulkModelSerializer
 from contentcuration.viewsets.base import ValuesViewset
@@ -25,7 +26,12 @@ class InvitationSerializer(BulkModelSerializer):
     accepted = serializers.BooleanField(read_only=True)
     declined = serializers.BooleanField(read_only=True)
 
-    channel = UserFilteredPrimaryKeyRelatedField(queryset=Channel.objects.all())
+    channel = UserFilteredPrimaryKeyRelatedField(
+        queryset=Channel.objects.all(), required=False
+    )
+    organization = UserFilteredPrimaryKeyRelatedField(
+        queryset=Organization.objects.all(), required=False
+    )
 
     class Meta:
         model = Invitation
@@ -36,11 +42,27 @@ class InvitationSerializer(BulkModelSerializer):
             "revoked",
             "email",
             "channel",
+            "organization",
             "share_mode",
             "first_name",
             "last_name",
         )
         list_serializer_class = BulkListSerializer
+
+    def validate(self, data):
+        channel = data.get("channel", getattr(self.instance, "channel_id", None))
+        organization = data.get(
+            "organization", getattr(self.instance, "organization_id", None)
+        )
+        if not channel and not organization:
+            raise serializers.ValidationError(
+                "Invitation must specify either a channel or an organization."
+            )
+        if channel and organization:
+            raise serializers.ValidationError(
+                "Invitation cannot specify both a channel and an organization."
+            )
+        return data
 
     def create(self, validated_data):
         # Need to remove default values for these non-model fields here
@@ -52,8 +74,10 @@ class InvitationSerializer(BulkModelSerializer):
 
     def update(self, instance, validated_data):
         instance = super(InvitationSerializer, self).update(instance, validated_data)
-        accepted = self.initial_data.get("accepted") or instance.accepted
-        revoked = self.initial_data.get("revoked") or instance.revoked
+        # validated_data, not initial_data, respects get_fields' read-only
+        # flags; only trigger accept() on an actual incoming toggle.
+        accepted = validated_data.get("accepted")
+        revoked = validated_data.get("revoked") or instance.revoked
 
         if accepted and not revoked:
             instance.accept()
@@ -65,6 +89,7 @@ class InvitationSerializer(BulkModelSerializer):
                         "accepted": True,
                     },
                     channel_id=instance.channel_id,
+                    user_id=self.context["request"].user.id,
                 )
             )
 
@@ -76,10 +101,22 @@ class InvitationSerializer(BulkModelSerializer):
 
         # allow invitation state to be modified under the right conditions
         if request and request.user and self.instance:
-            if self.instance.invited == request.user:
+            # Match on email, not the `invited` FK - `invited` is only set by
+            # the channel email-invite flow, never for sync-created invitations.
+            if (request.user.email or "").lower() == (
+                self.instance.email or ""
+            ).lower():
                 fields["accepted"].read_only = self.instance.revoked
                 fields["declined"].read_only = False
             if self.instance.sender == request.user:
+                fields["revoked"].read_only = False
+            if (
+                self.instance.organization_id
+                and Organization.filter_edit_queryset(
+                    Organization.objects.filter(id=self.instance.organization_id),
+                    request.user,
+                ).exists()
+            ):
                 fields["revoked"].read_only = False
 
         return fields
@@ -88,12 +125,14 @@ class InvitationSerializer(BulkModelSerializer):
 class InvitationFilter(FilterSet):
     invited = CharFilter(method="filter_invited")
     channel = CharFilter(method="filter_channel")
+    organization = CharFilter(method="filter_organization")
 
     class Meta:
         model = Invitation
         fields = (
             "invited",
             "channel",
+            "organization",
         )
 
     def filter_invited(self, queryset, name, value):
@@ -101,6 +140,9 @@ class InvitationFilter(FilterSet):
 
     def filter_channel(self, queryset, name, value):
         return queryset.filter(channel_id=value)
+
+    def filter_organization(self, queryset, name, value):
+        return queryset.filter(organization_id=value)
 
 
 def get_sender_name(item):
@@ -124,6 +166,7 @@ class InvitationViewSet(ValuesViewset):
         "sender__first_name",
         "sender__last_name",
         "channel_id",
+        "organization_id",
         "share_mode",
         "channel__name",
     )
@@ -133,6 +176,7 @@ class InvitationViewSet(ValuesViewset):
         "sender_name": get_sender_name,
         "channel_name": "channel__name",
         "channel": "channel_id",
+        "organization": "organization_id",
     }
 
     def perform_update(self, serializer):
@@ -163,6 +207,7 @@ class InvitationViewSet(ValuesViewset):
                 INVITATION,
                 {"accepted": True},
                 channel_id=invitation.channel_id,
+                user_id=request.user.id,
             ),
             applied=True,
             created_by_id=request.user.id,
@@ -181,6 +226,7 @@ class InvitationViewSet(ValuesViewset):
                 INVITATION,
                 {"declined": True},
                 channel_id=invitation.channel_id,
+                user_id=request.user.id,
             ),
             applied=True,
             created_by_id=request.user.id,


### PR DESCRIPTION
## Summary

Following #6008 (which added `Invitation.organization`), this extends the invitation querysets and the `/sync` mechanism to actually support organization invitations end-to-end, per #6009.

- `Organization.filter_edit_queryset`/`filter_view_queryset` — new classmethods based on active `OrganizationRole` membership (admin = edit, admin/editor/viewer = view), mirroring the existing `Channel` pattern. Used both by `UserFilteredPrimaryKeyRelatedField` on the serializer (so a user can only submit an org they actually have edit rights to) and by `InvitationSerializer.get_fields`/`Invitation.filter_edit_queryset` for org-admin revoke access.
- `Invitation.filter_edit_queryset`/`filter_view_queryset` — extended to grant the same access to organization invitations.
- `InvitationSerializer` — accepts `organization` in place of `channel`; `channel` is now optional. Validation requires **exactly one** of `channel`/`organization` (not neither, not both) — this is the "Organizations XOR channels" requirement from #5971 that was deliberately deferred to this API-layer work (per rtibbles' comment on #6009 and the review thread on #6008).
- `/sync`'s `handle_changes()` is untouched — organization-scoped invitation changes route the same way any other self-only change does (client tags `user_id` as its own id). Permission is enforced entirely at the model layer (`Invitation.filter_edit_queryset`/`Organization.filter_edit_queryset`) when the change is actually applied, not by the sync-routing layer.

**Note on scope:** two earlier versions of this PR added sync-level machinery for organizations that rtibbles asked to be fully reverted, both times: first, full `organization_id` broadcast parity with `channel_id` (a `Change.organization` field/migration, a dedicated task, `organization_revs`), and second, a narrower `handle_changes()` permission gate/branch that special-cased `organization_id` as a routing key and server-derived the target `user_id` for org-scoped invitation changes. Neither is needed — `channel_id`/`user_id` on `Change` exist specifically to decide broadcast/routing, there's no established need for organizations to have that same live cross-admin behavior, and the model-layer permission checks (`filter_edit_queryset`) already re-enforce access when a change is applied regardless of how it was routed. `organization_id` isn't a recognized top-level change key anywhere in this PR; if present in a change payload it just rides along in `Change.kwargs` like any other unrecognized key.

**Known gap (frontend, out of scope for #6009):** the server contract for org-scoped invitation changes is now "the client must tag `user_id` as its own id," matching every other self-only change. No real frontend client can do this today — `Invitation`'s `getUserId` in `frontend/shared/data/resources.js` returns `obj.invited`, which is never populated for invitations created through the sync API. A client-emitted org invitation change would currently carry `user_id: null` and land in `disallowed`. Flagging so it isn't rediscovered as a silent failure later; fixing it is frontend work outside this PR's scope.

## Testing

- Tests in `test_models.py` (`OrganizationTestCase`, `InvitationOrganizationTestCase`) covering the queryset permission logic directly.
- Tests in `test_invitation.py` (`OrganizationInvitationSyncTestCase`) covering create/accept/revoke/delete via `/sync`, non-admin rejection, cross-org isolation, the "requires at least one of channel/organization" validation, and the mutual-exclusivity rejection.
- Full existing suite and pre-commit hooks pass locally (verified prior to the latest revert; re-verifying once local Postgres/Redis are back up).

## References

Closes #6009. Builds on #6008 (Invitation.organization field) and #5953 (Organization/OrganizationRole models).

## AI usage

Implemented with Claude Code: I worked through the codebase with it to trace how the existing channel-invitation sync mechanism works end-to-end (`handle_changes`, `Change` model, `apply_channel_changes_task`/`apply_user_changes_task`), identified that organization-scoped changes didn't fit either existing permission branch, and reviewed/directed the resulting implementation and test coverage rather than accepting it as-is. The channel/organization mutual-exclusivity requirement was added after re-reading the #6008 review thread and rtibbles' follow-up comment on #6009 flagging it as still outstanding. I initially built full `Change.organization` broadcast parity with `channel_id`, then reverted it after rtibbles' review correctly identified that permission-gating and broadcast-routing are separable concerns, and the latter wasn't needed here. When rtibbles flagged that sync-level machinery for organizations had reappeared in a narrower form (the `handle_changes()` permission gate), I removed that branch entirely and reworked the affected tests to have org-scoped changes self-route like any other user-only change, rather than trying to preserve a server-derived routing mechanism rtibbles had already ruled out. I also used it to trim several of my own overly verbose in-line comments down to 1-2 lines per rtibbles' request, and to scope `InvitationSerializer.update()`'s `accept()` call to actual incoming toggles instead of re-running on every update to an already-accepted invitation.
