### PR TITLE
Add ability to send a notification email on review of community libra…

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -48,6 +48,8 @@ from django.db.models.indexes import IndexExpression
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models.sql import Query
 from django.dispatch import receiver
+from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from django_cte import CTEManager
@@ -86,7 +88,9 @@ from contentcuration.db.models.functions import Unnest
 from contentcuration.db.models.manager import CustomContentNodeTreeManager
 from contentcuration.db.models.manager import CustomManager
 from contentcuration.utils.cache import delete_public_channel_cache_keys
+from contentcuration.utils.messages import get_messages
 from contentcuration.utils.parser import load_json_string
+from contentcuration.utils.urls import canonical_url
 from contentcuration.viewsets.sync.constants import ALL_CHANGES
 from contentcuration.viewsets.sync.constants import ALL_TABLES
 from contentcuration.viewsets.sync.constants import PUBLISHABLE_CHANGE_TABLES
@@ -3048,6 +3052,53 @@ class CommunityLibrarySubmission(models.Model):
             editors = editors.exclude(id=exclude_user_id)
 
         User.notify_users(editors, date=self.date_updated)
+
+    def send_resolution_email(self):
+        """
+        Send an email to the submission author letting them know their
+        Community Library submission has been resolved (approved or
+        rejected).
+        """
+        is_approved = self.status == community_library_submission.STATUS_APPROVED
+
+        community_strings = get_messages().get("CommunityChannelsStrings", {})
+        status_message = (
+            community_strings["approvedStatus"]
+            if is_approved
+            else community_strings["flaggedStatus"]
+        )
+        subject_text = "{}: {}".format(
+            community_strings["communityLibrarySubmissionLabel"], status_message
+        )
+
+        subject = render_to_string(
+            "registration/custom_email_subject.txt",
+            {"subject": subject_text},
+        )
+        subject = "".join(subject.splitlines())
+
+        message = render_to_string(
+            "community_library/submission_resolved_email.html",
+            {
+                "name": self.author.get_full_name(),
+                "channel": self.channel,
+                "channel_url": canonical_url(
+                    reverse("channel", kwargs={"channel_id": self.channel.pk})
+                ),
+                "approved": is_approved,
+                "status_message": (
+                    community_strings["availableStatus"]
+                    if is_approved
+                    else community_strings["needsChangesPrimaryInfo"]
+                ),
+                "feedback_notes_label": community_strings["feedbackNotesLabel"],
+                "feedback_notes": self.feedback_notes,
+            },
+        )
+
+        self.author.email_user(
+            subject, message, settings.DEFAULT_FROM_EMAIL, html_message=message
+        )
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -51,6 +51,7 @@ from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
+from django.utils import translation
 from django.utils.translation import gettext as _
 from django_cte import CTEManager
 from django_cte import CTEQuerySet
@@ -88,7 +89,7 @@ from contentcuration.db.models.functions import Unnest
 from contentcuration.db.models.manager import CustomContentNodeTreeManager
 from contentcuration.db.models.manager import CustomManager
 from contentcuration.utils.cache import delete_public_channel_cache_keys
-from contentcuration.utils.messages import get_messages
+from contentcuration.utils.i18n import closest_supported_locale
 from contentcuration.utils.parser import load_json_string
 from contentcuration.utils.urls import canonical_url
 from contentcuration.viewsets.sync.constants import ALL_CHANGES
@@ -3061,40 +3062,36 @@ class CommunityLibrarySubmission(models.Model):
         """
         is_approved = self.status == community_library_submission.STATUS_APPROVED
 
-        community_strings = get_messages().get("CommunityChannelsStrings", {})
-        status_message = (
-            community_strings["approvedStatus"]
-            if is_approved
-            else community_strings["flaggedStatus"]
-        )
-        subject_text = "{}: {}".format(
-            community_strings["communityLibrarySubmissionLabel"], status_message
-        )
+        channel_language = self.channel.language
+        locale_code = (
+            closest_supported_locale(channel_language.lang_code)
+            if channel_language
+            else None
+        ) or settings.LANGUAGE_CODE
+        with translation.override(locale_code):
+            if is_approved:
+                subject_text = _("Your Community Library submission has been approved")
+            else:
+                subject_text = _("Your Community Library submission needs changes")
 
-        subject = render_to_string(
-            "registration/custom_email_subject.txt",
-            {"subject": subject_text},
-        )
-        subject = "".join(subject.splitlines())
+            subject = render_to_string(
+                "registration/custom_email_subject.txt",
+                {"subject": subject_text},
+            )
+            subject = "".join(subject.splitlines())
 
-        message = render_to_string(
-            "community_library/submission_resolved_email.html",
-            {
-                "name": self.author.get_full_name(),
-                "channel": self.channel,
-                "channel_url": canonical_url(
-                    reverse("channel", kwargs={"channel_id": self.channel.pk})
-                ),
-                "approved": is_approved,
-                "status_message": (
-                    community_strings["availableStatus"]
-                    if is_approved
-                    else community_strings["needsChangesPrimaryInfo"]
-                ),
-                "feedback_notes_label": community_strings["feedbackNotesLabel"],
-                "feedback_notes": self.feedback_notes,
-            },
-        )
+            message = render_to_string(
+                "community_library/submission_resolved_email.html",
+                {
+                    "name": self.author.get_full_name(),
+                    "channel": self.channel,
+                    "channel_url": canonical_url(
+                        reverse("channel", kwargs={"channel_id": self.channel.pk})
+                    ),
+                    "approved": is_approved,
+                    "feedback_notes": self.feedback_notes,
+                },
+            )
 
         self.author.email_user(
             subject, message, settings.DEFAULT_FROM_EMAIL, html_message=message

--- a/contentcuration/contentcuration/templates/community_library/submission_resolved_email.html
+++ b/contentcuration/contentcuration/templates/community_library/submission_resolved_email.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+{% load i18n %}
+<html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+    {% autoescape off %}
+    <p>{% blocktrans with name=name %}Hello {{ name }},{% endblocktrans %}</p>
+
+    <p><a href="{{ channel_url }}" target="_blank">{% blocktrans with channel_name=channel.name %}{{ channel_name }}{% endblocktrans %}</a> ({{ channel_url }})</p>
+
+    <p>{{ status_message }}</p>
+
+    {% if feedback_notes %}
+    <p>{{ feedback_notes_label }}: {{ feedback_notes }}</p>
+    {% endif %}
+
+    <p>
+        {% translate "Thanks for using Kolibri Studio!" %}
+        <br>
+        {% translate "The Learning Equality Team" %}
+    </p>
+    {% endautoescape %}
+</body>
+</html>

--- a/contentcuration/contentcuration/templates/community_library/submission_resolved_email.html
+++ b/contentcuration/contentcuration/templates/community_library/submission_resolved_email.html
@@ -1,20 +1,25 @@
 <!DOCTYPE html>
 {% load i18n %}
-<html>
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
-    {% autoescape off %}
     <p>{% blocktrans with name=name %}Hello {{ name }},{% endblocktrans %}</p>
 
-    <p><a href="{{ channel_url }}" target="_blank">{% blocktrans with channel_name=channel.name %}{{ channel_name }}{% endblocktrans %}</a> ({{ channel_url }})</p>
+    <p><a href="{{ channel_url }}" target="_blank">{{ channel.name }}</a> ({{ channel_url }})</p>
 
-    <p>{{ status_message }}</p>
+    {% if approved %}
+    <p>{% translate "Your submission has been approved and will be added to the Community Library soon." %}</p>
+    {% else %}
+    <p>{% translate "Your submission needs changes. Please review the notes below and resubmit after all feedback has been addressed." %}</p>
+    {% endif %}
 
     {% if feedback_notes %}
-    <p>{{ feedback_notes_label }}: {{ feedback_notes }}</p>
+    <p>{% translate "Notes from the reviewer" %}: {{ feedback_notes }}</p>
     {% endif %}
 
     <p>
@@ -22,6 +27,5 @@
         <br>
         {% translate "The Learning Equality Team" %}
     </p>
-    {% endautoescape %}
 </body>
 </html>

--- a/contentcuration/contentcuration/tests/viewsets/test_community_library_submission.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_community_library_submission.py
@@ -17,6 +17,7 @@ from contentcuration.models import User
 from contentcuration.tests import testdata
 from contentcuration.tests.base import StudioAPITestCase
 from contentcuration.tests.helpers import reverse_with_query
+from contentcuration.utils.urls import canonical_url
 from contentcuration.viewsets.sync.constants import ADDED_TO_COMMUNITY_LIBRARY
 
 
@@ -736,8 +737,53 @@ class AdminViewSetTestCase(StudioAPITestCase):
         sent_email = mail.outbox[0]
         self.assertEqual(sent_email.to, [self.submission.author.email])
         self.assertIn("approved", sent_email.subject.lower())
-        self.assertIn("available in community library", sent_email.body.lower())
+        self.assertIn("approved", sent_email.body.lower())
         self.assertIn(self.submission.channel.name, sent_email.body)
+        self.assertIn(
+            canonical_url(
+                reverse("channel", kwargs={"channel_id": self.submission.channel.pk})
+            ),
+            sent_email.body,
+        )
+
+    @mock.patch(
+        "contentcuration.viewsets.community_library_submission.apply_channel_changes_task"
+    )
+    @mock.patch(
+        "contentcuration.models.CommunityLibrarySubmission.send_resolution_email",
+        side_effect=Exception("SMTP is down"),
+    )
+    def test_resolve_submission__accept_correct_when_email_fails(
+        self, send_email_mock, apply_task_mock
+    ):
+        """A failure to notify the author shouldn't undo or fail the resolution."""
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(
+            reverse(
+                "admin-community-library-submission-resolve",
+                args=[self.submission.id],
+            ),
+            self.resolve_approve_metadata,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        resolved_submission = CommunityLibrarySubmission.objects.get(
+            id=self.submission.id
+        )
+        self.assertEqual(
+            resolved_submission.status,
+            community_library_submission_constants.STATUS_APPROVED,
+        )
+        Change.objects.get(
+            channel=self.submission.channel,
+            change_type=ADDED_TO_COMMUNITY_LIBRARY,
+        )
+        apply_task_mock.fetch_or_enqueue.assert_called_once_with(
+            self.admin_user,
+            channel_id=self.submission.channel.id,
+        )
+        self.assertEqual(len(mail.outbox), 0)
 
     @mock.patch(
         "contentcuration.viewsets.community_library_submission.apply_channel_changes_task"
@@ -784,6 +830,12 @@ class AdminViewSetTestCase(StudioAPITestCase):
         self.assertIn("needs changes", sent_email.subject.lower())
         self.assertIn("needs changes", sent_email.body.lower())
         self.assertIn(self.submission.channel.name, sent_email.body)
+        self.assertIn(
+            canonical_url(
+                reverse("channel", kwargs={"channel_id": self.submission.channel.pk})
+            ),
+            sent_email.body,
+        )
         self.assertIn(self.feedback_notes, sent_email.body)
 
     def test_resolve_submission__reject_missing_resolution_reason(self):

--- a/contentcuration/contentcuration/tests/viewsets/test_community_library_submission.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_community_library_submission.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import mock
 
 import pytz
+from django.core import mail
 from django.urls import reverse
 
 from contentcuration.constants import (
@@ -731,6 +732,13 @@ class AdminViewSetTestCase(StudioAPITestCase):
             channel_id=self.submission.channel.id,
         )
 
+        self.assertEqual(len(mail.outbox), 1)
+        sent_email = mail.outbox[0]
+        self.assertEqual(sent_email.to, [self.submission.author.email])
+        self.assertIn("approved", sent_email.subject.lower())
+        self.assertIn("available in community library", sent_email.body.lower())
+        self.assertIn(self.submission.channel.name, sent_email.body)
+
     @mock.patch(
         "contentcuration.viewsets.community_library_submission.apply_channel_changes_task"
     )
@@ -769,6 +777,14 @@ class AdminViewSetTestCase(StudioAPITestCase):
             ).exists()
         )
         apply_task_mock.fetch_or_enqueue.assert_not_called()
+
+        self.assertEqual(len(mail.outbox), 1)
+        sent_email = mail.outbox[0]
+        self.assertEqual(sent_email.to, [self.submission.author.email])
+        self.assertIn("needs changes", sent_email.subject.lower())
+        self.assertIn("needs changes", sent_email.body.lower())
+        self.assertIn(self.submission.channel.name, sent_email.body)
+        self.assertIn(self.feedback_notes, sent_email.body)
 
     def test_resolve_submission__reject_missing_resolution_reason(self):
         self.client.force_authenticate(user=self.admin_user)

--- a/contentcuration/contentcuration/utils/i18n.py
+++ b/contentcuration/contentcuration/utils/i18n.py
@@ -41,6 +41,20 @@ def _get_language_info():
 LANGUAGE_INFO = _get_language_info()
 
 
+def closest_supported_locale(lang_code):
+    """
+    Given a content language's primary code (e.g. "es", "fr"), return the
+    Studio UI locale in SUPPORTED_LANGUAGES that matches it, ignoring region,
+    or None if Studio has no UI translation for that language.
+    """
+    if not lang_code:
+        return None
+    for supported in SUPPORTED_LANGUAGES:
+        if supported.split("-")[0] == lang_code:
+            return supported
+    return None
+
+
 def language_globals():
     language_code = get_language()
     lang_dir = "rtl" if get_language_bidi() else "ltr"

--- a/contentcuration/contentcuration/viewsets/community_library_submission.py
+++ b/contentcuration/contentcuration/viewsets/community_library_submission.py
@@ -358,4 +358,6 @@ class AdminCommunityLibrarySubmissionViewSet(
                 published_version.id
             )
 
+        submission.send_resolution_email()
+
         return Response(self.serialize_object())

--- a/contentcuration/contentcuration/viewsets/community_library_submission.py
+++ b/contentcuration/contentcuration/viewsets/community_library_submission.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django_filters import BaseInFilter
@@ -35,6 +37,8 @@ from contentcuration.viewsets.sync.utils import (
     generate_added_to_community_library_event,
 )
 from contentcuration.viewsets.user import IsAdminUser
+
+logger = logging.getLogger(__name__)
 
 
 class ChoiceInFilter(BaseInFilter, ChoiceFilter):
@@ -358,6 +362,13 @@ class AdminCommunityLibrarySubmissionViewSet(
                 published_version.id
             )
 
-        submission.send_resolution_email()
+        try:
+            submission.send_resolution_email()
+        except Exception:
+            # The resolution itself has already been committed; a failure to
+            # notify the author shouldn't turn that into a 500 response.
+            logger.exception(
+                "Failed to send resolution email for submission %s", submission.pk
+            )
 
         return Response(self.serialize_object())


### PR DESCRIPTION
## Summary
This implements a very basic notification email to support communication around community library submissions. It seems from a lack of updates/edits to reviewed channels that users maybe were not seeing their notifications. This repurposes existing strings (therefore, we may want to make future edits to the wording to be more detailed/informative), to send an update about accepted community library channels or requesting edits/updates.

## References
Fixes https://github.com/learningequality/studio/issues/5993

## Reviewer guidance
I think code review here is best, and then manual QA on hotfixes to confirm email end to end. I did some testing of this using assistance from Claude, but it was a bit of a workaround, and I think testing more fully (to a real email address) will be more helpful than trying to replicate that during PR review.


## AI usage
Implemented with Claude -- wrote up a spec together with me reviewing and providing inputs and guidance. Claude implementation, and then manual code review and testing in the browser and confirming logged outputs and email functions.