### PR TITLE
[Remove Vuetify from Studio] Sign-in page

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
@@ -58,6 +58,7 @@
               <StudioEmailField
                 v-model="username"
                 autofocus
+                :label="$tr('emailLabel')"
                 :errorMessages="touched.username && errors.username ? [usernameErrorText] : []"
                 :appearanceOverrides="{ maxWidth: '100%' }"
                 @blur="touched.username = true"
@@ -264,6 +265,9 @@
     },
     $trs: {
       kolibriStudio: 'Kolibri Studio',
+      // Matches the legacy EmailField's own label. StudioEmailField's default
+      // ('Email address') would otherwise change this page's visible text.
+      emailLabel: 'Email',
       forgotPasswordLink: 'Forgot your password?',
       signInButton: 'Sign in',
       createAccountButton: 'Create an account',

--- a/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div
-    class="page"
+    class="page theme--light"
     :style="{ backgroundColor: $themePalette.grey.v_100 }"
   >
     <div>

--- a/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
@@ -1,17 +1,13 @@
 <template>
 
-  <VApp>
-    <VLayout
-      fill-height
-      justify-center
-      class="main pt-5"
-    >
-      <div>
-        <!-- Sign in -->
-        <VCard
-          class="pa-4"
-          style="width: 300px; margin: 0 auto"
-        >
+  <div
+    class="page"
+    :style="{ backgroundColor: $themePalette.grey.v_100 }"
+  >
+    <div>
+      <!-- Sign in -->
+      <StudioRaisedBox class="sign-in-card">
+        <template #header>
           <div class="k-logo-container">
             <KLogo
               altText="Kolibri Logo with background"
@@ -19,103 +15,121 @@
               :size="120"
             />
           </div>
-          <h2 class="primary--text py-2 text-xs-center">
-            {{ $tr('kolibriStudio') }}
-          </h2>
-          <Banner
-            :value="loginFailed"
-            :text="$tr('loginFailed')"
-            error
-          />
-          <Banner
-            :value="offline"
-            :text="$tr('loginFailedOffline')"
-            error
-          />
-          <Banner
-            :value="Boolean(nextParam)"
-            :text="$tr('loginToProceed')"
-            class="pb-0 px-0"
-            data-test="loginToProceed"
-          />
-          <VForm
-            ref="form"
-            lazy-validation
-            class="py-3"
-            @submit.prevent="submit"
+          <h1
+            class="notranslate page-title"
+            :style="{ color: $themeTokens.primary }"
           >
-            <EmailField
-              v-model="username"
-              autofocus
-            />
-            <PasswordField
-              v-model="password"
-              :label="$tr('passwordLabel')"
-            />
-            <p>
+            {{ $tr('kolibriStudio') }}
+          </h1>
+        </template>
+        <template #main>
+          <div class="card-body">
+            <StudioBanner
+              v-if="loginFailed"
+              error
+            >
+              {{ $tr('loginFailed') }}
+            </StudioBanner>
+            <StudioBanner
+              v-if="offline"
+              error
+            >
+              {{ $tr('loginFailedOffline') }}
+            </StudioBanner>
+            <StudioBanner
+              v-if="nextParam"
+              data-test="loginToProceed"
+            >
+              {{ $tr('loginToProceed') }}
+            </StudioBanner>
+            <form
+              class="form"
+              @submit.prevent="submit"
+            >
+              <StudioEmailField
+                v-model="username"
+                autofocus
+                :errorMessages="touched.username && errors.username ? [usernameErrorText] : []"
+                :appearanceOverrides="{ maxWidth: '100%' }"
+                @blur="touched.username = true"
+              />
+              <StudioPasswordField
+                v-model="password"
+                :errorMessages="touched.password && errors.password ? [passwordErrorText] : []"
+                :appearanceOverrides="{ maxWidth: '100%' }"
+                @blur="touched.password = true"
+              />
+              <p>
+                <KRouterLink
+                  :to="{ name: 'ForgotPassword' }"
+                  :text="$tr('forgotPasswordLink')"
+                  appearance="basic-link"
+                />
+              </p>
+              <KButton
+                primary
+                class="w-100"
+                :text="$tr('signInButton')"
+                :disabled="offline || busy"
+                type="submit"
+              />
               <KRouterLink
-                :to="{ name: 'ForgotPassword' }"
-                :text="$tr('forgotPasswordLink')"
+                primary
+                class="create-account-link w-100"
+                :text="$tr('createAccountButton')"
+                :to="{ name: 'Create' }"
+                appearance="flat-button"
+              />
+            </form>
+            <hr
+              class="divider"
+              :style="{ borderTopColor: $themeTokens.fineLine }"
+            >
+            <p class="guest-link">
+              <KButton
+                href="/channels/#public"
+                :text="$tr('guestModeLink')"
                 appearance="basic-link"
               />
             </p>
-            <KButton
-              primary
-              class="w-100"
-              :text="$tr('signInButton')"
-              :disabled="offline || busy"
-              type="submit"
-            />
-            <KRouterLink
-              primary
-              class="mt-2 w-100"
-              :text="$tr('createAccountButton')"
-              :to="{ name: 'Create' }"
-              appearance="flat-button"
-            />
-          </VForm>
-          <VDivider />
-          <p class="mt-4 text-xs-center">
-            <KButton
-              href="/channels/#public"
-              :text="$tr('guestModeLink')"
-              appearance="basic-link"
-            />
-          </p>
-        </VCard>
+          </div>
+        </template>
+      </StudioRaisedBox>
 
-        <!-- Footer -->
-        <LanguageSwitcherList class="mt-3 text-xs-center" />
+      <!-- Footer -->
+      <LanguageSwitcherList class="language-switcher" />
 
-        <p class="links mt-3 text-xs-center">
-          <span>
-            <KButton
-              :text="$tr('privacyPolicyLink')"
-              appearance="basic-link"
-              @click="showPrivacyPolicy"
-            />
-          </span>
-          <span>
-            <KButton
-              :text="$tr('TOSLink')"
-              appearance="basic-link"
-              @click="showTermsOfService"
-            />
-          </span>
-          <span>
-            <KButton
-              href="https://learningequality.org/"
-              :text="$tr('copyright', { year: new Date().getFullYear() })"
-              appearance="basic-link"
-              iconAfter="openNewTab"
-              target="_blank"
-            />
-          </span>
-        </p>
-      </div>
-    </VLayout>
+      <p
+        class="links"
+        :style="{ color: $themePalette.grey.v_700 }"
+      >
+        <span>
+          <KButton
+            :text="$tr('privacyPolicyLink')"
+            appearance="basic-link"
+            @click="showPrivacyPolicy"
+          />
+        </span>
+        <span>
+          <KButton
+            :text="$tr('TOSLink')"
+            appearance="basic-link"
+            @click="showTermsOfService"
+          />
+        </span>
+        <span>
+          <KButton
+            href="https://learningequality.org/"
+            :text="$tr('copyright', { year: new Date().getFullYear() })"
+            appearance="basic-link"
+            iconAfter="openNewTab"
+            target="_blank"
+          />
+        </span>
+      </p>
+    </div>
     <PolicyModals />
-  </VApp>
+  </div>
 
 </template>
 
@@ -123,30 +137,46 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
-  import EmailField from 'shared/views/form/EmailField';
-  import PasswordField from 'shared/views/form/PasswordField';
-  import Banner from 'shared/views/Banner';
+  import StudioEmailField from '../components/form/StudioEmailField';
+  import StudioPasswordField from '../components/form/StudioPasswordField';
   import PolicyModals from 'shared/views/policies/PolicyModals';
-  import { policies } from 'shared/constants';
+  import StudioBanner from 'shared/views/StudioBanner';
+  import StudioRaisedBox from 'shared/views/StudioRaisedBox';
   import LanguageSwitcherList from 'shared/languageSwitcher/LanguageSwitcherList';
+  import { policies } from 'shared/constants';
+  import commonStrings from 'shared/translator';
+  import { generateFormMixin } from 'shared/mixins';
   import { redirectBrowser } from 'shared/utils/navigation';
+
+  const formMixin = generateFormMixin({
+    username: {
+      required: true,
+      validator: v => Boolean(v && v.trim()) && /.+@.+\..+/.test(v),
+    },
+    password: {
+      required: true,
+    },
+  });
 
   export default {
     name: 'AccountsMain',
     components: {
-      Banner,
-      EmailField,
       LanguageSwitcherList,
-      PasswordField,
       PolicyModals,
+      StudioBanner,
+      StudioEmailField,
+      StudioPasswordField,
+      StudioRaisedBox,
     },
+    mixins: [formMixin],
     data() {
       return {
-        username: '',
-        password: '',
         loginFailed: false,
         busy: false,
-        loginFailedOffline: false,
+        touched: {
+          username: false,
+          password: false,
+        },
       };
     },
     computed: {
@@ -157,6 +187,17 @@
         const params = new URLSearchParams(window.location.search.substring(1));
         return params.get('next');
       },
+      usernameErrorText() {
+        if (!this.username || !this.username.trim()) {
+          /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+          return commonStrings.$tr('fieldRequired');
+        }
+        return this.$tr('validEmailMessage');
+      },
+      passwordErrorText() {
+        /* eslint-disable-next-line kolibri/vue-no-undefined-string-uses */
+        return commonStrings.$tr('fieldRequired');
+      },
     },
     methods: {
       ...mapActions(['login']),
@@ -166,41 +207,43 @@
       showPrivacyPolicy() {
         this.$router.push({ query: { showPolicy: policies.PRIVACY } });
       },
-      submit() {
-        if (this.$refs.form.validate()) {
-          this.busy = true;
-          const credentials = {
-            username: this.username,
-            password: this.password,
-          };
-          return this.login(credentials)
-            .then(() => {
-              this.loginFailedOffline = false;
-              this.loginFailed = false;
-              redirectBrowser(this.nextParam || window.Urls.channels());
-            })
-            .catch(err => {
-              this.busy = false;
-              if (err.message === 'Network Error') {
-                this.loginFailedOffline = true;
-              } else if (err.response.status === 405) {
-                this.$router.push({ name: 'AccountNotActivated' });
-              } else {
-                this.loginFailed = true;
-              }
-            });
-        }
-        return Promise.resolve();
+      // eslint-disable-next-line vue/no-unused-properties
+      onValidationFailed() {
+        this.touched.username = true;
+        this.touched.password = true;
+      },
+      // eslint-disable-next-line vue/no-unused-properties
+      onSubmit(formData) {
+        this.busy = true;
+        const credentials = {
+          username: formData.username,
+          password: this.password,
+        };
+        return this.login(credentials)
+          .then(() => {
+            this.loginFailed = false;
+            redirectBrowser(this.nextParam || window.Urls.channels());
+          })
+          .catch(err => {
+            this.busy = false;
+            if (err.message === 'Network Error') {
+              return;
+            } else if (err.response.status === 405) {
+              this.$router.push({ name: 'AccountNotActivated' });
+            } else {
+              this.loginFailed = true;
+            }
+          });
       },
     },
     $trs: {
       kolibriStudio: 'Kolibri Studio',
-      passwordLabel: 'Password',
       forgotPasswordLink: 'Forgot your password?',
       signInButton: 'Sign in',
       createAccountButton: 'Create an account',
       guestModeLink: 'Explore without an account',
       loginFailed: 'Email or password is incorrect',
+      validEmailMessage: 'Please enter a valid email',
       privacyPolicyLink: 'Privacy policy',
       TOSLink: 'Terms of service',
       copyright: '© {year} Learning Equality',
@@ -215,31 +258,74 @@
 
 <style lang="scss" scoped>
 
-  .main {
+  .page {
+    display: flex;
+    justify-content: center;
+    min-height: 100vh;
+    padding-top: 48px;
     overflow: auto;
-    /* stylelint-disable-next-line custom-property-pattern */
-    background-color: var(--v-backgroundColor-base);
   }
 
-  .links {
-    span {
-      &:not(:last-child)::after {
-        margin: 0 8px 0 12px;
-        font-size: 14pt;
-        color: var(--v-grey-base);
-        vertical-align: middle;
-        content: '•';
-      }
-    }
+  .sign-in-card {
+    width: 300px;
+    margin: 0 auto;
+  }
+
+  .k-logo-container {
+    display: flex;
+    justify-content: center;
+  }
+
+  .page-title {
+    padding: 8px 0;
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+  }
+
+  .card-body {
+    padding: 0 16px;
+  }
+
+  .form {
+    padding: 16px 0;
+  }
+
+  .create-account-link {
+    margin-top: 8px;
+  }
+
+  .divider {
+    border: 0;
+    border-top: 1px solid;
+  }
+
+  .guest-link {
+    margin-top: 24px;
+    text-align: center;
   }
 
   .w-100 {
     width: 100%;
   }
 
-  .k-logo-container {
-    display: flex;
-    justify-content: center;
+  .language-switcher {
+    margin-top: 16px;
+    text-align: center;
+  }
+
+  .links {
+    margin-top: 16px;
+    text-align: center;
+
+    span {
+      &:not(:last-child)::after {
+        margin: 0 8px 0 12px;
+        font-size: 14pt;
+        vertical-align: middle;
+        content: '•';
+      }
+    }
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
@@ -182,6 +182,10 @@
       return {
         loginFailed: false,
         busy: false,
+        // Gates error display until blur, since formMixin's setters otherwise
+        // mark errors on every keystroke. Create.vue has no equivalent gate,
+        // so the two forms validate differently; epic-level decision tracked
+        // on #5060.
         touched: {
           username: false,
           password: false,

--- a/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/AccountsMain.vue
@@ -1,5 +1,12 @@
 <template>
 
+  <!--
+    theme--light is load-bearing: Vuetify 1.5 (still active via VApp on other
+    account pages, e.g. MessageLayout.vue) generates a global .link background
+    rule that collides with the basic-link KButtons below. It's only
+    neutralised under .theme--light in shared/styles/main.scss. Remove this
+    only once that rule is un-nested there.
+  -->
   <div
     class="page theme--light"
     :style="{ backgroundColor: $themePalette.grey.v_100 }"
@@ -26,12 +33,14 @@
           <div class="card-body">
             <StudioBanner
               v-if="loginFailed"
+              role="alert"
               error
             >
               {{ $tr('loginFailed') }}
             </StudioBanner>
             <StudioBanner
               v-if="offline"
+              role="alert"
               error
             >
               {{ $tr('loginFailedOffline') }}
@@ -211,10 +220,20 @@
       onValidationFailed() {
         this.touched.username = true;
         this.touched.password = true;
+        this.$nextTick(() => {
+          const selector = this.errors.username ? 'input[type="email"]' : 'input[type="password"]';
+          const firstInvalidInput = this.$el.querySelector(selector);
+          if (firstInvalidInput) {
+            firstInvalidInput.focus();
+          }
+        });
       },
       // eslint-disable-next-line vue/no-unused-properties
       onSubmit(formData) {
         this.busy = true;
+        // formMixin's clean() trims every field, including password, before
+        // building formData. Reading the untrimmed this.password here (not
+        // formData.password) preserves leading/trailing spaces the user typed.
         const credentials = {
           username: formData.username,
           password: this.password,
@@ -227,8 +246,11 @@
           .catch(err => {
             this.busy = false;
             if (err.message === 'Network Error') {
+              // The offline banner is driven by state.connection.online via
+              // the offline computed property, so no local flag is needed here.
               return;
-            } else if (err.response.status === 405) {
+            }
+            if (err.response.status === 405) {
               this.$router.push({ name: 'AccountNotActivated' });
             } else {
               this.loginFailed = true;

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
@@ -2,11 +2,25 @@ import { render, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import VueRouter from 'vue-router';
 import AccountsMain from '../AccountsMain.vue';
+import StudioPasswordField from '../../components/form/StudioPasswordField';
+import commonStrings from 'shared/translator';
+import { createTranslator } from 'shared/i18n';
 import { redirectBrowser } from 'shared/utils/navigation';
 
 jest.mock('shared/utils/navigation', () => ({
   redirectBrowser: jest.fn(),
 }));
+
+const { fieldRequired$ } = commonStrings;
+const {
+  emailLabel$,
+  signInButton$,
+  loginFailed$,
+  validEmailMessage$,
+  loginToProceed$,
+  loginFailedOffline$,
+} = createTranslator(AccountsMain.name, AccountsMain.$trs);
+const { passwordLabel$ } = createTranslator(StudioPasswordField.name, StudioPasswordField.$trs);
 
 window.Urls = {
   channels: () => '/channels/',
@@ -71,18 +85,18 @@ describe('AccountsMain', () => {
   it('should render sign-in form with email, password fields and sign in button', () => {
     makeWrapper();
 
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(emailLabel$())).toBeInTheDocument();
+    expect(screen.getByLabelText(passwordLabel$())).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: signInButton$() })).toBeInTheDocument();
   });
 
   it('should show error when submitting empty form', async () => {
     makeWrapper();
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     // User sees validation errors (from StudioEmailField and StudioPasswordField components)
     await waitFor(() => {
-      const errorMessages = screen.queryAllByText(/required|field is required/i);
+      const errorMessages = screen.queryAllByText(fieldRequired$());
       expect(errorMessages.length).toBeGreaterThan(0);
     });
   });
@@ -91,16 +105,16 @@ describe('AccountsMain', () => {
     const loginMock = jest.fn();
     makeWrapper({ loginMock });
 
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     expect(loginMock).not.toHaveBeenCalled();
   });
 
   it('should move focus to the email field when it is the first invalid field', async () => {
     makeWrapper();
-    const emailField = screen.getByLabelText(/email/i);
+    const emailField = screen.getByLabelText(emailLabel$());
 
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     await waitFor(() => {
       expect(emailField).toHaveFocus();
@@ -109,10 +123,10 @@ describe('AccountsMain', () => {
 
   it('should move focus to the password field when only it is invalid', async () => {
     makeWrapper();
-    const passwordField = screen.getByLabelText(/password/i);
+    const passwordField = screen.getByLabelText(passwordLabel$());
 
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.type(screen.getByLabelText(emailLabel$()), 'test@test.com');
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     await waitFor(() => {
       expect(passwordField).toHaveFocus();
@@ -122,41 +136,43 @@ describe('AccountsMain', () => {
   it('should not show the email error while the user is still typing', async () => {
     makeWrapper();
 
-    await user.type(screen.getByLabelText(/email/i), 'not-an-email');
+    await user.type(screen.getByLabelText(emailLabel$()), 'not-an-email');
 
-    expect(screen.queryByText('Please enter a valid email')).not.toBeInTheDocument();
+    expect(screen.queryByText(validEmailMessage$())).not.toBeInTheDocument();
   });
 
   it('should show the email error once the field loses focus', async () => {
     makeWrapper();
-    const emailField = screen.getByLabelText(/email/i);
+    const emailField = screen.getByLabelText(emailLabel$());
 
     await user.type(emailField, 'not-an-email');
     await user.tab();
 
     await waitFor(() => {
-      expect(screen.getByText('Please enter a valid email')).toBeInTheDocument();
+      expect(screen.getByText(validEmailMessage$())).toBeInTheDocument();
     });
   });
 
   it('should show and announce the offline banner when offline', () => {
     makeWrapper({ online: false });
 
-    expect(screen.getByRole('alert')).toHaveTextContent(/you seem to be offline/i);
+    expect(screen.getByRole('alert')).toHaveTextContent(loginFailedOffline$());
   });
 
   it('should preserve leading and trailing whitespace in the password', async () => {
+    const EMAIL = 'test@test.com';
+    const PASSWORD_WITH_SPACES = '  spaced  ';
     const loginMock = jest.fn().mockResolvedValue();
     makeWrapper({ loginMock });
 
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.type(screen.getByLabelText(/password/i), '  spaced  ');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.type(screen.getByLabelText(emailLabel$()), EMAIL);
+    await user.type(screen.getByLabelText(passwordLabel$()), PASSWORD_WITH_SPACES);
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     await waitFor(() => {
       expect(loginMock).toHaveBeenCalledWith('login', {
-        username: 'test@test.com',
-        password: '  spaced  ',
+        username: EMAIL,
+        password: PASSWORD_WITH_SPACES,
       });
     });
   });
@@ -167,12 +183,12 @@ describe('AccountsMain', () => {
     });
     makeWrapper({ loginMock });
 
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.type(screen.getByLabelText(/password/i), 'wrongpassword');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.type(screen.getByLabelText(emailLabel$()), 'test@test.com');
+    await user.type(screen.getByLabelText(passwordLabel$()), 'wrongpassword');
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Email or password is incorrect');
+      expect(screen.getByRole('alert')).toHaveTextContent(loginFailed$());
     });
   });
 
@@ -180,9 +196,9 @@ describe('AccountsMain', () => {
     const loginMock = jest.fn().mockResolvedValue();
     makeWrapper({ loginMock });
 
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.type(screen.getByLabelText(/password/i), 'testpassword');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.type(screen.getByLabelText(emailLabel$()), 'test@test.com');
+    await user.type(screen.getByLabelText(passwordLabel$()), 'testpassword');
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     // User is redirected to channels page
     await waitFor(() => {
@@ -193,7 +209,7 @@ describe('AccountsMain', () => {
   it('should show "You must sign in" banner when ?next= param is present', () => {
     makeWrapper({ nextParam: '/protected-page/' });
 
-    expect(screen.getByText('You must sign in to view that page')).toBeInTheDocument();
+    expect(screen.getByText(loginToProceed$())).toBeInTheDocument();
   });
 
   it('should redirect to next URL when provided after successful login', async () => {
@@ -201,9 +217,9 @@ describe('AccountsMain', () => {
     const nextUrl = '/protected-page/';
     makeWrapper({ loginMock, nextParam: nextUrl });
 
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.type(screen.getByLabelText(/password/i), 'testpassword');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.type(screen.getByLabelText(emailLabel$()), 'test@test.com');
+    await user.type(screen.getByLabelText(passwordLabel$()), 'testpassword');
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     // User is redirected to next URL
     await waitFor(() => {
@@ -217,9 +233,9 @@ describe('AccountsMain', () => {
     });
     const { router } = makeWrapper({ loginMock });
 
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.type(screen.getByLabelText(/password/i), 'testpassword');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await user.type(screen.getByLabelText(emailLabel$()), 'test@test.com');
+    await user.type(screen.getByLabelText(passwordLabel$()), 'testpassword');
+    await user.click(screen.getByRole('button', { name: signInButton$() }));
 
     // User is redirected to account not activated page
     await waitFor(() => {
@@ -230,6 +246,6 @@ describe('AccountsMain', () => {
   it('should disable sign in button when offline', () => {
     makeWrapper({ online: false });
 
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: signInButton$() })).toBeDisabled();
   });
 });

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/vue';
+import { fireEvent, render, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import VueRouter from 'vue-router';
 import AccountsMain from '../AccountsMain.vue';
@@ -84,6 +84,57 @@ describe('AccountsMain', () => {
     await waitFor(() => {
       const errorMessages = screen.queryAllByText(/required|field is required/i);
       expect(errorMessages.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should not attempt to log in when the form is invalid', async () => {
+    const loginMock = jest.fn();
+    makeWrapper({ loginMock });
+
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(loginMock).not.toHaveBeenCalled();
+  });
+
+  it('should not show the email error while the user is still typing', async () => {
+    makeWrapper();
+
+    await user.type(screen.getByLabelText(/email/i), 'not-an-email');
+
+    expect(screen.queryByText('Please enter a valid email')).not.toBeInTheDocument();
+  });
+
+  it('should show the email error once the field loses focus', async () => {
+    makeWrapper();
+    const emailField = screen.getByLabelText(/email/i);
+
+    await user.type(emailField, 'not-an-email');
+    await fireEvent.blur(emailField);
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a valid email')).toBeInTheDocument();
+    });
+  });
+
+  it('should show the offline banner when offline', () => {
+    makeWrapper({ online: false });
+
+    expect(screen.getByText(/you seem to be offline/i)).toBeInTheDocument();
+  });
+
+  it('should preserve leading and trailing whitespace in the password', async () => {
+    const loginMock = jest.fn().mockResolvedValue();
+    makeWrapper({ loginMock });
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.type(screen.getByLabelText(/password/i), '  spaced  ');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith('login', {
+        username: 'test@test.com',
+        password: '  spaced  ',
+      });
     });
   });
 

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
@@ -139,13 +139,7 @@ describe('AccountsMain', () => {
     });
   });
 
-  it('should show the offline banner when offline', () => {
-    makeWrapper({ online: false });
-
-    expect(screen.getByText(/you seem to be offline/i)).toBeInTheDocument();
-  });
-
-  it('should announce the offline banner to screen readers', () => {
+  it('should show and announce the offline banner when offline', () => {
     makeWrapper({ online: false });
 
     expect(screen.getByRole('alert')).toHaveTextContent(/you seem to be offline/i);
@@ -167,23 +161,7 @@ describe('AccountsMain', () => {
     });
   });
 
-  it('should show error message when login fails', async () => {
-    const loginMock = jest.fn().mockRejectedValue({
-      response: { status: 401 },
-    });
-    makeWrapper({ loginMock });
-
-    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await user.type(screen.getByLabelText(/password/i), 'wrongpassword');
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
-
-    // User sees error banner
-    await waitFor(() => {
-      expect(screen.getByText('Email or password is incorrect')).toBeInTheDocument();
-    });
-  });
-
-  it('should announce login failure to screen readers', async () => {
+  it('should show and announce login failure to screen readers', async () => {
     const loginMock = jest.fn().mockRejectedValue({
       response: { status: 401 },
     });

--- a/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
+++ b/contentcuration/contentcuration/frontend/accounts/pages/__tests__/accountsMain.spec.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/vue';
+import { render, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import VueRouter from 'vue-router';
 import AccountsMain from '../AccountsMain.vue';
@@ -80,7 +80,7 @@ describe('AccountsMain', () => {
     makeWrapper();
     await user.click(screen.getByRole('button', { name: /sign in/i }));
 
-    // User sees validation errors (from EmailField and PasswordField components)
+    // User sees validation errors (from StudioEmailField and StudioPasswordField components)
     await waitFor(() => {
       const errorMessages = screen.queryAllByText(/required|field is required/i);
       expect(errorMessages.length).toBeGreaterThan(0);
@@ -96,6 +96,29 @@ describe('AccountsMain', () => {
     expect(loginMock).not.toHaveBeenCalled();
   });
 
+  it('should move focus to the email field when it is the first invalid field', async () => {
+    makeWrapper();
+    const emailField = screen.getByLabelText(/email/i);
+
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(emailField).toHaveFocus();
+    });
+  });
+
+  it('should move focus to the password field when only it is invalid', async () => {
+    makeWrapper();
+    const passwordField = screen.getByLabelText(/password/i);
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(passwordField).toHaveFocus();
+    });
+  });
+
   it('should not show the email error while the user is still typing', async () => {
     makeWrapper();
 
@@ -109,7 +132,7 @@ describe('AccountsMain', () => {
     const emailField = screen.getByLabelText(/email/i);
 
     await user.type(emailField, 'not-an-email');
-    await fireEvent.blur(emailField);
+    await user.tab();
 
     await waitFor(() => {
       expect(screen.getByText('Please enter a valid email')).toBeInTheDocument();
@@ -120,6 +143,12 @@ describe('AccountsMain', () => {
     makeWrapper({ online: false });
 
     expect(screen.getByText(/you seem to be offline/i)).toBeInTheDocument();
+  });
+
+  it('should announce the offline banner to screen readers', () => {
+    makeWrapper({ online: false });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/you seem to be offline/i);
   });
 
   it('should preserve leading and trailing whitespace in the password', async () => {
@@ -151,6 +180,21 @@ describe('AccountsMain', () => {
     // User sees error banner
     await waitFor(() => {
       expect(screen.getByText('Email or password is incorrect')).toBeInTheDocument();
+    });
+  });
+
+  it('should announce login failure to screen readers', async () => {
+    const loginMock = jest.fn().mockRejectedValue({
+      response: { status: 401 },
+    });
+    makeWrapper({ loginMock });
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.type(screen.getByLabelText(/password/i), 'wrongpassword');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Email or password is incorrect');
     });
   });
 


### PR DESCRIPTION
## Summary
Removes Vuetify from the sign-in page.
- `VCard` → `StudioRaisedBox`, `Banner` → `StudioBanner`, `EmailField` / `PasswordField` → `StudioEmailField` / `StudioPasswordField`
- `VForm` → native `<form>` with `generateFormMixin`; `VApp` / `VLayout` / `VDivider` → plain elements + scoped styles
- Vuetify spacing/colour helpers → scoped CSS and `$themePalette` / `$themeTokens`
- Errors show on blur or after a failed submit, not on every keystroke (the mixin validates on every input)
- Password sent untrimmed the mixin's `clean()` would otherwise strip leading/trailing spaces
- Heading is now `<h1>`, styled the same, so the page doesn't start at level 2

## References
Fixes #5930 

## Reviewer guidance
https://github.com/user-attachments/assets/ba6f11f8-688a-41c8-81f7-4ab5f517a787

### Note
**`theme--light` on the page root is retained.** Vuetify generates a `.link` class that collides with KDS's basic-link class, `main.scss` only neutralises it under `.theme--light`, which `VApp` used to supply. Without it, links render as blue blocks after any `VApp` page mounts. 
Alternative is un-nesting that rule in `main.scss`, fixes it centrally for all of the pages/components, happy to switch.

## AI usage
Used Claude Code in a review-and-iterate loop.
- Wrote a first pass myself, had Claude research the issue/KDS docs and propose replacements before any code
- made it justify each scoped style, removed a dead class and a needless rename.
- Found the blue-block bug myself during manual testing, had Claude diagnose it, rejected its shared/styles/main.scss   fix (because it lies outside the scope of this issue), and applied the in-scope one.
- Reviewed every diff, ran tests and linter, verified manually in the browser
