### PR TITLE
Dedupe ChannelVersion.included_licenses in API responses

### DIFF
--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -1478,6 +1478,21 @@ class GetVersionDetailEndpointTestCase(StudioAPITestCase):
         for field in expected_fields:
             self.assertIn(field, data, f"Field '{field}' should be in response")
 
+    def test_get_version_detail_dedupes_duplicated_licenses(self):
+        """Test that duplicated license ids stored on the ChannelVersion (e.g. from a
+        backfill bug) are deduped in the response."""
+        self.channel_version.included_licenses = [1, 2, 2, 1]
+        self.channel_version.non_distributable_licenses_included = [1, 1]
+        self.channel_version.save()
+
+        url = reverse("channel-version-detail", kwargs={"pk": self.channel.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["included_licenses"], [1, 2])
+        self.assertEqual(data["non_distributable_licenses_included"], [1])
+
     def test_get_version_detail_excludes_special_permissions_included(self):
         """Test that special_permissions_included is not in the response."""
         special_license = AuditedSpecialPermissionsLicense.objects.create(
@@ -1586,6 +1601,26 @@ class ChannelVersionViewsetTestCase(StudioAPITestCase):
         self.assertEqual(data["id"], channel_version.id)
         self.assertEqual(data["channel"], self.channel.id)
         self.assertEqual(data["version"], channel_version.version)
+
+    def test_get_channel_version_dedupes_duplicated_licenses(self):
+        """Test that duplicated license ids stored on the ChannelVersion (e.g. from a
+        backfill bug) are deduped in both list and detail responses."""
+        channel_version = ChannelVersion.objects.filter(channel=self.channel).first()
+        channel_version.included_licenses = [2, 1, 2, 1]
+        channel_version.save()
+
+        detail_url = reverse("channelversion-detail", kwargs={"pk": channel_version.id})
+        detail_response = self.client.get(detail_url)
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertEqual(detail_response.json()["included_licenses"], [1, 2])
+
+        list_url = reverse("channelversion-list") + f"?channel={self.channel.id}"
+        list_response = self.client.get(list_url)
+        self.assertEqual(list_response.status_code, 200)
+        data = list_response.json()
+        results = data["results"] if "results" in data else data
+        version_data = next(r for r in results if r["id"] == channel_version.id)
+        self.assertEqual(version_data["included_licenses"], [1, 2])
 
     def test_get_channel_versions_ordering(self):
         """Test ordering of channel versions."""

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -953,6 +953,17 @@ class ChannelViewSet(ValuesViewset):
         if not version_data:
             return Response({})
 
+        # Older ChannelVersion rows may have been backfilled with duplicate
+        # license IDs - dedupe defensively.
+        if version_data.get("included_licenses") is not None:
+            version_data["included_licenses"] = sorted(
+                set(version_data["included_licenses"])
+            )
+        if version_data.get("non_distributable_licenses_included") is not None:
+            version_data["non_distributable_licenses_included"] = sorted(
+                set(version_data["non_distributable_licenses_included"])
+            )
+
         return Response(version_data)
 
     @action(
@@ -1072,6 +1083,12 @@ class ChannelVersionViewSet(ReadOnlyValuesViewset):
     filterset_class = ChannelVersionFilter
     ordering_fields = ["version"]
     ordering = "-version"
+
+    # Older ChannelVersion rows may have been backfilled with duplicate
+    # license IDs - dedupe defensively.
+    field_map = {
+        "included_licenses": lambda item: sorted(set(item["included_licenses"] or []))
+    }
 
     values = (
         "id",


### PR DESCRIPTION
## Summary

`ChannelVersion.included_licenses` can contain duplicate license IDs on some rows, from a past one-off backfill command that omitted a dedup step present in the live publish path. This dedupes defensively where the field is served: `ChannelViewSet.get_version_detail` and `ChannelVersionViewSet`.

## References

Closes #5907

## Reviewer guidance

Verified via `pytest contentcuration/contentcuration/tests/viewsets/test_channel.py -k "GetVersionDetailEndpointTestCase or ChannelVersionViewsetTestCase"` (19 passed) and `pre-commit run --all-files` on the changed files.

To manually check: seed a `ChannelVersion.included_licenses` with duplicate IDs, then hit `/api/channel/{id}/version_detail/` and `/api/channelversion/?channel={id}` — both should return the deduped list.

Worth a close look: the new `field_map` entry in `ChannelVersionViewSet` (viewsets/channel.py) overwrites `included_licenses` in place for every list/detail response from that viewset — confirm no other consumer relies on the raw (possibly duplicated) array.

## AI usage

Used Claude Code to investigate where `included_licenses` is read across the backend and frontend, and decide the fix location.