### PR TITLE
Fix SidePanelModals padding

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/components/sidePanels/ReviewSubmissionSidePanel.vue
+++ b/contentcuration/contentcuration/frontend/administration/components/sidePanels/ReviewSubmissionSidePanel.vue
@@ -621,6 +621,7 @@
     display: flex;
     flex-direction: column;
     gap: 15px;
+    padding: 24px 32px 16px;
   }
 
   .submission-info-text {

--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
@@ -97,7 +97,10 @@
               <h2>{{ filterLabel$() }}</h2>
             </template>
             <template #default>
-              <CommunityLibraryFilters :disabled="loading" />
+              <CommunityLibraryFilters
+                :disabled="loading"
+                :style="{ padding: '24px 32px 16px' }"
+              />
             </template>
           </SidePanelModal>
         </template>


### PR DESCRIPTION
## Summary

- Consumers of `SidePanelModal` lost their internal padding after a prior PR removed it from the shared component.

## Reviewer guidance

* Check side panel modals across Studio.

| Before | After |
| --- | --- |
| <img width="709" height="1004" alt="image" src="https://github.com/user-attachments/assets/aa3e7d84-7ea8-43ea-960c-2f2aeaba3554" /> | <img width="723" height="1008" alt="image" src="https://github.com/user-attachments/assets/39de8e27-d7e1-4c9c-a478-b7782bc65c31" /> |
