### PR TITLE
Community Library miscelaneous fixes

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/components/CommunityLibraryStatusButton.vue
+++ b/contentcuration/contentcuration/frontend/administration/components/CommunityLibraryStatusButton.vue
@@ -105,7 +105,6 @@
   .community-library-status-button {
     @extend %md-standard-func;
 
-    width: 9em;
     padding: 4px;
     color: v-bind('labelColor');
     background-color: v-bind('color');

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/ChannelTable.vue
@@ -304,11 +304,16 @@
         fetchQueryParams: keywordSearchFetchQueryParams,
       } = useKeywordSearch();
 
+      // channelStatusFilter is derived from the current channelType's options, so an
+      // existing status that's no longer valid for the new type already reads back as
+      // unset - only default it to the first option in that case.
       watch(
         channelTypeFilter,
         () => {
-          const options = channelStatusOptions.value;
-          channelStatusFilter.value = options.length ? options[0].value : null;
+          if (!channelStatusFilter.value) {
+            const options = channelStatusOptions.value;
+            channelStatusFilter.value = options.length ? options[0].value : null;
+          }
         },
         { immediate: true },
       );

--- a/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Channels/__tests__/channelTable.spec.js
@@ -11,8 +11,8 @@ localVue.use(router);
 
 const channelList = ['test', 'channel', 'table'];
 
-function makeWrapper(store) {
-  router.replace({ name: RouteNames.CHANNELS });
+function makeWrapper(store, query = {}) {
+  router.replace({ name: RouteNames.CHANNELS, query });
 
   return mount(ChannelTable, {
     router,
@@ -71,13 +71,32 @@ describe('channelTable', () => {
 
       expect(router.currentRoute.query.keywords).toBe('keyword test');
     });
-    it('changing channel type filter should reset channel status filter', async () => {
+    it('changing channel type filter should reset channel status filter when it is no longer valid', async () => {
+      wrapper.vm.channelTypeFilter = ChannelTypeFilter.COMMUNITY_LIBRARY;
+      wrapper.vm.channelStatusFilter = 'needsReview';
+      await wrapper.vm.$nextTick();
+      // Kolibri library channels have no "needs review" status
+      wrapper.vm.channelTypeFilter = ChannelTypeFilter.KOLIBRI_LIBRARY;
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.channelStatusFilter).toBe('live');
+    });
+    it('changing channel type filter should keep the channel status filter when it is still valid', async () => {
       wrapper.vm.channelTypeFilter = ChannelTypeFilter.COMMUNITY_LIBRARY;
       wrapper.vm.channelStatusFilter = 'published';
       await wrapper.vm.$nextTick();
+      // "published" is a valid status for unlisted channels too
       wrapper.vm.channelTypeFilter = ChannelTypeFilter.UNLISTED;
       await wrapper.vm.$nextTick();
-      expect(wrapper.vm.channelStatusFilter).toBe('live');
+      expect(wrapper.vm.channelStatusFilter).toBe('published');
+    });
+    it('should preserve a valid channel status filter already present in the URL on mount', () => {
+      // Simulates navigating back to this page with filters still in the URL
+      // (e.g. after opening a channel and hitting the browser back button).
+      const backNavWrapper = makeWrapper(store, {
+        channelType: ChannelTypeFilter.COMMUNITY_LIBRARY,
+        channelStatus: 'needsReview',
+      });
+      expect(backNavWrapper.vm.channelStatusFilter).toBe('needsReview');
     });
   });
   describe('selection', () => {


### PR DESCRIPTION
## Summary

* The admin Channels table reset its status filter (e.g. "Needs review") when navigating back to it, since an unconditional reset watcher fired on every mount instead of only when the status became genuinely invalid for the selected type.
* The community library status button had a fixed width that clipped longer labels.

## Reviewer guidance

To manually verify the channel table fix: in the admin Channels table, filter by "Community Library" + "Needs review", open a channel, then use the browser Back button — the filters should stay as set instead of resetting.

| Before | After |
| --- | --- |
| <img width="159" height="66" alt="image" src="https://github.com/user-attachments/assets/48a66ad7-2cbd-4ac8-9bd1-fc2ce6a57180" /> | <img width="219" height="89" alt="image" src="https://github.com/user-attachments/assets/14e18af1-bcc0-47d8-94ae-7f72d9bec72d" /> |

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->
## AI usage

Used Claude Code throughout: diagnosed the channel-table filter-reset bug via code exploration, implemented and iterated on the fix. I reviewed all diffs, decided the final fix approach for the filter bug, and ran the test suite and pre-commit before this PR.