### PR TITLE
Stop emitting pathinfo in production to limit heap size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,7 +122,7 @@ module.exports = (env = {}) => {
       chunkFilename: '[name]-[id]-[fullhash].js',
       path: bundleOutputDir,
       publicPath: dev ? devPublicPath : '/static/studio/',
-      pathinfo: !dev,
+      pathinfo: dev,
     },
     devServer: {
       port: 4000,


### PR DESCRIPTION
## Summary
* Google Cloud Builds have started failing because the wepback build has been exceeding 2GB
* Flips the "pathinfo" conditionality to limit heap size - it was accidentally set opposite to webpack's recommendation

## Reviewer guidance
Confirm the build passes on CI.

See here: https://webpack.js.org/configuration/output/#outputpathinfo

## AI usage
Used Claude to experiment with a few different possibilities, removing pathinfo from prod, using parallel webpack configurations, and increasing the max heap size for NodeJS. Ended up using pathinfo because it worked and was least intrusive, and seemed to just be an error from previous tweaks.