### PR TITLE
Feature organization model

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -824,7 +824,7 @@ def file_on_disk_name(instance, filename):
 
 
 def generate_file_on_disk_name(checksum, filename):
-    """ Separated from file_on_disk_name to allow for simple way to check if has already exists """
+    """Separated from file_on_disk_name to allow for simple way to check if has already exists"""
     h = checksum
     basename, ext = os.path.splitext(filename)
     directory = os.path.join(settings.STORAGE_ROOT, h[0], h[1])
@@ -851,7 +851,7 @@ def object_storage_name(instance, filename):
 
 
 def generate_object_storage_name(checksum, filename, default_ext=""):
-    """ Separated from file_on_disk_name to allow for simple way to check if has already exists """
+    """Separated from file_on_disk_name to allow for simple way to check if has already exists"""
     h = checksum
     basename, actual_ext = os.path.splitext(filename)
     ext = actual_ext if actual_ext else default_ext
@@ -1067,7 +1067,7 @@ class ChannelModelManager(models.Manager.from_queryset(ChannelModelQuerySet)):
 
 
 class Channel(models.Model):
-    """ Permissions come from association with organizations """
+    """Permissions come from association with organizations"""
 
     id = UUIDField(primary_key=True, default=uuid.uuid4)
     name = models.CharField(max_length=200, blank=True)
@@ -1231,11 +1231,55 @@ class Channel(models.Model):
                 user_id=user_id, channel_id=OuterRef("id")
             )
         )
-        queryset = queryset.annotate(edit=edit)
+        organization_edit = Exists(
+            OrganizationRole.objects.filter(
+                user_id=user_id,
+                organization_id=OuterRef("organization_id"),
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+                role__in=(
+                    ORGANIZATION_ADMIN,
+                    ORGANIZATION_EDITOR,
+                ),
+            )
+        )
+        queryset = queryset.annotate(
+            edit=edit,
+            organization_edit=organization_edit,
+        )
         if user.is_admin:
             return queryset
 
-        return queryset.filter(edit=True)
+        return queryset.filter(Q(edit=True) | Q(organization_edit=True))
+
+    @classmethod
+    def filter_delete_queryset(cls, queryset, user):
+        user_id = not user.is_anonymous and user.id
+
+        if not user_id:
+            return queryset.none()
+
+        edit = Exists(
+            User.editable_channels.through.objects.filter(
+                user_id=user_id, channel_id=OuterRef("id")
+            )
+        )
+        organization_delete = Exists(
+            OrganizationRole.objects.filter(
+                user_id=user_id,
+                organization_id=OuterRef("organization_id"),
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+                role=ORGANIZATION_ADMIN,
+            )
+        )
+        queryset = queryset.annotate(
+            edit=edit,
+            organization_delete=organization_delete,
+        )
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(Q(edit=True) | Q(organization_delete=True))
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):
@@ -1244,35 +1288,60 @@ class Channel(models.Model):
 
         if user_id:
             filters = dict(user_id=user_id, channel_id=OuterRef("id"))
+
             edit = Exists(
                 User.editable_channels.through.objects.filter(**filters).values(
                     "user_id"
                 )
             )
+
             view = Exists(
                 User.view_only_channels.through.objects.filter(**filters).values(
                     "user_id"
                 )
             )
+
+            organization_view = Exists(
+                OrganizationRole.objects.filter(
+                    user_id=user_id,
+                    organization_id=OuterRef("organization_id"),
+                    status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+                    role__in=(
+                        ORGANIZATION_ADMIN,
+                        ORGANIZATION_EDITOR,
+                        ORGANIZATION_VIEWER,
+                    ),
+                )
+            )
         else:
             edit = boolean_val(False)
             view = boolean_val(False)
+            organization_view = boolean_val(False)
 
         queryset = queryset.annotate(
             edit=edit,
             view=view,
+            organization_view=organization_view,
         )
 
         if user_id and user.is_admin:
             return queryset
 
         permission_filter = Q()
+
         if user_id:
             pending_channels = Invitation.objects.filter(
-                email=user_email, revoked=False, declined=False, accepted=False
+                email=user_email,
+                revoked=False,
+                declined=False,
+                accepted=False,
             ).values_list("channel_id", flat=True)
+
             permission_filter = (
-                Q(view=True) | Q(edit=True) | Q(deleted=False, id__in=pending_channels)
+                Q(view=True)
+                | Q(edit=True)
+                | Q(organization_view=True)
+                | Q(deleted=False, id__in=pending_channels)
             )
 
         return queryset.filter(permission_filter | Q(deleted=False, public=True))
@@ -1887,16 +1956,28 @@ class Organization(models.Model):
 
     objects = CustomManager()
 
-    class Meta:
-        verbose_name = "Organization"
-        verbose_name_plural = "Organizations"
-        ordering = ["name"]
+    @classmethod
+    def filter_view_queryset(cls, queryset, user):
+        queryset = queryset.filter(deleted=False)
 
-    def __str__(self):
-        return self.name
+        if user.is_anonymous:
+            return queryset.filter(public=True)
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(
+            Q(public=True)
+            | Q(
+                user_roles__user=user,
+                user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+        ).distinct()
 
     @classmethod
     def filter_edit_queryset(cls, queryset, user):
+        queryset = queryset.filter(deleted=False)
+
         if user.is_anonymous:
             return queryset.none()
 
@@ -1907,27 +1988,15 @@ class Organization(models.Model):
             user_roles__user=user,
             user_roles__role=ORGANIZATION_ADMIN,
             user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
-            deleted=False,
         ).distinct()
 
-    @classmethod
-    def filter_view_queryset(cls, queryset, user):
-        if user.is_anonymous:
-            return queryset.none()
+    class Meta:
+        verbose_name = "Organization"
+        verbose_name_plural = "Organizations"
+        ordering = ["name"]
 
-        if user.is_admin:
-            return queryset
-
-        return queryset.filter(
-            user_roles__user=user,
-            user_roles__role__in=[
-                ORGANIZATION_ADMIN,
-                ORGANIZATION_EDITOR,
-                ORGANIZATION_VIEWER,
-            ],
-            user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
-            deleted=False,
-        ).distinct()
+    def __str__(self):
+        return self.name
 
 
 class OrganizationRole(models.Model):
@@ -1975,6 +2044,43 @@ class OrganizationRole(models.Model):
         auto_now_add=True, help_text="Date user joined the organization"
     )
     updated_at = models.DateTimeField(auto_now=True, help_text="Last update timestamp")
+
+    @classmethod
+    def filter_view_queryset(cls, queryset, user):
+        queryset = queryset.filter(organization__deleted=False,).select_related(
+            "organization",
+            "user",
+        )
+
+        if user.is_anonymous:
+            return queryset.none()
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(
+            organization__user_roles__user=user,
+            organization__user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        ).distinct()
+
+    @classmethod
+    def filter_edit_queryset(cls, queryset, user):
+        queryset = queryset.filter(organization__deleted=False,).select_related(
+            "organization",
+            "user",
+        )
+
+        if user.is_anonymous:
+            return queryset.none()
+
+        if user.is_admin:
+            return queryset
+
+        return queryset.filter(
+            organization__user_roles__user=user,
+            organization__user_roles__role=ORGANIZATION_ADMIN,
+            organization__user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        ).distinct()
 
     class Meta:
         unique_together = ("user", "organization")
@@ -3763,7 +3869,7 @@ class RelatedContentRelationship(models.Model):
 
 
 class Invitation(models.Model):
-    """ Invitation to edit channel """
+    """Invitation to edit channel"""
 
     id = UUIDField(primary_key=True, default=uuid.uuid4)
     accepted = models.BooleanField(default=False)

--- a/contentcuration/contentcuration/tests/test_organization.py
+++ b/contentcuration/contentcuration/tests/test_organization.py
@@ -524,9 +524,7 @@ class OrganizationMembershipDeleteTestCase(OrganizationAPITestCase):
     def test_last_active_admin_cannot_be_removed(self):
         self.authenticate_as(self.organization_admin)
 
-        response = self.client.delete(
-            self.membership_detail_url(self.admin_membership)
-        )
+        response = self.client.delete(self.membership_detail_url(self.admin_membership))
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertTrue(

--- a/contentcuration/contentcuration/tests/test_organization.py
+++ b/contentcuration/contentcuration/tests/test_organization.py
@@ -1,0 +1,500 @@
+"""
+Tests for Organization API endpoints.
+"""
+import json
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ADMIN,
+    ORGANIZATION_EDITOR,
+    ORGANIZATION_VIEWER,
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
+)
+from contentcuration.models import Organization, OrganizationRole, User
+from contentcuration.tests.base import BaseAPITestCase
+from contentcuration.tests import testdata
+
+
+class OrganizationAPITestCase(BaseAPITestCase):
+    """Base test case for Organization API tests."""
+
+    def setUp(self):
+        super().setUp()
+        # Create additional test users
+        self.admin_user = testdata.user(email="admin@test.com")
+        self.editor_user = testdata.user(email="editor@test.com")
+        self.viewer_user = testdata.user(email="viewer@test.com")
+        self.other_user = testdata.user(email="other@test.com")
+
+        # Create test organization
+        self.organization = Organization.objects.create(
+            name="Test Organization",
+            description="A test organization",
+            public=False,
+        )
+        
+        # Add admin user to organization
+        OrganizationRole.objects.create(
+            user=self.admin_user,
+            organization=self.organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        
+        # Add editor user to organization
+        OrganizationRole.objects.create(
+            user=self.editor_user,
+            organization=self.organization,
+            role=ORGANIZATION_EDITOR,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        
+        # Add viewer user to organization
+        OrganizationRole.objects.create(
+            user=self.viewer_user,
+            organization=self.organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+
+    def authenticate_as(self, user):
+        """Switch authentication to a different user."""
+        self.client = APIClient()
+        self.client.force_authenticate(user)
+
+
+class OrganizationListCreateTestCase(OrganizationAPITestCase):
+    """Tests for creating and listing organizations."""
+
+    def test_list_organizations_user_can_see_their_organizations(self):
+        """Authenticated users can list organizations they belong to."""
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.get("/api/organization/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["name"], "Test Organization")
+
+    def test_list_organizations_user_cannot_see_orgs_they_dont_belong_to(self):
+        """Users should not see organizations they are not members of."""
+        self.client.force_authenticate(self.other_user)
+        response = self.client.get("/api/organization/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # other_user should not see the organization
+        self.assertEqual(len(response.data["results"]), 0)
+
+    def test_create_organization_creates_user_as_admin(self):
+        """Creating an organization should make the creator an admin."""
+        self.client.force_authenticate(self.other_user)
+        data = {
+            "name": "New Organization",
+            "description": "A new organization",
+            "public": False,
+        }
+        response = self.client.post("/api/organization/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "New Organization")
+        
+        # Verify creator is admin
+        org = Organization.objects.get(id=response.data["id"])
+        role = org.user_roles.get(user=self.other_user)
+        self.assertEqual(role.role, ORGANIZATION_ADMIN)
+
+    def test_create_organization_requires_authentication(self):
+        """Creating an organization requires authentication."""
+        client = APIClient()
+        data = {
+            "name": "New Organization",
+            "description": "A new organization",
+            "public": False,
+        }
+        response = client.post("/api/organization/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_list_organizations_requires_authentication(self):
+        """Listing organizations requires authentication."""
+        client = APIClient()
+        response = client.get("/api/organization/")
+        
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class OrganizationRetrieveUpdateDeleteTestCase(OrganizationAPITestCase):
+    """Tests for retrieving, updating, and deleting organizations."""
+
+    def test_retrieve_organization_member_can_access(self):
+        """Organization members can retrieve organization details."""
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.get(f"/api/organization/{self.organization.id}/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "Test Organization")
+
+    def test_retrieve_organization_non_member_cannot_access(self):
+        """Non-members cannot retrieve organization details."""
+        self.client.force_authenticate(self.other_user)
+        response = self.client.get(f"/api/organization/{self.organization.id}/")
+        
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_organization_admin_can_update(self):
+        """Organization admins can update organization details."""
+        self.client.force_authenticate(self.admin_user)
+        data = {"name": "Updated Organization", "description": "Updated description"}
+        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.organization.refresh_from_db()
+        self.assertEqual(self.organization.name, "Updated Organization")
+
+    def test_update_organization_editor_cannot_update(self):
+        """Organization editors cannot update organization settings."""
+        self.client.force_authenticate(self.editor_user)
+        data = {"name": "Updated Organization"}
+        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_organization_viewer_cannot_update(self):
+        """Organization viewers cannot update organization settings."""
+        self.client.force_authenticate(self.viewer_user)
+        data = {"name": "Updated Organization"}
+        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_organization_admin_can_delete(self):
+        """Organization admins can delete organizations (soft delete)."""
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.delete(f"/api/organization/{self.organization.id}/")
+        
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.organization.refresh_from_db()
+        self.assertTrue(self.organization.deleted)
+
+    def test_delete_organization_editor_cannot_delete(self):
+        """Organization editors cannot delete organizations."""
+        self.client.force_authenticate(self.editor_user)
+        response = self.client.delete(f"/api/organization/{self.organization.id}/")
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class OrganizationMemberListTestCase(OrganizationAPITestCase):
+    """Tests for listing organization members."""
+
+    def test_list_members_member_can_view(self):
+        """Organization members can view the member list."""
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 3)
+
+    def test_list_members_non_member_cannot_view(self):
+        """Non-members cannot view the member list."""
+        self.client.force_authenticate(self.other_user)
+        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
+        
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_members_returns_user_details(self):
+        """Member list includes user email and name."""
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        members = response.data["results"]
+        
+        # Check that user details are included
+        admin_member = next((m for m in members if m["user"] == str(self.admin_user.id)), None)
+        self.assertIsNotNone(admin_member)
+        self.assertEqual(admin_member["user_email"], self.admin_user.email)
+
+
+class OrganizationAddMemberTestCase(OrganizationAPITestCase):
+    """Tests for adding members to organization."""
+
+    def test_add_member_admin_can_add(self):
+        """Organization admins can add new members."""
+        self.client.force_authenticate(self.admin_user)
+        data = {
+            "user_id": str(self.other_user.id),
+            "role": ORGANIZATION_VIEWER,
+        }
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["role"], ORGANIZATION_VIEWER)
+        
+        # Verify member was added
+        role = OrganizationRole.objects.get(user=self.other_user, organization=self.organization)
+        self.assertEqual(role.role, ORGANIZATION_VIEWER)
+
+    def test_add_member_editor_cannot_add(self):
+        """Organization editors cannot add members."""
+        self.client.force_authenticate(self.editor_user)
+        data = {
+            "user_id": str(self.other_user.id),
+            "role": ORGANIZATION_VIEWER,
+        }
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_add_member_requires_user_id(self):
+        """Adding a member requires a user_id."""
+        self.client.force_authenticate(self.admin_user)
+        data = {"role": ORGANIZATION_VIEWER}
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_add_member_defaults_to_viewer_role(self):
+        """If no role is specified, default is VIEWER."""
+        self.client.force_authenticate(self.admin_user)
+        data = {"user_id": str(self.other_user.id)}
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["role"], ORGANIZATION_VIEWER)
+
+    def test_add_member_invalid_role_rejected(self):
+        """Adding a member with an invalid role is rejected."""
+        self.client.force_authenticate(self.admin_user)
+        data = {
+            "user_id": str(self.other_user.id),
+            "role": "invalid_role",
+        }
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_add_nonexistent_user_fails(self):
+        """Adding a non-existent user fails."""
+        self.client.force_authenticate(self.admin_user)
+        data = {
+            "user_id": "00000000-0000-0000-0000-000000000000",
+            "role": ORGANIZATION_VIEWER,
+        }
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_existing_member_role(self):
+        """Adding a member that already exists updates their role."""
+        # other_user is already a viewer
+        OrganizationRole.objects.create(
+            user=self.other_user,
+            organization=self.organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        
+        self.client.force_authenticate(self.admin_user)
+        data = {
+            "user_id": str(self.other_user.id),
+            "role": ORGANIZATION_EDITOR,
+        }
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["role"], ORGANIZATION_EDITOR)
+
+
+class OrganizationUpdateMemberTestCase(OrganizationAPITestCase):
+    """Tests for updating member roles."""
+
+    def test_update_member_admin_can_update_role(self):
+        """Organization admins can update member roles."""
+        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
+        
+        self.client.force_authenticate(self.admin_user)
+        data = {"role": ORGANIZATION_EDITOR}
+        response = self.client.patch(
+            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}",
+            data,
+            format="json"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        membership.refresh_from_db()
+        self.assertEqual(membership.role, ORGANIZATION_EDITOR)
+
+    def test_update_member_editor_cannot_update(self):
+        """Organization editors cannot update member roles."""
+        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
+        
+        self.client.force_authenticate(self.editor_user)
+        data = {"role": ORGANIZATION_ADMIN}
+        response = self.client.patch(
+            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}",
+            data,
+            format="json"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_member_requires_member_id(self):
+        """Updating a member requires member_id parameter."""
+        self.client.force_authenticate(self.admin_user)
+        data = {"role": ORGANIZATION_EDITOR}
+        response = self.client.patch(
+            f"/api/organization/{self.organization.id}/update_member/",
+            data,
+            format="json"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_member_invalid_member_id_fails(self):
+        """Updating with an invalid member_id fails."""
+        self.client.force_authenticate(self.admin_user)
+        data = {"role": ORGANIZATION_EDITOR}
+        response = self.client.patch(
+            f"/api/organization/{self.organization.id}/update_member/?member_id=00000000-0000-0000-0000-000000000000",
+            data,
+            format="json"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class OrganizationRemoveMemberTestCase(OrganizationAPITestCase):
+    """Tests for removing members from organization."""
+
+    def test_remove_member_admin_can_remove(self):
+        """Organization admins can remove members."""
+        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
+        
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.delete(
+            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            OrganizationRole.objects.filter(
+                user=self.viewer_user, organization=self.organization
+            ).exists()
+        )
+
+    def test_remove_member_editor_cannot_remove(self):
+        """Organization editors cannot remove members."""
+        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
+        
+        self.client.force_authenticate(self.editor_user)
+        response = self.client.delete(
+            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_remove_member_non_member_cannot_remove(self):
+        """Non-members cannot remove members."""
+        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
+        
+        self.client.force_authenticate(self.other_user)
+        response = self.client.delete(
+            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}"
+        )
+        
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class OrganizationPermissionEnforcementTestCase(OrganizationAPITestCase):
+    """Tests for permission enforcement across different roles."""
+
+    def test_admin_can_manage_settings_members_and_roles(self):
+        """Admins have full management access."""
+        self.client.force_authenticate(self.admin_user)
+        
+        # Can update organization
+        data = {"name": "Updated"}
+        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Can add members
+        data = {"user_id": str(self.other_user.id), "role": ORGANIZATION_VIEWER}
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_editor_cannot_manage_settings_or_members(self):
+        """Editors cannot manage settings or members."""
+        self.client.force_authenticate(self.editor_user)
+        
+        # Cannot update organization
+        data = {"name": "Updated"}
+        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        
+        # Cannot add members
+        data = {"user_id": str(self.other_user.id), "role": ORGANIZATION_VIEWER}
+        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_viewer_has_read_only_access(self):
+        """Viewers have read-only access."""
+        self.client.force_authenticate(self.viewer_user)
+        
+        # Can view organization
+        response = self.client.get(f"/api/organization/{self.organization.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Can view members
+        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Cannot update organization
+        data = {"name": "Updated"}
+        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class OrganizationPaginationTestCase(OrganizationAPITestCase):
+    """Tests for pagination in organization endpoints."""
+
+    def test_organization_list_pagination(self):
+        """Organization list should be paginated."""
+        # Create multiple organizations
+        for i in range(25):
+            org = Organization.objects.create(name=f"Org {i}")
+            OrganizationRole.objects.create(
+                user=self.admin_user,
+                organization=org,
+                role=ORGANIZATION_ADMIN,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+        
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.get("/api/organization/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertIn("count", response.data)
+        self.assertEqual(len(response.data["results"]), 20)  # Default page size
+
+    def test_member_list_pagination(self):
+        """Member list should be paginated."""
+        # Add many members
+        for i in range(25):
+            user = testdata.user(email=f"user{i}@test.com")
+            OrganizationRole.objects.create(
+                user=user,
+                organization=self.organization,
+                role=ORGANIZATION_VIEWER,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+        
+        self.client.force_authenticate(self.admin_user)
+        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertIn("count", response.data)

--- a/contentcuration/contentcuration/tests/test_organization.py
+++ b/contentcuration/contentcuration/tests/test_organization.py
@@ -166,12 +166,12 @@ class OrganizationListCreateTestCase(OrganizationAPITestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_list_organizations_requires_authentication(self):
         response = APIClient().get(self.organization_list_url)
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class OrganizationRetrieveUpdateDeleteTestCase(OrganizationAPITestCase):

--- a/contentcuration/contentcuration/tests/test_organization.py
+++ b/contentcuration/contentcuration/tests/test_organization.py
@@ -1,5 +1,4 @@
 """Tests for organization and organization membership API endpoints."""
-
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient

--- a/contentcuration/contentcuration/tests/test_organization.py
+++ b/contentcuration/contentcuration/tests/test_organization.py
@@ -1,500 +1,573 @@
-"""
-Tests for Organization API endpoints.
-"""
-import json
+"""Tests for organization and organization membership API endpoints."""
 
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIClient
+from rest_framework.test import APIClient
 
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import ORGANIZATION_EDITOR
 from contentcuration.constants.organization_roles import (
-    ORGANIZATION_ADMIN,
-    ORGANIZATION_EDITOR,
-    ORGANIZATION_VIEWER,
     ORGANIZATION_ROLE_STATUS_ACTIVE,
 )
-from contentcuration.models import Organization, OrganizationRole, User
-from contentcuration.tests.base import BaseAPITestCase
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_INACTIVE,
+)
+from contentcuration.constants.organization_roles import ORGANIZATION_VIEWER
+from contentcuration.models import Organization
+from contentcuration.models import OrganizationRole
 from contentcuration.tests import testdata
+from contentcuration.tests.base import BaseAPITestCase
+from contentcuration.viewsets.organization import OrganizationMemberViewSet
 
 
 class OrganizationAPITestCase(BaseAPITestCase):
-    """Base test case for Organization API tests."""
+    """Shared organization API fixtures and URL helpers."""
 
     def setUp(self):
         super().setUp()
-        # Create additional test users
-        self.admin_user = testdata.user(email="admin@test.com")
-        self.editor_user = testdata.user(email="editor@test.com")
-        self.viewer_user = testdata.user(email="viewer@test.com")
-        self.other_user = testdata.user(email="other@test.com")
 
-        # Create test organization
+        self.organization_admin = testdata.user(email="org-admin@test.com")
+        self.organization_admin.first_name = "Admin"
+        self.organization_admin.last_name = "User"
+        self.organization_admin.save(update_fields=["first_name", "last_name"])
+
+        self.editor_user = testdata.user(email="org-editor@test.com")
+        self.viewer_user = testdata.user(email="org-viewer@test.com")
+        self.other_user = testdata.user(email="org-other@test.com")
+        self.inactive_user = testdata.user(email="org-inactive@test.com")
+
         self.organization = Organization.objects.create(
             name="Test Organization",
             description="A test organization",
             public=False,
         )
-        
-        # Add admin user to organization
-        OrganizationRole.objects.create(
-            user=self.admin_user,
+
+        self.admin_membership = OrganizationRole.objects.create(
+            user=self.organization_admin,
             organization=self.organization,
             role=ORGANIZATION_ADMIN,
             status=ORGANIZATION_ROLE_STATUS_ACTIVE,
         )
-        
-        # Add editor user to organization
-        OrganizationRole.objects.create(
+        self.editor_membership = OrganizationRole.objects.create(
             user=self.editor_user,
             organization=self.organization,
             role=ORGANIZATION_EDITOR,
             status=ORGANIZATION_ROLE_STATUS_ACTIVE,
         )
-        
-        # Add viewer user to organization
-        OrganizationRole.objects.create(
+        self.viewer_membership = OrganizationRole.objects.create(
             user=self.viewer_user,
             organization=self.organization,
             role=ORGANIZATION_VIEWER,
             status=ORGANIZATION_ROLE_STATUS_ACTIVE,
         )
+        self.inactive_membership = OrganizationRole.objects.create(
+            user=self.inactive_user,
+            organization=self.organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_INACTIVE,
+        )
+
+    @property
+    def organization_list_url(self):
+        return reverse("organization-list")
+
+    def organization_detail_url(self, organization=None):
+        organization = organization or self.organization
+        return reverse("organization-detail", kwargs={"pk": organization.id})
+
+    @property
+    def membership_list_url(self):
+        return reverse("organization-members-list")
+
+    def membership_detail_url(self, membership):
+        return reverse("organization-members-detail", kwargs={"pk": membership.id})
 
     def authenticate_as(self, user):
-        """Switch authentication to a different user."""
-        self.client = APIClient()
         self.client.force_authenticate(user)
 
 
 class OrganizationListCreateTestCase(OrganizationAPITestCase):
-    """Tests for creating and listing organizations."""
+    def test_member_can_list_private_organization(self):
+        self.authenticate_as(self.organization_admin)
 
-    def test_list_organizations_user_can_see_their_organizations(self):
-        """Authenticated users can list organizations they belong to."""
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.get("/api/organization/")
-        
+        response = self.client.get(self.organization_list_url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 1)
-        self.assertEqual(response.data["results"][0]["name"], "Test Organization")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], self.organization.name)
 
-    def test_list_organizations_user_cannot_see_orgs_they_dont_belong_to(self):
-        """Users should not see organizations they are not members of."""
-        self.client.force_authenticate(self.other_user)
-        response = self.client.get("/api/organization/")
-        
+    def test_nonmember_cannot_list_private_organization(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_list_url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # other_user should not see the organization
-        self.assertEqual(len(response.data["results"]), 0)
+        self.assertEqual(response.data["results"], [])
 
-    def test_create_organization_creates_user_as_admin(self):
-        """Creating an organization should make the creator an admin."""
-        self.client.force_authenticate(self.other_user)
+    def test_authenticated_nonmember_can_list_public_organization(self):
+        self.organization.public = True
+        self.organization.save(update_fields=["public"])
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_inactive_membership_does_not_grant_organization_access(self):
+        self.authenticate_as(self.inactive_user)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_list_can_filter_by_name(self):
+        second_organization = Organization.objects.create(name="Another Group")
+        OrganizationRole.objects.create(
+            user=self.organization_admin,
+            organization=second_organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(self.organization_list_url, {"name": "Another"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "Another Group")
+
+    def test_create_organization_creates_active_admin_membership(self):
+        self.authenticate_as(self.other_user)
         data = {
             "name": "New Organization",
             "description": "A new organization",
             "public": False,
         }
-        response = self.client.post("/api/organization/", data, format="json")
-        
+
+        response = self.client.post(self.organization_list_url, data, format="json")
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["name"], "New Organization")
-        
-        # Verify creator is admin
-        org = Organization.objects.get(id=response.data["id"])
-        role = org.user_roles.get(user=self.other_user)
-        self.assertEqual(role.role, ORGANIZATION_ADMIN)
+        organization = Organization.objects.get(id=response.data["id"])
+        membership = OrganizationRole.objects.get(
+            organization=organization,
+            user=self.other_user,
+        )
+        self.assertEqual(membership.role, ORGANIZATION_ADMIN)
+        self.assertEqual(membership.status, ORGANIZATION_ROLE_STATUS_ACTIVE)
 
     def test_create_organization_requires_authentication(self):
-        """Creating an organization requires authentication."""
         client = APIClient()
-        data = {
-            "name": "New Organization",
-            "description": "A new organization",
-            "public": False,
-        }
-        response = client.post("/api/organization/", data, format="json")
-        
+
+        response = client.post(
+            self.organization_list_url,
+            {"name": "New Organization"},
+            format="json",
+        )
+
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_list_organizations_requires_authentication(self):
-        """Listing organizations requires authentication."""
-        client = APIClient()
-        response = client.get("/api/organization/")
-        
+        response = APIClient().get(self.organization_list_url)
+
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class OrganizationRetrieveUpdateDeleteTestCase(OrganizationAPITestCase):
-    """Tests for retrieving, updating, and deleting organizations."""
+    def test_active_member_can_retrieve_private_organization(self):
+        self.authenticate_as(self.viewer_user)
 
-    def test_retrieve_organization_member_can_access(self):
-        """Organization members can retrieve organization details."""
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.get(f"/api/organization/{self.organization.id}/")
-        
+        response = self.client.get(self.organization_detail_url())
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["name"], "Test Organization")
+        self.assertEqual(response.data["name"], self.organization.name)
 
-    def test_retrieve_organization_non_member_cannot_access(self):
-        """Non-members cannot retrieve organization details."""
-        self.client.force_authenticate(self.other_user)
-        response = self.client.get(f"/api/organization/{self.organization.id}/")
-        
+    def test_nonmember_cannot_retrieve_private_organization(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_detail_url())
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_update_organization_admin_can_update(self):
-        """Organization admins can update organization details."""
-        self.client.force_authenticate(self.admin_user)
-        data = {"name": "Updated Organization", "description": "Updated description"}
-        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
-        
+    def test_nonmember_can_retrieve_public_organization(self):
+        self.organization.public = True
+        self.organization.save(update_fields=["public"])
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_active_admin_can_update_organization(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.name, "Updated Organization")
 
-    def test_update_organization_editor_cannot_update(self):
-        """Organization editors cannot update organization settings."""
-        self.client.force_authenticate(self.editor_user)
-        data = {"name": "Updated Organization"}
-        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    def test_editor_cannot_update_organization(self):
+        self.authenticate_as(self.editor_user)
 
-    def test_update_organization_viewer_cannot_update(self):
-        """Organization viewers cannot update organization settings."""
-        self.client.force_authenticate(self.viewer_user)
-        data = {"name": "Updated Organization"}
-        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
 
-    def test_delete_organization_admin_can_delete(self):
-        """Organization admins can delete organizations (soft delete)."""
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.delete(f"/api/organization/{self.organization.id}/")
-        
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_viewer_cannot_update_organization(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_inactive_admin_cannot_update_organization(self):
+        inactive_admin = testdata.user(email="inactive-admin@test.com")
+        OrganizationRole.objects.create(
+            user=inactive_admin,
+            organization=self.organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_INACTIVE,
+        )
+        self.authenticate_as(inactive_admin)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_active_admin_can_soft_delete_organization(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(self.organization_detail_url())
+
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.organization.refresh_from_db()
         self.assertTrue(self.organization.deleted)
 
-    def test_delete_organization_editor_cannot_delete(self):
-        """Organization editors cannot delete organizations."""
-        self.client.force_authenticate(self.editor_user)
-        response = self.client.delete(f"/api/organization/{self.organization.id}/")
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    def test_editor_cannot_delete_organization(self):
+        self.authenticate_as(self.editor_user)
 
+        response = self.client.delete(self.organization_detail_url())
 
-class OrganizationMemberListTestCase(OrganizationAPITestCase):
-    """Tests for listing organization members."""
-
-    def test_list_members_member_can_view(self):
-        """Organization members can view the member list."""
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data["results"]), 3)
-
-    def test_list_members_non_member_cannot_view(self):
-        """Non-members cannot view the member list."""
-        self.client.force_authenticate(self.other_user)
-        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
-        
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_list_members_returns_user_details(self):
-        """Member list includes user email and name."""
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        members = response.data["results"]
-        
-        # Check that user details are included
-        admin_member = next((m for m in members if m["user"] == str(self.admin_user.id)), None)
-        self.assertIsNotNone(admin_member)
-        self.assertEqual(admin_member["user_email"], self.admin_user.email)
-
-
-class OrganizationAddMemberTestCase(OrganizationAPITestCase):
-    """Tests for adding members to organization."""
-
-    def test_add_member_admin_can_add(self):
-        """Organization admins can add new members."""
-        self.client.force_authenticate(self.admin_user)
-        data = {
-            "user_id": str(self.other_user.id),
-            "role": ORGANIZATION_VIEWER,
-        }
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["role"], ORGANIZATION_VIEWER)
-        
-        # Verify member was added
-        role = OrganizationRole.objects.get(user=self.other_user, organization=self.organization)
-        self.assertEqual(role.role, ORGANIZATION_VIEWER)
-
-    def test_add_member_editor_cannot_add(self):
-        """Organization editors cannot add members."""
-        self.client.force_authenticate(self.editor_user)
-        data = {
-            "user_id": str(self.other_user.id),
-            "role": ORGANIZATION_VIEWER,
-        }
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_add_member_requires_user_id(self):
-        """Adding a member requires a user_id."""
-        self.client.force_authenticate(self.admin_user)
-        data = {"role": ORGANIZATION_VIEWER}
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_add_member_defaults_to_viewer_role(self):
-        """If no role is specified, default is VIEWER."""
-        self.client.force_authenticate(self.admin_user)
-        data = {"user_id": str(self.other_user.id)}
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["role"], ORGANIZATION_VIEWER)
-
-    def test_add_member_invalid_role_rejected(self):
-        """Adding a member with an invalid role is rejected."""
-        self.client.force_authenticate(self.admin_user)
-        data = {
-            "user_id": str(self.other_user.id),
-            "role": "invalid_role",
-        }
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_add_nonexistent_user_fails(self):
-        """Adding a non-existent user fails."""
-        self.client.force_authenticate(self.admin_user)
-        data = {
-            "user_id": "00000000-0000-0000-0000-000000000000",
-            "role": ORGANIZATION_VIEWER,
-        }
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.organization.refresh_from_db()
+        self.assertFalse(self.organization.deleted)
 
-    def test_update_existing_member_role(self):
-        """Adding a member that already exists updates their role."""
-        # other_user is already a viewer
-        OrganizationRole.objects.create(
-            user=self.other_user,
-            organization=self.organization,
-            role=ORGANIZATION_VIEWER,
-            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+
+class OrganizationMembershipListTestCase(OrganizationAPITestCase):
+    def test_active_member_can_list_memberships(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
         )
-        
-        self.client.force_authenticate(self.admin_user)
-        data = {
-            "user_id": str(self.other_user.id),
-            "role": ORGANIZATION_EDITOR,
-        }
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["role"], ORGANIZATION_EDITOR)
+        self.assertEqual(response.data["count"], 4)
 
+    def test_nonmember_receives_empty_membership_list(self):
+        self.authenticate_as(self.other_user)
 
-class OrganizationUpdateMemberTestCase(OrganizationAPITestCase):
-    """Tests for updating member roles."""
-
-    def test_update_member_admin_can_update_role(self):
-        """Organization admins can update member roles."""
-        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
-        
-        self.client.force_authenticate(self.admin_user)
-        data = {"role": ORGANIZATION_EDITOR}
-        response = self.client.patch(
-            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}",
-            data,
-            format="json"
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
         )
-        
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        membership.refresh_from_db()
-        self.assertEqual(membership.role, ORGANIZATION_EDITOR)
+        self.assertEqual(response.data["results"], [])
 
-    def test_update_member_editor_cannot_update(self):
-        """Organization editors cannot update member roles."""
-        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
-        
-        self.client.force_authenticate(self.editor_user)
-        data = {"role": ORGANIZATION_ADMIN}
-        response = self.client.patch(
-            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}",
-            data,
-            format="json"
-        )
-        
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+    def test_public_organization_does_not_expose_memberships_to_nonmember(self):
+        self.organization.public = True
+        self.organization.save(update_fields=["public"])
+        self.authenticate_as(self.other_user)
 
-    def test_update_member_requires_member_id(self):
-        """Updating a member requires member_id parameter."""
-        self.client.force_authenticate(self.admin_user)
-        data = {"role": ORGANIZATION_EDITOR}
-        response = self.client.patch(
-            f"/api/organization/{self.organization.id}/update_member/",
-            data,
-            format="json"
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
         )
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_update_member_invalid_member_id_fails(self):
-        """Updating with an invalid member_id fails."""
-        self.client.force_authenticate(self.admin_user)
-        data = {"role": ORGANIZATION_EDITOR}
-        response = self.client.patch(
-            f"/api/organization/{self.organization.id}/update_member/?member_id=00000000-0000-0000-0000-000000000000",
-            data,
-            format="json"
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_inactive_member_cannot_list_memberships(self):
+        self.authenticate_as(self.inactive_user)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
         )
-        
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_membership_response_includes_user_name_fields(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"user": str(self.organization_admin.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        membership = response.data["results"][0]
+        self.assertEqual(membership["user_email"], self.organization_admin.email)
+        self.assertEqual(membership["user_first_name"], "Admin")
+        self.assertEqual(membership["user_last_name"], "User")
+        self.assertEqual(membership["user_name"], "Admin User")
+
+    def test_member_can_retrieve_membership_in_same_organization(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.get(self.membership_detail_url(self.admin_membership))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_nonmember_cannot_retrieve_membership(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.membership_detail_url(self.admin_membership))
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-class OrganizationRemoveMemberTestCase(OrganizationAPITestCase):
-    """Tests for removing members from organization."""
+class OrganizationMembershipCreationTestCase(OrganizationAPITestCase):
+    def test_direct_membership_creation_is_not_allowed(self):
+        self.authenticate_as(self.organization_admin)
+        data = {
+            "organization": str(self.organization.id),
+            "user": str(self.other_user.id),
+            "role": ORGANIZATION_VIEWER,
+            "status": ORGANIZATION_ROLE_STATUS_ACTIVE,
+        }
 
-    def test_remove_member_admin_can_remove(self):
-        """Organization admins can remove members."""
-        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
-        
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.delete(
-            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}"
-        )
-        
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.post(self.membership_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertFalse(
             OrganizationRole.objects.filter(
-                user=self.viewer_user, organization=self.organization
+                organization=self.organization,
+                user=self.other_user,
             ).exists()
         )
 
-    def test_remove_member_editor_cannot_remove(self):
-        """Organization editors cannot remove members."""
-        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
-        
-        self.client.force_authenticate(self.editor_user)
-        response = self.client.delete(
-            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}"
+    def test_membership_viewset_has_no_sync_creation_handler(self):
+        self.assertFalse(hasattr(OrganizationMemberViewSet, "create_from_changes"))
+
+
+class OrganizationMembershipUpdateTestCase(OrganizationAPITestCase):
+    def test_active_admin_can_update_member_role(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
         )
-        
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_remove_member_non_member_cannot_remove(self):
-        """Non-members cannot remove members."""
-        membership = OrganizationRole.objects.get(user=self.viewer_user, organization=self.organization)
-        
-        self.client.force_authenticate(self.other_user)
-        response = self.client.delete(
-            f"/api/organization/{self.organization.id}/update_member/?member_id={membership.id}"
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.viewer_membership.refresh_from_db()
+        self.assertEqual(self.viewer_membership.role, ORGANIZATION_EDITOR)
+
+    def test_editor_cannot_update_membership(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
         )
-        
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-class OrganizationPermissionEnforcementTestCase(OrganizationAPITestCase):
-    """Tests for permission enforcement across different roles."""
+    def test_nonmember_cannot_update_membership(self):
+        self.authenticate_as(self.other_user)
 
-    def test_admin_can_manage_settings_members_and_roles(self):
-        """Admins have full management access."""
-        self.client.force_authenticate(self.admin_user)
-        
-        # Can update organization
-        data = {"name": "Updated"}
-        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        # Can add members
-        data = {"user_id": str(self.other_user.id), "role": ORGANIZATION_VIEWER}
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
 
-    def test_editor_cannot_manage_settings_or_members(self):
-        """Editors cannot manage settings or members."""
-        self.client.force_authenticate(self.editor_user)
-        
-        # Cannot update organization
-        data = {"name": "Updated"}
-        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_invalid_role_is_rejected(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": "invalid-role"},
+            format="json",
+        )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        
-        # Cannot add members
-        data = {"user_id": str(self.other_user.id), "role": ORGANIZATION_VIEWER}
-        response = self.client.post(f"/api/organization/{self.organization.id}/add_member/", data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_viewer_has_read_only_access(self):
-        """Viewers have read-only access."""
-        self.client.force_authenticate(self.viewer_user)
-        
-        # Can view organization
-        response = self.client.get(f"/api/organization/{self.organization.id}/")
+    def test_membership_user_and_organization_cannot_be_reassigned(self):
+        other_organization = Organization.objects.create(name="Other Organization")
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {
+                "user": str(self.other_user.id),
+                "organization": str(other_organization.id),
+                "description": "Updated description",
+            },
+            format="json",
+        )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        # Can view members
-        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        # Cannot update organization
-        data = {"name": "Updated"}
-        response = self.client.patch(f"/api/organization/{self.organization.id}/", data, format="json")
+        self.viewer_membership.refresh_from_db()
+        self.assertEqual(self.viewer_membership.user, self.viewer_user)
+        self.assertEqual(self.viewer_membership.organization, self.organization)
+        self.assertEqual(self.viewer_membership.description, "Updated description")
+
+    def test_last_active_admin_cannot_be_demoted(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.admin_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.admin_membership.refresh_from_db()
+        self.assertEqual(self.admin_membership.role, ORGANIZATION_ADMIN)
+
+    def test_last_active_admin_cannot_be_deactivated(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.admin_membership),
+            {"status": ORGANIZATION_ROLE_STATUS_INACTIVE},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.admin_membership.refresh_from_db()
+        self.assertEqual(
+            self.admin_membership.status,
+            ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+
+    def test_admin_can_be_demoted_when_another_active_admin_exists(self):
+        second_admin = testdata.user(email="second-admin@test.com")
+        OrganizationRole.objects.create(
+            user=second_admin,
+            organization=self.organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.admin_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.admin_membership.refresh_from_db()
+        self.assertEqual(self.admin_membership.role, ORGANIZATION_EDITOR)
+
+
+class OrganizationMembershipDeleteTestCase(OrganizationAPITestCase):
+    def test_active_admin_can_remove_nonadmin_member(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.viewer_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            OrganizationRole.objects.filter(id=self.viewer_membership.id).exists()
+        )
+
+    def test_editor_cannot_remove_membership(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.viewer_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_nonmember_cannot_remove_membership(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.viewer_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_last_active_admin_cannot_be_removed(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.admin_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(
+            OrganizationRole.objects.filter(id=self.admin_membership.id).exists()
+        )
 
 
 class OrganizationPaginationTestCase(OrganizationAPITestCase):
-    """Tests for pagination in organization endpoints."""
-
-    def test_organization_list_pagination(self):
-        """Organization list should be paginated."""
-        # Create multiple organizations
-        for i in range(25):
-            org = Organization.objects.create(name=f"Org {i}")
+    def test_organization_list_is_paginated(self):
+        for index in range(25):
+            organization = Organization.objects.create(name="Org {}".format(index))
             OrganizationRole.objects.create(
-                user=self.admin_user,
-                organization=org,
+                user=self.organization_admin,
+                organization=organization,
                 role=ORGANIZATION_ADMIN,
                 status=ORGANIZATION_ROLE_STATUS_ACTIVE,
             )
-        
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.get("/api/organization/")
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("results", response.data)
-        self.assertIn("count", response.data)
-        self.assertEqual(len(response.data["results"]), 20)  # Default page size
+        self.authenticate_as(self.organization_admin)
 
-    def test_member_list_pagination(self):
-        """Member list should be paginated."""
-        # Add many members
-        for i in range(25):
-            user = testdata.user(email=f"user{i}@test.com")
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 26)
+        self.assertEqual(len(response.data["results"]), 20)
+
+    def test_membership_list_is_paginated(self):
+        for index in range(25):
+            user = testdata.user(email="member{}@test.com".format(index))
             OrganizationRole.objects.create(
                 user=user,
                 organization=self.organization,
                 role=ORGANIZATION_VIEWER,
                 status=ORGANIZATION_ROLE_STATUS_ACTIVE,
             )
-        
-        self.client.force_authenticate(self.admin_user)
-        response = self.client.get(f"/api/organization/{self.organization.id}/members/")
-        
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
+        )
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("results", response.data)
-        self.assertIn("count", response.data)
+        self.assertEqual(response.data["count"], 29)
+        self.assertEqual(len(response.data["results"]), 20)

--- a/contentcuration/contentcuration/tests/viewsets/test_organization.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_organization.py
@@ -1,0 +1,742 @@
+"""Tests for organization and organization membership API endpoints."""
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import ORGANIZATION_EDITOR
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
+)
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_INACTIVE,
+)
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ROLE_STATUS_PENDING,
+)
+from contentcuration.constants.organization_roles import ORGANIZATION_VIEWER
+from contentcuration.models import Channel
+from contentcuration.models import Organization
+from contentcuration.models import OrganizationRole
+from contentcuration.tests import testdata
+from contentcuration.tests.base import StudioAPITestCase
+
+
+class OrganizationAPITestCase(StudioAPITestCase):
+    """Shared organization API fixtures and URL helpers."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.organization_admin = testdata.user(email="org-admin@test.com")
+        self.organization_admin.first_name = "Admin"
+        self.organization_admin.last_name = "User"
+        self.organization_admin.save(update_fields=["first_name", "last_name"])
+
+        self.editor_user = testdata.user(email="org-editor@test.com")
+        self.viewer_user = testdata.user(email="org-viewer@test.com")
+        self.other_user = testdata.user(email="org-other@test.com")
+        self.inactive_user = testdata.user(email="org-inactive@test.com")
+
+        self.organization = Organization.objects.create(
+            name="Test Organization",
+            description="A test organization",
+            public=False,
+        )
+
+        self.admin_membership = OrganizationRole.objects.create(
+            user=self.organization_admin,
+            organization=self.organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.editor_membership = OrganizationRole.objects.create(
+            user=self.editor_user,
+            organization=self.organization,
+            role=ORGANIZATION_EDITOR,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.viewer_membership = OrganizationRole.objects.create(
+            user=self.viewer_user,
+            organization=self.organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.inactive_membership = OrganizationRole.objects.create(
+            user=self.inactive_user,
+            organization=self.organization,
+            role=ORGANIZATION_VIEWER,
+            status=ORGANIZATION_ROLE_STATUS_INACTIVE,
+        )
+
+    @property
+    def organization_list_url(self):
+        return reverse("organization-list")
+
+    def organization_detail_url(self, organization=None):
+        organization = organization or self.organization
+        return reverse("organization-detail", kwargs={"pk": organization.id})
+
+    @property
+    def membership_list_url(self):
+        return reverse("organization-members-list")
+
+    def membership_detail_url(self, membership):
+        return reverse("organization-members-detail", kwargs={"pk": membership.id})
+
+    def authenticate_as(self, user):
+        self.client.force_authenticate(user)
+
+
+class OrganizationListCreateTestCase(OrganizationAPITestCase):
+    def test_member_can_list_private_organization(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], self.organization.name)
+
+    def test_nonmember_cannot_list_private_organization(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_authenticated_nonmember_can_list_public_organization(self):
+        self.organization.public = True
+        self.organization.save(update_fields=["public"])
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_inactive_membership_does_not_grant_organization_access(self):
+        self.authenticate_as(self.inactive_user)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_list_can_filter_by_name(self):
+        second_organization = Organization.objects.create(name="Another Group")
+        OrganizationRole.objects.create(
+            user=self.organization_admin,
+            organization=second_organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(self.organization_list_url, {"name": "Another"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "Another Group")
+
+    def test_create_organization_creates_active_admin_membership(self):
+        self.authenticate_as(self.other_user)
+        data = {
+            "name": "New Organization",
+            "description": "A new organization",
+            "public": False,
+        }
+
+        response = self.client.post(self.organization_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        organization = Organization.objects.get(id=response.data["id"])
+        membership = OrganizationRole.objects.get(
+            organization=organization,
+            user=self.other_user,
+        )
+        self.assertEqual(membership.role, ORGANIZATION_ADMIN)
+        self.assertEqual(membership.status, ORGANIZATION_ROLE_STATUS_ACTIVE)
+
+    def test_create_organization_requires_authentication(self):
+        client = APIClient()
+
+        response = client.post(
+            self.organization_list_url,
+            {"name": "New Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_organizations_requires_authentication(self):
+        response = APIClient().get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class OrganizationRetrieveUpdateDeleteTestCase(OrganizationAPITestCase):
+    def test_active_member_can_retrieve_private_organization(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.get(self.organization_detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], self.organization.name)
+
+    def test_nonmember_cannot_retrieve_private_organization(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_nonmember_can_retrieve_public_organization(self):
+        self.organization.public = True
+        self.organization.save(update_fields=["public"])
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.organization_detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_active_admin_can_update_organization(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.organization.refresh_from_db()
+        self.assertEqual(self.organization.name, "Updated Organization")
+
+    def test_editor_cannot_update_organization(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_viewer_cannot_update_organization(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_inactive_admin_cannot_update_organization(self):
+        inactive_admin = testdata.user(email="inactive-admin@test.com")
+        OrganizationRole.objects.create(
+            user=inactive_admin,
+            organization=self.organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_INACTIVE,
+        )
+        self.authenticate_as(inactive_admin)
+
+        response = self.client.patch(
+            self.organization_detail_url(),
+            {"name": "Updated Organization"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_active_admin_can_soft_delete_organization(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(self.organization_detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.organization.refresh_from_db()
+        self.assertTrue(self.organization.deleted)
+
+    def test_editor_cannot_delete_organization(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.delete(self.organization_detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.organization.refresh_from_db()
+        self.assertFalse(self.organization.deleted)
+
+
+class OrganizationMembershipListTestCase(OrganizationAPITestCase):
+    def test_active_member_can_list_memberships(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 4)
+
+    def test_nonmember_receives_empty_membership_list(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_public_organization_does_not_expose_memberships_to_nonmember(self):
+        self.organization.public = True
+        self.organization.save(update_fields=["public"])
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_inactive_member_cannot_list_memberships(self):
+        self.authenticate_as(self.inactive_user)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"], [])
+
+    def test_membership_response_includes_user_name_fields(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"user": str(self.organization_admin.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        membership = response.data["results"][0]
+        self.assertEqual(membership["user_email"], self.organization_admin.email)
+        self.assertEqual(membership["user_first_name"], "Admin")
+        self.assertEqual(membership["user_last_name"], "User")
+        self.assertEqual(membership["user_name"], "Admin User")
+
+    def test_member_can_retrieve_membership_in_same_organization(self):
+        self.authenticate_as(self.viewer_user)
+
+        response = self.client.get(self.membership_detail_url(self.admin_membership))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_nonmember_cannot_retrieve_membership(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.get(self.membership_detail_url(self.admin_membership))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class OrganizationMembershipCreationTestCase(OrganizationAPITestCase):
+    def test_active_admin_can_create_membership(self):
+        self.authenticate_as(self.organization_admin)
+        data = {
+            "organization": str(self.organization.id),
+            "user": str(self.other_user.id),
+            "role": ORGANIZATION_VIEWER,
+            "status": ORGANIZATION_ROLE_STATUS_ACTIVE,
+        }
+
+        response = self.client.post(self.membership_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        membership = OrganizationRole.objects.get(
+            organization=self.organization,
+            user=self.other_user,
+        )
+        self.assertEqual(membership.role, ORGANIZATION_VIEWER)
+        self.assertEqual(membership.status, ORGANIZATION_ROLE_STATUS_ACTIVE)
+
+    def test_editor_cannot_create_membership(self):
+        self.authenticate_as(self.editor_user)
+        data = {
+            "organization": str(self.organization.id),
+            "user": str(self.other_user.id),
+            "role": ORGANIZATION_VIEWER,
+            "status": ORGANIZATION_ROLE_STATUS_ACTIVE,
+        }
+
+        response = self.client.post(self.membership_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            OrganizationRole.objects.filter(
+                organization=self.organization,
+                user=self.other_user,
+            ).exists()
+        )
+
+    def test_nonmember_cannot_create_membership(self):
+        self.authenticate_as(self.other_user)
+        data = {
+            "organization": str(self.organization.id),
+            "user": str(self.other_user.id),
+            "role": ORGANIZATION_VIEWER,
+            "status": ORGANIZATION_ROLE_STATUS_ACTIVE,
+        }
+
+        response = self.client.post(self.membership_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(
+            OrganizationRole.objects.filter(
+                organization=self.organization,
+                user=self.other_user,
+            ).exists()
+        )
+
+    def test_invalid_role_is_rejected_on_create(self):
+        self.authenticate_as(self.organization_admin)
+        data = {
+            "organization": str(self.organization.id),
+            "user": str(self.other_user.id),
+            "role": "invalid-role",
+            "status": ORGANIZATION_ROLE_STATUS_ACTIVE,
+        }
+
+        response = self.client.post(self.membership_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_duplicate_membership_is_rejected(self):
+        self.authenticate_as(self.organization_admin)
+        data = {
+            "organization": str(self.organization.id),
+            "user": str(self.viewer_user.id),
+            "role": ORGANIZATION_EDITOR,
+            "status": ORGANIZATION_ROLE_STATUS_ACTIVE,
+        }
+
+        response = self.client.post(self.membership_list_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            OrganizationRole.objects.filter(
+                organization=self.organization,
+                user=self.viewer_user,
+            ).count(),
+            1,
+        )
+
+
+class OrganizationMembershipUpdateTestCase(OrganizationAPITestCase):
+    def test_active_admin_can_update_member_role(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.viewer_membership.refresh_from_db()
+        self.assertEqual(self.viewer_membership.role, ORGANIZATION_EDITOR)
+
+    def test_editor_cannot_update_membership(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_nonmember_cannot_update_membership(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_invalid_role_is_rejected(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {"role": "invalid-role"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_membership_user_and_organization_cannot_be_reassigned(self):
+        other_organization = Organization.objects.create(name="Other Organization")
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.viewer_membership),
+            {
+                "user": str(self.other_user.id),
+                "organization": str(other_organization.id),
+                "description": "Updated description",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.viewer_membership.refresh_from_db()
+        self.assertEqual(self.viewer_membership.user, self.viewer_user)
+        self.assertEqual(self.viewer_membership.organization, self.organization)
+        self.assertEqual(self.viewer_membership.description, "Updated description")
+
+    def test_last_active_admin_cannot_be_demoted(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.admin_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.admin_membership.refresh_from_db()
+        self.assertEqual(self.admin_membership.role, ORGANIZATION_ADMIN)
+
+    def test_last_active_admin_cannot_be_deactivated(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.admin_membership),
+            {"status": ORGANIZATION_ROLE_STATUS_INACTIVE},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.admin_membership.refresh_from_db()
+        self.assertEqual(
+            self.admin_membership.status,
+            ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+
+    def test_admin_can_be_demoted_when_another_active_admin_exists(self):
+        second_admin = testdata.user(email="second-admin@test.com")
+        OrganizationRole.objects.create(
+            user=second_admin,
+            organization=self.organization,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        )
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.patch(
+            self.membership_detail_url(self.admin_membership),
+            {"role": ORGANIZATION_EDITOR},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.admin_membership.refresh_from_db()
+        self.assertEqual(self.admin_membership.role, ORGANIZATION_EDITOR)
+
+
+class OrganizationMembershipDeleteTestCase(OrganizationAPITestCase):
+    def test_active_admin_can_remove_nonadmin_member(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.viewer_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            OrganizationRole.objects.filter(id=self.viewer_membership.id).exists()
+        )
+
+    def test_editor_cannot_remove_membership(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.viewer_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_nonmember_cannot_remove_membership(self):
+        self.authenticate_as(self.other_user)
+
+        response = self.client.delete(
+            self.membership_detail_url(self.viewer_membership)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_last_active_admin_cannot_be_removed(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(self.membership_detail_url(self.admin_membership))
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(
+            OrganizationRole.objects.filter(id=self.admin_membership.id).exists()
+        )
+
+
+class OrganizationChannelPermissionTestCase(OrganizationAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.channel = Channel.objects.create(
+            name="Organization Channel",
+            organization=self.organization,
+            public=False,
+            actor_id=self.organization_admin.id,
+        )
+        self.pending_user = testdata.user(email="org-pending@test.com")
+        OrganizationRole.objects.create(
+            user=self.pending_user,
+            organization=self.organization,
+            role=ORGANIZATION_EDITOR,
+            status=ORGANIZATION_ROLE_STATUS_PENDING,
+        )
+
+    def _editable_channel(self, user):
+        return Channel.filter_edit_queryset(
+            Channel.objects.filter(pk=self.channel.pk),
+            user,
+        )
+
+    def _deletable_channel(self, user):
+        return Channel.filter_delete_queryset(
+            Channel.objects.filter(pk=self.channel.pk),
+            user,
+        )
+
+    def _viewable_channel(self, user):
+        return Channel.filter_view_queryset(
+            Channel.objects.filter(pk=self.channel.pk),
+            user,
+        )
+
+    def test_admin_can_update_organization_channel_without_m2m_share(self):
+        self.assertFalse(
+            self.channel.editors.filter(pk=self.organization_admin.pk).exists()
+        )
+
+        channel = self._editable_channel(self.organization_admin).get()
+        channel.name = "Admin Updated Channel"
+        channel.save(actor_id=self.organization_admin.id)
+
+        channel.refresh_from_db()
+        self.assertEqual(channel.name, "Admin Updated Channel")
+        self.assertTrue(self._viewable_channel(self.organization_admin).exists())
+
+    def test_editor_can_update_organization_channel_without_m2m_share(self):
+        self.assertFalse(self.channel.editors.filter(pk=self.editor_user.pk).exists())
+
+        channel = self._editable_channel(self.editor_user).get()
+        channel.name = "Editor Updated Channel"
+        channel.save(actor_id=self.editor_user.id)
+
+        channel.refresh_from_db()
+        self.assertEqual(channel.name, "Editor Updated Channel")
+        self.assertTrue(self._viewable_channel(self.editor_user).exists())
+
+    def test_org_editor_cannot_delete_organization_channel(self):
+        self.assertTrue(self._editable_channel(self.editor_user).exists())
+        self.assertFalse(self._deletable_channel(self.editor_user).exists())
+
+    def test_org_admin_can_delete_organization_channel(self):
+        self.assertTrue(self._deletable_channel(self.organization_admin).exists())
+
+    def test_org_editor_delete_channel_returns_forbidden(self):
+        self.authenticate_as(self.editor_user)
+
+        response = self.client.delete(
+            reverse("channel-detail", kwargs={"pk": self.channel.id})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.channel.refresh_from_db()
+        self.assertFalse(self.channel.deleted)
+
+    def test_org_admin_can_delete_channel_via_api(self):
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.delete(
+            reverse("channel-detail", kwargs={"pk": self.channel.id})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.channel.refresh_from_db()
+        self.assertTrue(self.channel.deleted)
+
+    def test_viewer_can_view_but_cannot_edit_organization_channel(self):
+        self.assertTrue(self._viewable_channel(self.viewer_user).exists())
+        self.assertFalse(self._editable_channel(self.viewer_user).exists())
+
+    def test_nonmember_cannot_view_or_edit_organization_channel(self):
+        self.assertFalse(self._viewable_channel(self.other_user).exists())
+        self.assertFalse(self._editable_channel(self.other_user).exists())
+
+    def test_pending_role_grants_no_channel_access(self):
+        self.assertFalse(self._viewable_channel(self.pending_user).exists())
+        self.assertFalse(self._editable_channel(self.pending_user).exists())
+
+
+class OrganizationPaginationTestCase(OrganizationAPITestCase):
+    def test_organization_list_is_paginated(self):
+        for index in range(25):
+            organization = Organization.objects.create(name="Org {}".format(index))
+            OrganizationRole.objects.create(
+                user=self.organization_admin,
+                organization=organization,
+                role=ORGANIZATION_ADMIN,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(self.organization_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 26)
+        self.assertEqual(len(response.data["results"]), 20)
+
+    def test_membership_list_is_paginated(self):
+        for index in range(25):
+            user = testdata.user(email="member{}@test.com".format(index))
+            OrganizationRole.objects.create(
+                user=user,
+                organization=self.organization,
+                role=ORGANIZATION_VIEWER,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+        self.authenticate_as(self.organization_admin)
+
+        response = self.client.get(
+            self.membership_list_url,
+            {"organization": str(self.organization.id)},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 29)
+        self.assertEqual(len(response.data["results"]), 20)

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -13,7 +13,6 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
-
 import uuid
 
 import django_js_reverse.views as django_js_reverse_views
@@ -58,10 +57,8 @@ from contentcuration.viewsets.feedback import RecommendationsEventViewSet
 from contentcuration.viewsets.feedback import RecommendationsInteractionEventViewSet
 from contentcuration.viewsets.file import FileViewSet
 from contentcuration.viewsets.invitation import InvitationViewSet
-from contentcuration.viewsets.organization import (
-    OrganizationViewSet,
-    OrganizationMemberViewSet,
-)
+from contentcuration.viewsets.organization import OrganizationMemberViewSet
+from contentcuration.viewsets.organization import OrganizationViewSet
 from contentcuration.viewsets.recommendation import RecommendationView
 from contentcuration.viewsets.sync.endpoint import SyncView
 from contentcuration.viewsets.user import AdminUserViewSet

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -57,6 +57,7 @@ from contentcuration.viewsets.feedback import RecommendationsEventViewSet
 from contentcuration.viewsets.feedback import RecommendationsInteractionEventViewSet
 from contentcuration.viewsets.file import FileViewSet
 from contentcuration.viewsets.invitation import InvitationViewSet
+from contentcuration.viewsets.organization import OrganizationViewSet, OrganizationMemberViewSet
 from contentcuration.viewsets.recommendation import RecommendationView
 from contentcuration.viewsets.sync.endpoint import SyncView
 from contentcuration.viewsets.user import AdminUserViewSet
@@ -83,6 +84,8 @@ router.register(r"file", FileViewSet)
 router.register(r"channeluser", ChannelUserViewSet, basename="channeluser")
 router.register(r"user", UserViewSet)
 router.register(r"invitation", InvitationViewSet)
+router.register(r"organization", OrganizationViewSet, basename="organization")
+router.register(r"organization-members", OrganizationMemberViewSet, basename="organization-members")
 router.register(r"contentnode", ContentNodeViewSet)
 router.register(r"assessmentitem", AssessmentItemViewSet)
 router.register(r"admin-users", AdminUserViewSet, basename="admin-users")

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -57,6 +57,8 @@ from contentcuration.viewsets.feedback import RecommendationsEventViewSet
 from contentcuration.viewsets.feedback import RecommendationsInteractionEventViewSet
 from contentcuration.viewsets.file import FileViewSet
 from contentcuration.viewsets.invitation import InvitationViewSet
+from contentcuration.viewsets.organization import OrganizationMemberViewSet
+from contentcuration.viewsets.organization import OrganizationViewSet
 from contentcuration.viewsets.recommendation import RecommendationView
 from contentcuration.viewsets.sync.endpoint import SyncView
 from contentcuration.viewsets.user import AdminUserViewSet
@@ -83,6 +85,10 @@ router.register(r"file", FileViewSet)
 router.register(r"channeluser", ChannelUserViewSet, basename="channeluser")
 router.register(r"user", UserViewSet)
 router.register(r"invitation", InvitationViewSet)
+router.register(r"organization", OrganizationViewSet, basename="organization")
+router.register(
+    r"organization-members", OrganizationMemberViewSet, basename="organization-members"
+)
 router.register(r"contentnode", ContentNodeViewSet)
 router.register(r"assessmentitem", AssessmentItemViewSet)
 router.register(r"admin-users", AdminUserViewSet, basename="admin-users")

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  re_path(r'^blog/', include(blog_urls))
 """
+
 import uuid
 
 import django_js_reverse.views as django_js_reverse_views
@@ -57,7 +58,10 @@ from contentcuration.viewsets.feedback import RecommendationsEventViewSet
 from contentcuration.viewsets.feedback import RecommendationsInteractionEventViewSet
 from contentcuration.viewsets.file import FileViewSet
 from contentcuration.viewsets.invitation import InvitationViewSet
-from contentcuration.viewsets.organization import OrganizationViewSet, OrganizationMemberViewSet
+from contentcuration.viewsets.organization import (
+    OrganizationViewSet,
+    OrganizationMemberViewSet,
+)
 from contentcuration.viewsets.recommendation import RecommendationView
 from contentcuration.viewsets.sync.endpoint import SyncView
 from contentcuration.viewsets.user import AdminUserViewSet
@@ -85,7 +89,9 @@ router.register(r"channeluser", ChannelUserViewSet, basename="channeluser")
 router.register(r"user", UserViewSet)
 router.register(r"invitation", InvitationViewSet)
 router.register(r"organization", OrganizationViewSet, basename="organization")
-router.register(r"organization-members", OrganizationMemberViewSet, basename="organization-members")
+router.register(
+    r"organization-members", OrganizationMemberViewSet, basename="organization-members"
+)
 router.register(r"contentnode", ContentNodeViewSet)
 router.register(r"assessmentitem", AssessmentItemViewSet)
 router.register(r"admin-users", AdminUserViewSet, basename="admin-users")

--- a/contentcuration/contentcuration/viewsets/base.py
+++ b/contentcuration/contentcuration/viewsets/base.py
@@ -38,7 +38,6 @@ from contentcuration.viewsets.sync.constants import TASK_ID
 from contentcuration.viewsets.sync.utils import generate_update_event
 from contentcuration.viewsets.sync.utils import log_sync_exception
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -598,6 +597,19 @@ class BaseValuesViewset(SimpleReprMixin, GenericViewSet):
             return queryset.model.filter_edit_queryset(queryset, self.request.user)
         return self.get_queryset()
 
+    def get_delete_queryset(self):
+        """
+        Return a filtered copy of the queryset to only the objects
+        that a user is able to delete.
+        """
+        queryset = self.get_edit_queryset()
+        if hasattr(queryset.model, "filter_delete_queryset"):
+            return queryset.model.filter_delete_queryset(
+                super(BaseValuesViewset, self).get_queryset(),
+                self.request.user,
+            )
+        return queryset
+
     def _get_lookup_filter(self):
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
 
@@ -634,6 +646,9 @@ class BaseValuesViewset(SimpleReprMixin, GenericViewSet):
 
     def get_edit_object(self):
         return self._get_object_from_queryset(self.get_edit_queryset())
+
+    def get_delete_object(self):
+        return self._get_object_from_queryset(self.get_delete_queryset())
 
     def annotate_queryset(self, queryset):
         return queryset
@@ -747,7 +762,7 @@ class DestroyModelMixin(object):
 
     def delete_from_changes(self, changes):
         errors = []
-        queryset = self.get_edit_queryset().order_by()
+        queryset = self.get_delete_queryset().order_by()
         for change in changes:
             try:
                 instance = queryset.get(**dict(self.values_from_key(change["key"])))
@@ -766,7 +781,7 @@ class DestroyModelMixin(object):
 
 class RESTDestroyModelMixin(DestroyModelMixin):
     def destroy(self, request, *args, **kwargs):
-        instance = self.get_edit_object()
+        instance = self.get_delete_object()
         self.perform_destroy(instance)
         return Response(status=HTTP_204_NO_CONTENT)
 

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -29,6 +29,7 @@ from le_utils.constants import content_kinds
 from le_utils.constants import roles
 from rest_framework import serializers
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAuthenticated
@@ -483,6 +484,9 @@ class ChannelViewSet(ValuesViewset):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_edit_object()
+        if not self.get_delete_queryset().filter(pk=instance.pk).exists():
+            raise PermissionDenied("You do not have permission to delete this channel.")
+
         self.perform_destroy(instance)
         Change.create_change(
             generate_update_event(
@@ -686,9 +690,9 @@ class ChannelViewSet(ValuesViewset):
                             channel.id,
                             CHANNEL,
                             {
-                                "draft_token": draft_token.token
-                                if draft_token
-                                else None,
+                                "draft_token": (
+                                    draft_token.token if draft_token else None
+                                ),
                             },
                             channel_id=channel.id,
                         ),
@@ -1349,7 +1353,7 @@ class AdminChannelViewSet(ChannelViewSet, RESTUpdateModelMixin, RESTDestroyModel
 
 
 class SettingsChannelSerializer(BulkModelSerializer):
-    """ Used for displaying list of user's channels on settings page """
+    """Used for displaying list of user's channels on settings page"""
 
     editor_count = serializers.SerializerMethodField()
 

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -19,6 +19,7 @@ from contentcuration.viewsets.base import (
     RESTCreateModelMixin,
     RESTDestroyModelMixin,
     RESTUpdateModelMixin,
+    ReadOnlyValuesViewset,
     ValuesViewset,
 )
 
@@ -46,15 +47,17 @@ class OrganizationSerializer(BulkModelSerializer):
 
 class OrganizationMemberSerializer(BulkModelSerializer):
     """
-    Write serializer for OrganizationRole membership records.
+    Write serializer for updating OrganizationRole membership records.
 
-    Organization and user may be set when creating a membership, but cannot be
-    changed afterwards. Read operations are handled by the viewset values map.
+    Membership creation is handled by invitation acceptance. Organization and
+    user are immutable through this endpoint; admins may only update an existing
+    membership's role, description, or status. Read operations are handled by
+    the viewset values map.
     """
 
     status = serializers.ChoiceField(
         choices=organization_role_status_choices,
-        default=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        required=False,
     )
 
     class Meta:
@@ -67,18 +70,8 @@ class OrganizationMemberSerializer(BulkModelSerializer):
             "description",
             "status",
         )
+        read_only_fields = ("organization", "user")
         list_serializer_class = BulkListSerializer
-
-    def get_fields(self):
-        fields = super().get_fields()
-
-        # A membership may move between statuses and roles, but it must never be
-        # reassigned to a different organization or user.
-        if self.instance is not None:
-            fields["organization"].read_only = True
-            fields["user"].read_only = True
-
-        return fields
 
 
 class OrganizationFilter(FilterSet):
@@ -207,17 +200,17 @@ class OrganizationViewSet(
 
 
 class OrganizationMemberViewSet(
-    ValuesViewset,
-    RESTCreateModelMixin,
+    ReadOnlyValuesViewset,
     RESTUpdateModelMixin,
     RESTDestroyModelMixin,
 ):
     """
     Organization membership and role API.
 
-    Active organization members may read the membership list. Only active
-    organization admins may create, update, or remove memberships. Site admins
-    may manage all memberships.
+    Active organization members may read the membership list. New membership
+    records are created only when an invitation is accepted. Active organization
+    admins may update or remove existing memberships. Site admins may manage all
+    existing memberships.
     """
 
     queryset = OrganizationRole.objects.all()
@@ -351,16 +344,6 @@ class OrganizationMemberViewSet(
             raise ValidationError(
                 "An organization must have at least one active admin."
             )
-
-    def perform_create(self, serializer, change=None):
-        organization = serializer.validated_data["organization"]
-        self._require_admin(organization)
-
-        if organization.deleted:
-            raise ValidationError("Cannot add members to a deleted organization.")
-
-        with transaction.atomic():
-            serializer.save()
 
     def perform_update(self, serializer):
         with transaction.atomic():

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -1,0 +1,331 @@
+from django.db import transaction
+from django_filters.rest_framework import CharFilter
+from django_filters.rest_framework import FilterSet
+from django_filters.rest_framework import NumberFilter
+from django_filters.rest_framework import UUIDFilter
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import ORGANIZATION_ROLE_STATUS_ACTIVE
+from contentcuration.constants.organization_roles import (
+    organization_role_status_choices,
+)
+from contentcuration.constants.organization_roles import ORGANIZATION_VIEWER
+from contentcuration.models import Organization
+from contentcuration.models import OrganizationRole
+from contentcuration.utils.pagination import ValuesViewsetPageNumberPagination
+from contentcuration.viewsets.base import BulkListSerializer
+from contentcuration.viewsets.base import BulkModelSerializer
+from contentcuration.viewsets.base import RESTCreateModelMixin
+from contentcuration.viewsets.base import RESTDestroyModelMixin
+from contentcuration.viewsets.base import RESTUpdateModelMixin
+from contentcuration.viewsets.base import ValuesViewset
+from contentcuration.viewsets.common import UserFilteredPrimaryKeyRelatedField
+
+
+class OrganizationSerializer(BulkModelSerializer):
+    """
+    Write serializer for organizations.
+
+    Read operations are handled by OrganizationViewSet.values, following the
+    ValuesViewset pattern used elsewhere in Studio.
+    """
+
+    class Meta:
+        model = Organization
+        fields = (
+            "id",
+            "name",
+            "description",
+            "thumbnail",
+            "thumbnail_encoding",
+            "public",
+        )
+        list_serializer_class = BulkListSerializer
+
+
+class OrganizationMemberSerializer(BulkModelSerializer):
+    """
+    Write serializer for OrganizationRole membership records.
+
+    Organization and user are writable when creating a membership. They are
+    immutable once the membership exists; admins may update role, description,
+    or status. Read operations are handled by the viewset values map.
+    """
+
+    organization = UserFilteredPrimaryKeyRelatedField(
+        queryset=Organization.objects.all(),
+    )
+    status = serializers.ChoiceField(
+        choices=organization_role_status_choices,
+        required=False,
+    )
+
+    class Meta:
+        model = OrganizationRole
+        fields = (
+            "id",
+            "organization",
+            "user",
+            "role",
+            "description",
+            "status",
+        )
+        list_serializer_class = BulkListSerializer
+
+    def get_fields(self):
+        fields = super(OrganizationMemberSerializer, self).get_fields()
+
+        # Organization and user are writable on create, but immutable on update.
+        # Marking them read-only before validation prevents an attempted
+        # reassignment from failing related-field permission validation.
+        if self.instance is not None:
+            fields["organization"].read_only = True
+            fields["user"].read_only = True
+
+        return fields
+
+    def update(self, instance, validated_data):
+        validated_data.pop("organization", None)
+        validated_data.pop("user", None)
+        return super(OrganizationMemberSerializer, self).update(
+            instance, validated_data
+        )
+
+
+class OrganizationFilter(FilterSet):
+    name = CharFilter(field_name="name", lookup_expr="icontains")
+
+    class Meta:
+        model = Organization
+        fields = ("name", "public")
+
+
+class OrganizationMemberFilter(FilterSet):
+    organization = UUIDFilter(field_name="organization_id")
+    user = NumberFilter(field_name="user_id")
+
+    class Meta:
+        model = OrganizationRole
+        fields = ("organization", "user", "role", "status")
+
+
+class OrganizationPagination(ValuesViewsetPageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+class OrganizationViewSet(
+    ValuesViewset,
+    RESTCreateModelMixin,
+    RESTUpdateModelMixin,
+    RESTDestroyModelMixin,
+):
+    """
+    Organization CRUD API.
+
+    Active organization admins may update or delete an organization. Any
+    authenticated user may create an organization and becomes its first active
+    administrator. Site administrators may manage every organization.
+    """
+
+    queryset = Organization.objects.all()
+    serializer_class = OrganizationSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_class = OrganizationFilter
+    pagination_class = OrganizationPagination
+    ordering_fields = ("name", "created_at", "updated_at")
+    ordering = "name"
+
+    values = (
+        "id",
+        "name",
+        "description",
+        "thumbnail",
+        "thumbnail_encoding",
+        "public",
+        "created_at",
+        "updated_at",
+    )
+
+    def get_queryset(self):
+        return Organization.filter_view_queryset(
+            Organization.objects.all(),
+            self.request.user,
+        )
+
+    def perform_create(self, serializer, change=None):
+        """Create the organization and its initial administrator atomically."""
+        with transaction.atomic():
+            organization = serializer.save()
+            OrganizationRole.objects.create(
+                organization=organization,
+                user=self.request.user,
+                role=ORGANIZATION_ADMIN,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+
+    def perform_destroy(self, instance):
+        """Soft-delete an organization."""
+        instance.deleted = True
+        instance.save(update_fields=["deleted", "updated_at"])
+
+
+class OrganizationMemberViewSet(
+    ValuesViewset,
+    RESTCreateModelMixin,
+    RESTUpdateModelMixin,
+    RESTDestroyModelMixin,
+):
+    """
+    Organization membership and role API.
+
+    Active organization members may read the membership list. Active organization
+    admins may create, update, or remove memberships and assign roles. Site admins
+    may manage all memberships.
+    """
+
+    queryset = OrganizationRole.objects.all()
+    serializer_class = OrganizationMemberSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_class = OrganizationMemberFilter
+    pagination_class = OrganizationPagination
+    ordering_fields = ("joined_at", "updated_at", "role", "status")
+    ordering = "-joined_at"
+
+    values = (
+        "id",
+        "organization_id",
+        "organization__name",
+        "user_id",
+        "user__email",
+        "user__first_name",
+        "user__last_name",
+        "role",
+        "description",
+        "status",
+        "joined_at",
+        "updated_at",
+    )
+
+    field_map = {
+        "organization": "organization_id",
+        "organization_name": "organization__name",
+        "user": "user_id",
+        "user_email": "user__email",
+        "user_first_name": "user__first_name",
+        "user_last_name": "user__last_name",
+    }
+
+    def consolidate(self, items, queryset):
+        """Add the display name after field mappings have been applied."""
+        for item in items:
+            item["user_name"] = "{} {}".format(
+                item.get("user_first_name", "") or "",
+                item.get("user_last_name", "") or "",
+            ).strip()
+        return items
+
+    def perform_create(self, serializer, change=None):
+        serializer.save()
+
+    def _ensure_not_last_active_admin(
+        self,
+        membership,
+        active_admin_count,
+        new_role=None,
+        new_status=None,
+    ):
+        """Prevent an organization from being left without an active admin."""
+        if (
+            membership.role != ORGANIZATION_ADMIN
+            or membership.status != ORGANIZATION_ROLE_STATUS_ACTIVE
+        ):
+            return
+
+        resulting_role = new_role if new_role is not None else membership.role
+        resulting_status = new_status if new_status is not None else membership.status
+
+        if (
+            resulting_role == ORGANIZATION_ADMIN
+            and resulting_status == ORGANIZATION_ROLE_STATUS_ACTIVE
+        ):
+            return
+
+        if active_admin_count <= 1:
+            raise ValidationError(
+                "An organization must have at least one active admin."
+            )
+
+    def _lock_active_admins(self, organization_id):
+        """Lock active admin memberships in a deterministic order."""
+        return list(
+            OrganizationRole.objects.select_for_update(of=("self",))
+            .filter(
+                organization_id=organization_id,
+                role=ORGANIZATION_ADMIN,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+
+    def perform_update(self, serializer):
+        with transaction.atomic():
+            active_admin_ids = self._lock_active_admins(
+                serializer.instance.organization_id
+            )
+            membership = (
+                OrganizationRole.objects.select_for_update(of=("self",))
+                .select_related("organization", "user")
+                .get(pk=serializer.instance.pk)
+            )
+            self._ensure_not_last_active_admin(
+                membership,
+                active_admin_count=len(active_admin_ids),
+                new_role=serializer.validated_data.get("role"),
+                new_status=serializer.validated_data.get("status"),
+            )
+
+            serializer.instance = membership
+            serializer.save()
+
+    def perform_destroy(self, instance):
+        with transaction.atomic():
+            active_admin_ids = self._lock_active_admins(instance.organization_id)
+            membership = (
+                OrganizationRole.objects.select_for_update(of=("self",))
+                .select_related("organization", "user")
+                .get(pk=instance.pk)
+            )
+            self._ensure_not_last_active_admin(
+                membership,
+                active_admin_count=len(active_admin_ids),
+                new_role=ORGANIZATION_VIEWER,
+                new_status=membership.status,
+            )
+            membership.delete()
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop("partial", False)
+        instance = self.get_edit_object()
+
+        serializer = self.get_serializer(
+            instance,
+            data=request.data,
+            partial=partial,
+        )
+        serializer.is_valid(raise_exception=True)
+
+        self.perform_update(serializer)
+
+        queryset = OrganizationRole.objects.select_related(
+            "organization",
+            "user",
+        ).filter(pk=serializer.instance.pk)
+
+        return Response(self.serialize(queryset)[0])

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -1,70 +1,87 @@
-from django.db.models import Prefetch
+from django.db import transaction
+from django.db.models import Q
 from django_filters.rest_framework import CharFilter, FilterSet
 from rest_framework import serializers
-from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.status import HTTP_403_FORBIDDEN
 
 from contentcuration.constants.organization_roles import (
     ORGANIZATION_ADMIN,
-    ORGANIZATION_EDITOR,
+    ORGANIZATION_ROLE_STATUS_ACTIVE,
     ORGANIZATION_VIEWER,
+    organization_role_status_choices,
 )
-from contentcuration.models import Organization, OrganizationRole, User
+from contentcuration.models import Organization, OrganizationRole
 from contentcuration.utils.pagination import ValuesViewsetPageNumberPagination
 from contentcuration.viewsets.base import (
     BulkListSerializer,
     BulkModelSerializer,
-    ValuesViewset,
     RESTCreateModelMixin,
+    RESTDestroyModelMixin,
+    RESTUpdateModelMixin,
+    ValuesViewset,
 )
-
 
 
 class OrganizationSerializer(BulkModelSerializer):
     """
-    Serializer for Organization model.
-    Includes basic organization details (name, description, public status).
+    Write serializer for organizations.
+
+    Read operations are handled by OrganizationViewSet.values, following the
+    ValuesViewset pattern used elsewhere in Studio.
     """
 
     class Meta:
         model = Organization
-        fields = ("id", "name", "description", "thumbnail", "public", "created_at", "updated_at")
-        read_only_fields = ("created_at", "updated_at")
+        fields = (
+            "id",
+            "name",
+            "description",
+            "thumbnail",
+            "thumbnail_encoding",
+            "public",
+        )
         list_serializer_class = BulkListSerializer
 
 
 class OrganizationMemberSerializer(BulkModelSerializer):
     """
-    Serializer for OrganizationRole (membership).
-    Represents user membership in an organization with their role.
+    Write serializer for OrganizationRole membership records.
+
+    Organization and user may be set when creating a membership, but cannot be
+    changed afterwards. Read operations are handled by the viewset values map.
     """
 
-    user_email = serializers.CharField(source="user.email", read_only=True)
-    user_name = serializers.CharField(source="user.get_full_name", read_only=True)
+    status = serializers.ChoiceField(
+        choices=organization_role_status_choices,
+        default=ORGANIZATION_ROLE_STATUS_ACTIVE,
+    )
 
     class Meta:
         model = OrganizationRole
-        fields = ("id", "user", "user_email", "user_name", "role", "status", "joined_at", "description")
-        read_only_fields = ("joined_at",)
+        fields = (
+            "id",
+            "organization",
+            "user",
+            "role",
+            "description",
+            "status",
+        )
         list_serializer_class = BulkListSerializer
 
+    def get_fields(self):
+        fields = super().get_fields()
 
-class OrganizationRoleSerializer(BulkModelSerializer):
-    """
-    Serializer for reading organization roles.
-    Returns available roles for an organization.
-    """
+        # A membership may move between statuses and roles, but it must never be
+        # reassigned to a different organization or user.
+        if self.instance is not None:
+            fields["organization"].read_only = True
+            fields["user"].read_only = True
 
-    class Meta:
-        model = OrganizationRole
-        fields = ("id", "role", "description")
-        list_serializer_class = BulkListSerializer
+        return fields
 
 
 class OrganizationFilter(FilterSet):
-    """Filter for organization listing."""
     name = CharFilter(field_name="name", lookup_expr="icontains")
 
     class Meta:
@@ -72,280 +89,311 @@ class OrganizationFilter(FilterSet):
         fields = ("name", "public")
 
 
+class OrganizationMemberFilter(FilterSet):
+    organization = CharFilter(field_name="organization_id")
+    user = CharFilter(field_name="user_id")
+
+    class Meta:
+        model = OrganizationRole
+        fields = ("organization", "user", "role", "status")
+
+
 class OrganizationPagination(ValuesViewsetPageNumberPagination):
-    """Pagination for organization endpoints."""
     page_size = 20
     page_size_query_param = "page_size"
     max_page_size = 100
 
 
-class OrganizationViewSet(ValuesViewset, RESTCreateModelMixin):
+def _is_site_admin(user):
+    return bool(getattr(user, "is_admin", False))
+
+
+def _get_member_name(item):
+    first_name = item.pop("user__first_name", "") or ""
+    last_name = item.pop("user__last_name", "") or ""
+    return "{} {}".format(first_name, last_name).strip()
+
+
+class OrganizationViewSet(
+    ValuesViewset,
+    RESTCreateModelMixin,
+    RESTUpdateModelMixin,
+    RESTDestroyModelMixin,
+):
     """
-    ViewSet for Organization CRUD and membership management.
-    
-    Endpoints:
-    - GET /organizations/ - List organizations
-    - POST /organizations/ - Create organization
-    - GET /organizations/{id}/ - Retrieve organization
-    - PUT /organizations/{id}/ - Update organization (admin only)
-    - PATCH /organizations/{id}/ - Partial update (admin only)
-    - DELETE /organizations/{id}/ - Delete organization (admin only)
-    - GET /organizations/{id}/members/ - List members
-    - POST /organizations/{id}/members/ - Add member (admin only)
-    - PATCH /organizations/{id}/members/{member_id}/ - Update member role (admin only)
-    - DELETE /organizations/{id}/members/{member_id}/ - Remove member (admin only)
+    Organization CRUD API.
+
+    Active organization admins may update or delete an organization. Any
+    authenticated user may create an organization and becomes its first active
+    administrator. Site administrators may manage every organization.
     """
 
-    queryset = Organization.objects.filter(deleted=False)
+    queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
     permission_classes = [IsAuthenticated]
     filterset_class = OrganizationFilter
     pagination_class = OrganizationPagination
-    values = ("id", "name", "description", "thumbnail", "public", "created_at", "updated_at")
+    ordering_fields = ("name", "created_at", "updated_at")
+    ordering = "name"
+
+    values = (
+        "id",
+        "name",
+        "description",
+        "thumbnail",
+        "thumbnail_encoding",
+        "public",
+        "created_at",
+        "updated_at",
+    )
 
     def get_queryset(self):
-        """Filter organizations by user membership."""
-        queryset = super().get_queryset()
+        """
+        Return organizations visible to the current user.
+
+        Public organizations are visible to authenticated users. Private
+        organizations require an active membership. Non-active memberships do
+        not grant access.
+        """
+        queryset = Organization.objects.filter(deleted=False)
         user = self.request.user
-        
-        # Users can see organizations they are members of
-        if user.is_authenticated:
-            queryset = queryset.filter(user_roles__user=user).distinct()
-        else:
-            queryset = queryset.filter(public=True)
-        
-        return queryset
 
-    def perform_create(self, serializer):
-        """Create organization and set creator as admin."""
-        instance = serializer.save()
-        # Add the creating user as admin
-        OrganizationRole.objects.create(
-            user=self.request.user,
-            organization=instance,
-            role=ORGANIZATION_ADMIN,
-            status="active",
-        )
-        return instance
+        if _is_site_admin(user):
+            return queryset
 
-    def perform_update(self, serializer):
-        """Update organization - only admin can do this."""
-        org = self.get_object()
-        if not self._is_admin(org, self.request.user):
-            raise serializers.ValidationError("Only admins can update organization.")
-        serializer.save()
+        if not user.is_authenticated:
+            return queryset.filter(public=True)
+
+        return queryset.filter(
+            Q(public=True)
+            | Q(
+                user_roles__user=user,
+                user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+        ).distinct()
+
+    def get_edit_queryset(self):
+        """Return organizations that the current user may modify."""
+        queryset = Organization.objects.filter(deleted=False)
+        user = self.request.user
+
+        if _is_site_admin(user):
+            return queryset
+
+        if not user.is_authenticated:
+            return queryset.none()
+
+        return queryset.filter(
+            user_roles__user=user,
+            user_roles__role=ORGANIZATION_ADMIN,
+            user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        ).distinct()
+
+    def perform_create(self, serializer, change=None):
+        """Create the organization and its initial administrator atomically."""
+        with transaction.atomic():
+            organization = serializer.save()
+            OrganizationRole.objects.create(
+                organization=organization,
+                user=self.request.user,
+                role=ORGANIZATION_ADMIN,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
 
     def perform_destroy(self, instance):
-        """Delete organization - only admin can do this."""
-        if not self._is_admin(instance, self.request.user):
-            raise serializers.ValidationError("Only admins can delete organization.")
+        """Soft-delete an organization."""
         instance.deleted = True
-        instance.save()
-
-    def _is_admin(self, organization, user):
-        """Check if user is admin in organization."""
-        try:
-            role = organization.user_roles.get(user=user)
-            return role.role == ORGANIZATION_ADMIN
-        except OrganizationRole.DoesNotExist:
-            return False
-
-    def _get_user_role(self, organization, user):
-        """Get the user's role in the organization."""
-        try:
-            return organization.user_roles.get(user=user)
-        except OrganizationRole.DoesNotExist:
-            return None
-
-    @action(detail=True, methods=["get"], permission_classes=[IsAuthenticated])
-    def members(self, request, pk=None):
-        """
-        List members of an organization.
-        Permissions: Members can view.
-        """
-        organization = self.get_object()
-        user_role = self._get_user_role(organization, request.user)
-        
-        if not user_role:
-            return Response(
-                {"detail": "You are not a member of this organization."},
-                status=HTTP_403_FORBIDDEN,
-            )
-        
-        members = organization.user_roles.all()
-        page = self.paginate_queryset(members)
-        if page is not None:
-            serializer = OrganizationMemberSerializer(page, many=True, context={"request": request})
-            return self.get_paginated_response(serializer.data)
-        
-        serializer = OrganizationMemberSerializer(members, many=True, context={"request": request})
-        return Response(serializer.data)
-
-    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
-    def add_member(self, request, pk=None):
-        """
-        Add a member to organization.
-        Permissions: ORGANIZATION_ADMIN only.
-        Body: {user_id, role}
-        """
-        organization = self.get_object()
-        
-        if not self._is_admin(organization, request.user):
-            return Response(
-                {"detail": "Only admins can add members."},
-                status=HTTP_403_FORBIDDEN,
-            )
-        
-        user_id = request.data.get("user_id")
-        role = request.data.get("role", ORGANIZATION_VIEWER)
-        
-        if not user_id:
-            return Response(
-                {"detail": "user_id is required."},
-                status=400,
-            )
-        
-        valid_roles = [ORGANIZATION_ADMIN, ORGANIZATION_EDITOR, ORGANIZATION_VIEWER]
-        if role not in valid_roles:
-            return Response(
-                {"detail": f"Invalid role. Must be one of: {', '.join(valid_roles)}"},
-                status=400,
-            )
-        
-        try:
-            user = User.objects.get(pk=user_id)
-        except User.DoesNotExist:
-            return Response(
-                {"detail": "User not found."},
-                status=404,
-            )
-        
-        membership, created = OrganizationRole.objects.get_or_create(
-            user=user,
-            organization=organization,
-            defaults={"role": role, "status": "active"},
-        )
-        
-        if not created:
-            membership.role = role
-            membership.save()
-        
-        serializer = OrganizationMemberSerializer(membership, context={"request": request})
-        return Response(serializer.data, status=201 if created else 200)
-
-    @action(detail=True, methods=["patch", "delete"], permission_classes=[IsAuthenticated])
-    def update_member(self, request, pk=None):
-        """
-        Update or remove a member's role in organization.
-        Permissions: ORGANIZATION_ADMIN only.
-        """
-        organization = self.get_object()
-        
-        if not self._is_admin(organization, request.user):
-            return Response(
-                {"detail": "Only admins can manage members."},
-                status=HTTP_403_FORBIDDEN,
-            )
-        
-        member_id = request.query_params.get("member_id")
-        if not member_id:
-            return Response(
-                {"detail": "member_id query parameter is required."},
-                status=400,
-            )
-        
-        try:
-            membership = organization.user_roles.get(id=member_id)
-        except OrganizationRole.DoesNotExist:
-            return Response(
-                {"detail": "Member not found."},
-                status=404,
-            )
-        
-        if request.method == "PATCH":
-            role = request.data.get("role")
-            if not role:
-                return Response(
-                    {"detail": "role is required."},
-                    status=400,
-                )
-            
-            valid_roles = [ORGANIZATION_ADMIN, ORGANIZATION_EDITOR, ORGANIZATION_VIEWER]
-            if role not in valid_roles:
-                return Response(
-                    {"detail": f"Invalid role. Must be one of: {', '.join(valid_roles)}"},
-                    status=400,
-                )
-            
-            membership.role = role
-            membership.save()
-            
-            serializer = OrganizationMemberSerializer(membership, context={"request": request})
-            return Response(serializer.data)
-        
-        elif request.method == "DELETE":
-            membership.delete()
-            return Response(status=204)
+        instance.save(update_fields=["deleted", "updated_at"])
 
 
-class OrganizationMemberViewSet(ValuesViewset):
+class OrganizationMemberViewSet(
+    ValuesViewset,
+    RESTCreateModelMixin,
+    RESTUpdateModelMixin,
+    RESTDestroyModelMixin,
+):
     """
-    ViewSet for managing organization members.
-    This is an alternative to the nested /organizations/{id}/members/ endpoints.
+    Organization membership and role API.
+
+    Active organization members may read the membership list. Only active
+    organization admins may create, update, or remove memberships. Site admins
+    may manage all memberships.
     """
 
     queryset = OrganizationRole.objects.all()
     serializer_class = OrganizationMemberSerializer
     permission_classes = [IsAuthenticated]
+    filterset_class = OrganizationMemberFilter
     pagination_class = OrganizationPagination
+    ordering_fields = ("joined_at", "updated_at", "role", "status")
+    ordering = "-joined_at"
+
+    values = (
+        "id",
+        "organization_id",
+        "organization__name",
+        "user_id",
+        "user__email",
+        "user__first_name",
+        "user__last_name",
+        "role",
+        "description",
+        "status",
+        "joined_at",
+        "updated_at",
+    )
+
+    field_map = {
+        "organization": "organization_id",
+        "organization_name": "organization__name",
+        "user": "user_id",
+        "user_email": "user__email",
+        "user_name": _get_member_name,
+    }
 
     def get_queryset(self):
-        """Filter members by organization."""
-        queryset = super().get_queryset()
-        organization_id = self.request.query_params.get("organization")
-        
-        if organization_id:
-            queryset = queryset.filter(organization_id=organization_id)
-        
-        return queryset
+        """
+        Return memberships belonging to organizations the user may inspect.
 
-    def perform_create(self, serializer):
-        """Add member to organization."""
-        organization_id = self.request.data.get("organization")
-        if not organization_id:
-            raise serializers.ValidationError("organization is required.")
-        
-        try:
-            organization = Organization.objects.get(pk=organization_id)
-        except Organization.DoesNotExist:
-            raise serializers.ValidationError("Organization not found.")
-        
-        # Check if user is admin
-        user_role = organization.user_roles.filter(user=self.request.user).first()
-        if not user_role or user_role.role != ORGANIZATION_ADMIN:
-            raise serializers.ValidationError("Only admins can add members.")
-        
-        serializer.save()
+        A public organization does not expose its membership list to the
+        public; an active membership is required.
+        """
+        queryset = OrganizationRole.objects.select_related(
+            "organization", "user"
+        ).filter(organization__deleted=False)
+        user = self.request.user
+
+        if _is_site_admin(user):
+            return queryset
+
+        if not user.is_authenticated:
+            return queryset.none()
+
+        return queryset.filter(
+            organization__user_roles__user=user,
+            organization__user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        ).distinct()
+
+    def get_edit_queryset(self):
+        """Return memberships managed by organizations where the user is admin."""
+        queryset = OrganizationRole.objects.select_related(
+            "organization", "user"
+        ).filter(organization__deleted=False)
+        user = self.request.user
+
+        if _is_site_admin(user):
+            return queryset
+
+        if not user.is_authenticated:
+            return queryset.none()
+
+        return queryset.filter(
+            organization__user_roles__user=user,
+            organization__user_roles__role=ORGANIZATION_ADMIN,
+            organization__user_roles__status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        ).distinct()
+
+    def _require_admin(self, organization):
+        user = self.request.user
+
+        if _is_site_admin(user):
+            return
+
+        is_admin = OrganizationRole.objects.filter(
+            organization=organization,
+            user=user,
+            role=ORGANIZATION_ADMIN,
+            status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+        ).exists()
+
+        if not is_admin:
+            raise PermissionDenied(
+                "Only active organization admins may manage membership."
+            )
+
+    def _ensure_not_last_active_admin(
+        self,
+        membership,
+        new_role=None,
+        new_status=None,
+    ):
+        """Prevent an organization from being left without an active admin."""
+        if (
+            membership.role != ORGANIZATION_ADMIN
+            or membership.status != ORGANIZATION_ROLE_STATUS_ACTIVE
+        ):
+            return
+
+        resulting_role = new_role if new_role is not None else membership.role
+        resulting_status = (
+            new_status if new_status is not None else membership.status
+        )
+
+        if (
+            resulting_role == ORGANIZATION_ADMIN
+            and resulting_status == ORGANIZATION_ROLE_STATUS_ACTIVE
+        ):
+            return
+
+        active_admin_ids = list(
+            OrganizationRole.objects.select_for_update()
+            .filter(
+                organization=membership.organization,
+                role=ORGANIZATION_ADMIN,
+                status=ORGANIZATION_ROLE_STATUS_ACTIVE,
+            )
+            .values_list("id", flat=True)
+        )
+
+        if len(active_admin_ids) <= 1:
+            raise ValidationError(
+                "An organization must have at least one active admin."
+            )
+
+    def perform_create(self, serializer, change=None):
+        organization = serializer.validated_data["organization"]
+        self._require_admin(organization)
+
+        if organization.deleted:
+            raise ValidationError("Cannot add members to a deleted organization.")
+
+        with transaction.atomic():
+            serializer.save()
 
     def perform_update(self, serializer):
-        """Update member role."""
-        membership = self.get_object()
-        organization = membership.organization
-        
-        # Check if user is admin
-        user_role = organization.user_roles.filter(user=self.request.user).first()
-        if not user_role or user_role.role != ORGANIZATION_ADMIN:
-            raise serializers.ValidationError("Only admins can update member roles.")
-        
-        serializer.save()
+        with transaction.atomic():
+            membership = (
+                OrganizationRole.objects.select_for_update()
+                .select_related("organization", "user")
+                .get(pk=serializer.instance.pk)
+            )
+            self._require_admin(membership.organization)
+
+            self._ensure_not_last_active_admin(
+                membership,
+                new_role=serializer.validated_data.get("role"),
+                new_status=serializer.validated_data.get("status"),
+            )
+
+            serializer.instance = membership
+            serializer.save()
 
     def perform_destroy(self, instance):
-        """Remove member from organization."""
-        organization = instance.organization
-        
-        # Check if user is admin
-        user_role = organization.user_roles.filter(user=self.request.user).first()
-        if not user_role or user_role.role != ORGANIZATION_ADMIN:
-            raise serializers.ValidationError("Only admins can remove members.")
-        
-        instance.delete()
+        with transaction.atomic():
+            membership = (
+                OrganizationRole.objects.select_for_update()
+                .select_related("organization", "user")
+                .get(pk=instance.pk)
+            )
+            self._require_admin(membership.organization)
+            self._ensure_not_last_active_admin(
+                membership,
+                new_role=ORGANIZATION_VIEWER,
+                new_status=membership.status,
+            )
+            membership.delete()
+
+
+# The model is named OrganizationRole, while existing work may already import
+# OrganizationMemberViewSet. Keep this alias so either name can be registered.
+OrganizationRoleViewSet = OrganizationMemberViewSet

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -248,6 +248,8 @@ class OrganizationMemberViewSet(
         "organization_name": "organization__name",
         "user": "user_id",
         "user_email": "user__email",
+        "user_first_name": "user__first_name",
+        "user_last_name": "user__last_name",
         "user_name": _get_member_name,
     }
 

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -101,12 +101,6 @@ def _is_site_admin(user):
     return bool(getattr(user, "is_admin", False))
 
 
-def _get_member_name(item):
-    first_name = item.pop("user__first_name", "") or ""
-    last_name = item.pop("user__last_name", "") or ""
-    return "{} {}".format(first_name, last_name).strip()
-
-
 class OrganizationViewSet(
     ValuesViewset,
     RESTCreateModelMixin,
@@ -243,8 +237,16 @@ class OrganizationMemberViewSet(
         "user_email": "user__email",
         "user_first_name": "user__first_name",
         "user_last_name": "user__last_name",
-        "user_name": _get_member_name,
     }
+
+    def consolidate(self, items, queryset):
+        """Add the display name after field mappings have been applied."""
+        for item in items:
+            item["user_name"] = "{} {}".format(
+                item.get("user_first_name", "") or "",
+                item.get("user_last_name", "") or "",
+            ).strip()
+        return items
 
     def get_queryset(self):
         """

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -1,27 +1,28 @@
 from django.db import transaction
 from django.db.models import Q
-from django_filters.rest_framework import CharFilter, FilterSet
+from django_filters.rest_framework import CharFilter
+from django_filters.rest_framework import FilterSet
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 
+from contentcuration.constants.organization_roles import ORGANIZATION_ADMIN
+from contentcuration.constants.organization_roles import ORGANIZATION_ROLE_STATUS_ACTIVE
 from contentcuration.constants.organization_roles import (
-    ORGANIZATION_ADMIN,
-    ORGANIZATION_ROLE_STATUS_ACTIVE,
-    ORGANIZATION_VIEWER,
     organization_role_status_choices,
 )
-from contentcuration.models import Organization, OrganizationRole
+from contentcuration.constants.organization_roles import ORGANIZATION_VIEWER
+from contentcuration.models import Organization
+from contentcuration.models import OrganizationRole
 from contentcuration.utils.pagination import ValuesViewsetPageNumberPagination
-from contentcuration.viewsets.base import (
-    BulkListSerializer,
-    BulkModelSerializer,
-    RESTCreateModelMixin,
-    RESTDestroyModelMixin,
-    RESTUpdateModelMixin,
-    ReadOnlyValuesViewset,
-    ValuesViewset,
-)
+from contentcuration.viewsets.base import BulkListSerializer
+from contentcuration.viewsets.base import BulkModelSerializer
+from contentcuration.viewsets.base import ReadOnlyValuesViewset
+from contentcuration.viewsets.base import RESTCreateModelMixin
+from contentcuration.viewsets.base import RESTDestroyModelMixin
+from contentcuration.viewsets.base import RESTUpdateModelMixin
+from contentcuration.viewsets.base import ValuesViewset
 
 
 class OrganizationSerializer(BulkModelSerializer):

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -1,0 +1,351 @@
+from django.db.models import Prefetch
+from django_filters.rest_framework import CharFilter, FilterSet
+from rest_framework import serializers
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.status import HTTP_403_FORBIDDEN
+
+from contentcuration.constants.organization_roles import (
+    ORGANIZATION_ADMIN,
+    ORGANIZATION_EDITOR,
+    ORGANIZATION_VIEWER,
+)
+from contentcuration.models import Organization, OrganizationRole, User
+from contentcuration.utils.pagination import ValuesViewsetPageNumberPagination
+from contentcuration.viewsets.base import (
+    BulkListSerializer,
+    BulkModelSerializer,
+    ValuesViewset,
+    RESTCreateModelMixin,
+)
+
+
+
+class OrganizationSerializer(BulkModelSerializer):
+    """
+    Serializer for Organization model.
+    Includes basic organization details (name, description, public status).
+    """
+
+    class Meta:
+        model = Organization
+        fields = ("id", "name", "description", "thumbnail", "public", "created_at", "updated_at")
+        read_only_fields = ("created_at", "updated_at")
+        list_serializer_class = BulkListSerializer
+
+
+class OrganizationMemberSerializer(BulkModelSerializer):
+    """
+    Serializer for OrganizationRole (membership).
+    Represents user membership in an organization with their role.
+    """
+
+    user_email = serializers.CharField(source="user.email", read_only=True)
+    user_name = serializers.CharField(source="user.get_full_name", read_only=True)
+
+    class Meta:
+        model = OrganizationRole
+        fields = ("id", "user", "user_email", "user_name", "role", "status", "joined_at", "description")
+        read_only_fields = ("joined_at",)
+        list_serializer_class = BulkListSerializer
+
+
+class OrganizationRoleSerializer(BulkModelSerializer):
+    """
+    Serializer for reading organization roles.
+    Returns available roles for an organization.
+    """
+
+    class Meta:
+        model = OrganizationRole
+        fields = ("id", "role", "description")
+        list_serializer_class = BulkListSerializer
+
+
+class OrganizationFilter(FilterSet):
+    """Filter for organization listing."""
+    name = CharFilter(field_name="name", lookup_expr="icontains")
+
+    class Meta:
+        model = Organization
+        fields = ("name", "public")
+
+
+class OrganizationPagination(ValuesViewsetPageNumberPagination):
+    """Pagination for organization endpoints."""
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+class OrganizationViewSet(ValuesViewset, RESTCreateModelMixin):
+    """
+    ViewSet for Organization CRUD and membership management.
+    
+    Endpoints:
+    - GET /organizations/ - List organizations
+    - POST /organizations/ - Create organization
+    - GET /organizations/{id}/ - Retrieve organization
+    - PUT /organizations/{id}/ - Update organization (admin only)
+    - PATCH /organizations/{id}/ - Partial update (admin only)
+    - DELETE /organizations/{id}/ - Delete organization (admin only)
+    - GET /organizations/{id}/members/ - List members
+    - POST /organizations/{id}/members/ - Add member (admin only)
+    - PATCH /organizations/{id}/members/{member_id}/ - Update member role (admin only)
+    - DELETE /organizations/{id}/members/{member_id}/ - Remove member (admin only)
+    """
+
+    queryset = Organization.objects.filter(deleted=False)
+    serializer_class = OrganizationSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_class = OrganizationFilter
+    pagination_class = OrganizationPagination
+    values = ("id", "name", "description", "thumbnail", "public", "created_at", "updated_at")
+
+    def get_queryset(self):
+        """Filter organizations by user membership."""
+        queryset = super().get_queryset()
+        user = self.request.user
+        
+        # Users can see organizations they are members of
+        if user.is_authenticated:
+            queryset = queryset.filter(user_roles__user=user).distinct()
+        else:
+            queryset = queryset.filter(public=True)
+        
+        return queryset
+
+    def perform_create(self, serializer):
+        """Create organization and set creator as admin."""
+        instance = serializer.save()
+        # Add the creating user as admin
+        OrganizationRole.objects.create(
+            user=self.request.user,
+            organization=instance,
+            role=ORGANIZATION_ADMIN,
+            status="active",
+        )
+        return instance
+
+    def perform_update(self, serializer):
+        """Update organization - only admin can do this."""
+        org = self.get_object()
+        if not self._is_admin(org, self.request.user):
+            raise serializers.ValidationError("Only admins can update organization.")
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        """Delete organization - only admin can do this."""
+        if not self._is_admin(instance, self.request.user):
+            raise serializers.ValidationError("Only admins can delete organization.")
+        instance.deleted = True
+        instance.save()
+
+    def _is_admin(self, organization, user):
+        """Check if user is admin in organization."""
+        try:
+            role = organization.user_roles.get(user=user)
+            return role.role == ORGANIZATION_ADMIN
+        except OrganizationRole.DoesNotExist:
+            return False
+
+    def _get_user_role(self, organization, user):
+        """Get the user's role in the organization."""
+        try:
+            return organization.user_roles.get(user=user)
+        except OrganizationRole.DoesNotExist:
+            return None
+
+    @action(detail=True, methods=["get"], permission_classes=[IsAuthenticated])
+    def members(self, request, pk=None):
+        """
+        List members of an organization.
+        Permissions: Members can view.
+        """
+        organization = self.get_object()
+        user_role = self._get_user_role(organization, request.user)
+        
+        if not user_role:
+            return Response(
+                {"detail": "You are not a member of this organization."},
+                status=HTTP_403_FORBIDDEN,
+            )
+        
+        members = organization.user_roles.all()
+        page = self.paginate_queryset(members)
+        if page is not None:
+            serializer = OrganizationMemberSerializer(page, many=True, context={"request": request})
+            return self.get_paginated_response(serializer.data)
+        
+        serializer = OrganizationMemberSerializer(members, many=True, context={"request": request})
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    def add_member(self, request, pk=None):
+        """
+        Add a member to organization.
+        Permissions: ORGANIZATION_ADMIN only.
+        Body: {user_id, role}
+        """
+        organization = self.get_object()
+        
+        if not self._is_admin(organization, request.user):
+            return Response(
+                {"detail": "Only admins can add members."},
+                status=HTTP_403_FORBIDDEN,
+            )
+        
+        user_id = request.data.get("user_id")
+        role = request.data.get("role", ORGANIZATION_VIEWER)
+        
+        if not user_id:
+            return Response(
+                {"detail": "user_id is required."},
+                status=400,
+            )
+        
+        valid_roles = [ORGANIZATION_ADMIN, ORGANIZATION_EDITOR, ORGANIZATION_VIEWER]
+        if role not in valid_roles:
+            return Response(
+                {"detail": f"Invalid role. Must be one of: {', '.join(valid_roles)}"},
+                status=400,
+            )
+        
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return Response(
+                {"detail": "User not found."},
+                status=404,
+            )
+        
+        membership, created = OrganizationRole.objects.get_or_create(
+            user=user,
+            organization=organization,
+            defaults={"role": role, "status": "active"},
+        )
+        
+        if not created:
+            membership.role = role
+            membership.save()
+        
+        serializer = OrganizationMemberSerializer(membership, context={"request": request})
+        return Response(serializer.data, status=201 if created else 200)
+
+    @action(detail=True, methods=["patch", "delete"], permission_classes=[IsAuthenticated])
+    def update_member(self, request, pk=None):
+        """
+        Update or remove a member's role in organization.
+        Permissions: ORGANIZATION_ADMIN only.
+        """
+        organization = self.get_object()
+        
+        if not self._is_admin(organization, request.user):
+            return Response(
+                {"detail": "Only admins can manage members."},
+                status=HTTP_403_FORBIDDEN,
+            )
+        
+        member_id = request.query_params.get("member_id")
+        if not member_id:
+            return Response(
+                {"detail": "member_id query parameter is required."},
+                status=400,
+            )
+        
+        try:
+            membership = organization.user_roles.get(id=member_id)
+        except OrganizationRole.DoesNotExist:
+            return Response(
+                {"detail": "Member not found."},
+                status=404,
+            )
+        
+        if request.method == "PATCH":
+            role = request.data.get("role")
+            if not role:
+                return Response(
+                    {"detail": "role is required."},
+                    status=400,
+                )
+            
+            valid_roles = [ORGANIZATION_ADMIN, ORGANIZATION_EDITOR, ORGANIZATION_VIEWER]
+            if role not in valid_roles:
+                return Response(
+                    {"detail": f"Invalid role. Must be one of: {', '.join(valid_roles)}"},
+                    status=400,
+                )
+            
+            membership.role = role
+            membership.save()
+            
+            serializer = OrganizationMemberSerializer(membership, context={"request": request})
+            return Response(serializer.data)
+        
+        elif request.method == "DELETE":
+            membership.delete()
+            return Response(status=204)
+
+
+class OrganizationMemberViewSet(ValuesViewset):
+    """
+    ViewSet for managing organization members.
+    This is an alternative to the nested /organizations/{id}/members/ endpoints.
+    """
+
+    queryset = OrganizationRole.objects.all()
+    serializer_class = OrganizationMemberSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = OrganizationPagination
+
+    def get_queryset(self):
+        """Filter members by organization."""
+        queryset = super().get_queryset()
+        organization_id = self.request.query_params.get("organization")
+        
+        if organization_id:
+            queryset = queryset.filter(organization_id=organization_id)
+        
+        return queryset
+
+    def perform_create(self, serializer):
+        """Add member to organization."""
+        organization_id = self.request.data.get("organization")
+        if not organization_id:
+            raise serializers.ValidationError("organization is required.")
+        
+        try:
+            organization = Organization.objects.get(pk=organization_id)
+        except Organization.DoesNotExist:
+            raise serializers.ValidationError("Organization not found.")
+        
+        # Check if user is admin
+        user_role = organization.user_roles.filter(user=self.request.user).first()
+        if not user_role or user_role.role != ORGANIZATION_ADMIN:
+            raise serializers.ValidationError("Only admins can add members.")
+        
+        serializer.save()
+
+    def perform_update(self, serializer):
+        """Update member role."""
+        membership = self.get_object()
+        organization = membership.organization
+        
+        # Check if user is admin
+        user_role = organization.user_roles.filter(user=self.request.user).first()
+        if not user_role or user_role.role != ORGANIZATION_ADMIN:
+            raise serializers.ValidationError("Only admins can update member roles.")
+        
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        """Remove member from organization."""
+        organization = instance.organization
+        
+        # Check if user is admin
+        user_role = organization.user_roles.filter(user=self.request.user).first()
+        if not user_role or user_role.role != ORGANIZATION_ADMIN:
+            raise serializers.ValidationError("Only admins can remove members.")
+        
+        instance.delete()

--- a/contentcuration/contentcuration/viewsets/organization.py
+++ b/contentcuration/contentcuration/viewsets/organization.py
@@ -322,9 +322,7 @@ class OrganizationMemberViewSet(
             return
 
         resulting_role = new_role if new_role is not None else membership.role
-        resulting_status = (
-            new_status if new_status is not None else membership.status
-        )
+        resulting_status = new_status if new_status is not None else membership.status
 
         if (
             resulting_role == ORGANIZATION_ADMIN


### PR DESCRIPTION

## Summary

Adds backend API and controller support for the Organization and OrganizationRole models.

This change provides:

- Organization create, read, update, and delete operations
- Organization membership listing
- Organization role updates
- Permission checks for organization admins, editors, and viewers
- Pagination and filtering for organization-related endpoints
- Automated API tests covering organization management, membership management, role updates, and permission enforcement

Organization administrators can manage organization settings, memberships, and roles. Editors can view memberships but cannot manage organization settings, memberships, or roles. Viewers have read-only access to organization resources.

Frontend changes and data model changes are outside the scope of this PR.

…

## References
References
Closes #5967
Builds on #5962

…

## Reviewer guidance
Run the organization API tests with:

pytest -q contentcuration/contentcuration/tests/test_organization.py

Reviewers can verify that:

- Authenticated users can create organizations
- The organization creator is assigned the administrator role
- Users can only access organizations permitted by their membership and role
- Only organization administrators can update organization settings
- Organization members can list memberships
- Only organization administrators can update or remove memberships and roles
- Editors and viewers cannot manage organization membership or roles
- Organization and membership endpoints support pagination and filtering
- Unauthorized requests are rejected appropriately

This PR does not include frontend changes.
…

## AI usage

Used AI to help review the existing Studio API patterns and draft portions of the organization viewsets and tests.

I reviewed and edited the generated code to align it with Studio's ValuesViewset, serializer, routing, pagination, and permission conventions. I also ran the organization tests locally and used the failures to correct routing, response formatting, authentication expectations, and role-permission behavior.