### PR TITLE
Admin Users: persist requested storage, rename and regroup filters, add clear action

### DIFF
--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -28,31 +28,24 @@
       :keywordFilter="keywordInput"
       :usersFilterFetchQueryParams="filterFetchQueryParams"
     />
-    <VLayout
-      wrap
-      class="mb-2"
-    >
-      <VFlex
-        xs12
-        sm4
-        xl3
-        class="px-3"
+    <KGrid class="filter-row">
+      <KGridItem
+        :layout12="{ span: 3 }"
+        :layout8="{ span: 2 }"
+        :layout4="{ span: 4 }"
       >
-        <VSelect
-          v-model="userTypeFilter"
-          :items="userTypeOptions"
-          item-text="label"
-          item-value="key"
+        <KSelect
+          class="user-type-select"
+          :value="userTypeFilter"
+          :options="userTypeOptions"
           :label="userTypeLabel$()"
-          box
-          :menu-props="{ offsetY: true }"
+          @select="userTypeFilter = $event"
         />
-      </VFlex>
-      <VFlex
-        xs12
-        sm4
-        xl3
-        class="px-3"
+      </KGridItem>
+      <KGridItem
+        :layout12="{ span: 3 }"
+        :layout8="{ span: 2 }"
+        :layout4="{ span: 4 }"
       >
         <CountryField
           ref="locationDropdown"
@@ -61,84 +54,80 @@
           :multiple="false"
           :label="targetLocationLabel$()"
         />
-      </VFlex>
-      <VFlex
-        xs12
-        sm4
-        xl3
-        class="px-3"
+      </KGridItem>
+      <KGridItem
+        :layout12="{ span: 3 }"
+        :layout8="{ span: 2 }"
+        :layout4="{ span: 4 }"
       >
-        <VTextField
+        <KTextbox
           v-model="keywordInput"
           :label="searchLabel$()"
-          prepend-inner-icon="search"
           clearable
-          box
-          :hint="searchHint$()"
-          persistent-hint
+          :clearAriaLabel="clearAction$()"
           @input="setKeywords"
-          @click:clear="clearSearch"
-        />
-      </VFlex>
-    </VLayout>
-    <VLayout
-      wrap
-      class="mb-2"
-    >
-      <VFlex
-        xs12
-        sm6
-        md3
-        class="px-3"
+        >
+          <template #innerBefore>
+            <KIcon
+              class="search-icon"
+              icon="search"
+              :color="$themeTokens.annotation"
+            />
+          </template>
+        </KTextbox>
+      </KGridItem>
+    </KGrid>
+    <KGrid class="filter-row">
+      <KGridItem
+        :layout12="{ span: 3 }"
+        :layout8="{ span: 2 }"
+        :layout4="{ span: 4 }"
       >
-        <VSelect
-          v-model="joinedWithinFilter"
-          :items="joinedWithinOptions"
-          item-text="label"
-          item-value="value"
+        <KSelect
+          :value="joinedWithinFilter"
+          :options="joinedWithinOptions"
           :label="joinedWithinLabel$()"
-          box
-          :menu-props="{ offsetY: true }"
+          @select="joinedWithinFilter = $event"
         />
-      </VFlex>
-      <VFlex
-        xs12
-        sm6
-        md3
-        class="px-3"
+      </KGridItem>
+      <KGridItem
+        :layout12="{ span: 3 }"
+        :layout8="{ span: 2 }"
+        :layout4="{ span: 4 }"
       >
-        <VSelect
-          v-model="activeWithinFilter"
-          :items="activeWithinOptions"
-          item-text="label"
-          item-value="value"
+        <KSelect
+          :value="activeWithinFilter"
+          :options="activeWithinOptions"
           :label="activeWithinLabel$()"
-          box
-          :menu-props="{ offsetY: true }"
+          @select="activeWithinFilter = $event"
         />
-      </VFlex>
-      <VFlex
-        xs12
-        md6
-        class="px-3 toggle-filters"
+      </KGridItem>
+      <KGridItem
+        :layout12="{ span: 6 }"
+        :layout8="{ span: 4 }"
+        :layout4="{ span: 4 }"
       >
-        <Checkbox
-          v-model="hasPublishedFilter"
-          :label="hasPublishedLabel$()"
-        />
-        <Checkbox
-          v-model="hasEditsFilter"
-          :label="hasStudioActivityLabel$()"
-        />
-        <KButton
-          v-if="hasActiveFilters"
-          appearance="basic-link"
-          :text="clearFiltersAction$()"
-          data-test="clear-filters"
-          @click="clearFilters"
-        />
-      </VFlex>
-    </VLayout>
+        <div class="toggle-filters">
+          <Checkbox
+            v-model="hasPublishedFilter"
+            class="toggle-checkbox"
+            :label="hasPublishedLabel$()"
+          />
+          <Checkbox
+            v-model="hasEditsFilter"
+            class="toggle-checkbox"
+            :label="hasStudioActivityLabel$()"
+          />
+          <KButton
+            v-if="hasActiveFilters"
+            appearance="basic-link"
+            :text="clearFiltersAction$()"
+            data-test="clear-filters"
+            @click="clearFilters"
+          />
+        </div>
+      </KGridItem>
+    </KGrid>
     <VDataTable
       v-model="selected"
       :headers="headers"
@@ -152,10 +141,9 @@
       :class="{ expanded: $vuetify.breakpoint.mdAndUp }"
     >
       <template #progress>
-        <VProgressLinear
+        <KLinearLoader
           v-if="loading"
-          color="loading"
-          indeterminate
+          delay
         />
       </template>
 
@@ -216,6 +204,7 @@
   import EmailUsersDialog from './EmailUsersDialog';
   import UserItem from './UserItem';
   import { usersStrings } from './usersStrings';
+  import { commonStrings } from 'shared/strings/commonStrings';
   import client from 'shared/client';
   import { useFilter } from 'shared/composables/useFilter';
   import { useKeywordSearch } from 'shared/composables/useKeywordSearch';
@@ -234,7 +223,6 @@
     userTypeLabel$,
     targetLocationLabel$,
     searchLabel$,
-    searchHint$,
     joinedWithinLabel$,
     activeWithinLabel$,
     hasPublishedLabel$,
@@ -265,6 +253,8 @@
     csvDownloadFailedMessage$,
     tabTitle$,
   } = usersStrings;
+
+  const { clearAction$ } = commonStrings;
 
   const userTypeFilterMap = {
     all: { label: userTypeAll$(), params: {} },
@@ -316,13 +306,7 @@
       filterMap: buildDateWindowFilterMap(paramName),
       defaultValue: 'any',
     });
-    const wrapped = computed({
-      get: () => filter.value.value || 'any',
-      set: value => {
-        filter.value = options.value.find(o => o.value === value) || {};
-      },
-    });
-    return { filter: wrapped, options, fetchQueryParams };
+    return { filter, options, fetchQueryParams };
   }
 
   function useBooleanFilter({ name, label, paramName }) {
@@ -362,26 +346,17 @@
       const { updateQueryParams } = useQueryParams();
 
       const {
-        filter: _userTypeFilter,
+        filter: userTypeFilter,
         options: userTypeOptions,
         fetchQueryParams: userTypeFetchQueryParams,
       } = useFilter({
         name: 'userType',
         filterMap: userTypeFilterMap,
       });
-      // Temporal wrapper, must be removed after migrating to KSelect
-      const userTypeFilter = computed({
-        get: () => _userTypeFilter.value.value || undefined,
-        set: value => {
-          _userTypeFilter.value =
-            userTypeOptions.value.find(option => option.value === value) || {};
-        },
-      });
 
       const {
         keywordInput,
         setKeywords,
-        clearSearch,
         fetchQueryParams: keywordSearchFetchQueryParams,
       } = useKeywordSearch();
 
@@ -396,7 +371,8 @@
         name: 'location',
         filterMap: locationFilterMap,
       });
-      // Temporal wrapper, must be removed after migrating to KSelect
+      // CountryField still wraps Vuetify's VAutocomplete, which binds a plain value
+      // rather than the option object useFilter holds.
       const locationFilter = computed({
         get: () => _locationFilter.value.value || undefined,
         set: value => {
@@ -485,10 +461,10 @@
         emailAction$,
         downloadCSVAction$,
         clearFiltersAction$,
+        clearAction$,
         userTypeLabel$,
         targetLocationLabel$,
         searchLabel$,
-        searchHint$,
         joinedWithinLabel$,
         activeWithinLabel$,
         hasPublishedLabel$,
@@ -501,7 +477,6 @@
         locationFilter,
         keywordInput,
         setKeywords,
-        clearSearch,
         joinedWithinFilter,
         joinedWithinOptions,
         activeWithinFilter,
@@ -610,11 +585,34 @@
 
 <style lang="scss" scoped>
 
+  .filter-row {
+    margin-bottom: 8px;
+  }
+
+  .filter-row .user-type-select {
+    height: 57px;
+  }
+
+  .search-icon {
+    position: relative;
+    left: 4px;
+    margin: 4px;
+    font-size: 19px;
+  }
+
   .toggle-filters {
     display: flex;
     flex-wrap: wrap;
     gap: 16px;
-    align-items: center;
+    align-items: flex-end;
+  }
+
+  .filter-row .toggle-filters {
+    height: 54px;
+  }
+
+  .filter-row .toggle-checkbox {
+    margin-bottom: -5px;
   }
 
 </style>

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -2,20 +2,20 @@
 
   <div>
     <h1 class="font-weight-bold px-4 py-2 title">
-      {{ `${$formatNumber(count)} ${count === 1 ? 'user' : 'users'}` }}
+      {{ userCount$({ count }) }}
       <IconButton
         v-if="count"
         icon="email"
         class="ma-0"
         :color="$themeTokens.primary"
-        :text="`Email ${$formatNumber(count)} ${count === 1 ? 'user' : 'users'}`"
+        :text="emailUsersAction$({ count })"
         @click="showMassEmailDialog = true"
       />
       <IconButton
         icon="download"
         class="ma-0"
         :color="$themeTokens.primary"
-        text="Download CSV"
+        :text="downloadCSVAction$()"
         data-test="csv"
         :disabled="!count"
         @click="onDownloadCSV"
@@ -43,7 +43,7 @@
           :items="userTypeOptions"
           item-text="label"
           item-value="key"
-          label="User Type"
+          :label="userTypeLabel$()"
           box
           :menu-props="{ offsetY: true }"
         />
@@ -59,7 +59,7 @@
           v-model="locationFilter"
           :outline="false"
           :multiple="false"
-          label="Target location"
+          :label="targetLocationLabel$()"
         />
       </VFlex>
       <VFlex
@@ -70,11 +70,11 @@
       >
         <VTextField
           v-model="keywordInput"
-          label="Search for a user..."
+          :label="searchLabel$()"
           prepend-inner-icon="search"
           clearable
           box
-          hint="Search for users by their names, emails, or channels"
+          :hint="searchHint$()"
           persistent-hint
           @input="setKeywords"
           @click:clear="clearSearch"
@@ -96,7 +96,7 @@
           :items="joinedWithinOptions"
           item-text="label"
           item-value="value"
-          label="Joined within"
+          :label="joinedWithinLabel$()"
           box
           :menu-props="{ offsetY: true }"
         />
@@ -112,7 +112,7 @@
           :items="activeWithinOptions"
           item-text="label"
           item-value="value"
-          label="Active within"
+          :label="activeWithinLabel$()"
           box
           :menu-props="{ offsetY: true }"
         />
@@ -124,16 +124,16 @@
       >
         <Checkbox
           v-model="hasPublishedFilter"
-          label="Has published a channel"
+          :label="hasPublishedLabel$()"
         />
         <Checkbox
           v-model="hasEditsFilter"
-          label="Has Studio activity"
+          :label="hasStudioActivityLabel$()"
         />
         <KButton
           v-if="hasActiveFilters"
           appearance="basic-link"
-          text="Clear filters"
+          :text="clearFiltersAction$()"
           data-test="clear-filters"
           @click="clearFilters"
         />
@@ -148,7 +148,7 @@
       :total-items="count"
       :rows-per-page-items="rowsPerPageItems"
       :items="users"
-      :no-data-text="loading ? 'Loading...' : 'No users found'"
+      :no-data-text="loading ? loadingMessage$() : noUsersFoundMessage$()"
       :class="{ expanded: $vuetify.breakpoint.mdAndUp }"
     >
       <template #progress>
@@ -177,7 +177,7 @@
           <IconButton
             icon="email"
             class="ma-0"
-            text="Email"
+            :text="emailAction$()"
             data-test="email"
             @click="showEmailDialog = true"
           />
@@ -215,6 +215,7 @@
   import { RouteNames, rowsPerPageItems } from '../../constants';
   import EmailUsersDialog from './EmailUsersDialog';
   import UserItem from './UserItem';
+  import { usersStrings } from './usersStrings';
   import client from 'shared/client';
   import { useFilter } from 'shared/composables/useFilter';
   import { useKeywordSearch } from 'shared/composables/useKeywordSearch';
@@ -224,12 +225,53 @@
   import Checkbox from 'shared/views/form/Checkbox';
   import CountryField from 'shared/views/form/CountryField';
 
+  const {
+    userCount$,
+    emailUsersAction$,
+    emailAction$,
+    downloadCSVAction$,
+    clearFiltersAction$,
+    userTypeLabel$,
+    targetLocationLabel$,
+    searchLabel$,
+    searchHint$,
+    joinedWithinLabel$,
+    activeWithinLabel$,
+    hasPublishedLabel$,
+    hasStudioActivityLabel$,
+    userTypeAll$,
+    userTypeActive$,
+    userTypeInactive$,
+    userTypeAdministrators$,
+    userTypeSushiChef$,
+    booleanFilterAny$,
+    dateWindowAnyTime$,
+    dateWindowLastMonth$,
+    dateWindowLast3Months$,
+    dateWindowLast6Months$,
+    dateWindowLastYear$,
+    nameHeader$,
+    emailHeader$,
+    diskSpaceHeader$,
+    canEditHeader$,
+    canViewHeader$,
+    dateJoinedHeader$,
+    lastActiveHeader$,
+    actionsHeader$,
+    loadingMessage$,
+    noUsersFoundMessage$,
+    generatingCSVMessage$,
+    noFiltersAppliedMessage$,
+    csvDownloadFailedMessage$,
+    tabTitle$,
+  } = usersStrings;
+
   const userTypeFilterMap = {
-    all: { label: 'All', params: {} },
-    active: { label: 'Active', params: { is_active: true } },
-    inactive: { label: 'Inactive', params: { is_active: false } },
-    administrator: { label: 'Administrators', params: { is_admin: true } },
-    sushichef: { label: 'Sushi chef', params: { chef: true } },
+    all: { label: userTypeAll$(), params: {} },
+    active: { label: userTypeActive$(), params: { is_active: true } },
+    inactive: { label: userTypeInactive$(), params: { is_active: false } },
+    administrator: { label: userTypeAdministrators$(), params: { is_admin: true } },
+    sushichef: { label: userTypeSushiChef$(), params: { chef: true } },
   };
 
   const TABLE_STATE_QUERY_PARAMS = ['page', 'page_size', 'sortBy', 'descending'];
@@ -246,23 +288,23 @@
   };
 
   const DATE_WINDOWS = [
-    { key: 'any', label: 'Any time', months: null },
-    { key: '1mo', label: 'Last month', months: 1 },
-    { key: '3mo', label: 'Last 3 months', months: 3 },
-    { key: '6mo', label: 'Last 6 months', months: 6 },
-    { key: '1yr', label: 'Last year', months: 12 },
+    { key: 'any', label: dateWindowAnyTime$, months: null },
+    { key: '1mo', label: dateWindowLastMonth$, months: 1 },
+    { key: '3mo', label: dateWindowLast3Months$, months: 3 },
+    { key: '6mo', label: dateWindowLast6Months$, months: 6 },
+    { key: '1yr', label: dateWindowLastYear$, months: 12 },
   ];
 
   function buildDateWindowFilterMap(paramName) {
     const map = {};
     for (const window of DATE_WINDOWS) {
       if (window.months === null) {
-        map[window.key] = { label: window.label, params: {} };
+        map[window.key] = { label: window.label(), params: {} };
       } else {
         const cutoff = new Date();
         cutoff.setMonth(cutoff.getMonth() - window.months);
         const iso = cutoff.toISOString().slice(0, 10);
-        map[window.key] = { label: window.label, params: { [paramName]: iso } };
+        map[window.key] = { label: window.label(), params: { [paramName]: iso } };
       }
     }
     return map;
@@ -285,7 +327,7 @@
 
   function useBooleanFilter({ name, label, paramName }) {
     const filterMap = {
-      no: { label: 'Any', params: {} },
+      no: { label: booleanFilterAny$(), params: {} },
       yes: { label, params: { [paramName]: true } },
     };
     const { filter, options, fetchQueryParams } = useFilter({
@@ -378,14 +420,14 @@
       const { filter: hasPublishedFilter, fetchQueryParams: hasPublishedFetchQueryParams } =
         useBooleanFilter({
           name: 'hasPublished',
-          label: 'Has published a channel',
+          label: hasPublishedLabel$(),
           paramName: 'published_channel',
         });
 
       const { filter: hasEditsFilter, fetchQueryParams: hasEditsFetchQueryParams } =
         useBooleanFilter({
           name: 'hasEdits',
-          label: 'Has Studio activity',
+          label: hasStudioActivityLabel$(),
           paramName: 'has_edits',
         });
 
@@ -438,6 +480,21 @@
       });
 
       return {
+        userCount$,
+        emailUsersAction$,
+        emailAction$,
+        downloadCSVAction$,
+        clearFiltersAction$,
+        userTypeLabel$,
+        targetLocationLabel$,
+        searchLabel$,
+        searchHint$,
+        joinedWithinLabel$,
+        activeWithinLabel$,
+        hasPublishedLabel$,
+        hasStudioActivityLabel$,
+        loadingMessage$,
+        noUsersFoundMessage$,
         userTypeFilter,
         userTypeOptions,
         locationDropdown,
@@ -490,18 +547,18 @@
           : [];
         return firstColumn.concat([
           {
-            text: 'Name',
+            text: nameHeader$(),
             align: 'left',
             value: 'last_name',
             class: `${this.$vuetify.breakpoint.smAndDown ? '' : 'first'}`,
           },
-          { text: 'Email', value: 'email' },
-          { text: 'Disk space', value: 'disk_space' },
-          { text: 'Can edit', value: 'edit_count', sortable: false },
-          { text: 'Can view', value: 'view_count', sortable: false },
-          { text: 'Date joined', value: 'date_joined' },
-          { text: 'Last active', value: 'last_login' },
-          { text: 'Actions', sortable: false, align: 'center' },
+          { text: emailHeader$(), value: 'email' },
+          { text: diskSpaceHeader$(), value: 'disk_space' },
+          { text: canEditHeader$(), value: 'edit_count', sortable: false },
+          { text: canViewHeader$(), value: 'view_count', sortable: false },
+          { text: dateJoinedHeader$(), value: 'date_joined' },
+          { text: lastActiveHeader$(), value: 'last_login' },
+          { text: actionsHeader$(), sortable: false, align: 'center' },
         ]);
       },
       selectedCount() {
@@ -524,11 +581,11 @@
       },
     },
     mounted() {
-      this.updateTabTitle('Users - Administration');
+      this.updateTabTitle(tabTitle$());
     },
     methods: {
       async onDownloadCSV() {
-        this.$store.dispatch('showSnackbarSimple', 'Generating CSV...');
+        this.$store.dispatch('showSnackbarSimple', generatingCSVMessage$());
         try {
           const response = await client.get(window.Urls.admin_users_download_csv(), {
             params: this.filterFetchQueryParams,
@@ -539,12 +596,9 @@
         } catch (error) {
           const status = error.response && error.response.status;
           if (status === 412) {
-            this.$store.dispatch(
-              'showSnackbarSimple',
-              'No filters applied. Pick at least one filter and try again.',
-            );
+            this.$store.dispatch('showSnackbarSimple', noFiltersAppliedMessage$());
           } else {
-            this.$store.dispatch('showSnackbarSimple', 'CSV download failed. Try again.');
+            this.$store.dispatch('showSnackbarSimple', csvDownloadFailedMessage$());
           }
         }
       },

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -131,10 +131,10 @@
           label="Has Studio activity"
         />
         <KButton
+          v-if="hasActiveFilters"
           appearance="basic-link"
           text="Clear filters"
           data-test="clear-filters"
-          :disabled="!hasActiveFilters"
           @click="clearFilters"
         />
       </VFlex>

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -119,24 +119,23 @@
       </VFlex>
       <VFlex
         xs12
-        sm6
-        md3
-        class="align-center d-flex px-3"
+        md6
+        class="px-3 toggle-filters"
       >
         <Checkbox
           v-model="hasPublishedFilter"
           label="Has published a channel"
         />
-      </VFlex>
-      <VFlex
-        xs12
-        sm6
-        md3
-        class="align-center d-flex px-3"
-      >
         <Checkbox
           v-model="hasEditsFilter"
-          label="Has Studio edits"
+          label="Has Studio activity"
+        />
+        <KButton
+          appearance="basic-link"
+          text="Clear filters"
+          data-test="clear-filters"
+          :disabled="!hasActiveFilters"
+          @click="clearFilters"
         />
       </VFlex>
     </VLayout>
@@ -208,8 +207,10 @@
 
   import { ref, onMounted, computed, getCurrentInstance } from 'vue';
   import { mapGetters } from 'vuex';
+  import pick from 'lodash/pick';
   import transform from 'lodash/transform';
   import { saveAs } from 'file-saver';
+  import { useRoute } from 'vue-router/composables';
   import { useTable } from '../../composables/useTable';
   import { RouteNames, rowsPerPageItems } from '../../constants';
   import EmailUsersDialog from './EmailUsersDialog';
@@ -217,6 +218,7 @@
   import client from 'shared/client';
   import { useFilter } from 'shared/composables/useFilter';
   import { useKeywordSearch } from 'shared/composables/useKeywordSearch';
+  import { useQueryParams } from 'shared/composables/useQueryParams';
   import { routerMixin } from 'shared/mixins';
   import IconButton from 'shared/views/IconButton';
   import Checkbox from 'shared/views/form/Checkbox';
@@ -228,6 +230,19 @@
     inactive: { label: 'Inactive', params: { is_active: false } },
     administrator: { label: 'Administrators', params: { is_admin: true } },
     sushichef: { label: 'Sushi chef', params: { chef: true } },
+  };
+
+  const TABLE_STATE_QUERY_PARAMS = ['page', 'page_size', 'sortBy', 'descending'];
+
+  // Mirrors the defaultValue each filter below declares.
+  const FILTER_DEFAULTS = {
+    userType: undefined,
+    location: undefined,
+    keywords: undefined,
+    joinedWithin: 'any',
+    activeWithin: 'any',
+    hasPublished: 'no',
+    hasEdits: 'no',
   };
 
   const DATE_WINDOWS = [
@@ -301,6 +316,8 @@
     setup() {
       const { proxy } = getCurrentInstance();
       const store = proxy.$store;
+      const route = useRoute();
+      const { updateQueryParams } = useQueryParams();
 
       const {
         filter: _userTypeFilter,
@@ -368,7 +385,7 @@
       const { filter: hasEditsFilter, fetchQueryParams: hasEditsFetchQueryParams } =
         useBooleanFilter({
           name: 'hasEdits',
-          label: 'Has Studio edits',
+          label: 'Has Studio activity',
           paramName: 'has_edits',
         });
 
@@ -401,6 +418,16 @@
         };
       });
 
+      const hasActiveFilters = computed(() =>
+        Object.entries(FILTER_DEFAULTS).some(
+          ([name, defaultValue]) => (route.query[name] ?? defaultValue) !== defaultValue,
+        ),
+      );
+
+      function clearFilters() {
+        updateQueryParams(pick(route.query, TABLE_STATE_QUERY_PARAMS));
+      }
+
       function loadUsers(fetchParams) {
         return store.dispatch('userAdmin/loadUsers', fetchParams);
       }
@@ -424,6 +451,8 @@
         activeWithinOptions,
         hasPublishedFilter,
         hasEditsFilter,
+        hasActiveFilters,
+        clearFilters,
         pagination,
         loading,
         loadItems,
@@ -525,4 +554,13 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .toggle-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+  }
+
+</style>

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -77,6 +77,7 @@
         </KTextbox>
       </KGridItem>
     </KGrid>
+
     <KGrid class="filter-row">
       <KGridItem
         :layout12="{ span: 3 }"
@@ -130,7 +131,7 @@
     </KGrid>
     <VDataTable
       v-model="selected"
-      :headers="headers"
+      :headers="headersFor($vuetify.breakpoint.smAndDown)"
       :loading="loading"
       class="table-col-freeze"
       :pagination.sync="pagination"
@@ -161,7 +162,7 @@
         </div>
 
         <template v-if="header.class === 'first' && selected.length">
-          <span>({{ selectedCount }})</span>
+          <span>({{ selected.length }})</span>
           <IconButton
             icon="email"
             class="ma-0"
@@ -191,10 +192,9 @@
 </template>
 
 
-<script>
+<script setup>
 
-  import { ref, onMounted, computed, getCurrentInstance } from 'vue';
-  import { mapGetters } from 'vuex';
+  import { computed, onMounted, ref, watch } from 'vue';
   import pick from 'lodash/pick';
   import transform from 'lodash/transform';
   import { saveAs } from 'file-saver';
@@ -209,7 +209,8 @@
   import { useFilter } from 'shared/composables/useFilter';
   import { useKeywordSearch } from 'shared/composables/useKeywordSearch';
   import { useQueryParams } from 'shared/composables/useQueryParams';
-  import { routerMixin } from 'shared/mixins';
+  import useStore from 'shared/composables/useStore';
+  import { updateTabTitle } from 'shared/i18n';
   import IconButton from 'shared/views/IconButton';
   import Checkbox from 'shared/views/form/Checkbox';
   import CountryField from 'shared/views/form/CountryField';
@@ -256,18 +257,9 @@
 
   const { clearAction$ } = commonStrings;
 
-  const userTypeFilterMap = {
-    all: { label: userTypeAll$(), params: {} },
-    active: { label: userTypeActive$(), params: { is_active: true } },
-    inactive: { label: userTypeInactive$(), params: { is_active: false } },
-    administrator: { label: userTypeAdministrators$(), params: { is_admin: true } },
-    sushichef: { label: userTypeSushiChef$(), params: { chef: true } },
-  };
+  const tableStateQueryParams = ['page', 'page_size', 'sortBy', 'descending'];
 
-  const TABLE_STATE_QUERY_PARAMS = ['page', 'page_size', 'sortBy', 'descending'];
-
-  // Mirrors the defaultValue each filter below declares.
-  const FILTER_DEFAULTS = {
+  const filterDefaults = {
     userType: undefined,
     location: undefined,
     keywords: undefined,
@@ -277,308 +269,224 @@
     hasEdits: 'no',
   };
 
-  const DATE_WINDOWS = [
-    { key: 'any', label: dateWindowAnyTime$, months: null },
-    { key: '1mo', label: dateWindowLastMonth$, months: 1 },
-    { key: '3mo', label: dateWindowLast3Months$, months: 3 },
-    { key: '6mo', label: dateWindowLast6Months$, months: 6 },
-    { key: '1yr', label: dateWindowLastYear$, months: 12 },
+  const userTypeFilterMap = {
+    all: { label: userTypeAll$(), params: {} },
+    active: { label: userTypeActive$(), params: { is_active: true } },
+    inactive: { label: userTypeInactive$(), params: { is_active: false } },
+    administrator: { label: userTypeAdministrators$(), params: { is_admin: true } },
+    sushichef: { label: userTypeSushiChef$(), params: { chef: true } },
+  };
+
+  const dateWindows = [
+    { key: 'any', label: dateWindowAnyTime$, monthsAgo: null },
+    { key: '1mo', label: dateWindowLastMonth$, monthsAgo: 1 },
+    { key: '3mo', label: dateWindowLast3Months$, monthsAgo: 3 },
+    { key: '6mo', label: dateWindowLast6Months$, monthsAgo: 6 },
+    { key: '1yr', label: dateWindowLastYear$, monthsAgo: 12 },
   ];
 
+  function isoDateMonthsAgo(monthsAgo) {
+    const cutoff = new Date();
+    cutoff.setMonth(cutoff.getMonth() - monthsAgo);
+    return cutoff.toISOString().slice(0, 10);
+  }
+
   function buildDateWindowFilterMap(paramName) {
-    const map = {};
-    for (const window of DATE_WINDOWS) {
-      if (window.months === null) {
-        map[window.key] = { label: window.label(), params: {} };
-      } else {
-        const cutoff = new Date();
-        cutoff.setMonth(cutoff.getMonth() - window.months);
-        const iso = cutoff.toISOString().slice(0, 10);
-        map[window.key] = { label: window.label(), params: { [paramName]: iso } };
-      }
-    }
-    return map;
+    return transform(
+      dateWindows,
+      (map, { key, label, monthsAgo }) => {
+        const params = monthsAgo === null ? {} : { [paramName]: isoDateMonthsAgo(monthsAgo) };
+        map[key] = { label: label(), params };
+      },
+      {},
+    );
+  }
+
+  function buildLocationFilterMap(countries) {
+    return transform(
+      countries,
+      (map, { id, name }) => {
+        map[id] = { label: name, params: { location: id } };
+      },
+      {},
+    );
   }
 
   function useDateWindowFilter({ name, paramName }) {
-    const { filter, options, fetchQueryParams } = useFilter({
+    return useFilter({
       name,
       filterMap: buildDateWindowFilterMap(paramName),
       defaultValue: 'any',
     });
-    return { filter, options, fetchQueryParams };
   }
 
   function useBooleanFilter({ name, label, paramName }) {
-    const filterMap = {
-      no: { label: booleanFilterAny$(), params: {} },
-      yes: { label, params: { [paramName]: true } },
-    };
     const { filter, options, fetchQueryParams } = useFilter({
       name,
-      filterMap,
+      filterMap: {
+        no: { label: booleanFilterAny$(), params: {} },
+        yes: { label, params: { [paramName]: true } },
+      },
       defaultValue: 'no',
     });
-    const wrapped = computed({
+    const isChecked = computed({
       get: () => filter.value.value === 'yes',
-      set: value => {
-        const targetKey = value ? 'yes' : 'no';
-        filter.value = options.value.find(o => o.value === targetKey) || {};
+      set: checked => {
+        filter.value =
+          options.value.find(option => option.value === (checked ? 'yes' : 'no')) || {};
       },
     });
-    return { filter: wrapped, fetchQueryParams };
+    return { filter: isChecked, fetchQueryParams };
   }
 
-  export default {
-    name: 'UserTable',
-    components: {
-      Checkbox,
-      IconButton,
-      EmailUsersDialog,
-      UserItem,
-      CountryField,
+  const store = useStore();
+  const route = useRoute();
+  const { updateQueryParams } = useQueryParams();
+
+  const selected = ref([]);
+  const showEmailDialog = ref(false);
+  const showMassEmailDialog = ref(false);
+  const locationDropdown = ref(null);
+  const locationFilterMap = ref({});
+
+  const users = computed(() => store.getters['userAdmin/users']);
+  const count = computed(() => store.getters['userAdmin/count']);
+
+  const {
+    filter: userTypeFilter,
+    options: userTypeOptions,
+    fetchQueryParams: userTypeParams,
+  } = useFilter({ name: 'userType', filterMap: userTypeFilterMap });
+
+  const {
+    filter: locationOption,
+    options: locationOptions,
+    fetchQueryParams: locationParams,
+  } = useFilter({ name: 'location', filterMap: locationFilterMap });
+
+  const locationFilter = computed({
+    get: () => locationOption.value.value,
+    set: countryId => {
+      locationOption.value = locationOptions.value.find(option => option.value === countryId) || {};
     },
-    mixins: [routerMixin],
-    setup() {
-      const { proxy } = getCurrentInstance();
-      const store = proxy.$store;
-      const route = useRoute();
-      const { updateQueryParams } = useQueryParams();
+  });
 
-      const {
-        filter: userTypeFilter,
-        options: userTypeOptions,
-        fetchQueryParams: userTypeFetchQueryParams,
-      } = useFilter({
-        name: 'userType',
-        filterMap: userTypeFilterMap,
+  const { keywordInput, setKeywords, fetchQueryParams: keywordParams } = useKeywordSearch();
+
+  const {
+    filter: joinedWithinFilter,
+    options: joinedWithinOptions,
+    fetchQueryParams: joinedWithinParams,
+  } = useDateWindowFilter({ name: 'joinedWithin', paramName: 'joined_since' });
+
+  const {
+    filter: activeWithinFilter,
+    options: activeWithinOptions,
+    fetchQueryParams: activeWithinParams,
+  } = useDateWindowFilter({ name: 'activeWithin', paramName: 'active_since' });
+
+  const { filter: hasPublishedFilter, fetchQueryParams: hasPublishedParams } = useBooleanFilter({
+    name: 'hasPublished',
+    label: hasPublishedLabel$(),
+    paramName: 'published_channel',
+  });
+
+  const { filter: hasEditsFilter, fetchQueryParams: hasEditsParams } = useBooleanFilter({
+    name: 'hasEdits',
+    label: hasStudioActivityLabel$(),
+    paramName: 'has_edits',
+  });
+
+  const filterFetchQueryParams = computed(() => ({
+    ...userTypeParams.value,
+    ...locationParams.value,
+    ...keywordParams.value,
+    ...joinedWithinParams.value,
+    ...activeWithinParams.value,
+    ...hasPublishedParams.value,
+    ...hasEditsParams.value,
+  }));
+
+  const hasActiveFilters = computed(() =>
+    Object.entries(filterDefaults).some(
+      ([name, defaultValue]) => (route.query[name] ?? defaultValue) !== defaultValue,
+    ),
+  );
+
+  function clearFilters() {
+    updateQueryParams(pick(route.query, tableStateQueryParams));
+  }
+
+  const { pagination, loading, loadItems } = useTable({
+    fetchFunc: fetchParams => store.dispatch('userAdmin/loadUsers', fetchParams),
+    filterFetchQueryParams,
+  });
+
+  const selectAll = computed({
+    get: () =>
+      selected.value.length > 0 && selected.value.length === users.value.length && !loading.value,
+    set: checked => {
+      selected.value = checked ? users.value : [];
+    },
+  });
+
+  function headersFor(stackedForMobile) {
+    const selectionColumn = stackedForMobile ? [{ class: 'first', sortable: false }] : [];
+    return [
+      ...selectionColumn,
+      {
+        text: nameHeader$(),
+        align: 'left',
+        value: 'last_name',
+        class: stackedForMobile ? '' : 'first',
+      },
+      { text: emailHeader$(), value: 'email' },
+      { text: diskSpaceHeader$(), value: 'disk_space' },
+      { text: canEditHeader$(), value: 'edit_count', sortable: false },
+      { text: canViewHeader$(), value: 'view_count', sortable: false },
+      { text: dateJoinedHeader$(), value: 'date_joined' },
+      { text: lastActiveHeader$(), value: 'last_login' },
+      { text: actionsHeader$(), sortable: false, align: 'center' },
+    ];
+  }
+
+  async function onDownloadCSV() {
+    store.dispatch('showSnackbarSimple', generatingCSVMessage$());
+    try {
+      const response = await client.get(window.Urls.admin_users_download_csv(), {
+        params: filterFetchQueryParams.value,
+        responseType: 'blob',
       });
-
-      const {
-        keywordInput,
-        setKeywords,
-        fetchQueryParams: keywordSearchFetchQueryParams,
-      } = useKeywordSearch();
-
-      const locationFilterMap = ref({});
-      const locationDropdown = ref(null);
-
-      const {
-        filter: _locationFilter,
-        options: locationOptions,
-        fetchQueryParams: locationFetchQueryParams,
-      } = useFilter({
-        name: 'location',
-        filterMap: locationFilterMap,
-      });
-      // CountryField still wraps Vuetify's VAutocomplete, which binds a plain value
-      // rather than the option object useFilter holds.
-      const locationFilter = computed({
-        get: () => _locationFilter.value.value || undefined,
-        set: value => {
-          _locationFilter.value =
-            locationOptions.value.find(option => option.value === value) || {};
-        },
-      });
-
-      const {
-        filter: joinedWithinFilter,
-        options: joinedWithinOptions,
-        fetchQueryParams: joinedWithinFetchQueryParams,
-      } = useDateWindowFilter({ name: 'joinedWithin', paramName: 'joined_since' });
-
-      const {
-        filter: activeWithinFilter,
-        options: activeWithinOptions,
-        fetchQueryParams: activeWithinFetchQueryParams,
-      } = useDateWindowFilter({ name: 'activeWithin', paramName: 'active_since' });
-
-      const { filter: hasPublishedFilter, fetchQueryParams: hasPublishedFetchQueryParams } =
-        useBooleanFilter({
-          name: 'hasPublished',
-          label: hasPublishedLabel$(),
-          paramName: 'published_channel',
-        });
-
-      const { filter: hasEditsFilter, fetchQueryParams: hasEditsFetchQueryParams } =
-        useBooleanFilter({
-          name: 'hasEdits',
-          label: hasStudioActivityLabel$(),
-          paramName: 'has_edits',
-        });
-
-      onMounted(() => {
-        // The locationFilterMap is built from the options in the CountryField component,
-        // so we need to wait until it's mounted to access them.
-        const locationOptions = locationDropdown.value.options;
-
-        locationFilterMap.value = transform(
-          locationOptions,
-          (result, option) => {
-            result[option.id] = {
-              label: option.name,
-              params: { location: option.id },
-            };
-          },
-          {},
-        );
-      });
-
-      const filterFetchQueryParams = computed(() => {
-        return {
-          ...userTypeFetchQueryParams.value,
-          ...locationFetchQueryParams.value,
-          ...keywordSearchFetchQueryParams.value,
-          ...joinedWithinFetchQueryParams.value,
-          ...activeWithinFetchQueryParams.value,
-          ...hasPublishedFetchQueryParams.value,
-          ...hasEditsFetchQueryParams.value,
-        };
-      });
-
-      const hasActiveFilters = computed(() =>
-        Object.entries(FILTER_DEFAULTS).some(
-          ([name, defaultValue]) => (route.query[name] ?? defaultValue) !== defaultValue,
-        ),
+      saveAs(response.data, `studio_users_${new Date().toISOString().slice(0, 10)}.csv`);
+    } catch (error) {
+      const noFiltersApplied = error.response && error.response.status === 412;
+      store.dispatch(
+        'showSnackbarSimple',
+        noFiltersApplied ? noFiltersAppliedMessage$() : csvDownloadFailedMessage$(),
       );
+    }
+  }
 
-      function clearFilters() {
-        updateQueryParams(pick(route.query, TABLE_STATE_QUERY_PARAMS));
+  watch(
+    () => route.fullPath,
+    () => {
+      if (route.name === RouteNames.USERS) {
+        selected.value = [];
       }
+    },
+  );
 
-      function loadUsers(fetchParams) {
-        return store.dispatch('userAdmin/loadUsers', fetchParams);
-      }
+  watch(
+    () => users.value.length,
+    () => {
+      selected.value = [];
+    },
+  );
 
-      const { pagination, loading, loadItems } = useTable({
-        fetchFunc: fetchParams => loadUsers(fetchParams),
-        filterFetchQueryParams,
-      });
-
-      return {
-        userCount$,
-        emailUsersAction$,
-        emailAction$,
-        downloadCSVAction$,
-        clearFiltersAction$,
-        clearAction$,
-        userTypeLabel$,
-        targetLocationLabel$,
-        searchLabel$,
-        joinedWithinLabel$,
-        activeWithinLabel$,
-        hasPublishedLabel$,
-        hasStudioActivityLabel$,
-        loadingMessage$,
-        noUsersFoundMessage$,
-        userTypeFilter,
-        userTypeOptions,
-        locationDropdown,
-        locationFilter,
-        keywordInput,
-        setKeywords,
-        joinedWithinFilter,
-        joinedWithinOptions,
-        activeWithinFilter,
-        activeWithinOptions,
-        hasPublishedFilter,
-        hasEditsFilter,
-        hasActiveFilters,
-        clearFilters,
-        pagination,
-        loading,
-        loadItems,
-        filterFetchQueryParams,
-      };
-    },
-    data() {
-      return {
-        selected: [],
-        showEmailDialog: false,
-        showMassEmailDialog: false,
-      };
-    },
-    computed: {
-      ...mapGetters('userAdmin', ['users', 'count']),
-      selectAll: {
-        get() {
-          return (
-            Boolean(this.selected.length) &&
-            this.selected.length === this.users.length &&
-            !this.loading
-          );
-        },
-        set(value) {
-          if (value) {
-            this.selected = this.users;
-          } else {
-            this.selected = [];
-          }
-        },
-      },
-      headers() {
-        const firstColumn = this.$vuetify.breakpoint.smAndDown
-          ? [{ class: 'first', sortable: false }]
-          : [];
-        return firstColumn.concat([
-          {
-            text: nameHeader$(),
-            align: 'left',
-            value: 'last_name',
-            class: `${this.$vuetify.breakpoint.smAndDown ? '' : 'first'}`,
-          },
-          { text: emailHeader$(), value: 'email' },
-          { text: diskSpaceHeader$(), value: 'disk_space' },
-          { text: canEditHeader$(), value: 'edit_count', sortable: false },
-          { text: canViewHeader$(), value: 'view_count', sortable: false },
-          { text: dateJoinedHeader$(), value: 'date_joined' },
-          { text: lastActiveHeader$(), value: 'last_login' },
-          { text: actionsHeader$(), sortable: false, align: 'center' },
-        ]);
-      },
-      selectedCount() {
-        return this.selected.length;
-      },
-      rowsPerPageItems() {
-        return rowsPerPageItems;
-      },
-    },
-    watch: {
-      $route: {
-        deep: true,
-        handler(newRoute, oldRoute) {
-          if (newRoute.name === oldRoute.name && newRoute.name === RouteNames.USERS)
-            this.selected = [];
-        },
-      },
-      'users.length'() {
-        this.selected = [];
-      },
-    },
-    mounted() {
-      this.updateTabTitle(tabTitle$());
-    },
-    methods: {
-      async onDownloadCSV() {
-        this.$store.dispatch('showSnackbarSimple', generatingCSVMessage$());
-        try {
-          const response = await client.get(window.Urls.admin_users_download_csv(), {
-            params: this.filterFetchQueryParams,
-            responseType: 'blob',
-          });
-          const filename = `studio_users_${new Date().toISOString().slice(0, 10)}.csv`;
-          saveAs(response.data, filename);
-        } catch (error) {
-          const status = error.response && error.response.status;
-          if (status === 412) {
-            this.$store.dispatch('showSnackbarSimple', noFiltersAppliedMessage$());
-          } else {
-            this.$store.dispatch('showSnackbarSimple', csvDownloadFailedMessage$());
-          }
-        }
-      },
-    },
-  };
+  onMounted(() => {
+    updateTabTitle(tabTitle$());
+    locationFilterMap.value = buildLocationFilterMap(locationDropdown.value.options);
+  });
 
 </script>
 

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/UserTable.vue
@@ -31,7 +31,6 @@
     <KGrid class="filter-row">
       <KGridItem
         :layout12="{ span: 3 }"
-        :layout8="{ span: 2 }"
         :layout4="{ span: 4 }"
       >
         <KSelect
@@ -44,7 +43,6 @@
       </KGridItem>
       <KGridItem
         :layout12="{ span: 3 }"
-        :layout8="{ span: 2 }"
         :layout4="{ span: 4 }"
       >
         <CountryField
@@ -52,16 +50,17 @@
           v-model="locationFilter"
           :outline="false"
           :multiple="false"
+          fullWidth
           :label="targetLocationLabel$()"
         />
       </KGridItem>
       <KGridItem
         :layout12="{ span: 3 }"
-        :layout8="{ span: 2 }"
         :layout4="{ span: 4 }"
       >
         <KTextbox
           v-model="keywordInput"
+          :appearanceOverrides="{ maxWidth: '100%' }"
           :label="searchLabel$()"
           clearable
           :clearAriaLabel="clearAction$()"
@@ -81,7 +80,7 @@
     <KGrid class="filter-row">
       <KGridItem
         :layout12="{ span: 3 }"
-        :layout8="{ span: 2 }"
+        :layout8="{ span: 4 }"
         :layout4="{ span: 4 }"
       >
         <KSelect
@@ -93,7 +92,7 @@
       </KGridItem>
       <KGridItem
         :layout12="{ span: 3 }"
-        :layout8="{ span: 2 }"
+        :layout8="{ span: 4 }"
         :layout4="{ span: 4 }"
       >
         <KSelect
@@ -516,7 +515,7 @@
   }
 
   .filter-row .toggle-filters {
-    height: 54px;
+    min-height: 54px;
   }
 
   .filter-row .toggle-checkbox {

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -66,16 +66,11 @@ function renderComponent({ users, query = {} } = {}) {
 }
 
 /**
- * KSelect mounts its dropdown through Popper into a shared overlay element, so
- * every select's options land in the same detached container. Where two selects
- * offer identical option labels — the date windows both offer "Last month" and
- * friends — a click cannot be aimed unambiguously, so those filters are reached
- * through the URL the control would produce instead. A shared or bookmarked
- * filter link is a real entry point, but it is navigation rather than a click.
+ * KSelect mounts every dropdown into one shared Popper overlay, so the two date
+ * windows offering identical labels cannot be told apart by a click.
  */
 const renderWithFilters = query => renderComponent({ query });
 
-/** Payload of the most recent user fetch. */
 function lastFetchParams() {
   const { calls } = mockLoadUsers.mock;
   return calls[calls.length - 1][1];
@@ -87,7 +82,6 @@ function lastFetchParams() {
  */
 const clearFiltersLink = () => screen.queryByText(clearFiltersAction$());
 
-/** The select-all checkbox lives in the table header, after the filter checkboxes. */
 const selectAllCheckbox = () => within(screen.getByRole('table')).getAllByRole('checkbox')[0];
 
 describe('UserTable', () => {
@@ -188,7 +182,6 @@ describe('UserTable', () => {
       });
     });
 
-    // Reached by URL rather than by clicking — see renderWithFilters.
     it('a joined-within selection fetches users filtered by an ISO joined_since date', async () => {
       renderWithFilters({ joinedWithin: '3mo' });
 
@@ -197,7 +190,6 @@ describe('UserTable', () => {
       });
     });
 
-    // Reached by URL rather than by clicking — see renderWithFilters.
     it('an active-within selection fetches users filtered by an ISO active_since date', async () => {
       renderWithFilters({ activeWithin: '1mo' });
 
@@ -270,8 +262,7 @@ describe('UserTable', () => {
       renderComponent();
 
       await user.type(screen.getByLabelText(searchLabel$()), 'keyword test');
-      // The search is debounced; let it reach the URL before clearing, otherwise a
-      // pending write lands after the clear and restores the term.
+      // useKeywordSearch debounces, so a pending write would land after the clear.
       await waitFor(() => {
         expect(router.currentRoute.query.keywords).toBe('keyword test');
       });

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -65,10 +65,6 @@ function renderComponent({ users, query = {} } = {}) {
   });
 }
 
-/**
- * KSelect mounts every dropdown into one shared Popper overlay, so the two date
- * windows offering identical labels cannot be told apart by a click.
- */
 const renderWithFilters = query => renderComponent({ query });
 
 function lastFetchParams() {
@@ -76,12 +72,7 @@ function lastFetchParams() {
   return calls[calls.length - 1][1];
 }
 
-/**
- * KButton renders `appearance="basic-link"` as an anchor with no href, which has
- * no implicit role, so the clear action is matched by its text.
- */
 const clearFiltersLink = () => screen.queryByText(clearFiltersAction$());
-
 const selectAllCheckbox = () => within(screen.getByRole('table')).getAllByRole('checkbox')[0];
 
 describe('UserTable', () => {
@@ -113,8 +104,6 @@ describe('UserTable', () => {
     it('renders every filter control', () => {
       renderComponent();
 
-      // KSelect renders its label as plain text in a div, with no <label> element
-      // and no aria-label, so its controls cannot be found by accessible name.
       expect(screen.getByText(userTypeLabel$())).toBeInTheDocument();
       expect(screen.getByText(joinedWithinLabel$())).toBeInTheDocument();
       expect(screen.getByText(activeWithinLabel$())).toBeInTheDocument();

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -1,5 +1,6 @@
-import { mount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
+import { render, screen, waitFor, within, configure } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { Store } from 'vuex';
 import router from '../../../router';
 import { RouteNames } from '../../../constants';
 import UserTable from '../UserTable';
@@ -10,285 +11,332 @@ jest.mock('shared/client', () => ({
 }));
 jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
 
-const localVue = createLocalVue();
+// Studio's IconButton passes `ariaLabel="text"` as a literal rather than binding it
+// (shared/views/IconButton.vue), so icon buttons have no usable accessible name and
+// have to be reached by their existing data-test hooks.
+configure({ testIdAttribute: 'data-test' });
 
-localVue.use(Vuex);
-localVue.use(router);
+const USER_IDS = ['user-a', 'user-b', 'user-c'];
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
-const userList = ['test', 'user', 'table'];
+const mockLoadUsers = jest.fn(() => Promise.resolve({}));
+const mockSendEmail = jest.fn(() => Promise.resolve());
 
-function makeWrapper(store) {
-  router.replace({ name: RouteNames.USERS });
-
-  const wrapper = mount(UserTable, {
-    router,
-    store,
-    localVue,
-    stubs: {
-      UserItem: true,
-      EmailUsersDialog: true,
-    },
-  });
-
-  return wrapper;
-}
-
-describe('userTable', () => {
-  let wrapper, store;
-  const loadUsers = jest.fn(() => Promise.resolve({}));
-
-  beforeEach(() => {
-    store = new Store({
-      modules: {
-        userAdmin: {
-          namespaced: true,
-          actions: {
-            loadUsers,
-          },
-          getters: {
-            users: () => userList,
-            count: () => userList.length,
-          },
+function createStore({ users = USER_IDS } = {}) {
+  return new Store({
+    modules: {
+      userAdmin: {
+        namespaced: true,
+        actions: {
+          loadUsers: mockLoadUsers,
+          sendEmail: mockSendEmail,
+        },
+        getters: {
+          users: () => users,
+          count: () => users.length,
+          getUsers: () => ids => ids.map(id => ({ id, email: `${id}@test.com` })),
         },
       },
-    });
-    wrapper = makeWrapper(store);
+    },
   });
-  afterEach(() => {
-    loadUsers.mockRestore();
+}
+
+function renderComponent({ users, query = {} } = {}) {
+  router.replace({ name: RouteNames.USERS, query }).catch(() => {});
+  return render(UserTable, {
+    store: createStore({ users }),
+    routes: router,
+    stubs: { UserItem: true },
+  });
+}
+
+/**
+ * Vuetify's VSelect menu does not open reliably under jsdom, so select-backed
+ * filters are reached through the URL the control would produce. A shared or
+ * bookmarked filter link is a real entry point, but it is navigation rather than
+ * a click — each test relying on it says so.
+ */
+const renderWithFilters = query => renderComponent({ query });
+
+/** Payload of the most recent user fetch. */
+function lastFetchParams() {
+  const { calls } = mockLoadUsers.mock;
+  return calls[calls.length - 1][1];
+}
+
+/**
+ * KButton renders `appearance="basic-link"` as an anchor with no href, which has
+ * no implicit role, so the clear action is matched by its text.
+ */
+const clearFiltersLink = () => screen.queryByText('Clear filters');
+
+/** The select-all checkbox lives in the table header, after the filter checkboxes. */
+const selectAllCheckbox = () => within(screen.getByRole('table')).getAllByRole('checkbox')[0];
+
+describe('UserTable', () => {
+  let user;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    jest.clearAllMocks();
+    require('shared/client').default.get.mockResolvedValue({
+      data: new Blob(['col1,col2\n1,2'], { type: 'text/csv' }),
+    });
   });
 
-  describe('filters', () => {
-    it('changing user type filter should set query params', () => {
-      wrapper.vm.userTypeFilter = 'administrator';
-      expect(router.currentRoute.query.userType).toBe('administrator');
+  describe('filter controls', () => {
+    it('renders every filter control', () => {
+      renderComponent();
+
+      expect(screen.getByLabelText('User Type')).toBeInTheDocument();
+      expect(screen.getByLabelText('Target location')).toBeInTheDocument();
+      expect(screen.getByLabelText('Search for a user...')).toBeInTheDocument();
+      expect(screen.getByLabelText('Joined within')).toBeInTheDocument();
+      expect(screen.getByLabelText('Active within')).toBeInTheDocument();
+      expect(screen.getByLabelText('Has published a channel')).toBeInTheDocument();
+      expect(screen.getByLabelText('Has Studio activity')).toBeInTheDocument();
     });
 
-    it('changing location filter should set query params', () => {
-      wrapper.vm.locationFilter = 'Afghanistan';
-      expect(router.currentRoute.query.location).toBe('Afghanistan');
+    it('typing a search term fetches users filtered by keyword', async () => {
+      renderComponent();
+
+      await user.type(screen.getByLabelText('Search for a user...'), 'keyword test');
+
+      await waitFor(() => {
+        expect(lastFetchParams()).toMatchObject({ keywords: 'keyword test' });
+      });
     });
 
-    it('changing search text should set query params', () => {
-      jest.useFakeTimers();
-      wrapper.vm.keywordInput = 'keyword test';
-      wrapper.vm.setKeywords();
-      jest.runAllTimers();
-      jest.useRealTimers();
+    it('ticking "has published a channel" fetches users filtered by published_channel', async () => {
+      renderComponent();
 
-      expect(router.currentRoute.query.keywords).toBe('keyword test');
+      await user.click(screen.getByLabelText('Has published a channel'));
+
+      await waitFor(() => {
+        expect(lastFetchParams()).toMatchObject({ published_channel: true });
+      });
     });
 
-    it('changing joined-within filter sets joined_since query param to an ISO date', () => {
-      wrapper.vm.joinedWithinFilter = '3mo';
-      const params = wrapper.vm.filterFetchQueryParams;
-      expect(params.joined_since).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    it('ticking "has Studio activity" fetches users filtered by has_edits', async () => {
+      renderComponent();
+
+      await user.click(screen.getByLabelText('Has Studio activity'));
+
+      await waitFor(() => {
+        expect(lastFetchParams()).toMatchObject({ has_edits: true });
+      });
     });
 
-    it('changing active-within filter sets active_since query param to an ISO date', () => {
-      wrapper.vm.activeWithinFilter = '1mo';
-      const params = wrapper.vm.filterFetchQueryParams;
-      expect(params.active_since).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Reached by URL rather than by opening the select — see renderWithFilters.
+    it('a user type selection fetches users filtered by that type', async () => {
+      renderWithFilters({ userType: 'administrator' });
+
+      await waitFor(() => {
+        expect(lastFetchParams()).toMatchObject({ is_admin: true });
+      });
     });
 
-    it('toggling has-published filter sets published_channel=true', () => {
-      wrapper.vm.hasPublishedFilter = true;
-      const params = wrapper.vm.filterFetchQueryParams;
-      expect(params.published_channel).toBe(true);
+    // Reached by URL rather than by opening the select — see renderWithFilters.
+    it('a joined-within selection fetches users filtered by an ISO joined_since date', async () => {
+      renderWithFilters({ joinedWithin: '3mo' });
+
+      await waitFor(() => {
+        expect(lastFetchParams().joined_since).toMatch(ISO_DATE);
+      });
     });
 
-    it('toggling has-edits filter sets has_edits=true', () => {
-      wrapper.vm.hasEditsFilter = true;
-      const params = wrapper.vm.filterFetchQueryParams;
-      expect(params.has_edits).toBe(true);
+    // Reached by URL rather than by opening the select — see renderWithFilters.
+    it('an active-within selection fetches users filtered by an ISO active_since date', async () => {
+      renderWithFilters({ activeWithin: '1mo' });
+
+      await waitFor(() => {
+        expect(lastFetchParams().active_since).toMatch(ISO_DATE);
+      });
+    });
+
+    // Reached by URL rather than by opening the select — see renderWithFilters.
+    it('a target location selection fetches users filtered by that location', async () => {
+      renderWithFilters({ location: 'Afghanistan' });
+
+      await waitFor(() => {
+        expect(lastFetchParams()).toMatchObject({ location: 'Afghanistan' });
+      });
     });
   });
 
   describe('clearing filters', () => {
-    it('is disabled while no filter is applied', () => {
-      expect(wrapper.vm.hasActiveFilters).toBe(false);
-      expect(wrapper.findComponent('[data-test="clear-filters"]').props().disabled).toBe(true);
+    it('is not offered on a page with no filters applied', () => {
+      renderComponent();
+
+      expect(clearFiltersLink()).not.toBeInTheDocument();
     });
 
-    it('is enabled once a filter is applied', async () => {
-      wrapper.vm.userTypeFilter = 'administrator';
-      await wrapper.vm.$nextTick();
+    it('is offered once a filter is applied', async () => {
+      renderComponent();
 
-      expect(wrapper.vm.hasActiveFilters).toBe(true);
-      expect(wrapper.findComponent('[data-test="clear-filters"]').props().disabled).toBe(false);
+      await user.click(screen.getByLabelText('Has published a channel'));
+
+      await waitFor(() => {
+        expect(clearFiltersLink()).toBeInTheDocument();
+      });
     });
 
-    it('is enabled by a user type of "All", which narrows nothing but is still a selection', async () => {
-      wrapper.vm.userTypeFilter = 'all';
-      await wrapper.vm.$nextTick();
+    // Reached by URL rather than by opening the select — see renderWithFilters.
+    it('is offered for a user type of "All", which narrows nothing but is still a selection', async () => {
+      renderWithFilters({ userType: 'all' });
 
-      expect(wrapper.vm.filterFetchQueryParams).toEqual({});
-      expect(wrapper.vm.hasActiveFilters).toBe(true);
-      expect(wrapper.findComponent('[data-test="clear-filters"]').props().disabled).toBe(false);
+      await waitFor(() => {
+        expect(clearFiltersLink()).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(mockLoadUsers).toHaveBeenCalled();
+      });
+      expect(lastFetchParams()).not.toHaveProperty('is_admin');
     });
 
-    it('stays disabled for date windows left at their default', async () => {
-      wrapper.vm.joinedWithinFilter = 'any';
-      wrapper.vm.activeWithinFilter = 'any';
-      await wrapper.vm.$nextTick();
+    // Reached by URL rather than by opening the select — see renderWithFilters.
+    it('stays unoffered for date windows left at their default', () => {
+      renderWithFilters({ joinedWithin: 'any', activeWithin: 'any' });
 
-      expect(wrapper.vm.hasActiveFilters).toBe(false);
+      expect(clearFiltersLink()).not.toBeInTheDocument();
     });
 
-    it('stays disabled after a checkbox is ticked and unticked again', async () => {
-      wrapper.vm.hasPublishedFilter = true;
-      await wrapper.vm.$nextTick();
-      expect(wrapper.vm.hasActiveFilters).toBe(true);
+    it('is withdrawn again after a checkbox is ticked and unticked', async () => {
+      renderComponent();
+      const checkbox = screen.getByLabelText('Has published a channel');
 
-      wrapper.vm.hasPublishedFilter = false;
-      await wrapper.vm.$nextTick();
+      await user.click(checkbox);
+      await waitFor(() => {
+        expect(clearFiltersLink()).toBeInTheDocument();
+      });
 
-      expect(wrapper.vm.hasActiveFilters).toBe(false);
+      await user.click(checkbox);
+
+      await waitFor(() => {
+        expect(clearFiltersLink()).not.toBeInTheDocument();
+      });
     });
 
-    it('drops every filter, including the keyword search', async () => {
-      jest.useFakeTimers();
-      wrapper.vm.keywordInput = 'keyword test';
-      wrapper.vm.setKeywords();
-      jest.runAllTimers();
-      jest.useRealTimers();
+    it('clears the checkboxes and the keyword search', async () => {
+      renderComponent();
 
-      wrapper.vm.userTypeFilter = 'administrator';
-      wrapper.vm.locationFilter = 'Afghanistan';
-      wrapper.vm.joinedWithinFilter = '3mo';
-      wrapper.vm.activeWithinFilter = '1mo';
-      wrapper.vm.hasPublishedFilter = true;
-      wrapper.vm.hasEditsFilter = true;
-      await wrapper.vm.$nextTick();
-      expect(wrapper.vm.filterFetchQueryParams).not.toEqual({});
+      await user.type(screen.getByLabelText('Search for a user...'), 'keyword test');
+      // The search is debounced; let it reach the URL before clearing, otherwise a
+      // pending write lands after the clear and restores the term.
+      await waitFor(() => {
+        expect(router.currentRoute.query.keywords).toBe('keyword test');
+      });
+      await user.click(screen.getByLabelText('Has published a channel'));
+      await user.click(screen.getByLabelText('Has Studio activity'));
+      await waitFor(() => {
+        expect(clearFiltersLink()).toBeInTheDocument();
+      });
 
-      await wrapper.findComponent('[data-test="clear-filters"]').trigger('click');
-      await wrapper.vm.$nextTick();
+      await user.click(clearFiltersLink());
 
-      expect(wrapper.vm.filterFetchQueryParams).toEqual({});
-      expect(wrapper.vm.keywordInput).toBe('');
-      expect(Object.keys(router.currentRoute.query).sort()).toEqual([
-        'descending',
-        'page',
-        'page_size',
-        'sortBy',
-      ]);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search for a user...')).toHaveValue('');
+      });
+      expect(screen.getByLabelText('Has published a channel')).not.toBeChecked();
+      expect(screen.getByLabelText('Has Studio activity')).not.toBeChecked();
+      expect(clearFiltersLink()).not.toBeInTheDocument();
     });
 
-    it('preserves pagination and sorting', async () => {
-      wrapper.vm.pagination = { ...wrapper.vm.pagination, page: 3, sortBy: 'email' };
-      wrapper.vm.userTypeFilter = 'administrator';
-      await wrapper.vm.$nextTick();
+    it('removes every filter query param while preserving pagination and sorting', async () => {
+      renderWithFilters({
+        userType: 'administrator',
+        location: 'Afghanistan',
+        joinedWithin: '3mo',
+        activeWithin: '1mo',
+        hasPublished: 'yes',
+        hasEdits: 'yes',
+        keywords: 'keyword test',
+        page: '3',
+        page_size: '25',
+        sortBy: 'email',
+        descending: 'false',
+      });
 
-      wrapper.vm.clearFilters();
-      await wrapper.vm.$nextTick();
+      await user.click(clearFiltersLink());
 
+      await waitFor(() => {
+        expect(Object.keys(router.currentRoute.query).sort()).toEqual([
+          'descending',
+          'page',
+          'page_size',
+          'sortBy',
+        ]);
+      });
       expect(router.currentRoute.query.sortBy).toBe('email');
-      expect(router.currentRoute.query.userType).toBeUndefined();
     });
   });
 
-  describe('selection', () => {
-    it('selectAll should set selected to channel list', () => {
-      wrapper.vm.selectAll = true;
-      expect(wrapper.vm.selected).toEqual(userList);
+  describe('selection and bulk actions', () => {
+    it('offers no bulk email action until users are selected', () => {
+      renderComponent();
+
+      expect(screen.queryByTestId('email')).not.toBeInTheDocument();
     });
 
-    it('removing selectAll should set selected to empty list', () => {
-      wrapper.vm.selected = userList;
-      wrapper.vm.selectAll = false;
-      wrapper.vm.$nextTick(() => {
-        expect(wrapper.vm.selected).toEqual([]);
+    it('selecting all users offers a bulk email action for them', async () => {
+      renderComponent();
+
+      await user.click(selectAllCheckbox());
+
+      expect(await screen.findByTestId('email')).toBeInTheDocument();
+      expect(screen.getByText(`(${USER_IDS.length})`)).toBeInTheDocument();
+    });
+
+    it('discards the selection when the filters change', async () => {
+      renderComponent();
+
+      await user.click(selectAllCheckbox());
+      expect(await screen.findByTestId('email')).toBeInTheDocument();
+
+      await user.click(screen.getByLabelText('Has published a channel'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('email')).not.toBeInTheDocument();
       });
     });
 
-    it('selectedCount should match the selected length', () => {
-      wrapper.vm.selected = ['test'];
-      expect(wrapper.vm.selectedCount).toBe(1);
-    });
+    it('the bulk email action opens the send email dialog', async () => {
+      renderComponent();
 
-    it('selected should clear on query changes', () => {
-      wrapper.vm.selected = ['test'];
-      router.push({
-        ...wrapper.vm.$route,
-        query: {
-          param: 'test',
-        },
-      });
-      wrapper.vm.$nextTick(() => {
-        expect(wrapper.vm.selected).toEqual([]);
-      });
+      await user.click(selectAllCheckbox());
+      await user.click(await screen.findByTestId('email'));
+
+      expect(await screen.findByRole('heading', { name: 'Send email' })).toBeInTheDocument();
     });
   });
 
-  describe('bulk actions', () => {
-    it('should be hidden if no items are selected', () => {
-      expect(wrapper.find('[data-test="email"]').exists()).toBe(false);
+  describe('CSV download', () => {
+    it('offers the download when there are users to export', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('csv')).toBeEnabled();
     });
 
-    it('should be visible if items are selected', async () => {
-      wrapper.vm.selected = userList;
-      await wrapper.vm.$nextTick();
-      expect(wrapper.find('[data-test="email"]').exists()).toBe(true);
+    it('is unavailable when there are no users to export', () => {
+      renderComponent({ users: [] });
+
+      expect(screen.getByTestId('csv')).toBeDisabled();
     });
 
-    it('email should open email dialog', async () => {
-      wrapper.vm.selected = userList;
-      await wrapper.vm.$nextTick();
-      await wrapper.findComponent('[data-test="email"]').trigger('click');
-      expect(wrapper.vm.showEmailDialog).toBe(true);
-    });
-  });
-
-  describe('csv download', () => {
-    beforeEach(() => {
+    it('downloads a dated CSV built from the current filters', async () => {
       const client = require('shared/client').default;
       const { saveAs } = require('file-saver');
-      client.get.mockReset();
-      client.get.mockResolvedValue({
-        data: new Blob(['col1,col2\n1,2'], { type: 'text/csv' }),
+      renderComponent();
+
+      await user.click(screen.getByTestId('csv'));
+
+      await waitFor(() => {
+        expect(saveAs).toHaveBeenCalled();
       });
-      saveAs.mockClear();
-    });
-
-    it('renders the Download CSV button when count > 0', () => {
-      expect(wrapper.find('[data-test="csv"]').exists()).toBe(true);
-    });
-
-    it('clicking Download CSV calls the API with the current filter params', async () => {
-      await wrapper.findComponent('[data-test="csv"]').trigger('click');
-      // Flush the microtask queue so the chained .then() runs.
-      await new Promise(resolve => setImmediate(resolve));
-
-      const client = require('shared/client').default;
-      const { saveAs } = require('file-saver');
-      expect(client.get).toHaveBeenCalled();
-      const [, options] = client.get.mock.calls[0];
-      expect(options.responseType).toBe('blob');
-      expect(saveAs).toHaveBeenCalled();
+      expect(client.get.mock.calls[0][1].responseType).toBe('blob');
       const [savedBlob, savedName] = saveAs.mock.calls[0];
       expect(savedBlob).toBeInstanceOf(Blob);
       expect(savedName).toMatch(/^studio_users_\d{4}-\d{2}-\d{2}\.csv$/);
-    });
-  });
-
-  describe('csv download disabled state', () => {
-    it('disables Download CSV when count is zero', () => {
-      const emptyStore = new Store({
-        modules: {
-          userAdmin: {
-            namespaced: true,
-            actions: { loadUsers },
-            getters: {
-              users: () => [],
-              count: () => 0,
-            },
-          },
-        },
-      });
-      const emptyWrapper = makeWrapper(emptyStore);
-      const button = emptyWrapper.find('[data-test="csv"]');
-      expect(button.attributes('disabled') !== undefined || button.props().disabled).toBe(true);
     });
   });
 });

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -4,6 +4,19 @@ import { Store } from 'vuex';
 import router from '../../../router';
 import { RouteNames } from '../../../constants';
 import UserTable from '../UserTable';
+import { usersStrings } from '../usersStrings';
+
+const {
+  userCount$,
+  userTypeLabel$,
+  targetLocationLabel$,
+  searchLabel$,
+  joinedWithinLabel$,
+  activeWithinLabel$,
+  hasPublishedLabel$,
+  hasStudioActivityLabel$,
+  clearFiltersAction$,
+} = usersStrings;
 
 jest.mock('shared/client', () => ({
   __esModule: true,
@@ -68,7 +81,7 @@ function lastFetchParams() {
  * KButton renders `appearance="basic-link"` as an anchor with no href, which has
  * no implicit role, so the clear action is matched by its text.
  */
-const clearFiltersLink = () => screen.queryByText('Clear filters');
+const clearFiltersLink = () => screen.queryByText(clearFiltersAction$());
 
 /** The select-all checkbox lives in the table header, after the filter checkboxes. */
 const selectAllCheckbox = () => within(screen.getByRole('table')).getAllByRole('checkbox')[0];
@@ -84,23 +97,37 @@ describe('UserTable', () => {
     });
   });
 
+  describe('heading', () => {
+    it('pluralises the match count', () => {
+      renderComponent();
+
+      expect(screen.getByText(userCount$({ count: USER_IDS.length }))).toBeInTheDocument();
+    });
+
+    it('uses the singular form for one match', () => {
+      renderComponent({ users: [USER_IDS[0]] });
+
+      expect(screen.getByText(userCount$({ count: 1 }))).toBeInTheDocument();
+    });
+  });
+
   describe('filter controls', () => {
     it('renders every filter control', () => {
       renderComponent();
 
-      expect(screen.getByLabelText('User Type')).toBeInTheDocument();
-      expect(screen.getByLabelText('Target location')).toBeInTheDocument();
-      expect(screen.getByLabelText('Search for a user...')).toBeInTheDocument();
-      expect(screen.getByLabelText('Joined within')).toBeInTheDocument();
-      expect(screen.getByLabelText('Active within')).toBeInTheDocument();
-      expect(screen.getByLabelText('Has published a channel')).toBeInTheDocument();
-      expect(screen.getByLabelText('Has Studio activity')).toBeInTheDocument();
+      expect(screen.getByLabelText(userTypeLabel$())).toBeInTheDocument();
+      expect(screen.getByLabelText(targetLocationLabel$())).toBeInTheDocument();
+      expect(screen.getByLabelText(searchLabel$())).toBeInTheDocument();
+      expect(screen.getByLabelText(joinedWithinLabel$())).toBeInTheDocument();
+      expect(screen.getByLabelText(activeWithinLabel$())).toBeInTheDocument();
+      expect(screen.getByLabelText(hasPublishedLabel$())).toBeInTheDocument();
+      expect(screen.getByLabelText(hasStudioActivityLabel$())).toBeInTheDocument();
     });
 
     it('typing a search term fetches users filtered by keyword', async () => {
       renderComponent();
 
-      await user.type(screen.getByLabelText('Search for a user...'), 'keyword test');
+      await user.type(screen.getByLabelText(searchLabel$()), 'keyword test');
 
       await waitFor(() => {
         expect(lastFetchParams()).toMatchObject({ keywords: 'keyword test' });
@@ -110,7 +137,7 @@ describe('UserTable', () => {
     it('ticking "has published a channel" fetches users filtered by published_channel', async () => {
       renderComponent();
 
-      await user.click(screen.getByLabelText('Has published a channel'));
+      await user.click(screen.getByLabelText(hasPublishedLabel$()));
 
       await waitFor(() => {
         expect(lastFetchParams()).toMatchObject({ published_channel: true });
@@ -120,7 +147,7 @@ describe('UserTable', () => {
     it('ticking "has Studio activity" fetches users filtered by has_edits', async () => {
       renderComponent();
 
-      await user.click(screen.getByLabelText('Has Studio activity'));
+      await user.click(screen.getByLabelText(hasStudioActivityLabel$()));
 
       await waitFor(() => {
         expect(lastFetchParams()).toMatchObject({ has_edits: true });
@@ -174,7 +201,7 @@ describe('UserTable', () => {
     it('is offered once a filter is applied', async () => {
       renderComponent();
 
-      await user.click(screen.getByLabelText('Has published a channel'));
+      await user.click(screen.getByLabelText(hasPublishedLabel$()));
 
       await waitFor(() => {
         expect(clearFiltersLink()).toBeInTheDocument();
@@ -203,7 +230,7 @@ describe('UserTable', () => {
 
     it('is withdrawn again after a checkbox is ticked and unticked', async () => {
       renderComponent();
-      const checkbox = screen.getByLabelText('Has published a channel');
+      const checkbox = screen.getByLabelText(hasPublishedLabel$());
 
       await user.click(checkbox);
       await waitFor(() => {
@@ -220,14 +247,14 @@ describe('UserTable', () => {
     it('clears the checkboxes and the keyword search', async () => {
       renderComponent();
 
-      await user.type(screen.getByLabelText('Search for a user...'), 'keyword test');
+      await user.type(screen.getByLabelText(searchLabel$()), 'keyword test');
       // The search is debounced; let it reach the URL before clearing, otherwise a
       // pending write lands after the clear and restores the term.
       await waitFor(() => {
         expect(router.currentRoute.query.keywords).toBe('keyword test');
       });
-      await user.click(screen.getByLabelText('Has published a channel'));
-      await user.click(screen.getByLabelText('Has Studio activity'));
+      await user.click(screen.getByLabelText(hasPublishedLabel$()));
+      await user.click(screen.getByLabelText(hasStudioActivityLabel$()));
       await waitFor(() => {
         expect(clearFiltersLink()).toBeInTheDocument();
       });
@@ -235,10 +262,10 @@ describe('UserTable', () => {
       await user.click(clearFiltersLink());
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Search for a user...')).toHaveValue('');
+        expect(screen.getByLabelText(searchLabel$())).toHaveValue('');
       });
-      expect(screen.getByLabelText('Has published a channel')).not.toBeChecked();
-      expect(screen.getByLabelText('Has Studio activity')).not.toBeChecked();
+      expect(screen.getByLabelText(hasPublishedLabel$())).not.toBeChecked();
+      expect(screen.getByLabelText(hasStudioActivityLabel$())).not.toBeChecked();
       expect(clearFiltersLink()).not.toBeInTheDocument();
     });
 
@@ -293,7 +320,7 @@ describe('UserTable', () => {
       await user.click(selectAllCheckbox());
       expect(await screen.findByTestId('email')).toBeInTheDocument();
 
-      await user.click(screen.getByLabelText('Has published a channel'));
+      await user.click(screen.getByLabelText(hasPublishedLabel$()));
 
       await waitFor(() => {
         expect(screen.queryByTestId('email')).not.toBeInTheDocument();

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -5,9 +5,11 @@ import router from '../../../router';
 import { RouteNames } from '../../../constants';
 import UserTable from '../UserTable';
 import { usersStrings } from '../usersStrings';
+import { commonStrings } from 'shared/strings/commonStrings';
 
 const {
   userCount$,
+  clearFiltersAction$,
   userTypeLabel$,
   targetLocationLabel$,
   searchLabel$,
@@ -15,8 +17,11 @@ const {
   activeWithinLabel$,
   hasPublishedLabel$,
   hasStudioActivityLabel$,
-  clearFiltersAction$,
+  userTypeAdministrators$,
+  userTypeAll$,
 } = usersStrings;
+
+const { clearAction$ } = commonStrings;
 
 jest.mock('shared/client', () => ({
   __esModule: true,
@@ -24,9 +29,6 @@ jest.mock('shared/client', () => ({
 }));
 jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
 
-// Studio's IconButton passes `ariaLabel="text"` as a literal rather than binding it
-// (shared/views/IconButton.vue), so icon buttons have no usable accessible name and
-// have to be reached by their existing data-test hooks.
 configure({ testIdAttribute: 'data-test' });
 
 const USER_IDS = ['user-a', 'user-b', 'user-c'];
@@ -64,10 +66,12 @@ function renderComponent({ users, query = {} } = {}) {
 }
 
 /**
- * Vuetify's VSelect menu does not open reliably under jsdom, so select-backed
- * filters are reached through the URL the control would produce. A shared or
- * bookmarked filter link is a real entry point, but it is navigation rather than
- * a click — each test relying on it says so.
+ * KSelect mounts its dropdown through Popper into a shared overlay element, so
+ * every select's options land in the same detached container. Where two selects
+ * offer identical option labels — the date windows both offer "Last month" and
+ * friends — a click cannot be aimed unambiguously, so those filters are reached
+ * through the URL the control would produce instead. A shared or bookmarked
+ * filter link is a real entry point, but it is navigation rather than a click.
  */
 const renderWithFilters = query => renderComponent({ query });
 
@@ -115,11 +119,14 @@ describe('UserTable', () => {
     it('renders every filter control', () => {
       renderComponent();
 
-      expect(screen.getByLabelText(userTypeLabel$())).toBeInTheDocument();
+      // KSelect renders its label as plain text in a div, with no <label> element
+      // and no aria-label, so its controls cannot be found by accessible name.
+      expect(screen.getByText(userTypeLabel$())).toBeInTheDocument();
+      expect(screen.getByText(joinedWithinLabel$())).toBeInTheDocument();
+      expect(screen.getByText(activeWithinLabel$())).toBeInTheDocument();
+
       expect(screen.getByLabelText(targetLocationLabel$())).toBeInTheDocument();
       expect(screen.getByLabelText(searchLabel$())).toBeInTheDocument();
-      expect(screen.getByLabelText(joinedWithinLabel$())).toBeInTheDocument();
-      expect(screen.getByLabelText(activeWithinLabel$())).toBeInTheDocument();
       expect(screen.getByLabelText(hasPublishedLabel$())).toBeInTheDocument();
       expect(screen.getByLabelText(hasStudioActivityLabel$())).toBeInTheDocument();
     });
@@ -132,6 +139,22 @@ describe('UserTable', () => {
       await waitFor(() => {
         expect(lastFetchParams()).toMatchObject({ keywords: 'keyword test' });
       });
+    });
+
+    it("the search field's clear button drops the keyword filter", async () => {
+      renderComponent();
+
+      await user.type(screen.getByLabelText(searchLabel$()), 'keyword test');
+      await waitFor(() => {
+        expect(router.currentRoute.query.keywords).toBe('keyword test');
+      });
+
+      await user.click(screen.getByRole('button', { name: clearAction$() }));
+
+      await waitFor(() => {
+        expect(router.currentRoute.query.keywords).toBeUndefined();
+      });
+      expect(screen.getByLabelText(searchLabel$())).toHaveValue('');
     });
 
     it('ticking "has published a channel" fetches users filtered by published_channel', async () => {
@@ -154,16 +177,18 @@ describe('UserTable', () => {
       });
     });
 
-    // Reached by URL rather than by opening the select — see renderWithFilters.
     it('a user type selection fetches users filtered by that type', async () => {
-      renderWithFilters({ userType: 'administrator' });
+      renderComponent();
+
+      await user.click(screen.getByText(userTypeLabel$()));
+      await user.click(await screen.findByText(userTypeAdministrators$()));
 
       await waitFor(() => {
         expect(lastFetchParams()).toMatchObject({ is_admin: true });
       });
     });
 
-    // Reached by URL rather than by opening the select — see renderWithFilters.
+    // Reached by URL rather than by clicking — see renderWithFilters.
     it('a joined-within selection fetches users filtered by an ISO joined_since date', async () => {
       renderWithFilters({ joinedWithin: '3mo' });
 
@@ -172,7 +197,7 @@ describe('UserTable', () => {
       });
     });
 
-    // Reached by URL rather than by opening the select — see renderWithFilters.
+    // Reached by URL rather than by clicking — see renderWithFilters.
     it('an active-within selection fetches users filtered by an ISO active_since date', async () => {
       renderWithFilters({ activeWithin: '1mo' });
 
@@ -181,7 +206,6 @@ describe('UserTable', () => {
       });
     });
 
-    // Reached by URL rather than by opening the select — see renderWithFilters.
     it('a target location selection fetches users filtered by that location', async () => {
       renderWithFilters({ location: 'Afghanistan' });
 
@@ -208,20 +232,18 @@ describe('UserTable', () => {
       });
     });
 
-    // Reached by URL rather than by opening the select — see renderWithFilters.
     it('is offered for a user type of "All", which narrows nothing but is still a selection', async () => {
-      renderWithFilters({ userType: 'all' });
+      renderComponent();
+
+      await user.click(screen.getByText(userTypeLabel$()));
+      await user.click(await screen.findByText(userTypeAll$()));
 
       await waitFor(() => {
         expect(clearFiltersLink()).toBeInTheDocument();
       });
-      await waitFor(() => {
-        expect(mockLoadUsers).toHaveBeenCalled();
-      });
       expect(lastFetchParams()).not.toHaveProperty('is_admin');
     });
 
-    // Reached by URL rather than by opening the select — see renderWithFilters.
     it('stays unoffered for date windows left at their default', () => {
       renderWithFilters({ joinedWithin: 'any', activeWithin: 'any' });
 
@@ -333,6 +355,7 @@ describe('UserTable', () => {
       await user.click(selectAllCheckbox());
       await user.click(await screen.findByTestId('email'));
 
+      // EmailUsersDialog has no $trs, so there is no key to reference for its title.
       expect(await screen.findByRole('heading', { name: 'Send email' })).toBeInTheDocument();
     });
   });

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/__tests__/userTable.spec.js
@@ -104,6 +104,90 @@ describe('userTable', () => {
     });
   });
 
+  describe('clearing filters', () => {
+    it('is disabled while no filter is applied', () => {
+      expect(wrapper.vm.hasActiveFilters).toBe(false);
+      expect(wrapper.findComponent('[data-test="clear-filters"]').props().disabled).toBe(true);
+    });
+
+    it('is enabled once a filter is applied', async () => {
+      wrapper.vm.userTypeFilter = 'administrator';
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.hasActiveFilters).toBe(true);
+      expect(wrapper.findComponent('[data-test="clear-filters"]').props().disabled).toBe(false);
+    });
+
+    it('is enabled by a user type of "All", which narrows nothing but is still a selection', async () => {
+      wrapper.vm.userTypeFilter = 'all';
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.filterFetchQueryParams).toEqual({});
+      expect(wrapper.vm.hasActiveFilters).toBe(true);
+      expect(wrapper.findComponent('[data-test="clear-filters"]').props().disabled).toBe(false);
+    });
+
+    it('stays disabled for date windows left at their default', async () => {
+      wrapper.vm.joinedWithinFilter = 'any';
+      wrapper.vm.activeWithinFilter = 'any';
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.hasActiveFilters).toBe(false);
+    });
+
+    it('stays disabled after a checkbox is ticked and unticked again', async () => {
+      wrapper.vm.hasPublishedFilter = true;
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.hasActiveFilters).toBe(true);
+
+      wrapper.vm.hasPublishedFilter = false;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.hasActiveFilters).toBe(false);
+    });
+
+    it('drops every filter, including the keyword search', async () => {
+      jest.useFakeTimers();
+      wrapper.vm.keywordInput = 'keyword test';
+      wrapper.vm.setKeywords();
+      jest.runAllTimers();
+      jest.useRealTimers();
+
+      wrapper.vm.userTypeFilter = 'administrator';
+      wrapper.vm.locationFilter = 'Afghanistan';
+      wrapper.vm.joinedWithinFilter = '3mo';
+      wrapper.vm.activeWithinFilter = '1mo';
+      wrapper.vm.hasPublishedFilter = true;
+      wrapper.vm.hasEditsFilter = true;
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.filterFetchQueryParams).not.toEqual({});
+
+      await wrapper.findComponent('[data-test="clear-filters"]').trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.filterFetchQueryParams).toEqual({});
+      expect(wrapper.vm.keywordInput).toBe('');
+      expect(Object.keys(router.currentRoute.query).sort()).toEqual([
+        'descending',
+        'page',
+        'page_size',
+        'sortBy',
+      ]);
+    });
+
+    it('preserves pagination and sorting', async () => {
+      wrapper.vm.pagination = { ...wrapper.vm.pagination, page: 3, sortBy: 'email' };
+      wrapper.vm.userTypeFilter = 'administrator';
+      await wrapper.vm.$nextTick();
+
+      wrapper.vm.clearFilters();
+      await wrapper.vm.$nextTick();
+
+      expect(router.currentRoute.query.sortBy).toBe('email');
+      expect(router.currentRoute.query.userType).toBeUndefined();
+    });
+  });
+
   describe('selection', () => {
     it('selectAll should set selected to channel list', () => {
       wrapper.vm.selectAll = true;

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/usersStrings.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/usersStrings.js
@@ -34,10 +34,6 @@ export const usersStrings = createTranslator('UsersStrings', {
     message: 'Search for a user...',
     context: 'Placeholder of the users search field',
   },
-  searchHint: {
-    message: 'Search for users by their names, emails, or channels',
-    context: 'Hint below the users search field explaining what it matches',
-  },
   joinedWithinLabel: {
     message: 'Joined within',
     context: 'Label of the dropdown filtering users by how recently they registered',

--- a/contentcuration/contentcuration/frontend/administration/pages/Users/usersStrings.js
+++ b/contentcuration/contentcuration/frontend/administration/pages/Users/usersStrings.js
@@ -1,0 +1,163 @@
+import { createTranslator } from 'shared/i18n';
+
+export const usersStrings = createTranslator('UsersStrings', {
+  userCount: {
+    message: '{count, plural,\n =1 {# user}\n other {# users}}',
+    context: 'Heading above the administration users table, showing how many users match',
+  },
+  emailUsersAction: {
+    message: 'Email {count, plural,\n =1 {# user}\n other {# users}}',
+    context: 'Action to email every user matching the current filters',
+  },
+  emailAction: {
+    message: 'Email',
+    context: 'Action to email the users selected in the table',
+  },
+  downloadCSVAction: {
+    message: 'Download CSV',
+    context: 'Action to export the filtered users as a CSV file',
+  },
+  clearFiltersAction: {
+    message: 'Clear filters',
+    context: 'Action to remove every filter applied to the users table',
+  },
+
+  userTypeLabel: {
+    message: 'User Type',
+    context: 'Label of the dropdown filtering users by their type, such as administrators',
+  },
+  targetLocationLabel: {
+    message: 'Target location',
+    context: 'Label of the dropdown filtering users by the country they work in',
+  },
+  searchLabel: {
+    message: 'Search for a user...',
+    context: 'Placeholder of the users search field',
+  },
+  searchHint: {
+    message: 'Search for users by their names, emails, or channels',
+    context: 'Hint below the users search field explaining what it matches',
+  },
+  joinedWithinLabel: {
+    message: 'Joined within',
+    context: 'Label of the dropdown filtering users by how recently they registered',
+  },
+  activeWithinLabel: {
+    message: 'Active within',
+    context: 'Label of the dropdown filtering users by how recently they signed in',
+  },
+  hasPublishedLabel: {
+    message: 'Has published a channel',
+    context: 'Checkbox filtering to users who have published at least one channel',
+  },
+  hasStudioActivityLabel: {
+    message: 'Has Studio activity',
+    context: 'Checkbox filtering to users who have ever made a change in Studio',
+  },
+
+  userTypeAll: {
+    message: 'All',
+    context: 'User type option that applies no filtering',
+  },
+  userTypeActive: {
+    message: 'Active',
+    context: 'User type option for accounts that are currently active',
+  },
+  userTypeInactive: {
+    message: 'Inactive',
+    context: 'User type option for accounts that have been deactivated',
+  },
+  userTypeAdministrators: {
+    message: 'Administrators',
+    context: 'User type option for accounts with administrator privileges',
+  },
+  userTypeSushiChef: {
+    message: 'Sushi chef',
+    context:
+      'User type option for accounts that upload content using a Sushi Chef script. Sushi Chef is a proper name and is not translated.',
+  },
+  booleanFilterAny: {
+    message: 'Any',
+    context: 'Option of a checkbox filter meaning that the filter is not applied',
+  },
+
+  dateWindowAnyTime: {
+    message: 'Any time',
+    context: 'Date range option that applies no filtering',
+  },
+  dateWindowLastMonth: {
+    message: 'Last month',
+    context: 'Date range option covering the past month',
+  },
+  dateWindowLast3Months: {
+    message: 'Last 3 months',
+    context: 'Date range option covering the past three months',
+  },
+  dateWindowLast6Months: {
+    message: 'Last 6 months',
+    context: 'Date range option covering the past six months',
+  },
+  dateWindowLastYear: {
+    message: 'Last year',
+    context: 'Date range option covering the past year',
+  },
+
+  nameHeader: {
+    message: 'Name',
+    context: "Column heading for the user's name",
+  },
+  emailHeader: {
+    message: 'Email',
+    context: "Column heading for the user's email address",
+  },
+  diskSpaceHeader: {
+    message: 'Disk space',
+    context: 'Column heading for how much storage the user has been granted',
+  },
+  canEditHeader: {
+    message: 'Can edit',
+    context: 'Column heading for how many channels the user can edit',
+  },
+  canViewHeader: {
+    message: 'Can view',
+    context: 'Column heading for how many channels the user can view',
+  },
+  dateJoinedHeader: {
+    message: 'Date joined',
+    context: 'Column heading for when the user registered',
+  },
+  lastActiveHeader: {
+    message: 'Last active',
+    context: 'Column heading for when the user last signed in',
+  },
+  actionsHeader: {
+    message: 'Actions',
+    context: 'Column heading for the per-user actions menu',
+  },
+
+  loadingMessage: {
+    message: 'Loading...',
+    context: 'Shown in the table while users are being fetched',
+  },
+  noUsersFoundMessage: {
+    message: 'No users found',
+    context: 'Shown in the table when no users match the current filters',
+  },
+  generatingCSVMessage: {
+    message: 'Generating CSV...',
+    context: 'Notification shown while the CSV export is being prepared',
+  },
+  noFiltersAppliedMessage: {
+    message: 'No filters applied. Pick at least one filter and try again.',
+    context: 'Notification shown when a CSV export is attempted with no filters set',
+  },
+  csvDownloadFailedMessage: {
+    message: 'CSV download failed. Try again.',
+    context: 'Notification shown when the CSV export request fails',
+  },
+
+  tabTitle: {
+    message: 'Users - Administration',
+    context: 'Browser tab title for the administration users page',
+  },
+});

--- a/contentcuration/contentcuration/tests/views/test_settings.py
+++ b/contentcuration/contentcuration/tests/views/test_settings.py
@@ -15,6 +15,63 @@ class StorageSettingsViewTestCase(StudioAPITestCase):
         self.view.request = mock.Mock()
         self.view.request.user = testdata.user(email="tester@tester.com")
 
+    def _form(self, **overrides):
+        data = dict(
+            storage="storage",
+            kind="kind",
+            resource_count="resource_count",
+            resource_size="resource_size",
+            creators="creators",
+            sample_link="sample_link",
+            license="license",
+            public="channel1, channel2",
+            audience="audience",
+            import_count="import_count",
+            location="location",
+            uploading_for="uploading_for",
+            organization_type="organization_type",
+            time_constraint="time_constraint",
+            message="message",
+        )
+        data.update(overrides)
+        form = StorageRequestForm(data=data)
+        self.assertTrue(form.is_valid())
+        return form
+
+    def test_storage_request_records_requested_storage(self):
+        user = self.view.request.user
+        user.information = {"space_needed": "500MB", "heard_from": "newsletter"}
+        user.save()
+
+        with mock.patch("contentcuration.views.settings.send_mail"):
+            self.view.form_valid(self._form(storage="10GB"))
+
+        user.refresh_from_db()
+        self.assertEqual(user.information["latest_storage_request"], "10GB")
+        self.assertEqual(user.information["space_needed"], "500MB")
+        self.assertEqual(user.information["heard_from"], "newsletter")
+
+    def test_storage_request_records_requested_storage_without_prior_information(self):
+        user = self.view.request.user
+        user.information = None
+        user.save()
+
+        with mock.patch("contentcuration.views.settings.send_mail"):
+            self.view.form_valid(self._form(storage="1TB"))
+
+        user.refresh_from_db()
+        self.assertEqual(user.information["latest_storage_request"], "1TB")
+
+    def test_storage_request_overwrites_the_previous_request(self):
+        user = self.view.request.user
+
+        with mock.patch("contentcuration.views.settings.send_mail"):
+            self.view.form_valid(self._form(storage="1GB"))
+            self.view.form_valid(self._form(storage="2GB"))
+
+        user.refresh_from_db()
+        self.assertEqual(user.information["latest_storage_request"], "2GB")
+
     def test_storage_request(self):
 
         with mock.patch("contentcuration.views.settings.send_mail") as send_mail:

--- a/contentcuration/contentcuration/tests/viewsets/test_user.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_user.py
@@ -306,6 +306,26 @@ class CRUDTestCase(StudioAPITestCase):
         self.assertIn("United States", body)
         self.assertIn("Mexico", body)
 
+    def test_admin_users_download_csv_prefers_the_latest_storage_request(self):
+        target = testdata.user(email="csv-storage@e.com")
+        target.information = {
+            "space_needed": "500MB",
+            "latest_storage_request": "10GB",
+        }
+        target.save()
+
+        self.user.is_admin = True
+        self.user.save()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self._csv_url() + f"?ids={target.id}")
+        self.assertEqual(response.status_code, 200)
+
+        body = self._csv_body(response)
+        self.assertIn("Has Studio activity", body)
+        self.assertIn("10GB", body)
+        self.assertNotIn("500MB", body)
+
     def test_admin_users_download_csv_handles_null_information(self):
         user_no_info = testdata.user(email="no-info@e.com")
         user_no_info.information = None

--- a/contentcuration/contentcuration/views/settings.py
+++ b/contentcuration/contentcuration/views/settings.py
@@ -177,6 +177,8 @@ class StorageSettingsView(PostFormMixin, FormView):
     form_class = StorageRequestForm
 
     def form_valid(self, form):
+        self.record_storage_request(self.request.user, form.cleaned_data["storage"])
+
         channels = [c for c in form.cleaned_data["public"].split(", ") if c]
         message = render_to_string(
             "settings/storage_request_email.txt",
@@ -193,6 +195,13 @@ class StorageSettingsView(PostFormMixin, FormView):
             ccsettings.DEFAULT_FROM_EMAIL,
             [ccsettings.SPACE_REQUEST_EMAIL, self.request.user.email],
         )
+
+    @staticmethod
+    def record_storage_request(user, storage):
+        information = user.information or {}
+        information["latest_storage_request"] = storage
+        user.information = information
+        user.save(update_fields=["information"])
 
 
 class PolicyAcceptView(PostFormMixin, FormView):

--- a/contentcuration/contentcuration/viewsets/user.py
+++ b/contentcuration/contentcuration/viewsets/user.py
@@ -463,7 +463,7 @@ CSV_HEADERS = [
     "Has viewable channels",
     "Has published a channel",
     "Most recent publish date",
-    "Has Studio edits",
+    "Has Studio activity",
     "Locations (country names)",
     "Primary location",
     "Location count",
@@ -500,6 +500,10 @@ def _iso_date(value):
     return value.date().isoformat() if hasattr(value, "date") else value.isoformat()
 
 
+def _storage_needed(info):
+    return info.get("latest_storage_request") or info.get("space_needed") or ""
+
+
 def _build_csv_row(values, country_names):
     """Translate one user .values() dict to a CSV row.
 
@@ -528,7 +532,7 @@ def _build_csv_row(values, country_names):
         ", ".join(location_names),
         location_names[0] if location_names else "",
         len(location_codes),
-        info.get("space_needed") or "",
+        _storage_needed(info),
         info.get("heard_from") or "",
     ]
 


### PR DESCRIPTION
## Summary

This fixes QA follow-ups from #5946, all on the admin Users page.

- **Requested storage never reached the "Storage needed" column.** `information["space_needed"]` is only written at registration, and only when the user ticks "Storing materials for private or local use" — the post-registration storage request flow just sent an email and persisted nothing. So users who requested storage after signing up showed blank, while older users who answered the registration question showed a value. `StorageSettingsView` now records the requested amount on the user, and the CSV prefers it over the registration answer. No migration: `information` is an existing `JSONField`.
- **"Has Studio edits" was misnamed.** The filter is `Exists(Change.objects.filter(created_by=...))`, which matches any `Change` row the user ever created — creating a channel qualifies, and deleting it later doesn't undo it. That is activity, not edits, which is what QA observed. Renamed in the filter row and the CSV header; the query param and backend annotation are unchanged, so existing bookmarked URLs still work.
- **The two checkboxes sat in separate quarter-width columns**, leaving the wide gap in QA's screenshot. They now share one half-width flex row with a "Clear filters" action at the end.
- **Clear filters** removes every filter while preserving pagination and sorting. It appears only once a filter differs from the default its control already displays — so choosing "All" for user type shows it (the select is blank until you pick something), while "Any time" on the date windows, or ticking and unticking a checkbox, does not.
- Migrated the UserTable.spec to Vue Testing Library.
- Internationalized the UserTable component.
- Migrated the UserTable component to KDS. VDataTable, CountryField, and UserItem still wrap Vuetify and are deliberately left unchanged, as they require more involved refactoring.
- Streamlined the UserTable component to the Composition API.

**On sign-up** (storage specified)
<img width="986" height="410" alt="Screenshot 2026-08-19 at 12 39 47" src="https://github.com/user-attachments/assets/bf377b71-850c-4928-9865-01edbbea5b6b" />

**On request storage** (storage requested)
<img width="986" height="410" alt="Screenshot 2026-08-19 at 12 44 01" src="https://github.com/user-attachments/assets/2fff9a39-2d04-4577-a733-ff0b042dbecd" />

**UI updates**
**Before**
<img width="3120" height="1846" alt="image" src="https://github.com/user-attachments/assets/3d49387d-e3c1-4c74-840e-ea4ca4e65573" />

**After**
<img width="3120" height="1846" alt="image" src="https://github.com/user-attachments/assets/ad52122b-d216-4a19-81a6-9ec8395d3c8e" />

## References

Fixes #5946

## Reviewer guidance

1. Register and activate a new user.
2. Generate a Users export from the Users table.
3. Verify that the storage size specified during registration matches the value in the report.
4. Log in as the new user and request additional storage.
5. Generate another Users export from the Users table.
6. Verify that the requested storage is reflected in the report.
7. Test the Users table filters and verify that they continue to work as expected.

## AI usage

Claude Code (Opus 5) diagnosed the reported bugs and proposed fixes and a refactoring plan. The code and approach were reviewed and verified by @akolson.
