### PR TITLE
Show the Community Library to signed-out visitors

### DIFF
--- a/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/Channel/CommunityLibraryList/index.vue
@@ -41,6 +41,7 @@
           @close="isAboutCommunityLibraryOpen = false"
         />
         <div
+          v-if="loggedIn"
           class="community-library-banner"
           :style="{
             backgroundColor: $themePalette.orange.v_100,
@@ -277,6 +278,8 @@
       } = communityChannelsStrings;
       const { copyChannelTokenAction$ } = commonStrings;
 
+      const loggedIn = computed(() => store.getters.loggedIn);
+
       const availableLabels = ref(null);
 
       const {
@@ -458,6 +461,7 @@
       return {
         windowIsSmall,
         windowBreakpoint,
+        loggedIn,
         tokenChannel,
         loading,
         loadError,

--- a/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
+++ b/contentcuration/contentcuration/frontend/channelList/views/ChannelListIndex.vue
@@ -28,10 +28,7 @@
       </VToolbarTitle>
     </VToolbar>
     <AppBar v-else>
-      <template
-        v-if="loggedIn"
-        #tabs
-      >
+      <template #tabs>
         <VTab
           v-for="listType in lists"
           :key="listType.id"
@@ -61,6 +58,7 @@
           {{ communityLibraryLabel$() }}
         </VTab>
         <VTab
+          v-if="loggedIn"
           :to="channelSetLink"
           @click="channelSetsTabClick"
         >
@@ -117,6 +115,11 @@
     RouteNames.CATALOG_FAQ,
   ];
 
+  const COMMUNITY_LIBRARY_PAGES = [
+    RouteNames.COMMUNITY_LIBRARY_ITEMS,
+    RouteNames.COMMUNITY_LIBRARY_DETAILS,
+  ];
+
   const CHANNEL_SETS = 'channel_sets';
   const ListTypeToAnalyticsLabel = {
     [ChannelListTypes.EDITABLE]: 'EDITABLE',
@@ -164,13 +167,19 @@
         return this.$route.name === RouteNames.COMMUNITY_LIBRARY_ITEMS;
       },
       toolbarHeight() {
-        return this.loggedIn && !this.isFAQPage ? 112 : 64;
+        return this.libraryMode || this.isFAQPage ? 64 : 112;
       },
       contentOffset() {
         return this.toolbarHeight + (this.offline ? 48 : 0);
       },
       lists() {
+        if (!this.loggedIn) {
+          return [];
+        }
         return Object.values(ChannelListTypes).filter(l => l !== 'public');
+      },
+      anonymousPages() {
+        return this.libraryMode ? CATALOG_PAGES : [...CATALOG_PAGES, ...COMMUNITY_LIBRARY_PAGES];
       },
       invitationsByListCounts() {
         const inviteMap = {};
@@ -205,10 +214,12 @@
     },
     watch: {
       $route(route) {
-        if (route.name === RouteNames.CHANNELS_EDITABLE) {
-          this.loggedIn
-            ? this.loadInvitationList()
-            : this.$router.replace({ name: RouteNames.CATALOG_ITEMS });
+        if (!this.loggedIn) {
+          if (!this.anonymousPages.includes(route.name)) {
+            this.$router.replace({ name: RouteNames.CATALOG_ITEMS });
+          }
+        } else if (route.name === RouteNames.CHANNELS_EDITABLE) {
+          this.loadInvitationList();
         }
         if (this.fullPageError) {
           this.$store.dispatch('errors/clearError');
@@ -222,7 +233,7 @@
     created() {
       if (this.loggedIn) {
         this.loadInvitationList();
-      } else if (!CATALOG_PAGES.includes(this.$route.name)) {
+      } else if (!this.anonymousPages.includes(this.$route.name)) {
         this.$router.replace({ name: RouteNames.CATALOG_ITEMS });
       }
     },

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -1702,13 +1702,27 @@ class ChannelVersion(models.Model):
 
     @classmethod
     def filter_view_queryset(cls, queryset, user):
+        live_in_community_library = Q(
+            Exists(
+                CommunityLibrarySubmission.objects.filter(
+                    channel=OuterRef("channel"),
+                    channel_version=OuterRef("version"),
+                    status=community_library_submission.STATUS_LIVE,
+                )
+            )
+        )
+
         if user.is_anonymous:
-            return queryset.none()
+            return queryset.filter(live_in_community_library)
 
         if user.is_admin:
             return queryset
 
-        return queryset.filter(Q(channel__viewers=user) | Q(channel__editors=user))
+        return queryset.filter(
+            live_in_community_library
+            | Q(channel__viewers=user)
+            | Q(channel__editors=user)
+        )
 
     @classmethod
     def filter_edit_queryset(cls, queryset, user):

--- a/contentcuration/contentcuration/tests/viewsets/test_channel.py
+++ b/contentcuration/contentcuration/tests/viewsets/test_channel.py
@@ -1717,3 +1717,76 @@ class ChannelVersionViewsetTestCase(StudioAPITestCase):
         response = self.client.get(url)
         results = response.json()
         self.assertEqual(len(results), 0)
+
+    def make_community_library_submission(self, channel, version, status):
+        submission = CommunityLibrarySubmission.objects.create(
+            channel=channel,
+            channel_version=version,
+            author=self.user,
+        )
+        submission.status = status
+        submission.save()
+        return submission
+
+    def test_anonymous_user_cannot_access_non_community_channel_versions(self):
+        """Test that an anonymous user gets an empty list rather than a permission error."""
+        self.client.force_authenticate(user=None)
+        url = reverse("channelversion-list") + f"?channel={self.channel.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 0)
+
+    def test_anonymous_user_can_access_live_community_library_version(self):
+        """Test that an anonymous user can read the version live in the Community Library."""
+        self.make_community_library_submission(
+            self.channel, 2, community_library_submission.STATUS_LIVE
+        )
+        self.client.force_authenticate(user=None)
+        url = reverse("channelversion-list") + f"?channel={self.channel.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        results = response.json()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["version"], 2)
+
+    def test_anonymous_user_cannot_access_unpublished_community_library_version(self):
+        """Test that submissions that never went live stay hidden from anonymous users."""
+        for status in (
+            community_library_submission.STATUS_PENDING,
+            community_library_submission.STATUS_APPROVED,
+            community_library_submission.STATUS_REJECTED,
+            community_library_submission.STATUS_SUPERSEDED,
+        ):
+            with self.subTest(status=status):
+                submission = self.make_community_library_submission(
+                    self.channel, 2, status
+                )
+                self.client.force_authenticate(user=None)
+                url = reverse("channelversion-list") + f"?channel={self.channel.id}"
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(len(response.json()), 0)
+                submission.delete()
+
+    def test_non_channel_viewer_can_access_live_community_library_version(self):
+        """Test that a signed-in non-editor can read the live Community Library version."""
+        self.make_community_library_submission(
+            self.channel, 2, community_library_submission.STATUS_LIVE
+        )
+        other_user = testdata.user(email="otheruser@example.com")
+        self.client.force_authenticate(user=other_user)
+        url = reverse("channelversion-list") + f"?channel={self.channel.id}"
+        response = self.client.get(url)
+        results = response.json()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["version"], 2)
+
+    def test_live_community_library_version_does_not_expose_other_versions(self):
+        """Test that going live exposes only that version, not the channel's other versions."""
+        self.make_community_library_submission(
+            self.channel, 2, community_library_submission.STATUS_LIVE
+        )
+        self.client.force_authenticate(user=None)
+        url = reverse("channelversion-list") + f"?channel={self.channel_2.id}"
+        response = self.client.get(url)
+        self.assertEqual(len(response.json()), 0)

--- a/contentcuration/contentcuration/viewsets/channel.py
+++ b/contentcuration/contentcuration/viewsets/channel.py
@@ -1078,7 +1078,7 @@ class ChannelVersionFilter(RequiredFilterSet):
 
 class ChannelVersionViewSet(ReadOnlyValuesViewset):
     queryset = ChannelVersion.objects.all()
-    permission_classes = [IsAuthenticated]
+    permission_classes = [AllowAny]
     pagination_class = ChannelVersionListPagination
     filterset_class = ChannelVersionFilter
     ordering_fields = ["version"]


### PR DESCRIPTION
## Summary

* Adds the Community Library tab for anonymous users alongside the Kolibri Library
* Allows live community library versions to be accessed from the API endpoint so their full metadata can be displayed

## References

In response to user feedback that most people won't have a Studio login to see this!

## Reviewer guidance

Needs a channel live in the Community Library locally: publish a non-public channel, create a `CommunityLibrarySubmission` for it, mark it live, then export it with `export_channel_to_kolibri_public(..., public=False)`.

1. Signed out, open `/channels/` — both Kolibri Library and Community Library tabs are present, and the Community Library lists the channel.
2. Open the channel's details — channel token, resource breakdown, categories and licences are populated, and the "Help grow the Community Library" banner is absent.
3. Copy the channel token from the card — the modal shows the token.
4. Signed out, open `/channels/#/my-channels` and `/channels/#/community-library/<id>/<submission-id>` — both redirect to the Kolibri Library.
5. Signed in as a user who neither edits nor views the channel — same details as step 2.

| State | Screenshot |
|-------|------------|
| Kolibri Library, signed out | ![Kolibri Library signed out](https://i.imgur.com/r9KbLyt.png) |
| Community Library, signed out | ![Community Library signed out](https://i.imgur.com/qsWPkQQ.png) |
| Channel details, signed out | ![Channel details signed out](https://i.imgur.com/oWGE7oS.png) |
| Copy token, signed out | ![Copy token signed out](https://i.imgur.com/cBYgfoj.png) |
| Community Library, signed in | ![Community Library signed in](https://i.imgur.com/cHy3FI7.png) |

Widening `ChannelVersion.filter_view_queryset` exposes version notes publicly.

No new a11y violations reported

## AI usage

Used Claude Code to implement the tab change and the queryset widening, and to drive a browser through the signed-out flows. Verified with the Django and Jest suites, axe-core, and manual QA against a local server.
