### PR TITLE
Fix "Show more" button display when more folder content exists

### DIFF
--- a/contentcuration/contentcuration/frontend/shared/data/__tests__/resources.spec.js
+++ b/contentcuration/contentcuration/frontend/shared/data/__tests__/resources.spec.js
@@ -1,7 +1,7 @@
 import { UpdatedDescendantsChange } from '../changes';
-import { ViewerM2M, ChannelUser, Channel, ContentNode } from '../resources';
+import { ViewerM2M, ChannelUser, Channel, ContentNode, TreeResource } from '../resources';
 import db from 'shared/data/db';
-import { CHANGE_TYPES, TABLE_NAMES } from 'shared/data/constants';
+import { CHANGE_TYPES, PAGINATION_TABLE, TABLE_NAMES } from 'shared/data/constants';
 import { ContentKindsNames } from 'shared/leUtils/ContentKinds';
 import { mockChannelScope, resetMockChannelScope } from 'shared/utils/testing';
 import client from 'shared/client';
@@ -172,6 +172,111 @@ describe('Resources', () => {
         expect(change.mods).toEqual(changes);
       });
     });
+    describe('Paginated where', () => {
+      const maxResults = 3;
+
+      // A full page of children for parent, plus the more obj the server would send with it
+      const makePage = parent => {
+        const results = [1, 2, 3].map(lft => ({
+          id: `${parent}-child-${lft}`,
+          parent,
+          lft,
+          title: `test-child-${lft}`,
+          kind: ContentKindsNames.TOPIC,
+        }));
+        return {
+          results,
+          more: { parent, max_results: maxResults, ordering: 'lft', lft__gt: maxResults },
+        };
+      };
+
+      const mockPage = (parent, { hasMore = true } = {}) => {
+        const page = makePage(parent);
+        const more = hasMore ? page.more : null;
+        jest
+          .spyOn(client, 'get')
+          .mockResolvedValue({ data: { results: page.results, more, count: 10 } });
+        return { ...page, more };
+      };
+
+      // Loads a page the way loadChildren does, without an explicit ordering
+      const loadPage = parent =>
+        ContentNode.where({ parent, max_results: maxResults, ordering: null });
+
+      beforeEach(async () => {
+        await db[PAGINATION_TABLE].clear();
+        // Test setup stubs out fetching for every resource, but saving pagination only happens
+        // inside the real fetchCollection
+        jest
+          .spyOn(ContentNode, 'fetchCollection')
+          .mockImplementation(params =>
+            TreeResource.prototype.fetchCollection.call(ContentNode, params),
+          );
+        ContentNode._requests = {};
+      });
+
+      afterEach(() => {
+        // Restore by registry, since a failure in the hook above could leave a spy uninstalled
+        jest.restoreAllMocks();
+        ContentNode._requests = {};
+      });
+
+      it('should return the server "more" object when nothing is cached locally', async () => {
+        const parent = 'test-uncached-parent-id';
+        const { more } = mockPage(parent);
+
+        const response = await ContentNode.where({ parent, max_results: maxResults });
+
+        expect(response.more).toEqual(more);
+      });
+
+      it('should return the saved more obj when the cache holds exactly one full page', async () => {
+        const parent = 'test-cached-parent-id';
+        const { more } = mockPage(parent);
+
+        await loadPage(parent);
+
+        // One cached page is indistinguishable from a complete list locally, so the saved
+        // pagination has to supply the more obj
+        const response = await loadPage(parent);
+
+        expect(response.results.map(node => node.id)).toEqual([
+          `${parent}-child-1`,
+          `${parent}-child-2`,
+          `${parent}-child-3`,
+        ]);
+        expect(response.more).toEqual(more);
+      });
+
+      it('should not invent a more object when the server said there was nothing more', async () => {
+        const parent = 'test-final-page-parent-id';
+        mockPage(parent, { hasMore: false });
+
+        await loadPage(parent);
+        const response = await loadPage(parent);
+
+        expect(response.results).toHaveLength(maxResults);
+        expect(response.more).toBeNull();
+      });
+
+      it('should return the saved more obj even once children have been removed since it was saved', async () => {
+        const parent = 'test-shrunken-parent-id';
+        const { more } = mockPage(parent);
+
+        await loadPage(parent);
+        // Nothing invalidates saved pagination when children leave the parent. A more obj that
+        // fetches nothing beats hiding children that are still there, so it stands until the
+        // next fetch replaces it.
+        await db[TABLE_NAMES.CONTENTNODE].delete(`${parent}-child-2`);
+        await db[TABLE_NAMES.CONTENTNODE].delete(`${parent}-child-3`);
+
+        const response = await loadPage(parent);
+
+        expect(response.results).toHaveLength(1);
+        expect(response.more).toEqual(more);
+      });
+    });
+
     describe('ChannelUser resource', () => {
       const testChannelId = 'test-channel-id';
       const testUserId = 'test-user-id';

--- a/contentcuration/contentcuration/frontend/shared/data/resources.js
+++ b/contentcuration/contentcuration/frontend/shared/data/resources.js
@@ -400,6 +400,23 @@ class IndexedDBResource {
     });
   }
 
+  isPaginated(params = {}) {
+    return !isNaN(Number(params[PAGINATION_FIELD]));
+  }
+
+  /**
+   * Returns a copy of the params with implicit values made explicit, so that equivalent queries
+   * serialize identically. Saved pagination is keyed off that serialization, which is also
+   * sensitive to key order, so equivalent queries must build their params in the same order.
+   */
+  normalizeParams(params = {}) {
+    const normalized = { ...params };
+    if (this.isPaginated(normalized) && !normalized[ORDER_FIELD] && this.defaultOrdering) {
+      normalized[ORDER_FIELD] = this.defaultOrdering;
+    }
+    return normalized;
+  }
+
   async where(params = {}) {
     const table = db[this.tableName];
     // Indexed parameters
@@ -414,11 +431,17 @@ class IndexedDBResource {
     let sortBy;
     let reverse;
 
+    params = this.normalizeParams(params);
+
     // Check for pagination
     const maxResults = Number(params[PAGINATION_FIELD]);
-    const paginationActive = !isNaN(maxResults);
-    if (paginationActive && !params[ORDER_FIELD]) {
-      params[ORDER_FIELD] = this.defaultOrdering;
+    const paginationActive = this.isPaginated(params);
+    if (paginationActive && !params[ORDER_FIELD] && process.env.NODE_ENV !== 'production') {
+      // `normalizeParams` fills in the default ordering, so reaching here means the resource
+      // has none, and both this page and its cursor will be arbitrary
+      /* eslint-disable no-console */
+      console.warn(`Tried to paginate ${this.tableName} which has no defaultOrdering`);
+      /* eslint-enable */
     }
     for (const key of Object.keys(params)) {
       if (key === PAGINATION_FIELD) {
@@ -906,6 +929,8 @@ class Resource extends mix(APIResource, IndexedDBResource) {
    * @return {Promise<Object[]>}
    */
   where(params = {}, doRefresh = true) {
+    // Normalize before serializing, so this key matches the one `fetchCollection` saves under
+    params = this.normalizeParams(params);
     if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
       /* eslint-disable no-console */
       console.groupCollapsed(`Getting data for ${this.tableName} table with params: `, params);
@@ -926,6 +951,9 @@ class Resource extends mix(APIResource, IndexedDBResource) {
   }
 
   whereLiveQuery(params = {}, doRefresh = true) {
+    // `super.where` normalizes its own copy, so without this `conditionalFetch` below would
+    // fetch under a different key than the query it is refreshing
+    params = this.normalizeParams(params);
     if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
       /* eslint-disable no-console */
       console.groupCollapsed(`Getting liveQuery for ${this.tableName} table with params: `, params);


### PR DESCRIPTION
<!--
 1. REQUIRED: Always fill in the AI usage section at the bottom
 2. Following guidance below, replace …'s with your own words
 3. After saving the PR, tick of completed checklist items
 4. Skip checklist items that are not applicable or not necessary
 5. Delete instruction/comment blocks
-->

## Summary
<!--
 * headline description of the change
 * motivation for the change
 * reasoning for the approach taken
-->
This pull request resolves the bug that prevented the “Show more” button from appearing and loading additional content after opening a folder from the left sidebar, when the folder contains more than 25 resources. Opening the same folder from the main panel functioned as intended.

The implemented fix updates the timing of when the default sort order gets applied. `Resource.where` looks up a saved note that tells it "there is more after this”.  `IndexedDBResource.where` fills in a default sort order when the caller didn't give one. `IndexedDBResource.where` was doing that on the caller's own object, and it ran after the lookup but before the note was filed. So the lookup saw no sort order and the filing saw one, and the two never matched.

Now the default is applied at the top of `Resource.where`, on a copy. The lookup and the filing see the same thing, so the saved note, that causes the “Show more” button to appear, is found.

This pull request also updates `resources.spec.js` with 4 new tests:
- Checks that the more obj is returned when nothing is locally cached
- A saved more obj is returned when the cache has exactly 1 full page
- A more obj is not created if the server says that "more" does not exist
- Returns the saved more obj, even if children have been removed (because it was saved either way). **Note:** If most of a folder’s resources are removed after the more obj was saved, the `Show more` button will show, with nothing to load. Clicking it does nothing, besides causing the button to disappear. The alternative to fix this causes the original bug to return.

Corrected behavior:

https://github.com/user-attachments/assets/5b29b479-3e0d-40e8-9fe6-4c35a0e91781

## References
<!--
 * references to related issues and PRs
-->
Fixes #6052 

## Reviewer guidance
<!--
 * manual verification steps you have performed
 * anything additional a reviewer can do to test these changes?
 * screenshots if the PR affects the layout of the UI
 * screen recording(s) if the PR implements or updates a UI workflow
 * open questions or uncertainties about approach
-->
To avoid building a folder with 25+ children, temporarily lower the `max_results` in [actions.js:78](https://github.com/learningequality/studio/blob/796230974794c0e64318510e12d4ca14e162041d/contentcuration/contentcuration/frontend/channelEdit/vuex/contentNode/actions.js#L78) from 25 to 3, then use any folder with 3+ children.
1. Open a channel that has a folder with enough subfolders to trigger pagination
2. Navigate to that folder by clicking on it in the folder tree panel in the left sidebar, rather than clicking through the main content panel
3. Scroll to the bottom of the list
4. Ensure that the "Show more" button loads the next batch of resources and eventually disappears.

<!--
AI USAGE - REQUIRED

State explicitly whether you didn't use or used AI & how.

If you used it, ensure that the PR is aligned with [Using AI](https://learningequality.org/contributing-to-our-open-code-base/#using-generative-ai as well) as well as our DEEP framework. DEEP asks you:

  Disclose - Be open about when you've used AI for support.
  Engage critically - Question what is generated. Review code for correctness and unnecessary complexity.
  Edit - Review and refine AI output. Remove unnecessary code and verify it still works after your edits.
  Process sharing - Explain how you used the AI so others can learn.

Examples of good disclosures:

  "I used Claude Code to implement the component, prompting it to follow
  the pattern in ComponentX. I reviewed the generated code, removed
  unnecessary error handling, and verified the tests pass."

  "I brainstormed the approach with Gemini, then had it write failing
  tests for the feature. After reviewing the tests, I used Claude Code
  to generate the implementation. I refactored the output to reduce
  verbosity and ran the full test suite."

-->

## AI usage
I used Claude Code to help identify the root cause of the bug. I then implemented a fix, prompted Claude to review the code and tests, and iterated based on its feedback. I manually tested and checked the final output for correctness and removed any unnecessary changes before opening a PR.