### PR TITLE
Fix doubled words in three docstrings

### DIFF
--- a/contentcuration/contentcuration/tests/test_chef_pipeline.py
+++ b/contentcuration/contentcuration/tests/test_chef_pipeline.py
@@ -21,7 +21,7 @@ channel_metadata = {
 
 class EndpointNamesTestCase(BaseAPITestCase):
     """
-    Make sure the API endpoints defined in Ricecooker are the the expected ones.
+    Make sure the API endpoints defined in Ricecooker are the expected ones.
     """
 
     # checks

--- a/contentcuration/contentcuration/tests/test_gcs_storage.py
+++ b/contentcuration/contentcuration/tests/test_gcs_storage.py
@@ -68,7 +68,7 @@ class GoogleCloudStorageSaveTestCase(TestCase):
 
     def test_uploads_cache_control_private_if_content_database(self):
         """
-        Check that set set a cache-control of private if we're uploading a content database.
+        Check that we set a cache-control of private if we're uploading a content database.
         This ensures that no proxy will cache this file.
         """
         filename = "content/databases/myfile.sqlite3"

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -508,7 +508,7 @@ def get_tree_data(request):
 @permission_classes((IsAuthenticated,))
 def get_node_tree_data(request):
     """
-    Get one level of children data for for the node `node_id` of
+    Get one level of children data for the node `node_id` of
     the `tree` tree associated with channel `data['channel_id']`.
     Returns { success: true, tree:[ children of node_id ] }
     """


### PR DESCRIPTION
Three docstrings with a repeated word: "are the the expected ones" in
test_chef_pipeline.py and "children data for for the node" in
views/internal.py. The third, in test_gcs_storage.py, read "Check that set
set a cache-control of private" - that one was missing a word rather than
repeating one, so it now reads "Check that we set a cache-control".

## AI usage

- **Disclose:** I used Claude Code to search for repeated words in
  docstrings and comments, and to apply the resulting one-word edits.
- **Engage critically:** I read each hit in context rather than taking
  the search at face value, and confirmed none of the three strings is
  asserted on by a test or used as a translation key.
- **Edit:** the third hit needed rewriting rather than de-duplicating -
  "Check that set set a cache-control of private" is a missing word, not
  a repeated one, so it now reads "Check that we set a cache-control".
- **Process sharing:** the lesson worth passing on is that a
  doubled-word search returns three different kinds of hit - real
  duplicates, missing words, and deliberate repetition - so the
  candidates have to be read individually. Here one of three was not a
  plain duplicate.

Docstrings only; no code paths, tests or user-facing text change.
