### PR TITLE
[Remove Vuetify from Studio] 'Forgot password' page

### DIFF
--- a/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ForgotPassword.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ForgotPassword.vue
@@ -1,4 +1,5 @@
 <template>
+
   <StudioMessageLayout
     :header="$tr('forgotPasswordTitle')"
     :text="$tr('forgotPasswordPrompt')"
@@ -34,99 +35,105 @@
       />
     </form>
   </StudioMessageLayout>
+
 </template>
 
+
 <script>
-import { mapActions } from 'vuex';
-import StudioMessageLayout from '../../components/StudioMessageLayout';
-import StudioEmailField from '../../components/form/StudioEmailField';
-import StudioBanner from '../../../shared/views/StudioBanner';
-import { generateFormMixin } from '../../../shared/mixins.js';
 
-const formFields = {
-  email: {
-    required: true,
-    validator: value => Boolean(value && /.+@.+\..+/.test(value)),
-  },
-};
+  import { mapActions } from 'vuex';
+  import StudioMessageLayout from '../../components/StudioMessageLayout';
+  import StudioEmailField from '../../components/form/StudioEmailField';
+  import StudioBanner from '../../../shared/views/StudioBanner';
+  import { generateFormMixin } from '../../../shared/mixins.js';
 
-export default {
-  name: 'ForgotPassword',
-
-  mixins: [generateFormMixin(formFields)],
-
-  components: {
-    StudioMessageLayout,
-    StudioEmailField,
-    StudioBanner,
-  },
-
-  data() {
-    return {
-      error: false,
-      emailValidationVisible: false,
-    };
-  },
-
-  computed: {
-    emailErrors() {
-      if (!this.emailValidationVisible || !this.errors.email) {
-        return [];
-      }
-
-      return [this.$tr('validEmailMessage')];
+  const formFields = {
+    email: {
+      required: true,
+      validator: value => Boolean(value && /.+@.+\..+/.test(value)),
     },
-  },
+  };
 
-  methods: {
-    ...mapActions('account', ['sendPasswordResetLink']),
+  export default {
+    name: 'ForgotPassword',
 
-    hideEmailError() {
-      this.emailValidationVisible = false;
+    mixins: [generateFormMixin(formFields)],
+
+    components: {
+      StudioMessageLayout,
+      StudioEmailField,
+      StudioBanner,
     },
 
-    showEmailError() {
-      this.emailValidationVisible = true;
+    data() {
+      return {
+        error: false,
+        emailValidationVisible: false,
+      };
     },
 
-    submit() {
-      this.error = false;
+    computed: {
+      emailErrors() {
+        if (!this.emailValidationVisible || !this.errors.email) {
+          return [];
+        }
 
-      const formData = this.clean();
+        return [this.$tr('validEmailMessage')];
+      },
+    },
 
-      if (!this.validate(formData)) {
+    methods: {
+      ...mapActions('account', ['sendPasswordResetLink']),
+
+      hideEmailError() {
+        this.emailValidationVisible = false;
+      },
+
+      showEmailError() {
         this.emailValidationVisible = true;
-        return;
-      }
+      },
 
-      this.sendPasswordResetLink(formData.email)
-        .then(() => {
-          this.$router
-            .push({
-              name: 'PasswordInstructionsSent',
-            })
-            .catch(() => {});
-        })
-        .catch(() => {
-          this.error = true;
-        });
+      submit() {
+        this.error = false;
+
+        const formData = this.clean();
+
+        if (!this.validate(formData)) {
+          this.emailValidationVisible = true;
+          return;
+        }
+
+        this.sendPasswordResetLink(formData.email)
+          .then(() => {
+            this.$router
+              .push({
+                name: 'PasswordInstructionsSent',
+              })
+              .catch(() => {});
+          })
+          .catch(() => {
+            this.error = true;
+          });
+      },
     },
-  },
 
-  $trs: {
-    forgotPasswordTitle: 'Reset your password',
-    forgotPasswordPrompt:
-      'Please enter your email address to receive instructions for resetting your password',
-    submitButton: 'Submit',
-    forgotPasswordFailed:
-      'Failed to send a password reset link. Please try again.',
-    validEmailMessage: 'Please enter a valid email',
-  },
-};
+    $trs: {
+      forgotPasswordTitle: 'Reset your password',
+      forgotPasswordPrompt:
+        'Please enter your email address to receive instructions for resetting your password',
+      submitButton: 'Submit',
+      forgotPasswordFailed: 'Failed to send a password reset link. Please try again.',
+      validEmailMessage: 'Please enter a valid email',
+    },
+  };
+
 </script>
 
+
 <style lang="scss" scoped>
-.w-100 {
-  width: 100%;
-}
+
+  .w-100 {
+    width: 100%;
+  }
+
 </style>

--- a/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ForgotPassword.vue
+++ b/contentcuration/contentcuration/frontend/accounts/pages/resetPassword/ForgotPassword.vue
@@ -1,92 +1,132 @@
 <template>
-
-  <MessageLayout
+  <StudioMessageLayout
     :header="$tr('forgotPasswordTitle')"
     :text="$tr('forgotPasswordPrompt')"
   >
-    <VForm
+    <form
       ref="form"
-      lazy-validation
+      novalidate
       @submit.prevent="submit"
     >
-      <Banner
-        :text="$tr('forgotPasswordFailed')"
-        :value="error"
+      <StudioBanner
+        v-if="error"
         error
         class="mb-4"
         data-testid="error-banner"
-      />
-      <EmailField
+      >
+        {{ $tr('forgotPasswordFailed') }}
+      </StudioBanner>
+
+      <StudioEmailField
         v-model="email"
         autofocus
+        :error-messages="emailErrors"
+        @blur="showEmailError"
+        @input="hideEmailError"
+        @click.native="hideEmailError"
       />
+
       <KButton
         primary
         class="w-100"
         :text="$tr('submitButton')"
         type="submit"
       />
-    </VForm>
-  </MessageLayout>
-
+    </form>
+  </StudioMessageLayout>
 </template>
 
-
 <script>
+import { mapActions } from 'vuex';
+import StudioMessageLayout from '../../components/StudioMessageLayout';
+import StudioEmailField from '../../components/form/StudioEmailField';
+import StudioBanner from '../../../shared/views/StudioBanner';
+import { generateFormMixin } from '../../../shared/mixins.js';
 
-  import { mapActions } from 'vuex';
-  import MessageLayout from '../../components/MessageLayout';
-  import EmailField from 'shared/views/form/EmailField';
-  import Banner from 'shared/views/Banner';
+const formFields = {
+  email: {
+    required: true,
+    validator: value => Boolean(value && /.+@.+\..+/.test(value)),
+  },
+};
 
-  export default {
-    name: 'ForgotPassword',
-    components: {
-      MessageLayout,
-      EmailField,
-      Banner,
+export default {
+  name: 'ForgotPassword',
+
+  mixins: [generateFormMixin(formFields)],
+
+  components: {
+    StudioMessageLayout,
+    StudioEmailField,
+    StudioBanner,
+  },
+
+  data() {
+    return {
+      error: false,
+      emailValidationVisible: false,
+    };
+  },
+
+  computed: {
+    emailErrors() {
+      if (!this.emailValidationVisible || !this.errors.email) {
+        return [];
+      }
+
+      return [this.$tr('validEmailMessage')];
     },
-    data() {
-      return {
-        email: '',
-        error: false,
-      };
+  },
+
+  methods: {
+    ...mapActions('account', ['sendPasswordResetLink']),
+
+    hideEmailError() {
+      this.emailValidationVisible = false;
     },
-    methods: {
-      ...mapActions('account', ['sendPasswordResetLink']),
-      submit() {
-        this.error = false;
-        if (this.$refs.form.validate()) {
-          this.sendPasswordResetLink(this.email)
-            .then(() => {
-              this.$router
-                .push({
-                  name: 'PasswordInstructionsSent',
-                })
-                .catch(() => {});
+
+    showEmailError() {
+      this.emailValidationVisible = true;
+    },
+
+    submit() {
+      this.error = false;
+
+      const formData = this.clean();
+
+      if (!this.validate(formData)) {
+        this.emailValidationVisible = true;
+        return;
+      }
+
+      this.sendPasswordResetLink(formData.email)
+        .then(() => {
+          this.$router
+            .push({
+              name: 'PasswordInstructionsSent',
             })
-            .catch(() => {
-              this.error = true;
-            });
-        }
-      },
+            .catch(() => {});
+        })
+        .catch(() => {
+          this.error = true;
+        });
     },
-    $trs: {
-      forgotPasswordTitle: 'Reset your password',
-      forgotPasswordPrompt:
-        'Please enter your email address to receive instructions for resetting your password',
-      submitButton: 'Submit',
-      forgotPasswordFailed: 'Failed to send a password reset link. Please try again.',
-    },
-  };
+  },
 
+  $trs: {
+    forgotPasswordTitle: 'Reset your password',
+    forgotPasswordPrompt:
+      'Please enter your email address to receive instructions for resetting your password',
+    submitButton: 'Submit',
+    forgotPasswordFailed:
+      'Failed to send a password reset link. Please try again.',
+    validEmailMessage: 'Please enter a valid email',
+  },
+};
 </script>
 
-
 <style lang="scss" scoped>
-
-  .w-100 {
-    width: 100%;
-  }
-
+.w-100 {
+  width: 100%;
+}
 </style>


### PR DESCRIPTION
## Summary

Migrated the **Forgot Password** page from the legacy Vuetify components to the Studio/KDS components.

* Replaced `MessageLayout` with `StudioMessageLayout`.
* Replaced `EmailField` with `StudioEmailField`.
* Replaced the legacy `Banner` with `StudioBanner`.
* Removed the Vuetify `VForm` and its validation usage.
* Added email syntax validation to the Forgot Password page using the existing form validation pattern.
* Preserved the existing password-reset submission and navigation behavior.
* Kept validation changes limited to the Forgot Password page.

## References

* Related issue/PR: **Remove Vuetify from Studio – "Reset password" page #5931**
* Related PR: **Improve alert banner #5687**

## Reviewer guidance

### Manual verification

1. Open the **Reset your password** page.
2. Verify the page uses the Studio/KDS components.
3. Submit an empty/invalid email address and verify the email validation message is displayed.
4. Verify that no validation error is displayed while typing.
5. Click/tap the email field after an error is displayed and verify the error disappears.
6. Enter a valid email address and submit the form.
7. Verify the password reset request is sent and the user is redirected to the password-instructions page.
8. Simulate a failed password-reset request and verify the Studio error banner is displayed.
9. Verify the error banner is hidden when there is no API error.

### UI
<img width="1907" height="1015" alt="Screenshot 2026-09-08 174546" src="https://github.com/user-attachments/assets/9db567b0-ea41-43e8-83e0-5eee6b9e0512" />

Minor visual differences from the previous Vuetify implementation are expected because the page now uses Studio/KDS components.

## AI usage

I used ChatGPT to help understand the existing Vuetify implementation, the Studio components, and the project's form-validation pattern. I reviewed the generated suggestions critically, compared them with the existing code and maintainer guidance, and kept the implementation limited to the Forgot Password page as requested.
